### PR TITLE
chore(workflow): align collaborator env startup guidance

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -13,7 +13,8 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Main hub checkout: `$HOME/Repos/pika`
 - New named Pika worktrees: `$HOME/.codex/worktrees/pika/<branch-name>`
 - Codex Desktop may also use app-managed worktrees: `$HOME/.codex/worktrees/<id>/pika`
-- Shared env file: `$HOME/Repos/.env/pika/.env.local`; each worktree must symlink `.env.local` to it before running the app
+- Maintainer shared env file: `$HOME/Repos/.env/pika/.env.local`; worktrees on that setup symlink `.env.local` to it before running the app
+- Collaborator setup may keep a checkout-local `.env.local` copied from `.env.example`
 - Runtime and package-manager requirements live in `.nvmrc`, `package.json`, and `scripts/verify-env.sh`
 - Worktree and shared-env setup are defined only in `docs/dev-workflow.md`
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -11127,3 +11127,17 @@
 - `pnpm lint`
 - `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
 - `pnpm test`
+
+## 2026-06-14 — Teacher work-surface docs test wording
+
+**Completed:**
+- Updated stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests.
+- Removed active teacher quiz authoring/state-machine references from the canon.
+- Updated the work-surface audit and stable guidance index to match the active Tests product surface.
+- Left the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
+- `pnpm lint`
+- `pnpm test`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,20 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Teacher work-surface docs test wording
-
-**Completed:**
-- Updated stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests.
-- Removed active teacher quiz authoring/state-machine references from the canon.
-- Updated the work-surface audit and stable guidance index to match the active Tests product surface.
-- Left the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Individual test response fixture wording
 
 **Completed:**
@@ -865,3 +851,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `grep -rni staging` (only seed-data classroom title and journal archive remain)
 - `pnpm lint`
 - `pnpm exec tsc --noEmit`
+
+## 2026-07-11 — Collaborator-local env startup guidance
+
+**Completed:**
+- Aligned the remaining startup/env guidance drift so collaborator-owned `.env.local` files are explicitly valid outside the maintainer symlink setup.
+- Updated `AGENTS.md`, `.ai/CURRENT.md`, `.codex/prompts/session-start.md`, `.claude/commands/session-start.md`, and `docs/core/project-context.md` to describe the maintainer symlink as the default on that machine, while allowing collaborators to copy `.env.example`.
+- Replaced the `ai-startup-docs` invariant that enforced a universal symlink requirement with a dual-path check that requires both the maintainer shared-env path and collaborator-local setup guidance.
+- No product code, runtime behavior, migrations, or dependencies changed.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
+- `git diff --check`

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -12,7 +12,7 @@ Steps:
 1) Verify worktree environment
    - Run: `git rev-parse --show-toplevel`
    - If it equals `$HOME/Repos/pika`: STOP — tell me to open or create a feature worktree first.
-   - Ensure `.env.local` symlinks to `$HOME/Repos/.env/pika/.env.local`.
+   - Ensure `.env.local` exists. Maintainer setups usually symlink it to `$HOME/Repos/.env/pika/.env.local`; collaborators may copy `.env.example`.
    - Run: `bash scripts/verify-env.sh`
    - If verify-env.sh fails: STOP — report the failure.
    - For report-only, docs-only, or review work, use `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only` instead so startup stays read-only.

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -14,7 +14,7 @@ bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only
 
 Manual fallback:
 1. Resolve the repo root with `git rev-parse --show-toplevel` and verify it is not `$HOME/Repos/pika` for branch work.
-2. Ensure `.env.local` symlinks to `$HOME/Repos/.env/pika/.env.local`.
+2. Ensure `.env.local` exists: maintainer setups usually symlink it to `$HOME/Repos/.env/pika/.env.local`; collaborators may `cp .env.example .env.local`.
 3. Run `bash scripts/verify-env.sh`.
 4. Review `git status -sb` and `git log --oneline -8`.
 5. Read `.ai/START-HERE.md`, `.ai/CURRENT.md`, `.ai/features.json`, and `docs/ai-instructions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ Use `docs/guides/ai-ui-testing.md` and `.codex/prompts/ui-verify.md` for the act
 ## Environment Files (.env.local)
 
 - Shared `.env.local` setup is defined in `docs/dev-workflow.md`.
-- Default policy: every worktree has `.env.local` symlinked to `$HOME/Repos/.env/pika/.env.local`.
+- Maintainer default: each worktree symlinks `.env.local` to `$HOME/Repos/.env/pika/.env.local`.
+- Collaborators may keep a checkout-local `.env.local` copied from `.env.example`.
 - Only use branch-specific env files when intentionally isolating backend state or secrets.
 
 ## Project Overview

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -51,7 +51,8 @@ Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
    - `corepack enable`
    - `pnpm install`
 2. Set up `.env.local` using the shared-worktree flow in [`docs/dev-workflow.md`](../dev-workflow.md).
-   - Default: symlink the worktree’s `.env.local` to `$HOME/Repos/.env/pika/.env.local`
+   - Maintainer default: symlink the worktree’s `.env.local` to `$HOME/Repos/.env/pika/.env.local`
+   - Collaborator default: `cp .env.example .env.local`, then fill in the required values
    - Exception-only: use a branch-specific env file when intentionally isolating backend state
 3. Ensure pending migrations have been applied by a human before runtime work that depends on them.
    - AI agents may create or edit migration files, but must not run `supabase db push`, `supabase db reset`, or similar migration commands

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -144,18 +144,33 @@ describe('AI startup docs', () => {
     expect(workflow).toContain('git rev-parse --show-toplevel')
   })
 
-  it('documents the shared env symlink requirement', () => {
-    const files = [
+  it('documents both maintainer shared-env and collaborator-local env setups', () => {
+    const sharedEnvFiles = [
       '.ai/START-HERE.md',
       '.ai/CURRENT.md',
       'AGENTS.md',
       'docs/dev-workflow.md',
       '.codex/prompts/session-start.md',
       '.claude/commands/session-start.md',
+      'docs/core/project-context.md',
+    ]
+    const collaboratorFiles = [
+      '.ai/START-HERE.md',
+      '.ai/CURRENT.md',
+      'AGENTS.md',
+      'docs/dev-workflow.md',
+      '.codex/prompts/session-start.md',
+      '.claude/commands/session-start.md',
+      'docs/core/project-context.md',
     ]
 
-    for (const file of files) {
+    for (const file of sharedEnvFiles) {
       expect(readRepoFile(file)).toContain('$HOME/Repos/.env/pika/.env.local')
+    }
+
+    for (const file of collaboratorFiles) {
+      const content = readRepoFile(file)
+      expect(content).toMatch(/\.env\.example|collaborator/i)
     }
   })
 


### PR DESCRIPTION
## Summary
- align the remaining startup/env guidance with the collaborator-safe setup introduced in the onboarding docs
- make the maintainer symlink path explicit without treating it as the only valid `.env.local` workflow
- update the startup docs regression so it requires both maintainer shared-env and collaborator-local guidance
- append the required session log entry and trim/archive the log per repo policy

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
- `git diff --check`
- `node scripts/trim-session-log.mjs`
- `node scripts/trim-session-log.mjs --check`
