### PR TITLE
Add typed Supabase database contract

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -12325,3 +12325,562 @@
 - `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-06-16 — Legacy quiz markdown fixture clarity
+
+**Completed:**
+- Updated `tests/lib/quiz-markdown.test.ts` so the suite explicitly describes legacy quiz markdown compatibility.
+- Replaced arbitrary `Intro Quiz` fixture titles with `Legacy Check-in` while preserving the intentional `# Quiz` legacy markdown format.
+- Left production markdown helpers, schema, API payloads, and runtime behavior unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/lib/quiz-markdown.test.ts`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-16 — Test AI gold-set fixture wording
+
+**Completed:**
+- Renamed the active Test AI grading gold-set title from `Intro CS Concepts Quiz` to `Intro CS Concepts Test`.
+- Verified the old fixture wording is gone from scripts/tests/source docs.
+- Left AI grading logic, schema, API payloads, and runtime contracts unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm tsx scripts/measure-ai-grading-prompts.ts`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-19 — Skill progression map refresh
+
+**Completed:**
+- Reviewed recent merged PRs and review evidence to identify the next engineering skills worth deepening.
+- Anchored recommendations to the June 8-16, 2026 PR cluster around legacy quiz-to-test contract cleanup and classroom-switch race-condition fixes.
+- Found that the strongest recurring review signals were stale async state during classroom navigation and compatibility gaps during naming-contract migration.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`
+- `gh pr list --repo codepetca/pika --state merged --limit 15 --json number,title,mergedAt,url`
+- `gh api graphql` review scan across recent merged PRs
+
+## 2026-06-19 — Dev-flow skill upgrades
+
+**Completed:**
+- Implemented the three skill improvements as repo guidance updates instead of a separate process layer.
+- Strengthened `docs/guidance/dev-flow-risk-checklists.md` with explicit route-owner identity, stale-response guards, and A-then-B regression expectations for workspace-state work.
+- Expanded `docs/guidance/schema-rollout-checklist.md` and `docs/guidance/legacy-quiz-contract-cleanup.md` to require explicit migration slices, new-contract-first readers, and listed surviving legacy aliases.
+- Expanded `docs/guidance/component-refactor-checklist.md` to require sliced refactors with grep/test exit criteria.
+- Wired the new checks into `.codex/prompts/session-start.md`, `.codex/prompts/audit.md`, and `.codex/prompts/tdd.md`.
+
+**Validation:**
+- `git diff -- docs/guidance/dev-flow-risk-checklists.md docs/guidance/schema-rollout-checklist.md docs/guidance/component-refactor-checklist.md docs/guidance/legacy-quiz-contract-cleanup.md .codex/prompts/session-start.md .codex/prompts/audit.md .codex/prompts/tdd.md`
+- `sed -n '1,220p' .codex/prompts/tdd.md`
+
+## 2026-06-09 — Classroom theme colors
+
+**Completed:**
+- Created `codex/classroom-theme-colors` in a dedicated worktree.
+- Added a `theme_color` classroom field with deterministic backfill/default migration and centralized palette helpers.
+- Threaded classroom theme colors through teacher, student, and blueprint classroom APIs.
+- Added color recognition affordances in teacher/student classroom lists, classroom dropdown/header, and teacher settings.
+- Added teacher settings controls for changing the classroom color.
+- Rebasing checkpoint: stashed the uncommitted implementation, rebased `codex/classroom-theme-colors` onto `origin/main`, restored the stash without conflicts, and confirmed `079_classroom_theme_color.sql` remains the next migration after `origin/main`'s `078`.
+- Repeat rebase checkpoint: fetched `origin/main`; branch was already up to date, stash restored without conflicts, and `079_classroom_theme_color.sql` still follows `origin/main`'s `078` with no duplicate migration prefix.
+- Pre-PR self-review fix: kept the student classroom list query tolerant of the pre-migration schema but shaped the JSON response to avoid returning every classroom column.
+- Design revision after PR review: removed dot/swatch marker elements, themed the classroom appbar through the header surface/bottom rule, and kept classroom list recognition on existing card borders.
+- Final PR update: rebased the revised design commit onto the latest `origin/main`; migration `079_classroom_theme_color.sql` remained correctly sequenced.
+- Palette variant update: extended each classroom color to paired light/dark accents, kept the stored value as one palette key, and used CSS theme variables so the appbar/list/settings treatment adapts by mode.
+- Default color update: new classrooms and blueprint-instantiated classrooms now choose the least-used active teacher classroom color before repeating.
+- Performance follow-up: narrowed student and teacher classroom list queries to rendered fields instead of full classroom rows, with legacy fallbacks when `theme_color` is unavailable during rollout.
+- Duplicate-color follow-up: changed existing-classroom migration backfill to assign per-teacher ordered palette positions, changed new-classroom default selection to seed among least-used colors, and added list hydration fallback colors for pre-migration local data.
+- UI follow-up: fixed classroom card/settings theme border specificity so existing edges visibly render classroom colors instead of the generic border utility.
+- Classroom list card follow-up: added a subtle classroom-accent card surface gradient to teacher/student classroom list cards and drag previews so classroom color is apparent beyond the edge.
+- Gradient follow-up: extended classroom gradients farther into list cards and the classroom appbar while keeping the tint subtle.
+- Appbar underline follow-up: removed the classroom-colored appbar underline so the active classroom header is identified by the subtle gradient only, with the normal neutral border retained.
+- Final gradient/settings follow-up: removed colored list-card edge accents, extended card/appbar gradients further, changed settings color options so every swatch shows its gradient and only the selected option has the accent edge plus label, and propagated saved classroom changes to the page shell so the appbar updates without refresh.
+- Left-edge follow-up: restored the classroom accent edge on the appbar left side and classroom card left side while keeping the appbar bottom border neutral and retaining the extended gradients.
+- Hover follow-up: changed classroom list card hover/focus feedback from an inner button fill to a full-card classroom-accent outline.
+- Bottom-controls follow-up: made the classroom list bottom edit control shell chromeless so the pencil sits on the page without a visible card surface.
+- Appbar logo follow-up: changed the Pika logo to a classroom-accent masked mark only when an active classroom theme is present, leaving the normal brand image on unthemed appbars.
+- Appbar logo alignment follow-up: normalized brand and classroom logo rendering into the same fixed centered box and removed the appbar left accent edge now that the logo carries the classroom color.
+- Classroom card hover follow-up: replaced the full-card hover outline with a subtle whole-card lift and panel shadow increase.
+- Appbar logo revert follow-up: removed the classroom-colored Pika logo variant and restored the classroom accent edge on the appbar left side.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (after `pnpm install`; includes `pnpm test`, 301 files / 2655 tests)
+- `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm test` (302 files / 2669 tests)
+- `pnpm build`
+- `pnpm e2e:auth`
+- Playwright screenshots under `/tmp/pika-classroom-theme/` for teacher/student classroom lists, teacher/student detail headers, and teacher settings in light/dark modes.
+- Post-rebase: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Post-rebase: `pnpm lint`
+- Repeat post-rebase: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Repeat post-rebase: `pnpm lint`
+- Pre-PR: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Pre-PR: `pnpm lint`
+- Pre-PR: `pnpm build`
+- Design revision: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Design revision: `pnpm lint`
+- Design revision: `pnpm build`
+- Design revision visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; plus Playwright screenshots for teacher/student classroom detail and teacher settings in light/dark mode under `/tmp/pika-classroom-theme-appbar-*.png`.
+- Final post-rebase: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Final post-rebase: `pnpm lint`
+- Palette variant update: `pnpm test tests/unit/classroom-theme.test.ts tests/api/teacher/classrooms.test.ts tests/lib/server/course-blueprints.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Palette variant update: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Palette variant update: `pnpm lint`
+- Palette variant update: `pnpm build`
+- Palette variant visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; targeted screenshots in `/tmp/pika-classroom-theme-variants-*.png`; Playwright computed-style check confirmed light appbar accent `#2563eb` and dark appbar accent `#60a5fa`.
+- Performance follow-up: `pnpm test tests/api/student/classrooms.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/api/teacher/classrooms.test.ts`
+- Performance follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Performance follow-up: `pnpm lint`
+- Performance follow-up: `pnpm build`
+- Duplicate-color follow-up: `supabase db query --local --output json "<read-only CTE verification>"` confirmed same-teacher classrooms get Blue then Teal before repeating.
+- Duplicate-color follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/unit/classroom-theme-migration.test.ts tests/unit/server-classrooms.test.ts tests/api/teacher/classrooms.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/AppHeader.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Duplicate-color follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/unit/classroom-theme-migration.test.ts tests/unit/server-classrooms.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Duplicate-color follow-up: `pnpm lint`
+- Duplicate-color follow-up: `pnpm build`
+- Duplicate-color visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright computed-style check confirmed the local test list renders Blue and Teal card-edge colors for the two teacher classrooms.
+- Classroom list card follow-up: `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/unit/classroom-theme.test.ts tests/unit/server-classrooms.test.ts`
+- Classroom list card follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/unit/classroom-theme-migration.test.ts tests/unit/server-classrooms.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Classroom list card follow-up: `pnpm lint`
+- Classroom list card follow-up: `pnpm build` after clearing stale generated `.next` output from an overlapping dev-server build.
+- Classroom list card visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright computed-style check confirmed list cards render classroom-color gradients.
+- Gradient follow-up: `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Gradient follow-up: `pnpm lint`
+- Gradient follow-up: `pnpm build`
+- Gradient visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright computed-style check confirmed appbar gradient stops at 22%/78% and card gradient stops at 18%/62%.
+- Appbar underline follow-up: `pnpm test tests/components/AppHeader.test.tsx`
+- Appbar underline follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/unit/classroom-theme-migration.test.ts tests/unit/server-classrooms.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- Appbar underline follow-up: `pnpm lint`
+- Appbar underline follow-up: `pnpm build`
+- Appbar underline visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright computed-style check confirmed header gradient remains, box-shadow is `none`, and the bottom border is neutral.
+- Final gradient/settings follow-up: `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Final gradient/settings follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/unit/classroom-theme-migration.test.ts tests/unit/server-classrooms.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/student/classrooms.test.ts tests/api/student/classrooms-id.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/lib/server/course-blueprints.test.ts tests/unit/server-classroom-order.test.ts tests/lib/server/classroom-order.test.ts tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- Final gradient/settings follow-up: `pnpm lint`
+- Final gradient/settings follow-up: `pnpm build`
+- Final gradient/settings visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright screenshots `/tmp/pika-classroom-theme-no-edge-extended-card.png`, `/tmp/pika-classroom-theme-settings-swatches-before.png`, `/tmp/pika-classroom-theme-settings-swatches-after.png`, and `/tmp/pika-classroom-theme-no-edge-extended-appbar.png`; computed-style check confirmed list cards have neutral 1px left borders, all settings options have gradients, only the selected option has a 4px accent edge, and the appbar changed from Blue to Teal without refresh.
+- Left-edge follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/unit/classroom-theme.test.ts`
+- Left-edge follow-up: `pnpm lint`
+- Left-edge follow-up: `pnpm build`
+- Left-edge visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright screenshots `/tmp/pika-classroom-theme-left-edge-cards.png` and `/tmp/pika-classroom-theme-left-edge-appbar.png`; computed-style check confirmed 4px accent left borders on classroom cards and appbar, neutral card top borders, neutral appbar bottom border, and no appbar box-shadow underline.
+- Hover follow-up: `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Hover follow-up: `pnpm lint`
+- Hover follow-up: `pnpm build`
+- Hover visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; Playwright screenshots `/tmp/pika-classroom-theme-card-outline-before.png` and `/tmp/pika-classroom-theme-card-outline-hover.png`; computed-style check confirmed hover changes the full card outline while the inner button background stays transparent.
+- Bottom-controls follow-up: `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
+- Bottom-controls follow-up: `pnpm lint`
+- Bottom-controls follow-up: `pnpm build`
+- Bottom-controls visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-student.png`; dark-mode screenshot `/tmp/pika-classroom-bottom-controls-dark.png`; computed-style check confirmed the classroom bottom controls have transparent background, no shadow, no backdrop blur, and zero padding.
+- Appbar logo follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Appbar logo follow-up: `pnpm lint`
+- Appbar logo follow-up: `pnpm build`
+- Appbar logo visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; targeted classroom screenshots `/tmp/pika-classroom-logo-light.png` and `/tmp/pika-classroom-logo-dark.png`; computed-style check confirmed the masked logo uses the light classroom accent in light mode and the dark classroom accent in dark mode.
+- Appbar logo alignment follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Appbar logo alignment follow-up: `pnpm lint`
+- Appbar logo alignment follow-up: `pnpm build`
+- Appbar logo alignment visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; targeted screenshot `/tmp/pika-classroom-logo-centered-light.png`; computed geometry check confirmed the brand and classroom logo boxes share the same vertical center offset in the 48px appbar and themed appbars have `0px` left border width.
+- Classroom card hover follow-up: `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx`
+- Classroom card hover follow-up: `pnpm lint`
+- Classroom card hover follow-up: `pnpm build`
+- Classroom card hover visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; targeted screenshots `/tmp/pika-classroom-hover-elevation-before.png` and `/tmp/pika-classroom-hover-elevation-after.png`; computed-style check confirmed no outline, `translateY(-1px)`, and increased shadow on hover.
+- Appbar logo revert follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/unit/classroom-theme.test.ts`
+- Appbar logo revert follow-up: `pnpm lint`
+- Appbar logo revert follow-up: `pnpm build`
+- Appbar logo revert visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; targeted screenshot `/tmp/pika-classroom-appbar-brand-logo-left-edge.png`; computed-style check confirmed the appbar uses the brand image, has no masked logo, and renders a 4px classroom-accent left border.
+- Bright palette follow-up: updated classroom theme labels/colors to a brighter set (Sky, Mint, Lime, Sunshine, Coral, Grape, Aqua, Peach) while keeping stored theme keys stable.
+- Bright palette follow-up: `pnpm test tests/unit/classroom-theme.test.ts tests/components/TeacherSettingsTab.test.tsx tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx`
+- Bright palette follow-up: `pnpm lint`
+- Bright palette follow-up: `pnpm build`
+- Bright palette visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-student.png`; targeted settings screenshots `/tmp/pika-settings-light.png` and `/tmp/pika-settings-dark.png` confirmed brighter palette swatches and appbar gradients remain legible in light and dark mode.
+- Full-border follow-up: replaced the classroom-color left edge on classroom list cards and the classroom appbar with a 1px classroom-color border on all sides, keeping the existing gradients.
+- Full-border follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/SortableClassroomRow.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/unit/classroom-theme.test.ts`
+- Full-border follow-up: `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Full-border follow-up: `pnpm lint`
+- Full-border follow-up: `pnpm build`
+- Full-border visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms` and `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/ddb6fbe4-66b3-46cf-9efa-21cb4f2a5218`; computed-style check confirmed teacher classroom cards and the appbar all render 1px accent-colored borders on top/right/bottom/left.
+- Full-border post-rebase: rebased cleanly onto `origin/main`; migration `079_classroom_theme_color.sql` remains next after main's `078_assignment_gradex_run_metadata.sql` with no duplicate migration prefixes.
+- Gradient-only follow-up: removed classroom-colored border overrides from classroom cards and the appbar, leaving the existing classroom gradients as the sole classroom color signal on those surfaces.
+- Gradient-only follow-up: `pnpm test tests/components/AppHeader.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/SortableClassroomRow.test.tsx tests/unit/classroom-theme.test.ts`
+- Gradient-only follow-up: `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Gradient-only follow-up: `pnpm lint`
+- Gradient-only follow-up: `pnpm build`
+- Gradient-only visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms` and `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/ddb6fbe4-66b3-46cf-9efa-21cb4f2a5218`; computed-style check confirmed card/header borders are neutral while gradients remain.
+
+## 2026-06-13 — API auth-boundary negative coverage
+
+**Completed:**
+- Continued the systems/UI audit program with the API authorization-boundary slice.
+- Added negative teacher ownership and student enrollment coverage for legacy `GET /api/teacher/class-days`.
+- Added matching negative coverage for canonical `GET /api/classrooms/[classroomId]/class-days`.
+- Added teacher-side `GET /api/student/tests/[id]/history` coverage for non-owned tests and students outside the test classroom.
+- Confirmed the existing routes already block these paths before downstream class-day/history data reads; no production route changes were needed.
+
+**Validation:**
+- `pnpm vitest run tests/api/teacher/class-days.test.ts tests/api/classrooms-class-days.test.ts tests/api/student/tests-history.test.ts` (18 tests)
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2690 tests)
+
+## 2026-06-20 — Pika logo dark-token cleanup
+
+**Completed:**
+- Continued the systems/UI audit program with a bounded UI consistency slice.
+- Moved the Pika logo dark-mode filter out of component-local `dark:` utility classes and into `src/styles/tokens.css` as `--pika-logo-filter`.
+- Updated `PikaLogo` to use the semantic `pika-logo` class.
+- Removed the obsolete `PikaLogo` `dark:` exception from the active design guidance.
+- Added AppHeader regression coverage that asserts the logo uses the tokenized class and no component-level `dark:` utilities.
+- Addressed subagent review feedback by matching Tailwind's previous composed filter order for the dark-mode logo token.
+
+**Validation:**
+- `rg -n "dark:" src/app src/components --glob '*.tsx' --glob '*.ts'` returned no matches.
+- `pnpm vitest run tests/components/AppHeader.test.tsx`
+- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts tests/components/AppHeader.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- Visual verification: `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-student.png`.
+- Additional visual verification for role/viewport/theme matrix: reviewed `/tmp/pika-student-desktop.png`, `/tmp/pika-teacher-dark.png`, `/tmp/pika-teacher-mobile-dark.png`, `/tmp/pika-student-dark.png`, and `/tmp/pika-student-mobile-dark.png`.
+- Post-review fix validation: `pnpm vitest run tests/components/AppHeader.test.tsx tests/unit/ui-guidance-docs.test.ts`, `git diff --check`, `pnpm lint`, `bash .codex/skills/pika-audit/scripts/audit.sh`, `pnpm build`.
+- Post-review visual verification: reviewed `/tmp/pika-teacher-dark-after-review.png` and `/tmp/pika-student-mobile-dark-after-review.png`.
+
+## 2026-06-20 — Historical design-system dark-mode examples cleanup
+
+**Completed:**
+- Continued the systems/UI audit program with a docs-only UI guidance consistency slice.
+- Updated the historical `docs/design-system.md` dark-mode section so it points to semantic tokens instead of raw theme-switching utility examples.
+- Added UI guidance regression coverage to keep that historical section aligned with semantic-token guidance.
+- Addressed subagent review feedback by tightening the regression test to match exact semantic-token class examples.
+
+**Validation:**
+- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Post-review fix validation: `pnpm vitest run tests/unit/ui-guidance-docs.test.ts`, `git diff --check`, `pnpm lint`, `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-20 — Browser Supabase access audit guard
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the browser-side Supabase access slice.
+- Audited non-API/non-server source imports and confirmed current direct Supabase runtime usage is limited to server-rendered classroom pages and the shared server client module; `src/lib/user-profile.ts` uses a type-only Supabase import.
+- Added static regression coverage that fails if a browser-reachable module imports `@/lib/supabase` or `@supabase/supabase-js` at runtime.
+- Addressed subagent review feedback by changing the guard from a direct client-file scan to a TypeScript-AST runtime import graph rooted at every `use client` source file, while allowing type-only Supabase imports and catching static imports, dynamic imports, and `require()` calls.
+- No production UI or runtime behavior changed.
+
+**Validation:**
+- `rg -n "@/lib/supabase|@supabase/supabase-js|getSupabaseClient|getServiceRoleClient" src/app src/components src/hooks src/lib src/ui --glob '*.{ts,tsx}' --glob '!src/app/api/**' --glob '!src/lib/server/**'`
+- `pnpm test tests/unit/browser-supabase-access.test.ts tests/unit/api-route-standards.test.ts tests/unit/supabase.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+
+## 2026-06-20 — Student notification read-cache audit
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the client read-cache drift slice.
+- Audited client GET reads for repeated classroom-scoped requests and identified student notification reads as a concrete fix-now item.
+- Wrapped `StudentNotificationsProvider` notification GETs in `fetchJSONWithCache` with a short classroom-scoped TTL so same-classroom mounts/focus reads dedupe.
+- Invalidated the classroom notification cache when local notification helpers mark/decrement counts and before explicit `refresh()` so quick remounts or manual refreshes cannot replay stale pre-action counts.
+- Added regression coverage for simultaneous same-classroom provider reads, explicit refresh freshness, and post-local-update remount freshness.
+- No UI layout or styling changed.
+
+**Validation:**
+- `pnpm test tests/components/StudentNotificationsProvider.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+
+## 2026-06-20 — Composite widget accessibility audit
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the composite-widget accessibility slice.
+- Audited shared menu/listbox widgets and identified a concrete fix-now issue in the `useDropdownNav` consumers: closed account/classroom dropdown surfaces stayed exposed in the accessibility tree, and Escape/outside close did not return focus to the trigger.
+- Added a trigger ref and focus restoration path to `useDropdownNav` for Escape, outside click, and trigger-close behavior.
+- Marked closed `UserMenu` and `ClassroomDropdown` menu/listbox surfaces with `aria-hidden` while preserving their existing visual transitions.
+- Added semantic regression coverage for closed menus being unavailable by role and focus restoration after Escape/outside close.
+
+**Accessibility checklist:**
+- checklist reviewed: yes
+- keyboard behavior covered: yes
+- semantic state covered by tests: yes
+- remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/ClassroomDropdown.test.tsx tests/components/UserMenu.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+- Additional open-state visual verification: reviewed `/tmp/pika-user-menu-open.png` and `/tmp/pika-classroom-dropdown-open.png`.
+- `pnpm test` (308 files / 2742 tests)
+
+## 2026-06-21 — Teacher exam telemetry E2E coverage
+
+**Completed:**
+- Added a focused Playwright teacher exam-mode flow that creates an active open-response test, has the seeded student generate one route-exit attempt, one window/full-screen exit, and one away/focus event, then verifies the teacher grading row distinguishes those telemetry categories.
+- Reused existing teacher/student storage state setup and API-backed test creation/cleanup patterns; no app logic, migrations, or dependencies changed.
+- Selected this flow because student exam-mode E2E already covered lock/restoration/draft preservation, while teacher-side telemetry visibility remained a bounded exam-mode coverage gap.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
+- `pnpm lint`
+- Note: `E2E_BASE_URL=http://127.0.0.1:3101 ...` failed in auth setup with teacher login `Failed to fetch`; rerunning on `localhost:3101` passed.
+
+## 2026-06-21 — Teacher telemetry E2E review fix
+
+**Completed:**
+- Addressed review feedback on PR #815 by loosening the teacher grading-row away-duration assertion so valid one-away-session durations above nine seconds do not make the E2E flaky.
+- Kept the API-side `away_total_seconds >= 1` assertion as the source of truth for nonzero away time.
+
+**Validation:**
+- `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-21 — Stale async classroom-state audit
+
+**Completed:**
+- Continued the bounded systems/UI audit with the stale async classroom/workspace state slice.
+- Fixed `StudentLessonCalendarTab` so lesson plans, assignments, announcements, and max-date state clear on classroom changes and only current classroom request ids can write visible state.
+- Fixed `TeacherTestsTab` so the tests list and selected/grading workspace state reset on classroom changes, and late `/api/teacher/tests?classroom_id=...` responses cannot repaint the newly selected classroom with old-classroom tests.
+- Added regression coverage for late classroom A responses arriving after a switch to classroom B in both student calendar and teacher tests flows.
+- Addressed subagent review feedback by clearing owner-scoped teacher test modal/action state on classroom changes, including delete/edit/batch/status/access/return/unsubmit/delete-work pending state, and by ignoring late create-test responses from a previous classroom.
+- Addressed follow-up subagent review feedback by guarding create-test completion with a request id so an old classroom create cannot clear the current classroom's in-flight create state.
+
+**Workspace-state checklist:**
+- owner identity: classroom id
+- late responses ignored: yes, request id plus current classroom id checks
+- state clears immediately on owner change: yes, for calendar data and teacher tests workspace state
+- owner-scoped action state clears immediately on owner change: yes
+- current-owner create busy state protected from old requests: yes
+- cache boundary checked: yes, classroom-scoped cache keys invalidated in tests
+- remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+
+## 2026-06-22 — Teacher tests workspace navigation extraction
+
+**Completed:**
+- Started the bounded architecture/UI improvement goal with a behavior-preserving TeacherTestsTab decomposition slice.
+- Extracted controlled/uncontrolled tests workspace selection, workspace mode, selected grading student, and URL search-param mutation into `useTestWorkspaceNavigation`.
+- Kept grading data loading, business actions, modal state, and workspace side effects in `TeacherTestsTab`.
+- Added hook contract coverage for list defaults, grading navigation, authoring student-param cleanup, workspace clearing, and controlled-prop precedence.
+- Added a parent `TeacherTestsTab` regression proving grading row selection still writes `testStudentId` through search params.
+
+**Refactor checklist:**
+- boundary: workspace navigation/search-param state only
+- shell or behavior extraction: behavior extraction for local navigation state, no UI shell change
+- business logic moved: none
+- visible behavior intended to change: none
+- remaining decomposition: teacher tests grading/list/action state still intentionally stays in the parent for future slices
+
+**Validation:**
+- `pnpm test tests/hooks/useTestWorkspaceNavigation.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+
+## 2026-06-22 — Teacher tests list-state extraction
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the next behavior-preserving TeacherTestsTab decomposition slice.
+- Extracted classroom-owned tests-list loading, visible-list ownership, event reload handling, request freshness checks, and selected-draft summary patching into `useTeacherTestList`.
+- Moved shared selected-test summary patching into `src/lib/test-summary-patch.ts` so the hook and parent mutations use the same behavior.
+- Kept rendering, routing, grading rows, mutations, dialogs, batch actions, and workspace mode state in `TeacherTestsTab`.
+- Added hook-level coverage for current-classroom loads, hiding prior-classroom data while loading, late response rejection, matching update-event reloads, and draft-summary patching.
+- Updated the parent component regression for visible list reload after `TEACHER_TESTS_UPDATED_EVENT`.
+
+**Workspace-state checklist:**
+- owner identity: classroom id
+- late responses ignored: yes, request id plus current classroom id checks in the hook
+- state clears immediately on owner change: visible tests are hidden when loaded owner differs from current classroom
+- A-after-B regression: covered in `tests/hooks/useTeacherTestList.test.ts` and parent coverage remains in `TeacherTestsTab.test.tsx`
+- visible behavior intended to change: none
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/hooks/useTeacherTestList.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-22 — Teacher test results normalization
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a behavior-preserving legacy contract cleanup slice.
+- Moved teacher test results payload normalization from `TeacherTestsTab` into `readTeacherTestResultsFromPayload` in `src/lib/test-api-contract.ts`.
+- Kept current `test` payload keys preferred while retaining the legacy `quiz` fallback for compatibility.
+- Exported typed teacher grading student/question result shapes from the contract helper and kept UI state, fetch ownership, grading actions, and rendering in `TeacherTestsTab`.
+- Added contract tests for current-key preference, legacy fallback, active run/error passthrough, question summary mapping, and unknown-status filtering.
+- Strengthened the parent `TeacherTestsTab` legacy fallback regression to prove the normalized results request still loads without the generic results error.
+
+**Compatibility checklist:**
+- What widened: no API payload, query, or schema widened; only client-side normalization moved to a helper.
+- Fallback: legacy `quiz` detail key remains supported through `readTestFromPayload`.
+- Migration dependency: none; no schema or server contract changed.
+- Intended payload regression: `tests/lib/test-api-contract.test.ts` covers current `test` preference and legacy `quiz` fallback.
+- Legacy aliases still alive: `quiz`/`quizzes` response aliases and fallback readers remain intentionally alive.
+- Visible behavior intended to change: none.
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-22 — Cached API JSON helper
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a typed client API/cache helper slice.
+- Added `fetchJSON` and `fetchCachedJSON` to `src/lib/request-cache.ts` so repeated client reads can share JSON parsing, API error payload handling, and cache TTL wiring.
+- Migrated `useTeacherTestList`, `useGradebookData`, and `StudentNotificationsProvider` from inline cached fetcher lambdas to the typed helper.
+- Kept `fetchJSONWithCache` intact for existing custom fetcher callers and left API payload shape unchanged.
+- Added request-cache coverage for successful JSON parsing, API error precedence, fallback errors for non-JSON failures, and cached helper reuse.
+- Updated hook/component tests for the new helper call shape without changing visible UI behavior.
+- Addressed independent review by preserving JSON parse rejection for successful malformed responses and adding `init` passthrough coverage.
+
+**Cache/helper checklist:**
+- API schema or payload changed: no
+- Cache key semantics changed: no
+- TTL behavior changed: no; callers keep existing `0`, `60_000`, and notification TTL values
+- Error behavior changed: no; `{ error: string }` payloads still win over fallback messages
+- Successful malformed JSON behavior changed: no; successful parse failures still reject instead of caching `null`
+- Existing custom fetcher support: retained through `fetchJSONWithCache`
+- Visible behavior intended to change: none
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/unit/request-cache.test.ts tests/hooks/useTeacherTestList.test.ts tests/hooks/useGradebookData.test.ts tests/components/StudentNotificationsProvider.test.tsx`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-22 — Teacher classroom access helper reuse
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a Supabase route/query helper consolidation slice.
+- Extended `assertTeacherOwnsClassroom` to include classroom `title` and accept an optional existing service-role client, preserving the default helper call shape.
+- Reused the helper in read-only teacher routes that previously duplicated `classrooms.select('teacher_id')` ownership checks: attendance, export CSV, log summary, logs, and student history.
+- Kept each route's current response style, status codes, payloads, and downstream query shape unchanged.
+- Added helper-level coverage proving the shared classroom access helper returns `title` and reuses a provided Supabase client.
+
+**Route/query helper checklist:**
+- Schema or migration changed: no
+- Browser-side Supabase access changed: no
+- Authorization semantics changed: no; 404 not found and 403 forbidden still come from the same ownership predicate
+- Payload shape changed: no
+- Supabase query count changed: no intended extra queries; migrated routes pass their existing service client into the helper
+- Visible behavior intended to change: none
+
+**Validation:**
+- `pnpm test tests/unit/server-access.test.ts tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts tests/api/teacher/log-summary.test.ts tests/api/teacher/logs.test.ts tests/api/teacher/student-history.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-22 — Paged Supabase test helper
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a test mock simplification slice.
+- Extracted the duplicated paged Supabase table/query-log mock from teacher attendance and export CSV API tests into `tests/support/paged-supabase.ts`.
+- Updated both route suites to use `createPagedQueryLog` and `mockPagedTable` from the shared support helper.
+- Kept production code, route behavior, mock behavior, and assertions unchanged.
+
+**Test mock checklist:**
+- Production code changed: no
+- Test behavior changed: no intended behavior change; affected tests still cover pagination, chunking, and query scoping
+- Helper scope: paged `select().in().order().range()` mocks only
+- Broad migration attempted: no; only identical local duplicates were consolidated
+
+**Validation:**
+- `pnpm test tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-23 — Gradebook action surface
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the canonical classroom action-surface slice.
+- Replaced the Gradebook tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone score/email primary action plus a quiet icon menu.
+- Preserved existing Gradebook behavior: score display toggles when no students are selected, selected-student email remains the primary action, and column controls stay in the actions menu.
+- Added optional radio semantics to `TeacherWorkSurfaceActionItem` so mutually exclusive score display menu items expose `menuitemradio` while column controls remain `menuitemcheckbox`.
+- Added focused component coverage for Gradebook menu semantics and shared action-cluster checked roles.
+- Addressed independent review by including `menuitemradio` items in shared menu keyboard focus management and covering arrow/Home/End focus behavior.
+
+**UI verification:**
+- Teacher desktop light: default, open menu, selected email action
+- Teacher mobile light: default
+- Teacher desktop dark: default, open menu
+- Student: n/a; changed surface is teacher-only
+- Composite widget checklist reviewed: yes
+- Keyboard behavior covered by existing shared menu handling: yes
+- Semantic state covered by tests: yes
+- Remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Roster action surface
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the next canonical classroom action-surface slice.
+- Replaced the Roster tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone Students primary action plus a quiet icon menu.
+- Preserved existing Roster behavior: the primary action still opens Add Students, selected-student email actions remain in the Roster actions menu, and removal actions stay destructive menu items.
+- Updated focused Roster component tests to assert the shared action-cluster shape without changing roster management behavior.
+- Addressed independent review by keeping the compact visual label while exposing the primary action as `Add students` for assistive technology.
+
+**UI verification:**
+- Teacher desktop light: default, open menu, selected-student menu
+- Teacher mobile light: default
+- Teacher desktop dark: default, open menu
+- Student: n/a; changed surface is teacher-only
+- Composite widget checklist reviewed: yes
+- Keyboard behavior covered by shared menu handling: yes
+- Semantic state covered by tests: yes
+- Remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
+- `pnpm test`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,33 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-23 — Roster action surface
-
-**Completed:**
-- Continued the bounded architecture/UI improvement goal with the next canonical classroom action-surface slice.
-- Replaced the Roster tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone Students primary action plus a quiet icon menu.
-- Preserved existing Roster behavior: the primary action still opens Add Students, selected-student email actions remain in the Roster actions menu, and removal actions stay destructive menu items.
-- Updated focused Roster component tests to assert the shared action-cluster shape without changing roster management behavior.
-- Addressed independent review by keeping the compact visual label while exposing the primary action as `Add students` for assistive technology.
-
-**UI verification:**
-- Teacher desktop light: default, open menu, selected-student menu
-- Teacher mobile light: default
-- Teacher desktop dark: default, open menu
-- Student: n/a; changed surface is teacher-only
-- Composite widget checklist reviewed: yes
-- Keyboard behavior covered by shared menu handling: yes
-- Semantic state covered by tests: yes
-- Remaining manual follow-up: none
-
-**Validation:**
-- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-06-23 — Announcements action surface
 
 **Completed:**
@@ -706,4 +679,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test` (312 files, 2,788 tests passed)
 - `pnpm build`
 - `git diff --check`
+
+## 2026-07-13 — Generated Supabase database contract
+
+**Completed:**
+- Generated and committed the public Supabase schema contract in `src/types/database.generated.ts`; added `src/types/database.ts` for application-owned JSON/status/RPC refinements and typed both central Supabase client factories.
+- Added `db:types:generate` / `db:types:check`, plus a CI `Database Contract` job that starts an ephemeral database, replays migrations, and rejects generated-type drift.
+- Replaced generic persisted payload records exposed by the typed client with `TableRow`, `TableInsert`, and `TableUpdate` contracts; extracted assessment draft contracts into shared domain types.
+- Fixed blueprint instantiation when `points_possible` is null by omitting it so PostgreSQL applies the assignment default; added a regression for null and explicit point values.
+- Added documentation for generated types, custom refinements, compatibility exceptions, and the migration workflow.
+- CI's clean replay exposed migration `080` from another worktree in the shared local stack; aligned the generated file to this branch's `001-079` history and made generation reject mismatched worktree/database migration histories.
+- No production access or local migration-application command was used. Local type generation/checking only read the already-running development stack; CI used its own ephemeral database.
+
+**Validation:**
+- `pnpm test` (311 files, 2785 tests passed)
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm run lint`
+- `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Start ephemeral Supabase and replay migrations
         run: supabase start -x analytics,edge-runtime,functions,imgproxy,inbucket,meta,realtime,studio,vector
 
+      - name: Check generated database types
+        run: pnpm run db:types:check
+
       - name: Verify atomic blueprint rollback and replay
         run: bash scripts/check-atomic-blueprint-operations.sh
 

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -67,7 +67,7 @@ src/
 │   │   └── tests.ts               # Test query helpers
 │   ├── assignments.ts, quizzes.ts, test-responses.ts, scheduling.ts …
 │   └── auth.ts, crypto.ts, timezone.ts, attendance.ts …
-├── types/                         # Shared TypeScript types (src/types/index.ts)
+├── types/                         # Domain types plus generated/custom database contracts
 └── ui/                            # Design-system primitives (import from @/ui NOT @/components)
     ├── Button, Input, FormField, Select, AlertDialog, ConfirmDialog, Card, Tooltip, SplitButton
 
@@ -81,6 +81,13 @@ tests/                             # Vitest unit + API suites
 ---
 
 ## Key Patterns
+
+### Supabase Database Contracts
+- `src/types/database.generated.ts` is generated from the public schema and must not be edited manually.
+- `src/types/database.ts` composes the generated schema with application-owned JSON, status, and RPC result contracts that PostgreSQL metadata cannot express precisely.
+- Both central clients in `src/lib/supabase.ts` use the composed `Database` type. New server data access should flow through those factories.
+- Use `TableRow`, `TableInsert`, and `TableUpdate` from `@/types/database` for persisted payloads instead of generic records or local copies of table shapes.
+- After changing a migration, start the local Supabase stack through the documented human workflow and run `pnpm run db:types:generate`. CI replays migrations in an ephemeral database and runs `pnpm run db:types:check` to reject drift.
 
 ### UI/Theming (Required)
 - **All UI must use semantic design tokens** — NOT raw color or `dark:` classes in app code.

--- a/docs/guidance/schema-rollout-checklist.md
+++ b/docs/guidance/schema-rollout-checklist.md
@@ -28,6 +28,17 @@ Use this checklist for migrations, Supabase query-shape changes, compatibility s
 - Any compatibility window is documented in the PR notes
 - AI does not apply migrations locally; humans do
 
+## Generated Database Contract
+
+- Do not edit `src/types/database.generated.ts` by hand
+- Regenerate it from the local migration schema with `pnpm run db:types:generate`
+- Generation stops if the running local database migration history differs from the current worktree
+- Keep application-specific JSON/status/RPC refinements in `src/types/database.ts`
+- Use `TableRow`, `TableInsert`, or `TableUpdate` for persisted payloads instead of `Record<string, ...>`
+- Run `pnpm run db:types:check` before opening the PR
+- Confirm the CI `Database Contract` job passes; it replays the branch migrations in an ephemeral Supabase database before checking drift
+- If a compatibility shim intentionally writes a pre-migration shape, isolate and document that exception instead of weakening the shared current-schema contract
+
 ## Query And Payload Checklist
 
 - Narrow the select list to rendered or returned fields

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "verify:classroom-archive-recovery": "bash scripts/check-classroom-archive-recovery-drill.sh",
+    "db:types:generate": "bash scripts/supabase-types.sh generate",
+    "db:types:check": "bash scripts/supabase-types.sh check",
     "measure:ai-grading-prompts": "tsx scripts/measure-ai-grading-prompts.ts",
     "dev-feedback": "node scripts/dev-feedback.mjs",
     "eval:test-ai-grading-gold-set": "tsx scripts/eval-test-ai-grading-gold-set.ts",

--- a/scripts/supabase-types.sh
+++ b/scripts/supabase-types.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OUTPUT="$ROOT/src/types/database.generated.ts"
+MODE="${1:-check}"
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI is required. Install the pinned CI version (2.103.0)." >&2
+  exit 1
+fi
+
+MIGRATION_STATUS="$(supabase migration list --local 2>&1)" || {
+  echo "Failed to read the local Supabase migration history." >&2
+  echo "$MIGRATION_STATUS" >&2
+  exit 1
+}
+MIGRATION_DRIFT="$(printf '%s\n' "$MIGRATION_STATUS" | awk -F '|' '
+  {
+    local_version = $1
+    database_version = $2
+    gsub(/[[:space:]]/, "", local_version)
+    gsub(/[[:space:]]/, "", database_version)
+    if ((local_version ~ /^[0-9]+$/ || database_version ~ /^[0-9]+$/) && local_version != database_version) {
+      local_display = local_version == "" ? "missing" : local_version
+      database_display = database_version == "" ? "missing" : database_version
+      printf "  files=%s database=%s\n", local_display, database_display
+    }
+  }
+')"
+
+if [[ -n "$MIGRATION_DRIFT" ]]; then
+  echo "Local database migration history does not match this worktree:" >&2
+  echo "$MIGRATION_DRIFT" >&2
+  echo "Use a local database created from this branch before generating database types." >&2
+  exit 1
+fi
+
+TEMP_FILE="$(mktemp)"
+NORMALIZED_FILE="${TEMP_FILE}.normalized"
+trap 'rm -f "$TEMP_FILE" "$NORMALIZED_FILE"' EXIT
+
+supabase gen types typescript --local --schema public > "$TEMP_FILE"
+
+# Keep generated output stable for Git while preserving blank lines within the file.
+awk '
+  /^[[:space:]]*$/ { blank_lines += 1; next }
+  {
+    while (blank_lines > 0) { print ""; blank_lines -= 1 }
+    print
+  }
+' "$TEMP_FILE" > "$NORMALIZED_FILE"
+mv "$NORMALIZED_FILE" "$TEMP_FILE"
+
+case "$MODE" in
+  generate)
+    mv "$TEMP_FILE" "$OUTPUT"
+    trap - EXIT
+    echo "Updated ${OUTPUT#$ROOT/}"
+    ;;
+  check)
+    if ! cmp -s "$OUTPUT" "$TEMP_FILE"; then
+      echo "Generated Supabase types are out of date." >&2
+      echo "Run: pnpm run db:types:generate" >&2
+      diff -u "$OUTPUT" "$TEMP_FILE" || true
+      exit 1
+    fi
+    echo "Generated Supabase types match the local migration schema."
+    ;;
+  *)
+    echo "Usage: $0 <generate|check>" >&2
+    exit 2
+    ;;
+esac

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -13,7 +13,6 @@ import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
 import { withLegacyQuizListKey } from '@/lib/test-api-contract'
-import type { TestAssessment } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -27,6 +26,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
   if (!classroomId) {
     return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
   }
+  const requestedClassroomId = classroomId
 
   const supabase = getServiceRoleClient()
 
@@ -39,7 +39,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
     return supabase
       .from('tests')
       .select('*')
-      .eq('classroom_id', classroomId)
+      .eq('classroom_id', requestedClassroomId)
       .eq('status', status)
       .order('position', { ascending: false })
   }
@@ -219,7 +219,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
 
   const allTests = [...visibleActiveTests, ...visibleClosedTests]
 
-  const testsWithStatus = allTests.map((test: TestAssessment) => {
+  const testsWithStatus = allTests.map((test) => {
     const hasResponded = respondedTestIds.has(test.id)
     const isReturned = returnedTestIds.has(test.id)
     const access = getEffectiveStudentTestAccess({

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/assignments'
 import { loadTeacherOwnedAssignmentForGrade } from '@/lib/server/assignment-grades'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
+import type { TableInsert, TableUpdate } from '@/types/database'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -17,7 +18,7 @@ async function updateAssignmentDocsForStudents(opts: {
   supabase: ReturnType<typeof getServiceRoleClient>
   assignmentId: string
   studentIds: string[]
-  values: Record<string, unknown>
+  values: TableUpdate<'assignment_docs'>
 }) {
   const { supabase, assignmentId, studentIds, values } = opts
   const { error } = await supabase
@@ -37,7 +38,7 @@ async function insertZeroReturnedAssignmentDocsForStudents(opts: {
   includeTeacherClearedAt: boolean
 }) {
   const { supabase, assignmentId, studentIds, now, includeTeacherClearedAt } = opts
-  const rows = studentIds.map((studentId) => ({
+  const rows: TableInsert<'assignment_docs'>[] = studentIds.map((studentId) => ({
     assignment_id: assignmentId,
     student_id: studentId,
     content: { type: 'doc', content: [] },

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -28,6 +28,7 @@ import {
   replaceAssignmentSubmissionRequirements,
 } from '@/lib/server/assignment-submission-artifacts'
 import type { AssignmentDoc, AssignmentSubmissionArtifact } from '@/types'
+import type { TableRow } from '@/types/database'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -506,7 +507,7 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
     ? await collectRemovedImageArtifactStoragePaths(supabase, id, submission_requirements as any[])
     : []
 
-  let assignment = existing
+  let assignment: TableRow<'assignments'> = existing
   if (Object.keys(updates).length > 0) {
     const { data: updatedAssignment, error } = await supabase
       .from('assignments')

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -9,6 +9,7 @@ import {
 import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { calculateAssignmentStats } from '@/lib/assignments'
 import { withErrorHandler } from '@/lib/api-handler'
+import type { TableInsert } from '@/types/database'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
 import { isMissingSurveysTableError } from '@/lib/server/surveys'
 import {
@@ -294,7 +295,7 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
           description: '',
         }).markdown
   )
-  const insertBody: Record<string, any> = {
+  const insertBody: TableInsert<'assignments'> = {
     classroom_id,
     title: title.trim(),
     instructions_markdown: instructionFields.instructions_markdown,

--- a/src/app/api/teacher/classrooms/[id]/materials/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/materials/route.ts
@@ -5,6 +5,7 @@ import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/l
 import { getServiceRoleClient } from '@/lib/supabase'
 import { isMissingSurveysTableError } from '@/lib/server/surveys'
 import type { TiptapContent } from '@/types'
+import type { TableInsert } from '@/types/database'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -137,7 +138,7 @@ export const POST = withErrorHandler('PostTeacherClassworkMaterial', async (requ
   }
 
   const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition, lastSurveyPosition) + 1
-  const insertBody: Record<string, unknown> = {
+  const insertBody: TableInsert<'classwork_materials'> = {
     classroom_id: classroomId,
     title: cleanTitle,
     content,

--- a/src/app/api/teacher/classrooms/route.ts
+++ b/src/app/api/teacher/classrooms/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
+import type { TableInsert } from '@/types/database'
 import { createClassroomSchema } from '@/lib/validations/teacher'
 import { getNextTeacherClassroomPosition, listActiveTeacherClassrooms } from '@/lib/server/classroom-order'
 import { hydrateClassroomRecord, hydrateClassroomRecords } from '@/lib/server/classrooms'
@@ -68,7 +69,7 @@ export const POST = withErrorHandler('CreateClassroom', async (request: NextRequ
     (activeClassroomsResult?.data || []).map((classroom: any) => classroom.theme_color),
     `${user.id}:${title}`
   )
-  const insertBody: Record<string, any> = {
+  const insertBody: TableInsert<'classrooms'> = {
     teacher_id: user.id,
     title,
     class_code: finalClassCode,

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -616,10 +616,11 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     } satisfies TestAssessmentResponse]
   })
 
-  const aggregated = aggregateTestResults(
-    multipleChoiceQuestions as TestAssessmentQuestion[],
-    multipleChoiceResponses
-  )
+  const aggregateQuestions: TestAssessmentQuestion[] = multipleChoiceQuestions.map((question) => ({
+    ...question,
+    quiz_id: question.test_id,
+  }))
+  const aggregated = aggregateTestResults(aggregateQuestions, multipleChoiceResponses)
 
   const openQuestionIds = new Set(
     (questions || [])

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -15,9 +15,24 @@ import {
 } from '@/lib/server/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
 import { withLegacyQuizKey } from '@/lib/test-api-contract'
+import type { TableRow } from '@/types/database'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+type TestQuestionResponse = Omit<
+  TableRow<'test_questions'>,
+  | 'ai_reference_cache_answers'
+  | 'ai_reference_cache_generated_at'
+  | 'ai_reference_cache_key'
+  | 'ai_reference_cache_model'
+> & Partial<Pick<
+  TableRow<'test_questions'>,
+  | 'ai_reference_cache_answers'
+  | 'ai_reference_cache_generated_at'
+  | 'ai_reference_cache_key'
+  | 'ai_reference_cache_model'
+>>
 
 function isMissingCloseTestRpcError(error: {
   code?: string
@@ -61,7 +76,7 @@ export const GET = withErrorHandler('GetTestById', async (_request, context) => 
 
   let title = test.title
   let showResults = test.show_results
-  let responseQuestions = questions || []
+  let responseQuestions: TestQuestionResponse[] = questions || []
 
   const { draft, error: draftError } = await getAssessmentDraftByType<TestDraftContent>(
     supabase,

--- a/src/lib/assignment-submission-requirements.ts
+++ b/src/lib/assignment-submission-requirements.ts
@@ -27,6 +27,8 @@ export interface AssignmentSubmissionValidationPolicy {
   expected_domains: string[]
 }
 
+export type AssignmentSubmissionValidationPolicyJson = Partial<AssignmentSubmissionValidationPolicy>
+
 export const LINK_VALIDATION_MODE_LABELS: Record<AssignmentLinkValidationMode, string> = {
   format_only: 'Basic URL',
   reachable: 'Reachable page',
@@ -47,6 +49,16 @@ export type AssignmentSubmissionRequirementDraft = {
   required?: boolean | null
   position?: number | null
   validation_policy_json?: Record<string, unknown> | null
+}
+
+export type NormalizedAssignmentSubmissionRequirementDraft = {
+  id?: string
+  type: AssignmentSubmissionRequirementType
+  label: string
+  instructions: string
+  required: boolean
+  position: number
+  validation_policy_json: AssignmentSubmissionValidationPolicyJson
 }
 
 function normalizeExpectedDomain(value: unknown): string | null {
@@ -90,7 +102,7 @@ export function normalizeAssignmentSubmissionValidationPolicy(
 export function buildAssignmentSubmissionValidationPolicyJson(
   type: AssignmentSubmissionRequirementType,
   policy: Partial<AssignmentSubmissionValidationPolicy>
-): Record<string, unknown> {
+): AssignmentSubmissionValidationPolicyJson {
   const normalized = normalizeAssignmentSubmissionValidationPolicy(type, {
     mode: policy.mode,
     expected_domains: policy.expected_domains,
@@ -131,7 +143,7 @@ export function isAssignmentSubmissionRequirementType(
 
 export function normalizeAssignmentSubmissionRequirementDrafts(
   drafts: AssignmentSubmissionRequirementDraft[]
-): AssignmentSubmissionRequirementDraft[] {
+): NormalizedAssignmentSubmissionRequirementDraft[] {
   return drafts
     .filter((draft) => isAssignmentSubmissionRequirementType(draft.type))
     .map((draft, index) => {

--- a/src/lib/contracts/classroom-data.ts
+++ b/src/lib/contracts/classroom-data.ts
@@ -169,15 +169,15 @@ export const classroomResourceInventorySchema = z.array(classroomResourceSchema)
   },
 )
 
-function resource(
-  table: string,
+function resource<const Table extends string>(
+  table: Table,
   parent: string | null,
   column: string | null,
   privacy: ClassroomDataPrivacyClass[],
   gradex: GradexDisposition = 'exclude',
   additionalRestoreDependencies: string[] = [],
   primaryKey: string[] = ['id'],
-): ClassroomResource {
+): ClassroomResource & { table: Table } {
   const actorColumns = CLASSROOM_ACTOR_REFERENCE_COLUMNS[
     table as keyof typeof CLASSROOM_ACTOR_REFERENCE_COLUMNS
   ] || []
@@ -197,7 +197,7 @@ function resource(
   }
 }
 
-export const CLASSROOM_RELATIONAL_RESOURCES: ClassroomResource[] = [
+export const CLASSROOM_RELATIONAL_RESOURCES = [
   resource('classrooms', null, null, ['teacher_content', 'operations']),
   resource('announcements', 'classrooms', 'classroom_id', ['teacher_content']),
   resource('announcement_reads', 'announcements', 'announcement_id', ['student_identity', 'operations']),
@@ -240,7 +240,9 @@ export const CLASSROOM_RELATIONAL_RESOURCES: ClassroomResource[] = [
   resource('test_questions', 'tests', 'test_id', ['teacher_content'], 'include_structured'),
   resource('test_responses', 'tests', 'test_id', ['student_identity', 'student_work', 'grades_and_feedback'], 'include_structured', ['test_questions']),
   resource('test_student_availability', 'tests', 'test_id', ['student_identity', 'operations']),
-]
+] as const satisfies readonly ClassroomResource[]
+
+export type ClassroomResourceTable = (typeof CLASSROOM_RELATIONAL_RESOURCES)[number]['table']
 
 classroomResourceInventorySchema.parse(CLASSROOM_RELATIONAL_RESOURCES)
 
@@ -291,10 +293,10 @@ export function auditClassroomResourceSchema(
     }
   }
 
-  const resourcesByTable = new Map(
+  const resourcesByTable = new Map<string, ClassroomResource>(
     CLASSROOM_RELATIONAL_RESOURCES.map((item) => [item.table, item]),
   )
-  const contractTables = new Set(resourcesByTable.keys())
+  const contractTables = new Set<string>(resourcesByTable.keys())
   const untrackedTables = Array.from(descendants)
     .filter((table) => !contractTables.has(table))
     .sort()
@@ -388,15 +390,16 @@ export function auditClassroomResourceSchema(
 
 export function getClassroomResourceOrder(
   direction: 'export' | 'restore' | 'purge',
-): string[] {
-  const ordered: string[] = []
+): ClassroomResourceTable[] {
+  const ordered: ClassroomResourceTable[] = []
   const remaining = new Map(
     CLASSROOM_RELATIONAL_RESOURCES.map((item) => [item.table, item]),
   )
 
   while (remaining.size > 0) {
+    const restored = new Set<string>(ordered)
     const ready = Array.from(remaining.values()).filter((item) =>
-      item.restore_after.every((dependency) => ordered.includes(dependency)),
+      item.restore_after.every((dependency) => restored.has(dependency)),
     )
 
     if (ready.length === 0) {

--- a/src/lib/developer-log-feedback.ts
+++ b/src/lib/developer-log-feedback.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { redactDirectIdentifiers } from '@/lib/log-summary'
+import type { Database } from '@/types/database'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
 const MIN_CONFIDENCE = 0.55
@@ -59,9 +61,12 @@ export interface DirectDeveloperFeedbackRecord {
   id: string
 }
 
-type SupabaseLike = {
-  from: (table: string) => any
-  rpc?: (fn: string, args: Record<string, unknown>) => any
+type DeveloperFeedbackRpcClient = {
+  rpc?: SupabaseClient<Database>['rpc']
+}
+
+type DeveloperFeedbackInsertClient = {
+  from: SupabaseClient<Database>['from']
 }
 
 export function buildDeveloperFeedbackPrompt(
@@ -189,7 +194,7 @@ export function normalizeDeveloperFeedbackDedupeKey(input: string): string {
 }
 
 export async function extractAndStoreDeveloperFeedbackCandidates(
-  supabase: SupabaseLike,
+  supabase: DeveloperFeedbackRpcClient,
   context: DeveloperFeedbackRecordContext & { sanitizedLogs: SanitizedDeveloperFeedbackLog[] }
 ): Promise<DeveloperFeedbackRecordResult> {
   if (context.sanitizedLogs.length === 0) {
@@ -202,7 +207,7 @@ export async function extractAndStoreDeveloperFeedbackCandidates(
 }
 
 export async function recordDeveloperFeedbackCandidates(
-  supabase: SupabaseLike,
+  supabase: DeveloperFeedbackRpcClient,
   candidates: DeveloperFeedbackCandidateInput[],
   context: DeveloperFeedbackRecordContext
 ): Promise<DeveloperFeedbackRecordResult> {
@@ -254,7 +259,7 @@ export async function recordDeveloperFeedbackCandidates(
 }
 
 export async function recordDirectDeveloperFeedback(
-  supabase: SupabaseLike,
+  supabase: DeveloperFeedbackInsertClient,
   input: DirectDeveloperFeedbackInput
 ): Promise<DirectDeveloperFeedbackRecord> {
   const sanitizedDescription = redactDirectIdentifiers(input.description).trim()

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -1,53 +1,29 @@
 import { tryApplyJsonPatch } from '@/lib/json-patch'
 import { validateAssessmentOptions } from '@/lib/assessments'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
-import type { JsonPatchOperation, TestQuestionType } from '@/types'
+import type {
+  AssessmentDraftContent,
+  AssessmentDraftQuestion,
+  AssessmentDraftType,
+  JsonPatchOperation,
+  TestDraftContent,
+  TestDraftQuestion,
+} from '@/types'
+
+export type {
+  AssessmentDraftContent,
+  AssessmentDraftQuestion,
+  AssessmentDraftType,
+  QuizDraftContent,
+  QuizDraftQuestion,
+  TestDraftContent,
+  TestDraftQuestion,
+} from '@/types'
 
 type SupabaseLike = any
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-export type AssessmentDraftType = 'quiz' | 'test'
-
-export type AssessmentDraftQuestion = {
-  id: string
-  question_text: string
-  options: string[]
-}
-
-export type QuizDraftQuestion = AssessmentDraftQuestion
-
-export type TestDraftQuestion = {
-  id: string
-  question_type: TestQuestionType
-  question_text: string
-  options: string[]
-  correct_option: number | null
-  answer_key: string | null
-  sample_solution: string | null
-  points: number
-  response_max_chars: number
-  response_monospace: boolean
-}
-
-export type AssessmentDraftContent = {
-  title: string
-  show_results: boolean
-  questions: AssessmentDraftQuestion[]
-  source_format?: 'markdown'
-  source_markdown?: string
-}
-
-export type QuizDraftContent = AssessmentDraftContent
-
-export type TestDraftContent = {
-  title: string
-  show_results: boolean
-  questions: TestDraftQuestion[]
-  source_format?: 'markdown'
-  source_markdown?: string
-}
 
 export type AssessmentDraftRow<TContent> = {
   id: string

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -602,6 +602,11 @@ async function processAssignmentAiRunItem(opts: {
     })
   }
 
+  if (!item.assignment_doc_id) {
+    await markMissingGradeAndSkip('missing_doc')
+    return
+  }
+
   await updateRunItem(supabase, item.id, {
     status: 'processing',
     started_at: item.started_at ?? now,

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -1,5 +1,6 @@
 import { ApiError, apiErrors } from '@/lib/api-handler'
 import { getServiceRoleClient } from '@/lib/supabase'
+import type { TableInsert } from '@/types/database'
 
 export type AssignmentGradeSaveMode = 'draft' | 'graded'
 export type AssignmentGradeApplyTarget = 'grade' | 'comments' | 'grade-and-comments'
@@ -181,14 +182,14 @@ export function buildAssignmentGradeRows(opts: {
   studentIds: string[]
   grade: ParsedAssignmentGradePayload
   now: string
-}) {
+}): TableInsert<'assignment_docs'>[] {
   const { assignmentId, studentIds, grade, now } = opts
 
   const shouldApplyGrade = grade.apply_target === 'grade' || grade.apply_target === 'grade-and-comments'
   const shouldApplyComments = grade.apply_target === 'comments' || grade.apply_target === 'grade-and-comments'
 
   return studentIds.map((studentId) => {
-    const row: Record<string, string | number | null> = {
+    const row: TableInsert<'assignment_docs'> = {
       assignment_id: assignmentId,
       student_id: studentId,
     }

--- a/src/lib/server/classroom-archive-compaction.ts
+++ b/src/lib/server/classroom-archive-compaction.ts
@@ -13,6 +13,7 @@ import {
   type ClassroomArchiveRestorePlan,
 } from '@/lib/server/classroom-archive-restore'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { parseDatabaseJson } from '@/lib/validations/database-json'
 
 const CLASSROOM_ARCHIVE_BUCKET = 'classroom-archives' as const
 const CLASSROOM_ARCHIVE_COMPACTION_MAX_BATCH_BYTES = 512 * 1024
@@ -497,7 +498,7 @@ async function stageRestorePreflight(args: {
         p_operation_id: args.operationId,
         p_teacher_id: args.teacherId,
         p_table_name: table,
-        p_rows: rows,
+        p_rows: parseDatabaseJson(rows),
       })
       const parsed = !response.error ? stageRowSuccessSchema.safeParse(response.data) : null
       if (!parsed || !parsed.success) {

--- a/src/lib/server/classroom-archive-format.ts
+++ b/src/lib/server/classroom-archive-format.ts
@@ -351,7 +351,9 @@ function countAndValidateNdjson(bytes: Buffer, validate?: (value: unknown) => vo
 export function buildClassroomArchiveBundle(
   input: BuildClassroomArchiveBundleInput,
 ): BuiltClassroomArchiveBundle {
-  const expectedTables = new Set(CLASSROOM_RELATIONAL_RESOURCES.map((resource) => resource.table))
+  const expectedTables = new Set<string>(
+    CLASSROOM_RELATIONAL_RESOURCES.map((resource) => resource.table),
+  )
   for (const table of expectedTables) {
     if (!Array.isArray(input.resources[table])) {
       throw new Error(`Missing classroom archive resource: ${table}`)

--- a/src/lib/server/classroom-archive-operations.ts
+++ b/src/lib/server/classroom-archive-operations.ts
@@ -3,7 +3,10 @@ import { z } from 'zod'
 import {
   classroomArchiveRetentionSchema,
 } from '@/lib/contracts/classroom-artifacts'
-import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
+import {
+  CLASSROOM_RELATIONAL_RESOURCES,
+  type ClassroomResourceTable,
+} from '@/lib/contracts/classroom-data'
 import {
   buildClassroomArchiveBundle,
   canonicalJsonStringify,
@@ -13,6 +16,7 @@ import {
   type ClassroomArchiveStorageObject,
 } from '@/lib/server/classroom-archive-format'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { parseDatabaseJson } from '@/lib/validations/database-json'
 
 export const CLASSROOM_ARCHIVE_BUCKET = 'classroom-archives' as const
 export const CLASSROOM_ARCHIVE_SOURCE_MIGRATION = '082_verified_classroom_archive_exports' as const
@@ -21,6 +25,7 @@ export const CLASSROOM_ARCHIVE_MAX_BYTES = 50 * 1024 * 1024
 const uuidSchema = z.string().uuid()
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/)
 const resourceCountsSchema = z.record(z.string(), z.number().int().nonnegative())
+const archiveResourceRowsSchema = z.array(z.record(z.string(), z.json()))
 
 const archiveVerificationSchema = z.object({
   read_back_verified: z.literal(true),
@@ -106,6 +111,23 @@ export type ClassroomArchiveExportResult =
 
 type SupabaseClient = ReturnType<typeof getServiceRoleClient>
 type ArchiveRetention = z.infer<typeof classroomArchiveRetentionSchema>
+
+type ArchiveResourceSelect = {
+  in: (column: string, values: readonly string[]) => {
+    order: (
+      column: string,
+      options: { ascending: boolean },
+    ) => PromiseLike<{ data: unknown; error: unknown }>
+  }
+}
+
+function selectArchiveResourceRows(
+  supabase: SupabaseClient,
+  table: ClassroomResourceTable,
+): ArchiveResourceSelect {
+  // Supabase cannot correlate a runtime table/primary-key pair; the result is parsed below.
+  return supabase.from(table).select('*') as unknown as ArchiveResourceSelect
+}
 
 class ClassroomArchiveExportError extends Error {
   constructor(
@@ -220,10 +242,10 @@ async function loadSnapshotIds(
   return ids
 }
 
-async function loadResourceRows(
+async function loadResourceRows<Table extends ClassroomResourceTable>(
   supabase: SupabaseClient,
   operationId: string,
-  table: string,
+  table: Table,
   primaryKey: string,
   expectedCount: number,
 ): Promise<unknown[]> {
@@ -241,9 +263,7 @@ async function loadResourceRows(
   const chunkSize = 200
   for (let offset = 0; offset < ids.length; offset += chunkSize) {
     const chunk = ids.slice(offset, offset + chunkSize)
-    const { data, error } = await supabase
-      .from(table)
-      .select('*')
+    const { data, error } = await selectArchiveResourceRows(supabase, table)
       .in(primaryKey, chunk)
       .order(primaryKey, { ascending: true })
     if (error) {
@@ -254,7 +274,16 @@ async function loadResourceRows(
         true,
       )
     }
-    rows.push(...((data || []) as Record<string, unknown>[]))
+    const parsedRows = archiveResourceRowsSchema.safeParse(data || [])
+    if (!parsedRows.success) {
+      throw new ClassroomArchiveExportError(
+        'archive_resource_contract_invalid',
+        `Archive resource ${table} returned non-JSON rows`,
+        500,
+        false,
+      )
+    }
+    rows.push(...parsedRows.data)
   }
 
   if (rows.length !== expectedCount) {
@@ -676,7 +705,7 @@ export async function exportClassroomArchive(args: {
       p_compressed_byte_size: bundle.archive.byteLength,
       p_uncompressed_byte_size: bundle.uncompressedByteSize,
       p_resource_counts: snapshot.resource_counts,
-      p_storage_object_counts: storageObjectCounts,
+      p_storage_object_counts: parseDatabaseJson(storageObjectCounts),
       p_verification: verificationEvidence,
     })
     if (completeResponse.error) {

--- a/src/lib/server/classroom-archive-restore-operations.ts
+++ b/src/lib/server/classroom-archive-restore-operations.ts
@@ -17,6 +17,7 @@ import {
   type ClassroomArchiveRestorePlan,
 } from '@/lib/server/classroom-archive-restore'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { parseDatabaseJson } from '@/lib/validations/database-json'
 
 const CLASSROOM_ARCHIVE_BUCKET = 'classroom-archives' as const
 const STAGING_BATCH_MAX_BYTES = 900 * 1024
@@ -564,7 +565,7 @@ export async function restoreClassroomArchive(args: {
           p_operation_id: args.operationId,
           p_teacher_id: args.teacherId,
           p_table_name: table,
-          p_rows: chunk,
+          p_rows: parseDatabaseJson(chunk),
         })
         if (response.error) {
           throw new ClassroomArchiveRestoreError(

--- a/src/lib/server/classroom-gradex-extract.ts
+++ b/src/lib/server/classroom-gradex-extract.ts
@@ -644,7 +644,7 @@ export function buildGradexExtractFromClassroomArchive(input: {
   deleteAfter: string
   hmacSecret: string
 }): BuiltGradexExtractBundle {
-  const expectedTables = new Set(GRADEX_RESOURCE_TABLES)
+  const expectedTables = new Set<string>(GRADEX_RESOURCE_TABLES)
   const configuredTables = Object.keys(PROJECTION_SPECS)
   if (
     configuredTables.length !== expectedTables.size ||

--- a/src/lib/server/course-blueprint-operations.ts
+++ b/src/lib/server/course-blueprint-operations.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { addDays, format, isValid, parse } from 'date-fns'
 import { fromZonedTime } from 'date-fns-tz'
 import { z } from 'zod'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { buildAssignmentInstructionFields } from '@/lib/assignment-instructions'
 import { normalizeAssignmentSubmissionRequirementDrafts } from '@/lib/assignment-submission-requirements'
 import { generateClassDays, generateClassDaysFromRange, getSemesterDates } from '@/lib/calendar'
@@ -18,6 +19,8 @@ import type {
   Semester,
 } from '@/types'
 import type { TestDraftContent } from '@/lib/server/assessment-drafts'
+import { parseDatabaseJson } from '@/lib/validations/database-json'
+import type { Database } from '@/types/database'
 
 const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
 const dateTimeSchema = z.string().datetime({ offset: true })
@@ -210,12 +213,12 @@ export const blueprintOperationResultSchema = z.discriminatedUnion('ok', [
 
 export type BlueprintOperationResult = z.infer<typeof blueprintOperationResultSchema>
 
-type SupabaseRpcClient = {
-  rpc: (name: string, args: Record<string, unknown>) => PromiseLike<{
-    data: unknown
-    error: { code?: string; message?: string } | null
-  }>
-}
+type BlueprintRpcName =
+  | 'create_course_blueprint_atomic'
+  | 'instantiate_course_blueprint_atomic'
+type BlueprintRpcArgs<Name extends BlueprintRpcName> =
+  Database['public']['Functions'][Name]['Args']
+type SupabaseRpcClient = Pick<SupabaseClient<Database>, 'rpc'>
 
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize)
@@ -266,10 +269,10 @@ function emitBlueprintOperationMetric(result: BlueprintOperationResult, duration
   }))
 }
 
-async function executeBlueprintOperation(
+async function executeBlueprintOperation<Name extends BlueprintRpcName>(
   supabase: SupabaseRpcClient,
-  rpcName: 'create_course_blueprint_atomic' | 'instantiate_course_blueprint_atomic',
-  args: Record<string, unknown>,
+  rpcName: Name,
+  args: BlueprintRpcArgs<Name>,
   operationId: string,
   operationType: 'import' | 'capture' | 'instantiate',
 ): Promise<BlueprintOperationResult> {
@@ -349,7 +352,7 @@ export async function createCourseBlueprintAtomic(args: {
       p_request_sha256: requestSha256,
       p_source_classroom_id: args.sourceClassroomId ?? null,
       p_expected_source_revision: expectedSourceRevision,
-      p_plan: plan,
+      p_plan: parseDatabaseJson(plan),
     },
     args.operationId,
     args.operationType,
@@ -378,7 +381,7 @@ export async function instantiateCourseBlueprintAtomic(args: {
       p_blueprint_id: args.blueprintId,
       p_request_sha256: requestSha256,
       p_expected_content_revision: plan.expected_content_revision,
-      p_plan: plan,
+      p_plan: parseDatabaseJson(plan),
     },
     args.operationId,
     'instantiate',

--- a/src/lib/server/test-ai-grading-runs.ts
+++ b/src/lib/server/test-ai-grading-runs.ts
@@ -21,6 +21,7 @@ import type {
   TestAiGradingRunStatus,
   TestAiGradingRunSummary,
 } from '@/types'
+import type { TableInsert } from '@/types/database'
 
 const TEST_AI_RETRY_BACKOFF_SECONDS = [7, 20, 45]
 export const TEST_AI_GRADING_RUN_CHUNK_SIZE = 8
@@ -883,7 +884,7 @@ export async function createOrResumeTestAiGradingRun(opts: {
     }
   }
 
-  const runPayload = {
+  const runPayload: TableInsert<'test_ai_grading_runs'> = {
     test_id: opts.testId,
     status: 'queued',
     triggered_by: opts.teacherId,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
 
 // Server-side client with secret key for admin operations
 export function getSupabaseClient() {
@@ -9,7 +10,7 @@ export function getSupabaseClient() {
     throw new Error('Missing Supabase environment variables')
   }
 
-  return createClient(supabaseUrl, supabasePublishableKey)
+  return createClient<Database>(supabaseUrl, supabasePublishableKey)
 }
 
 export function getServiceRoleClient() {
@@ -25,7 +26,7 @@ export function getServiceRoleClient() {
     throw new Error('Missing SUPABASE_SECRET_KEY')
   }
 
-  return createClient(supabaseUrl, secretKey, {
+  return createClient<Database>(supabaseUrl, secretKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false

--- a/src/lib/validations/database-json.ts
+++ b/src/lib/validations/database-json.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import type { Json } from '@/types/database.generated'
+
+const databaseJsonSchema = z.json()
+
+export function parseDatabaseJson(value: unknown): Json {
+  return databaseJsonSchema.parse(value)
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1,0 +1,4529 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      announcement_reads: {
+        Row: {
+          announcement_id: string
+          id: string
+          read_at: string
+          user_id: string
+        }
+        Insert: {
+          announcement_id: string
+          id?: string
+          read_at?: string
+          user_id: string
+        }
+        Update: {
+          announcement_id?: string
+          id?: string
+          read_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "announcement_reads_announcement_id_fkey"
+            columns: ["announcement_id"]
+            isOneToOne: false
+            referencedRelation: "announcements"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "announcement_reads_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      announcements: {
+        Row: {
+          classroom_id: string
+          content: string
+          created_at: string
+          created_by: string
+          id: string
+          scheduled_for: string | null
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          content: string
+          created_at?: string
+          created_by: string
+          id?: string
+          scheduled_for?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          content?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          scheduled_for?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "announcements_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "announcements_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assessment_drafts: {
+        Row: {
+          assessment_id: string
+          assessment_type: string
+          classroom_id: string
+          content: Json
+          created_at: string
+          created_by: string
+          id: string
+          updated_at: string
+          updated_by: string
+          version: number
+        }
+        Insert: {
+          assessment_id: string
+          assessment_type: string
+          classroom_id: string
+          content?: Json
+          created_at?: string
+          created_by: string
+          id?: string
+          updated_at?: string
+          updated_by: string
+          version?: number
+        }
+        Update: {
+          assessment_id?: string
+          assessment_type?: string
+          classroom_id?: string
+          content?: Json
+          created_at?: string
+          created_by?: string
+          id?: string
+          updated_at?: string
+          updated_by?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assessment_drafts_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assessment_drafts_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assessment_drafts_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_ai_grading_run_items: {
+        Row: {
+          assignment_doc_id: string | null
+          assignment_id: string
+          attempt_count: number
+          completed_at: string | null
+          created_at: string
+          id: string
+          last_error_code: string | null
+          last_error_message: string | null
+          next_retry_at: string | null
+          queue_position: number
+          run_id: string
+          skip_reason: string | null
+          started_at: string | null
+          status: string
+          student_id: string
+          updated_at: string
+        }
+        Insert: {
+          assignment_doc_id?: string | null
+          assignment_id: string
+          attempt_count?: number
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          last_error_code?: string | null
+          last_error_message?: string | null
+          next_retry_at?: string | null
+          queue_position?: number
+          run_id: string
+          skip_reason?: string | null
+          started_at?: string | null
+          status?: string
+          student_id: string
+          updated_at?: string
+        }
+        Update: {
+          assignment_doc_id?: string | null
+          assignment_id?: string
+          attempt_count?: number
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          last_error_code?: string | null
+          last_error_message?: string | null
+          next_retry_at?: string | null
+          queue_position?: number
+          run_id?: string
+          skip_reason?: string | null
+          started_at?: string | null
+          status?: string
+          student_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_ai_grading_run_items_assignment_doc_id_fkey"
+            columns: ["assignment_doc_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_docs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_ai_grading_run_items_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_ai_grading_run_items_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_ai_grading_runs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_ai_grading_run_items_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_ai_grading_runs: {
+        Row: {
+          assignment_id: string
+          completed_at: string | null
+          completed_count: number
+          created_at: string
+          error_samples_json: Json
+          failed_count: number
+          gradable_count: number
+          gradex_last_polled_at: string | null
+          gradex_run_id: string | null
+          gradex_status: string | null
+          gradex_submitted_at: string | null
+          id: string
+          lease_expires_at: string | null
+          lease_token: string | null
+          model: string | null
+          processed_count: number
+          requested_count: number
+          requested_student_ids_json: Json
+          selection_hash: string
+          skipped_empty_count: number
+          skipped_missing_count: number
+          started_at: string | null
+          status: string
+          triggered_by: string
+          updated_at: string
+        }
+        Insert: {
+          assignment_id: string
+          completed_at?: string | null
+          completed_count?: number
+          created_at?: string
+          error_samples_json?: Json
+          failed_count?: number
+          gradable_count?: number
+          gradex_last_polled_at?: string | null
+          gradex_run_id?: string | null
+          gradex_status?: string | null
+          gradex_submitted_at?: string | null
+          id?: string
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          model?: string | null
+          processed_count?: number
+          requested_count?: number
+          requested_student_ids_json?: Json
+          selection_hash: string
+          skipped_empty_count?: number
+          skipped_missing_count?: number
+          started_at?: string | null
+          status?: string
+          triggered_by: string
+          updated_at?: string
+        }
+        Update: {
+          assignment_id?: string
+          completed_at?: string | null
+          completed_count?: number
+          created_at?: string
+          error_samples_json?: Json
+          failed_count?: number
+          gradable_count?: number
+          gradex_last_polled_at?: string | null
+          gradex_run_id?: string | null
+          gradex_status?: string | null
+          gradex_submitted_at?: string | null
+          id?: string
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          model?: string | null
+          processed_count?: number
+          requested_count?: number
+          requested_student_ids_json?: Json
+          selection_hash?: string
+          skipped_empty_count?: number
+          skipped_missing_count?: number
+          started_at?: string | null
+          status?: string
+          triggered_by?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_ai_grading_runs_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_ai_grading_runs_triggered_by_fkey"
+            columns: ["triggered_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_doc_history: {
+        Row: {
+          assignment_doc_id: string
+          char_count: number
+          created_at: string
+          id: string
+          keystroke_count: number | null
+          paste_word_count: number | null
+          patch: Json | null
+          snapshot: Json | null
+          trigger: string
+          word_count: number
+        }
+        Insert: {
+          assignment_doc_id: string
+          char_count: number
+          created_at?: string
+          id?: string
+          keystroke_count?: number | null
+          paste_word_count?: number | null
+          patch?: Json | null
+          snapshot?: Json | null
+          trigger: string
+          word_count: number
+        }
+        Update: {
+          assignment_doc_id?: string
+          char_count?: number
+          created_at?: string
+          id?: string
+          keystroke_count?: number | null
+          paste_word_count?: number | null
+          patch?: Json | null
+          snapshot?: Json | null
+          trigger?: string
+          word_count?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_doc_history_assignment_doc_id_fkey"
+            columns: ["assignment_doc_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_docs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_docs: {
+        Row: {
+          ai_feedback_model: string | null
+          ai_feedback_suggested_at: string | null
+          ai_feedback_suggestion: string | null
+          assignment_id: string
+          authenticity_flags: Json | null
+          authenticity_score: number | null
+          content: Json
+          content_legacy: string
+          created_at: string
+          feedback: string | null
+          feedback_returned_at: string | null
+          github_username: string | null
+          graded_at: string | null
+          graded_by: string | null
+          id: string
+          is_submitted: boolean
+          repo_url: string | null
+          returned_at: string | null
+          score_completion: number | null
+          score_thinking: number | null
+          score_workflow: number | null
+          student_id: string
+          submitted_at: string | null
+          teacher_cleared_at: string | null
+          teacher_feedback_draft: string | null
+          teacher_feedback_draft_updated_at: string | null
+          updated_at: string
+          viewed_at: string | null
+        }
+        Insert: {
+          ai_feedback_model?: string | null
+          ai_feedback_suggested_at?: string | null
+          ai_feedback_suggestion?: string | null
+          assignment_id: string
+          authenticity_flags?: Json | null
+          authenticity_score?: number | null
+          content?: Json
+          content_legacy?: string
+          created_at?: string
+          feedback?: string | null
+          feedback_returned_at?: string | null
+          github_username?: string | null
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          is_submitted?: boolean
+          repo_url?: string | null
+          returned_at?: string | null
+          score_completion?: number | null
+          score_thinking?: number | null
+          score_workflow?: number | null
+          student_id: string
+          submitted_at?: string | null
+          teacher_cleared_at?: string | null
+          teacher_feedback_draft?: string | null
+          teacher_feedback_draft_updated_at?: string | null
+          updated_at?: string
+          viewed_at?: string | null
+        }
+        Update: {
+          ai_feedback_model?: string | null
+          ai_feedback_suggested_at?: string | null
+          ai_feedback_suggestion?: string | null
+          assignment_id?: string
+          authenticity_flags?: Json | null
+          authenticity_score?: number | null
+          content?: Json
+          content_legacy?: string
+          created_at?: string
+          feedback?: string | null
+          feedback_returned_at?: string | null
+          github_username?: string | null
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          is_submitted?: boolean
+          repo_url?: string | null
+          returned_at?: string | null
+          score_completion?: number | null
+          score_thinking?: number | null
+          score_workflow?: number | null
+          student_id?: string
+          submitted_at?: string | null
+          teacher_cleared_at?: string | null
+          teacher_feedback_draft?: string | null
+          teacher_feedback_draft_updated_at?: string | null
+          updated_at?: string
+          viewed_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_docs_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_docs_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_feedback_entries: {
+        Row: {
+          assignment_id: string
+          author_type: string
+          body: string
+          created_at: string
+          created_by: string | null
+          entry_kind: string
+          id: string
+          returned_at: string
+          student_id: string
+        }
+        Insert: {
+          assignment_id: string
+          author_type: string
+          body: string
+          created_at?: string
+          created_by?: string | null
+          entry_kind: string
+          id?: string
+          returned_at?: string
+          student_id: string
+        }
+        Update: {
+          assignment_id?: string
+          author_type?: string
+          body?: string
+          created_at?: string
+          created_by?: string | null
+          entry_kind?: string
+          id?: string
+          returned_at?: string
+          student_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_feedback_entries_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_feedback_entries_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_feedback_entries_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_repo_review_results: {
+        Row: {
+          active_days: number
+          assignment_id: string
+          burst_ratio: number
+          commit_count: number
+          confidence: number
+          created_at: string
+          draft_feedback: string | null
+          draft_score_completion: number | null
+          draft_score_thinking: number | null
+          draft_score_workflow: number | null
+          evidence_json: Json
+          github_login: string | null
+          id: string
+          iteration_score: number
+          relative_contribution_share: number
+          run_id: string
+          semantic_breakdown_json: Json
+          session_count: number
+          spread_score: number
+          student_id: string
+          timeline_json: Json
+          weighted_contribution: number
+        }
+        Insert: {
+          active_days?: number
+          assignment_id: string
+          burst_ratio?: number
+          commit_count?: number
+          confidence?: number
+          created_at?: string
+          draft_feedback?: string | null
+          draft_score_completion?: number | null
+          draft_score_thinking?: number | null
+          draft_score_workflow?: number | null
+          evidence_json?: Json
+          github_login?: string | null
+          id?: string
+          iteration_score?: number
+          relative_contribution_share?: number
+          run_id: string
+          semantic_breakdown_json?: Json
+          session_count?: number
+          spread_score?: number
+          student_id: string
+          timeline_json?: Json
+          weighted_contribution?: number
+        }
+        Update: {
+          active_days?: number
+          assignment_id?: string
+          burst_ratio?: number
+          commit_count?: number
+          confidence?: number
+          created_at?: string
+          draft_feedback?: string | null
+          draft_score_completion?: number | null
+          draft_score_thinking?: number | null
+          draft_score_workflow?: number | null
+          evidence_json?: Json
+          github_login?: string | null
+          id?: string
+          iteration_score?: number
+          relative_contribution_share?: number
+          run_id?: string
+          semantic_breakdown_json?: Json
+          session_count?: number
+          spread_score?: number
+          student_id?: string
+          timeline_json?: Json
+          weighted_contribution?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_repo_review_results_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_repo_review_results_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_repo_review_runs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_repo_review_results_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_repo_review_runs: {
+        Row: {
+          assignment_id: string
+          completed_at: string | null
+          created_at: string
+          id: string
+          metrics_version: string
+          model: string | null
+          prompt_version: string
+          repo_name: string | null
+          repo_owner: string | null
+          source_ref: string | null
+          started_at: string
+          status: string
+          triggered_by: string
+          warnings_json: Json
+        }
+        Insert: {
+          assignment_id: string
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          metrics_version?: string
+          model?: string | null
+          prompt_version?: string
+          repo_name?: string | null
+          repo_owner?: string | null
+          source_ref?: string | null
+          started_at?: string
+          status?: string
+          triggered_by: string
+          warnings_json?: Json
+        }
+        Update: {
+          assignment_id?: string
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          metrics_version?: string
+          model?: string | null
+          prompt_version?: string
+          repo_name?: string | null
+          repo_owner?: string | null
+          source_ref?: string | null
+          started_at?: string
+          status?: string
+          triggered_by?: string
+          warnings_json?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_repo_review_runs_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_repo_review_runs_triggered_by_fkey"
+            columns: ["triggered_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_repo_targets: {
+        Row: {
+          assignment_id: string
+          created_at: string
+          id: string
+          override_github_username: string | null
+          repo_name: string | null
+          repo_owner: string | null
+          selected_repo_url: string | null
+          selection_mode: string
+          student_id: string
+          updated_at: string
+          validated_at: string | null
+          validation_message: string | null
+          validation_status: string
+        }
+        Insert: {
+          assignment_id: string
+          created_at?: string
+          id?: string
+          override_github_username?: string | null
+          repo_name?: string | null
+          repo_owner?: string | null
+          selected_repo_url?: string | null
+          selection_mode?: string
+          student_id: string
+          updated_at?: string
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Update: {
+          assignment_id?: string
+          created_at?: string
+          id?: string
+          override_github_username?: string | null
+          repo_name?: string | null
+          repo_owner?: string | null
+          selected_repo_url?: string | null
+          selection_mode?: string
+          student_id?: string
+          updated_at?: string
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_repo_targets_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_repo_targets_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_submission_artifacts: {
+        Row: {
+          assignment_doc_id: string
+          created_at: string
+          id: string
+          metadata_json: Json
+          requirement_id: string
+          storage_path: string | null
+          student_id: string
+          type: string
+          updated_at: string
+          url: string | null
+          validated_at: string | null
+          validation_message: string | null
+          validation_status: string
+        }
+        Insert: {
+          assignment_doc_id: string
+          created_at?: string
+          id?: string
+          metadata_json?: Json
+          requirement_id: string
+          storage_path?: string | null
+          student_id: string
+          type: string
+          updated_at?: string
+          url?: string | null
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Update: {
+          assignment_doc_id?: string
+          created_at?: string
+          id?: string
+          metadata_json?: Json
+          requirement_id?: string
+          storage_path?: string | null
+          student_id?: string
+          type?: string
+          updated_at?: string
+          url?: string | null
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_submission_artifacts_assignment_doc_id_fkey"
+            columns: ["assignment_doc_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_docs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_submission_artifacts_requirement_id_fkey"
+            columns: ["requirement_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_submission_requirements"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_submission_artifacts_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignment_submission_requirements: {
+        Row: {
+          assignment_id: string
+          created_at: string
+          id: string
+          instructions: string
+          label: string
+          position: number
+          required: boolean
+          type: string
+          updated_at: string
+          validation_policy_json: Json
+        }
+        Insert: {
+          assignment_id: string
+          created_at?: string
+          id?: string
+          instructions?: string
+          label: string
+          position?: number
+          required?: boolean
+          type: string
+          updated_at?: string
+          validation_policy_json?: Json
+        }
+        Update: {
+          assignment_id?: string
+          created_at?: string
+          id?: string
+          instructions?: string
+          label?: string
+          position?: number
+          required?: boolean
+          type?: string
+          updated_at?: string
+          validation_policy_json?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_submission_requirements_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "assignments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      assignments: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          created_by: string
+          description: string
+          due_at: string
+          gradebook_weight: number
+          id: string
+          include_in_final: boolean
+          instructions_markdown: string | null
+          is_draft: boolean
+          points_possible: number
+          position: number
+          released_at: string | null
+          rich_instructions: Json | null
+          title: string
+          track_authenticity: boolean
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          created_by: string
+          description?: string
+          due_at: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          instructions_markdown?: string | null
+          is_draft?: boolean
+          points_possible?: number
+          position?: number
+          released_at?: string | null
+          rich_instructions?: Json | null
+          title: string
+          track_authenticity?: boolean
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          created_by?: string
+          description?: string
+          due_at?: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          instructions_markdown?: string | null
+          is_draft?: boolean
+          points_possible?: number
+          position?: number
+          released_at?: string | null
+          rich_instructions?: Json | null
+          title?: string
+          track_authenticity?: boolean
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignments_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignments_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      class_days: {
+        Row: {
+          classroom_id: string
+          date: string
+          id: string
+          is_class_day: boolean
+          prompt_text: string | null
+        }
+        Insert: {
+          classroom_id: string
+          date: string
+          id?: string
+          is_class_day?: boolean
+          prompt_text?: string | null
+        }
+        Update: {
+          classroom_id?: string
+          date?: string
+          id?: string
+          is_class_day?: boolean
+          prompt_text?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "class_days_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archive_object_upload_cleanup: {
+        Row: {
+          attempt_count: number
+          created_at: string
+          deleted_at: string | null
+          expected_byte_size: number
+          expected_sha256: string
+          last_error_code: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          operation_id: string
+          status: string
+          storage_bucket: string
+          storage_path: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          created_at?: string
+          deleted_at?: string | null
+          expected_byte_size: number
+          expected_sha256: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          operation_id: string
+          status?: string
+          storage_bucket: string
+          storage_path: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          created_at?: string
+          deleted_at?: string | null
+          expected_byte_size?: number
+          expected_sha256?: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          operation_id?: string
+          status?: string
+          storage_bucket?: string
+          storage_path?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_object_upload_cleanup_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archive_operations: {
+        Row: {
+          adapter_chain: Json | null
+          archive_id: string | null
+          artifact_sha256: string | null
+          attempt_count: number
+          classroom_id: string
+          completed_at: string | null
+          compressed_byte_size: number | null
+          content_sha256: string | null
+          error_code: string | null
+          id: string
+          operation_type: string
+          request_sha256: string
+          resource_counts: Json
+          retention: Json
+          retryable: boolean | null
+          snapshot_created_at: string
+          snapshot_expires_at: string
+          source_app_commit: string
+          source_object_cleanup_staged_at: string | null
+          source_revision: number
+          source_schema_migration: string
+          status: string
+          storage_bucket: string | null
+          storage_object_counts: Json
+          storage_path: string | null
+          target_schema_migration: string | null
+          teacher_id: string
+          uncompressed_byte_size: number | null
+          updated_at: string
+          verification: Json | null
+        }
+        Insert: {
+          adapter_chain?: Json | null
+          archive_id?: string | null
+          artifact_sha256?: string | null
+          attempt_count?: number
+          classroom_id: string
+          completed_at?: string | null
+          compressed_byte_size?: number | null
+          content_sha256?: string | null
+          error_code?: string | null
+          id: string
+          operation_type?: string
+          request_sha256: string
+          resource_counts?: Json
+          retention: Json
+          retryable?: boolean | null
+          snapshot_created_at: string
+          snapshot_expires_at: string
+          source_app_commit: string
+          source_object_cleanup_staged_at?: string | null
+          source_revision: number
+          source_schema_migration: string
+          status: string
+          storage_bucket?: string | null
+          storage_object_counts?: Json
+          storage_path?: string | null
+          target_schema_migration?: string | null
+          teacher_id: string
+          uncompressed_byte_size?: number | null
+          updated_at?: string
+          verification?: Json | null
+        }
+        Update: {
+          adapter_chain?: Json | null
+          archive_id?: string | null
+          artifact_sha256?: string | null
+          attempt_count?: number
+          classroom_id?: string
+          completed_at?: string | null
+          compressed_byte_size?: number | null
+          content_sha256?: string | null
+          error_code?: string | null
+          id?: string
+          operation_type?: string
+          request_sha256?: string
+          resource_counts?: Json
+          retention?: Json
+          retryable?: boolean | null
+          snapshot_created_at?: string
+          snapshot_expires_at?: string
+          source_app_commit?: string
+          source_object_cleanup_staged_at?: string | null
+          source_revision?: number
+          source_schema_migration?: string
+          status?: string
+          storage_bucket?: string | null
+          storage_object_counts?: Json
+          storage_path?: string | null
+          target_schema_migration?: string | null
+          teacher_id?: string
+          uncompressed_byte_size?: number | null
+          updated_at?: string
+          verification?: Json | null
+        }
+        Relationships: []
+      }
+      classroom_archive_resource_contract: {
+        Row: {
+          actor_columns: string[]
+          export_position: number
+          parent_column: string | null
+          parent_table: string | null
+          primary_key_columns: string[]
+          restore_after: string[]
+          table_name: string
+        }
+        Insert: {
+          actor_columns?: string[]
+          export_position: number
+          parent_column?: string | null
+          parent_table?: string | null
+          primary_key_columns: string[]
+          restore_after: string[]
+          table_name: string
+        }
+        Update: {
+          actor_columns?: string[]
+          export_position?: number
+          parent_column?: string | null
+          parent_table?: string | null
+          primary_key_columns?: string[]
+          restore_after?: string[]
+          table_name?: string
+        }
+        Relationships: []
+      }
+      classroom_archive_restore_expected_objects: {
+        Row: {
+          expected_byte_size: number
+          expected_sha256: string
+          operation_id: string
+          storage_bucket: string
+          storage_path: string
+        }
+        Insert: {
+          expected_byte_size: number
+          expected_sha256: string
+          operation_id: string
+          storage_bucket: string
+          storage_path: string
+        }
+        Update: {
+          expected_byte_size?: number
+          expected_sha256?: string
+          operation_id?: string
+          storage_bucket?: string
+          storage_path?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_restore_expected_objects_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archive_restore_staging: {
+        Row: {
+          operation_id: string
+          row_data: Json
+          row_id: string
+          staged_at: string
+          table_name: string
+        }
+        Insert: {
+          operation_id: string
+          row_data: Json
+          row_id: string
+          staged_at?: string
+          table_name: string
+        }
+        Update: {
+          operation_id?: string
+          row_data?: Json
+          row_id?: string
+          staged_at?: string
+          table_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_restore_staging_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_archive_restore_staging_table_name_fkey"
+            columns: ["table_name"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_resource_contract"
+            referencedColumns: ["table_name"]
+          },
+        ]
+      }
+      classroom_archive_revisions: {
+        Row: {
+          classroom_id: string
+          revision: number
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          revision?: number
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          revision?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      classroom_archive_snapshot_actors: {
+        Row: {
+          actor_id: string
+          operation_id: string
+          snapshot: Json
+        }
+        Insert: {
+          actor_id: string
+          operation_id: string
+          snapshot: Json
+        }
+        Update: {
+          actor_id?: string
+          operation_id?: string
+          snapshot?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_snapshot_actors_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archive_snapshot_resources: {
+        Row: {
+          operation_id: string
+          row_id: string
+          table_name: string
+        }
+        Insert: {
+          operation_id: string
+          row_id: string
+          table_name: string
+        }
+        Update: {
+          operation_id?: string
+          row_id?: string
+          table_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_snapshot_resources_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_archive_snapshot_resources_table_name_fkey"
+            columns: ["table_name"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_resource_contract"
+            referencedColumns: ["table_name"]
+          },
+        ]
+      }
+      classroom_archive_source_object_cleanup: {
+        Row: {
+          archive_id: string
+          attempt_count: number
+          classroom_id: string
+          created_at: string
+          deleted_at: string | null
+          expected_byte_size: number
+          expected_sha256: string
+          last_error_code: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          operation_id: string
+          ownership_verified: boolean
+          status: string
+          storage_bucket: string
+          storage_path: string
+          updated_at: string
+        }
+        Insert: {
+          archive_id: string
+          attempt_count?: number
+          classroom_id: string
+          created_at?: string
+          deleted_at?: string | null
+          expected_byte_size: number
+          expected_sha256: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          operation_id: string
+          ownership_verified?: boolean
+          status?: string
+          storage_bucket: string
+          storage_path: string
+          updated_at?: string
+        }
+        Update: {
+          archive_id?: string
+          attempt_count?: number
+          classroom_id?: string
+          created_at?: string
+          deleted_at?: string | null
+          expected_byte_size?: number
+          expected_sha256?: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          operation_id?: string
+          ownership_verified?: boolean
+          status?: string
+          storage_bucket?: string
+          storage_path?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_source_object_cleanup_archive_id_fkey"
+            columns: ["archive_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archives"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_archive_source_object_cleanup_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archives: {
+        Row: {
+          artifact_sha256: string
+          classroom_id: string
+          compressed_byte_size: number
+          content_sha256: string
+          created_at: string
+          format: string
+          format_version: number
+          id: string
+          operation_id: string
+          resource_counts: Json
+          retention: Json
+          source_app_commit: string
+          source_revision: number
+          source_schema_migration: string
+          storage_bucket: string
+          storage_object_counts: Json
+          storage_path: string
+          teacher_id: string
+          uncompressed_byte_size: number
+          verification: Json
+          verified_at: string
+        }
+        Insert: {
+          artifact_sha256: string
+          classroom_id: string
+          compressed_byte_size: number
+          content_sha256: string
+          created_at: string
+          format: string
+          format_version: number
+          id: string
+          operation_id: string
+          resource_counts: Json
+          retention: Json
+          source_app_commit: string
+          source_revision: number
+          source_schema_migration: string
+          storage_bucket: string
+          storage_object_counts: Json
+          storage_path: string
+          teacher_id: string
+          uncompressed_byte_size: number
+          verification: Json
+          verified_at: string
+        }
+        Update: {
+          artifact_sha256?: string
+          classroom_id?: string
+          compressed_byte_size?: number
+          content_sha256?: string
+          created_at?: string
+          format?: string
+          format_version?: number
+          id?: string
+          operation_id?: string
+          resource_counts?: Json
+          retention?: Json
+          source_app_commit?: string
+          source_revision?: number
+          source_schema_migration?: string
+          storage_bucket?: string
+          storage_object_counts?: Json
+          storage_path?: string
+          teacher_id?: string
+          uncompressed_byte_size?: number
+          verification?: Json
+          verified_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archives_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_cold_archive_actors: {
+        Row: {
+          actor_id: string
+          actor_role: string
+          classroom_id: string
+        }
+        Insert: {
+          actor_id: string
+          actor_role: string
+          classroom_id: string
+        }
+        Update: {
+          actor_id?: string
+          actor_role?: string
+          classroom_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_cold_archive_actors_actor_id_fkey"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_cold_archive_actors_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_cold_tombstones"
+            referencedColumns: ["classroom_id"]
+          },
+        ]
+      }
+      classroom_cold_tombstones: {
+        Row: {
+          archive_id: string
+          archived_at: string
+          classroom_id: string
+          compacted_at: string
+          created_at: string
+          source_revision: number
+          teacher_id: string
+          title: string
+        }
+        Insert: {
+          archive_id: string
+          archived_at: string
+          classroom_id: string
+          compacted_at?: string
+          created_at?: string
+          source_revision: number
+          teacher_id: string
+          title: string
+        }
+        Update: {
+          archive_id?: string
+          archived_at?: string
+          classroom_id?: string
+          compacted_at?: string
+          created_at?: string
+          source_revision?: number
+          teacher_id?: string
+          title?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_cold_tombstones_archive_id_fkey"
+            columns: ["archive_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_archives"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_enrollments: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          id: string
+          student_id: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          id?: string
+          student_id: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          id?: string
+          student_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_enrollments_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_enrollments_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_gradex_extract_cleanup: {
+        Row: {
+          attempt_count: number
+          delete_after: string
+          deleted_at: string | null
+          extract_id: string | null
+          last_error_code: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          operation_id: string
+          status: string
+          storage_bucket: string
+          storage_path: string
+          superseded_by_extract_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          delete_after: string
+          deleted_at?: string | null
+          extract_id?: string | null
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at: string
+          operation_id: string
+          status?: string
+          storage_bucket: string
+          storage_path: string
+          superseded_by_extract_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          delete_after?: string
+          deleted_at?: string | null
+          extract_id?: string | null
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          operation_id?: string
+          status?: string
+          storage_bucket?: string
+          storage_path?: string
+          superseded_by_extract_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_gradex_extract_cleanup_extract_id_fkey"
+            columns: ["extract_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_gradex_extracts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_gradex_extract_cleanup_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_gradex_extract_cleanup_superseded_by_extract_id_fkey"
+            columns: ["superseded_by_extract_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_gradex_extracts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_gradex_extracts: {
+        Row: {
+          artifact_sha256: string
+          classroom_id: string
+          compressed_byte_size: number
+          content_sha256: string
+          delete_after: string
+          format: string
+          format_version: number
+          generated_at: string
+          id: string
+          operation_id: string
+          resource_counts: Json
+          source_archive_id: string
+          source_archive_sha256: string
+          storage_bucket: string
+          storage_path: string
+          teacher_id: string
+          uncompressed_byte_size: number
+          verification: Json
+          verified_at: string
+        }
+        Insert: {
+          artifact_sha256: string
+          classroom_id: string
+          compressed_byte_size: number
+          content_sha256: string
+          delete_after: string
+          format: string
+          format_version: number
+          generated_at: string
+          id: string
+          operation_id: string
+          resource_counts: Json
+          source_archive_id: string
+          source_archive_sha256: string
+          storage_bucket: string
+          storage_path: string
+          teacher_id: string
+          uncompressed_byte_size: number
+          verification: Json
+          verified_at: string
+        }
+        Update: {
+          artifact_sha256?: string
+          classroom_id?: string
+          compressed_byte_size?: number
+          content_sha256?: string
+          delete_after?: string
+          format?: string
+          format_version?: number
+          generated_at?: string
+          id?: string
+          operation_id?: string
+          resource_counts?: Json
+          source_archive_id?: string
+          source_archive_sha256?: string
+          storage_bucket?: string
+          storage_path?: string
+          teacher_id?: string
+          uncompressed_byte_size?: number
+          verification?: Json
+          verified_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_gradex_extracts_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_gradex_extracts_source_archive_id_fkey"
+            columns: ["source_archive_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archives"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_gradex_resource_contract: {
+        Row: {
+          table_name: string
+        }
+        Insert: {
+          table_name: string
+        }
+        Update: {
+          table_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_gradex_resource_contract_table_name_fkey"
+            columns: ["table_name"]
+            isOneToOne: true
+            referencedRelation: "classroom_archive_resource_contract"
+            referencedColumns: ["table_name"]
+          },
+        ]
+      }
+      classroom_resources: {
+        Row: {
+          classroom_id: string
+          content: Json
+          id: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          classroom_id: string
+          content?: Json
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          classroom_id?: string
+          content?: Json
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_materials_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: true
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_materials_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_roster: {
+        Row: {
+          classroom_id: string
+          counselor_email: string | null
+          created_at: string
+          email: string
+          first_name: string | null
+          id: string
+          join_source: string
+          last_name: string | null
+          student_number: string | null
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          counselor_email?: string | null
+          created_at?: string
+          email: string
+          first_name?: string | null
+          id?: string
+          join_source?: string
+          last_name?: string | null
+          student_number?: string | null
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          counselor_email?: string | null
+          created_at?: string
+          email?: string
+          first_name?: string | null
+          id?: string
+          join_source?: string
+          last_name?: string | null
+          student_number?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_roster_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classrooms: {
+        Row: {
+          actual_site_config: Json
+          actual_site_published: boolean
+          actual_site_slug: string | null
+          allow_enrollment: boolean
+          archived_at: string | null
+          blueprint_source_revision: number
+          class_code: string
+          course_outline_markdown: string
+          course_overview_markdown: string
+          created_at: string
+          end_date: string | null
+          id: string
+          join_policy: string
+          lesson_plan_visibility: string
+          position: number
+          source_blueprint_id: string | null
+          source_blueprint_origin: Json | null
+          start_date: string | null
+          teacher_id: string
+          term_label: string | null
+          theme_color: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          actual_site_config?: Json
+          actual_site_published?: boolean
+          actual_site_slug?: string | null
+          allow_enrollment?: boolean
+          archived_at?: string | null
+          blueprint_source_revision?: number
+          class_code: string
+          course_outline_markdown?: string
+          course_overview_markdown?: string
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          join_policy?: string
+          lesson_plan_visibility?: string
+          position?: number
+          source_blueprint_id?: string | null
+          source_blueprint_origin?: Json | null
+          start_date?: string | null
+          teacher_id: string
+          term_label?: string | null
+          theme_color?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          actual_site_config?: Json
+          actual_site_published?: boolean
+          actual_site_slug?: string | null
+          allow_enrollment?: boolean
+          archived_at?: string | null
+          blueprint_source_revision?: number
+          class_code?: string
+          course_outline_markdown?: string
+          course_overview_markdown?: string
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          join_policy?: string
+          lesson_plan_visibility?: string
+          position?: number
+          source_blueprint_id?: string | null
+          source_blueprint_origin?: Json | null
+          start_date?: string | null
+          teacher_id?: string
+          term_label?: string | null
+          theme_color?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classrooms_source_blueprint_id_fkey"
+            columns: ["source_blueprint_id"]
+            isOneToOne: false
+            referencedRelation: "course_blueprints"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classrooms_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classwork_materials: {
+        Row: {
+          classroom_id: string
+          content: Json
+          created_at: string
+          created_by: string
+          id: string
+          is_draft: boolean
+          position: number
+          released_at: string | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          content?: Json
+          created_at?: string
+          created_by: string
+          id?: string
+          is_draft?: boolean
+          position: number
+          released_at?: string | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          content?: Json
+          created_at?: string
+          created_by?: string
+          id?: string
+          is_draft?: boolean
+          position?: number
+          released_at?: string | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classwork_materials_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classwork_materials_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      course_blueprint_assessments: {
+        Row: {
+          assessment_type: string
+          content: Json
+          course_blueprint_id: string
+          created_at: string
+          documents: Json
+          gradebook_weight: number
+          id: string
+          include_in_final: boolean
+          points_possible: number | null
+          position: number
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          assessment_type: string
+          content?: Json
+          course_blueprint_id: string
+          created_at?: string
+          documents?: Json
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          points_possible?: number | null
+          position?: number
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          assessment_type?: string
+          content?: Json
+          course_blueprint_id?: string
+          created_at?: string
+          documents?: Json
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          points_possible?: number | null
+          position?: number
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_blueprint_assessments_course_blueprint_id_fkey"
+            columns: ["course_blueprint_id"]
+            isOneToOne: false
+            referencedRelation: "course_blueprints"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      course_blueprint_assignments: {
+        Row: {
+          course_blueprint_id: string
+          created_at: string
+          default_due_days: number
+          default_due_time: string
+          gradebook_weight: number
+          id: string
+          include_in_final: boolean
+          instructions_markdown: string
+          is_draft: boolean
+          points_possible: number | null
+          position: number
+          submission_requirements_json: Json
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          course_blueprint_id: string
+          created_at?: string
+          default_due_days?: number
+          default_due_time?: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          instructions_markdown?: string
+          is_draft?: boolean
+          points_possible?: number | null
+          position?: number
+          submission_requirements_json?: Json
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          course_blueprint_id?: string
+          created_at?: string
+          default_due_days?: number
+          default_due_time?: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          instructions_markdown?: string
+          is_draft?: boolean
+          points_possible?: number | null
+          position?: number
+          submission_requirements_json?: Json
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_blueprint_assignments_course_blueprint_id_fkey"
+            columns: ["course_blueprint_id"]
+            isOneToOne: false
+            referencedRelation: "course_blueprints"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      course_blueprint_lesson_templates: {
+        Row: {
+          content_markdown: string
+          course_blueprint_id: string
+          created_at: string
+          id: string
+          position: number
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          content_markdown?: string
+          course_blueprint_id: string
+          created_at?: string
+          id?: string
+          position?: number
+          title?: string
+          updated_at?: string
+        }
+        Update: {
+          content_markdown?: string
+          course_blueprint_id?: string
+          created_at?: string
+          id?: string
+          position?: number
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_blueprint_lesson_templates_course_blueprint_id_fkey"
+            columns: ["course_blueprint_id"]
+            isOneToOne: false
+            referencedRelation: "course_blueprints"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      course_blueprint_operations: {
+        Row: {
+          attempt_count: number
+          completed_at: string | null
+          error_code: string | null
+          error_sqlstate: string | null
+          id: string
+          operation_type: string
+          request_sha256: string
+          resource_counts: Json
+          result: Json | null
+          result_blueprint_id: string | null
+          result_classroom_id: string | null
+          source_blueprint_id: string | null
+          source_classroom_id: string | null
+          started_at: string
+          status: string
+          teacher_id: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          completed_at?: string | null
+          error_code?: string | null
+          error_sqlstate?: string | null
+          id: string
+          operation_type: string
+          request_sha256: string
+          resource_counts?: Json
+          result?: Json | null
+          result_blueprint_id?: string | null
+          result_classroom_id?: string | null
+          source_blueprint_id?: string | null
+          source_classroom_id?: string | null
+          started_at?: string
+          status: string
+          teacher_id: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          completed_at?: string | null
+          error_code?: string | null
+          error_sqlstate?: string | null
+          id?: string
+          operation_type?: string
+          request_sha256?: string
+          resource_counts?: Json
+          result?: Json | null
+          result_blueprint_id?: string | null
+          result_classroom_id?: string | null
+          source_blueprint_id?: string | null
+          source_classroom_id?: string | null
+          started_at?: string
+          status?: string
+          teacher_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_blueprint_operations_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      course_blueprints: {
+        Row: {
+          content_revision: number
+          course_code: string
+          created_at: string
+          grade_level: string
+          id: string
+          outline_markdown: string
+          overview_markdown: string
+          planned_site_config: Json
+          planned_site_published: boolean
+          planned_site_slug: string | null
+          position: number
+          resources_markdown: string
+          subject: string
+          teacher_id: string
+          term_template: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          content_revision?: number
+          course_code?: string
+          created_at?: string
+          grade_level?: string
+          id?: string
+          outline_markdown?: string
+          overview_markdown?: string
+          planned_site_config?: Json
+          planned_site_published?: boolean
+          planned_site_slug?: string | null
+          position?: number
+          resources_markdown?: string
+          subject?: string
+          teacher_id: string
+          term_template?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          content_revision?: number
+          course_code?: string
+          created_at?: string
+          grade_level?: string
+          id?: string
+          outline_markdown?: string
+          overview_markdown?: string
+          planned_site_config?: Json
+          planned_site_published?: boolean
+          planned_site_slug?: string | null
+          position?: number
+          resources_markdown?: string
+          subject?: string
+          teacher_id?: string
+          term_template?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_blueprints_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      developer_feedback_candidates: {
+        Row: {
+          affected_area: string | null
+          approved_at: string | null
+          completed_at: string | null
+          confidence: number
+          created_at: string
+          dedupe_key: string
+          direct_feedback_category: string | null
+          dismissed_at: string | null
+          first_seen_at: string
+          id: string
+          implementation_hint: string | null
+          last_seen_at: string
+          last_seen_date: string | null
+          model: string | null
+          original_request: string
+          pr_url: string | null
+          refined_request: string
+          signal_count: number
+          source_classroom_ids: string[]
+          source_dates: string[]
+          source_entry_count: number
+          source_keys: string[]
+          source_metadata: Json
+          source_type: string
+          started_at: string | null
+          status: string
+          status_note: string | null
+          status_updated_at: string
+          submitter_role: string | null
+          submitter_user_id: string | null
+          suggested_agent: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          affected_area?: string | null
+          approved_at?: string | null
+          completed_at?: string | null
+          confidence?: number
+          created_at?: string
+          dedupe_key: string
+          direct_feedback_category?: string | null
+          dismissed_at?: string | null
+          first_seen_at?: string
+          id?: string
+          implementation_hint?: string | null
+          last_seen_at?: string
+          last_seen_date?: string | null
+          model?: string | null
+          original_request: string
+          pr_url?: string | null
+          refined_request: string
+          signal_count?: number
+          source_classroom_ids?: string[]
+          source_dates?: string[]
+          source_entry_count?: number
+          source_keys?: string[]
+          source_metadata?: Json
+          source_type?: string
+          started_at?: string | null
+          status?: string
+          status_note?: string | null
+          status_updated_at?: string
+          submitter_role?: string | null
+          submitter_user_id?: string | null
+          suggested_agent?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          affected_area?: string | null
+          approved_at?: string | null
+          completed_at?: string | null
+          confidence?: number
+          created_at?: string
+          dedupe_key?: string
+          direct_feedback_category?: string | null
+          dismissed_at?: string | null
+          first_seen_at?: string
+          id?: string
+          implementation_hint?: string | null
+          last_seen_at?: string
+          last_seen_date?: string | null
+          model?: string | null
+          original_request?: string
+          pr_url?: string | null
+          refined_request?: string
+          signal_count?: number
+          source_classroom_ids?: string[]
+          source_dates?: string[]
+          source_entry_count?: number
+          source_keys?: string[]
+          source_metadata?: Json
+          source_type?: string
+          started_at?: string | null
+          status?: string
+          status_note?: string | null
+          status_updated_at?: string
+          submitter_role?: string | null
+          submitter_user_id?: string | null
+          suggested_agent?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "developer_feedback_candidates_submitter_user_id_fkey"
+            columns: ["submitter_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      entries: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          date: string
+          id: string
+          minutes_reported: number | null
+          mood: string | null
+          on_time: boolean
+          rich_content: Json | null
+          student_id: string
+          text: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          date: string
+          id?: string
+          minutes_reported?: number | null
+          mood?: string | null
+          on_time: boolean
+          rich_content?: Json | null
+          student_id: string
+          text: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          date?: string
+          id?: string
+          minutes_reported?: number | null
+          mood?: string | null
+          on_time?: boolean
+          rich_content?: Json | null
+          student_id?: string
+          text?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "entries_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "entries_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gradebook_settings: {
+        Row: {
+          assignments_weight: number
+          classroom_id: string
+          created_at: string
+          quizzes_weight: number
+          tests_weight: number
+          updated_at: string
+          use_weights: boolean
+        }
+        Insert: {
+          assignments_weight?: number
+          classroom_id: string
+          created_at?: string
+          quizzes_weight?: number
+          tests_weight?: number
+          updated_at?: string
+          use_weights?: boolean
+        }
+        Update: {
+          assignments_weight?: number
+          classroom_id?: string
+          created_at?: string
+          quizzes_weight?: number
+          tests_weight?: number
+          updated_at?: string
+          use_weights?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gradebook_settings_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: true
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lesson_plans: {
+        Row: {
+          classroom_id: string
+          content: Json
+          content_markdown: string | null
+          created_at: string
+          date: string
+          id: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          content?: Json
+          content_markdown?: string | null
+          created_at?: string
+          date: string
+          id?: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          content?: Json
+          content_markdown?: string | null
+          created_at?: string
+          date?: string
+          id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_plans_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      log_summaries: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          date: string
+          entries_updated_at: string | null
+          entry_count: number
+          generated_at: string
+          id: string
+          initials_map: Json
+          model: string
+          summary_items: Json
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          date: string
+          entries_updated_at?: string | null
+          entry_count?: number
+          generated_at?: string
+          id?: string
+          initials_map?: Json
+          model: string
+          summary_items?: Json
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          date?: string
+          entries_updated_at?: string | null
+          entry_count?: number
+          generated_at?: string
+          id?: string
+          initials_map?: Json
+          model?: string
+          summary_items?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "log_summaries_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quiz_questions: {
+        Row: {
+          correct_option: number | null
+          created_at: string
+          id: string
+          options: Json
+          position: number
+          question_text: string
+          quiz_id: string
+          updated_at: string
+        }
+        Insert: {
+          correct_option?: number | null
+          created_at?: string
+          id?: string
+          options: Json
+          position?: number
+          question_text: string
+          quiz_id: string
+          updated_at?: string
+        }
+        Update: {
+          correct_option?: number | null
+          created_at?: string
+          id?: string
+          options?: Json
+          position?: number
+          question_text?: string
+          quiz_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quiz_questions_quiz_id_fkey"
+            columns: ["quiz_id"]
+            isOneToOne: false
+            referencedRelation: "quizzes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quiz_responses: {
+        Row: {
+          id: string
+          question_id: string
+          quiz_id: string
+          selected_option: number
+          student_id: string
+          submitted_at: string
+        }
+        Insert: {
+          id?: string
+          question_id: string
+          quiz_id: string
+          selected_option: number
+          student_id: string
+          submitted_at?: string
+        }
+        Update: {
+          id?: string
+          question_id?: string
+          quiz_id?: string
+          selected_option?: number
+          student_id?: string
+          submitted_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quiz_responses_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "quiz_questions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quiz_responses_quiz_id_fkey"
+            columns: ["quiz_id"]
+            isOneToOne: false
+            referencedRelation: "quizzes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quiz_responses_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quiz_student_scores: {
+        Row: {
+          created_at: string
+          graded_at: string | null
+          graded_by: string | null
+          id: string
+          manual_override_score: number | null
+          quiz_id: string
+          student_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          manual_override_score?: number | null
+          quiz_id: string
+          student_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          manual_override_score?: number | null
+          quiz_id?: string
+          student_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quiz_student_scores_quiz_id_fkey"
+            columns: ["quiz_id"]
+            isOneToOne: false
+            referencedRelation: "quizzes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quiz_student_scores_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quizzes: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          created_by: string
+          gradebook_weight: number
+          id: string
+          include_in_final: boolean
+          opens_at: string | null
+          points_possible: number
+          position: number
+          show_results: boolean
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          created_by: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          opens_at?: string | null
+          points_possible?: number
+          position?: number
+          show_results?: boolean
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          created_by?: string
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          opens_at?: string | null
+          points_possible?: number
+          position?: number
+          show_results?: boolean
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quizzes_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quizzes_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      report_card_rows: {
+        Row: {
+          created_at: string
+          final_percent: number
+          id: string
+          report_card_id: string
+          student_id: string
+          teacher_comment: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          final_percent: number
+          id?: string
+          report_card_id: string
+          student_id: string
+          teacher_comment?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          final_percent?: number
+          id?: string
+          report_card_id?: string
+          student_id?: string
+          teacher_comment?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "report_card_rows_report_card_id_fkey"
+            columns: ["report_card_id"]
+            isOneToOne: false
+            referencedRelation: "report_cards"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "report_card_rows_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      report_cards: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          created_by: string
+          id: string
+          locked_at: string | null
+          term: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          created_by: string
+          id?: string
+          locked_at?: string | null
+          term: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          locked_at?: string | null
+          term?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "report_cards_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "report_cards_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_profiles: {
+        Row: {
+          created_at: string
+          first_name: string
+          id: string
+          last_name: string
+          student_number: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          first_name: string
+          id?: string
+          last_name: string
+          student_number?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          first_name?: string
+          id?: string
+          last_name?: string
+          student_number?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_profiles_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      survey_questions: {
+        Row: {
+          created_at: string
+          id: string
+          options: Json
+          position: number
+          question_text: string
+          question_type: string
+          response_max_chars: number
+          survey_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          options?: Json
+          position?: number
+          question_text: string
+          question_type?: string
+          response_max_chars?: number
+          survey_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          options?: Json
+          position?: number
+          question_text?: string
+          question_type?: string
+          response_max_chars?: number
+          survey_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "survey_questions_survey_id_fkey"
+            columns: ["survey_id"]
+            isOneToOne: false
+            referencedRelation: "surveys"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      survey_responses: {
+        Row: {
+          id: string
+          question_id: string
+          response_text: string | null
+          selected_option: number | null
+          student_id: string
+          submitted_at: string
+          survey_id: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          question_id: string
+          response_text?: string | null
+          selected_option?: number | null
+          student_id: string
+          submitted_at?: string
+          survey_id: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          question_id?: string
+          response_text?: string | null
+          selected_option?: number | null
+          student_id?: string
+          submitted_at?: string
+          survey_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "survey_responses_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "survey_questions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survey_responses_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survey_responses_survey_id_fkey"
+            columns: ["survey_id"]
+            isOneToOne: false
+            referencedRelation: "surveys"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      surveys: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          created_by: string
+          dynamic_responses: boolean
+          id: string
+          opens_at: string | null
+          position: number
+          show_results: boolean
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          created_by: string
+          dynamic_responses?: boolean
+          id?: string
+          opens_at?: string | null
+          position: number
+          show_results?: boolean
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          created_by?: string
+          dynamic_responses?: boolean
+          id?: string
+          opens_at?: string | null
+          position?: number
+          show_results?: boolean
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "surveys_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "surveys_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_ai_grading_run_items: {
+        Row: {
+          attempt_count: number
+          completed_at: string | null
+          created_at: string
+          id: string
+          last_error_code: string | null
+          last_error_message: string | null
+          next_retry_at: string | null
+          question_id: string
+          queue_position: number
+          response_id: string
+          run_id: string
+          started_at: string | null
+          status: string
+          student_id: string
+          test_id: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          last_error_code?: string | null
+          last_error_message?: string | null
+          next_retry_at?: string | null
+          question_id: string
+          queue_position?: number
+          response_id: string
+          run_id: string
+          started_at?: string | null
+          status?: string
+          student_id: string
+          test_id: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          last_error_code?: string | null
+          last_error_message?: string | null
+          next_retry_at?: string | null
+          question_id?: string
+          queue_position?: number
+          response_id?: string
+          run_id?: string
+          started_at?: string | null
+          status?: string
+          student_id?: string
+          test_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_ai_grading_run_items_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "test_questions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_ai_grading_run_items_response_id_fkey"
+            columns: ["response_id"]
+            isOneToOne: false
+            referencedRelation: "test_responses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_ai_grading_run_items_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "test_ai_grading_runs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_ai_grading_run_items_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_ai_grading_run_items_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_ai_grading_runs: {
+        Row: {
+          completed_at: string | null
+          completed_count: number
+          created_at: string
+          eligible_student_count: number
+          error_samples_json: Json
+          failed_count: number
+          id: string
+          lease_expires_at: string | null
+          lease_token: string | null
+          model: string | null
+          processed_count: number
+          prompt_guideline_override: string | null
+          queued_response_count: number
+          requested_count: number
+          requested_student_ids_json: Json
+          selection_hash: string
+          skipped_already_graded_count: number
+          skipped_unanswered_count: number
+          started_at: string | null
+          status: string
+          test_id: string
+          triggered_by: string
+          updated_at: string
+        }
+        Insert: {
+          completed_at?: string | null
+          completed_count?: number
+          created_at?: string
+          eligible_student_count?: number
+          error_samples_json?: Json
+          failed_count?: number
+          id?: string
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          model?: string | null
+          processed_count?: number
+          prompt_guideline_override?: string | null
+          queued_response_count?: number
+          requested_count?: number
+          requested_student_ids_json?: Json
+          selection_hash: string
+          skipped_already_graded_count?: number
+          skipped_unanswered_count?: number
+          started_at?: string | null
+          status?: string
+          test_id: string
+          triggered_by: string
+          updated_at?: string
+        }
+        Update: {
+          completed_at?: string | null
+          completed_count?: number
+          created_at?: string
+          eligible_student_count?: number
+          error_samples_json?: Json
+          failed_count?: number
+          id?: string
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          model?: string | null
+          processed_count?: number
+          prompt_guideline_override?: string | null
+          queued_response_count?: number
+          requested_count?: number
+          requested_student_ids_json?: Json
+          selection_hash?: string
+          skipped_already_graded_count?: number
+          skipped_unanswered_count?: number
+          started_at?: string | null
+          status?: string
+          test_id?: string
+          triggered_by?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_ai_grading_runs_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_ai_grading_runs_triggered_by_fkey"
+            columns: ["triggered_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_attempt_history: {
+        Row: {
+          char_count: number
+          created_at: string
+          id: string
+          keystroke_count: number
+          paste_word_count: number
+          patch: Json | null
+          snapshot: Json | null
+          test_attempt_id: string
+          trigger: string
+          word_count: number
+        }
+        Insert: {
+          char_count?: number
+          created_at?: string
+          id?: string
+          keystroke_count?: number
+          paste_word_count?: number
+          patch?: Json | null
+          snapshot?: Json | null
+          test_attempt_id: string
+          trigger: string
+          word_count?: number
+        }
+        Update: {
+          char_count?: number
+          created_at?: string
+          id?: string
+          keystroke_count?: number
+          paste_word_count?: number
+          patch?: Json | null
+          snapshot?: Json | null
+          test_attempt_id?: string
+          trigger?: string
+          word_count?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_attempt_history_test_attempt_id_fkey"
+            columns: ["test_attempt_id"]
+            isOneToOne: false
+            referencedRelation: "test_attempts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_attempts: {
+        Row: {
+          authenticity_flags: Json | null
+          authenticity_score: number | null
+          closed_for_grading_at: string | null
+          closed_for_grading_by: string | null
+          created_at: string
+          id: string
+          is_submitted: boolean
+          responses: Json
+          returned_at: string | null
+          returned_by: string | null
+          student_id: string
+          submitted_at: string | null
+          test_id: string
+          updated_at: string
+        }
+        Insert: {
+          authenticity_flags?: Json | null
+          authenticity_score?: number | null
+          closed_for_grading_at?: string | null
+          closed_for_grading_by?: string | null
+          created_at?: string
+          id?: string
+          is_submitted?: boolean
+          responses?: Json
+          returned_at?: string | null
+          returned_by?: string | null
+          student_id: string
+          submitted_at?: string | null
+          test_id: string
+          updated_at?: string
+        }
+        Update: {
+          authenticity_flags?: Json | null
+          authenticity_score?: number | null
+          closed_for_grading_at?: string | null
+          closed_for_grading_by?: string | null
+          created_at?: string
+          id?: string
+          is_submitted?: boolean
+          responses?: Json
+          returned_at?: string | null
+          returned_by?: string | null
+          student_id?: string
+          submitted_at?: string | null
+          test_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_attempts_closed_for_grading_by_fkey"
+            columns: ["closed_for_grading_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_attempts_returned_by_fkey"
+            columns: ["returned_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_attempts_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_attempts_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_focus_events: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          metadata: Json | null
+          occurred_at: string
+          session_id: string
+          student_id: string
+          test_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          metadata?: Json | null
+          occurred_at?: string
+          session_id: string
+          student_id: string
+          test_id: string
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          metadata?: Json | null
+          occurred_at?: string
+          session_id?: string
+          student_id?: string
+          test_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_focus_events_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_focus_events_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_questions: {
+        Row: {
+          ai_reference_cache_answers: Json | null
+          ai_reference_cache_generated_at: string | null
+          ai_reference_cache_key: string | null
+          ai_reference_cache_model: string | null
+          answer_key: string | null
+          correct_option: number | null
+          created_at: string
+          id: string
+          options: Json
+          points: number
+          position: number
+          question_text: string
+          question_type: string
+          response_max_chars: number
+          response_monospace: boolean
+          sample_solution: string | null
+          test_id: string
+          updated_at: string
+        }
+        Insert: {
+          ai_reference_cache_answers?: Json | null
+          ai_reference_cache_generated_at?: string | null
+          ai_reference_cache_key?: string | null
+          ai_reference_cache_model?: string | null
+          answer_key?: string | null
+          correct_option?: number | null
+          created_at?: string
+          id?: string
+          options?: Json
+          points?: number
+          position?: number
+          question_text: string
+          question_type?: string
+          response_max_chars?: number
+          response_monospace?: boolean
+          sample_solution?: string | null
+          test_id: string
+          updated_at?: string
+        }
+        Update: {
+          ai_reference_cache_answers?: Json | null
+          ai_reference_cache_generated_at?: string | null
+          ai_reference_cache_key?: string | null
+          ai_reference_cache_model?: string | null
+          answer_key?: string | null
+          correct_option?: number | null
+          created_at?: string
+          id?: string
+          options?: Json
+          points?: number
+          position?: number
+          question_text?: string
+          question_type?: string
+          response_max_chars?: number
+          response_monospace?: boolean
+          sample_solution?: string | null
+          test_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_questions_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_responses: {
+        Row: {
+          ai_grading_basis: string | null
+          ai_model: string | null
+          ai_reference_answers: Json | null
+          feedback: string | null
+          graded_at: string | null
+          graded_by: string | null
+          id: string
+          question_id: string
+          response_text: string | null
+          score: number | null
+          selected_option: number | null
+          student_id: string
+          submitted_at: string
+          test_id: string
+        }
+        Insert: {
+          ai_grading_basis?: string | null
+          ai_model?: string | null
+          ai_reference_answers?: Json | null
+          feedback?: string | null
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          question_id: string
+          response_text?: string | null
+          score?: number | null
+          selected_option?: number | null
+          student_id: string
+          submitted_at?: string
+          test_id: string
+        }
+        Update: {
+          ai_grading_basis?: string | null
+          ai_model?: string | null
+          ai_reference_answers?: Json | null
+          feedback?: string | null
+          graded_at?: string | null
+          graded_by?: string | null
+          id?: string
+          question_id?: string
+          response_text?: string | null
+          score?: number | null
+          selected_option?: number | null
+          student_id?: string
+          submitted_at?: string
+          test_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_responses_graded_by_fkey"
+            columns: ["graded_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_responses_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "test_questions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_responses_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_responses_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test_student_availability: {
+        Row: {
+          created_at: string
+          id: string
+          state: string
+          student_id: string
+          test_id: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          state: string
+          student_id: string
+          test_id: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          state?: string
+          student_id?: string
+          test_id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "test_student_availability_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_student_availability_test_id_fkey"
+            columns: ["test_id"]
+            isOneToOne: false
+            referencedRelation: "tests"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "test_student_availability_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tests: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          created_by: string
+          documents: Json
+          gradebook_weight: number
+          id: string
+          include_in_final: boolean
+          points_possible: number
+          position: number
+          show_results: boolean
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          created_by: string
+          documents?: Json
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          points_possible?: number
+          position?: number
+          show_results?: boolean
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          created_by?: string
+          documents?: Json
+          gradebook_weight?: number
+          id?: string
+          include_in_final?: boolean
+          points_possible?: number
+          position?: number
+          show_results?: boolean
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tests_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tests_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_github_identities: {
+        Row: {
+          commit_emails: string[]
+          created_at: string
+          github_login: string | null
+          id: string
+          updated_at: string
+          user_id: string
+          validated_at: string | null
+          validation_message: string | null
+          validation_status: string
+        }
+        Insert: {
+          commit_emails?: string[]
+          created_at?: string
+          github_login?: string | null
+          id?: string
+          updated_at?: string
+          user_id: string
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Update: {
+          commit_emails?: string[]
+          created_at?: string
+          github_login?: string | null
+          id?: string
+          updated_at?: string
+          user_id?: string
+          validated_at?: string | null
+          validation_message?: string | null
+          validation_status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_github_identities_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          created_at: string
+          email: string
+          email_verified_at: string | null
+          id: string
+          password_hash: string | null
+          role: string
+          workos_user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          email: string
+          email_verified_at?: string | null
+          id?: string
+          password_hash?: string | null
+          role: string
+          workos_user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          email_verified_at?: string | null
+          id?: string
+          password_hash?: string | null
+          role?: string
+          workos_user_id?: string | null
+        }
+        Relationships: []
+      }
+      verification_codes: {
+        Row: {
+          attempts: number
+          code_hash: string
+          created_at: string
+          expires_at: string
+          handoff_consumed_at: string | null
+          handoff_expires_at: string | null
+          handoff_token_hash: string | null
+          id: string
+          purpose: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          attempts?: number
+          code_hash: string
+          created_at?: string
+          expires_at: string
+          handoff_consumed_at?: string | null
+          handoff_expires_at?: string | null
+          handoff_token_hash?: string | null
+          id?: string
+          purpose: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          attempts?: number
+          code_hash?: string
+          created_at?: string
+          expires_at?: string
+          handoff_consumed_at?: string | null
+          handoff_expires_at?: string | null
+          handoff_token_hash?: string | null
+          id?: string
+          purpose?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "verification_codes_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      begin_classroom_archive_compaction: {
+        Args: {
+          p_archive_id: string
+          p_classroom_id: string
+          p_operation_id: string
+          p_request_sha256: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      begin_classroom_archive_export: {
+        Args: {
+          p_classroom_id: string
+          p_operation_id: string
+          p_request_sha256: string
+          p_retention: Json
+          p_source_app_commit: string
+          p_source_schema_migration: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      begin_classroom_archive_restore: {
+        Args: {
+          p_adapter_chain: Json
+          p_archive_id: string
+          p_classroom_id: string
+          p_database_budget_bytes: number
+          p_operation_id: string
+          p_request_sha256: string
+          p_resource_counts: Json
+          p_storage_objects: Json
+          p_target_schema_migration: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      begin_classroom_gradex_extract: {
+        Args: {
+          p_classroom_id: string
+          p_delete_after: string
+          p_operation_id: string
+          p_request_sha256: string
+          p_source_archive_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      claim_assignment_ai_grading_run: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_run_id: string
+        }
+        Returns: {
+          assignment_id: string
+          completed_at: string | null
+          completed_count: number
+          created_at: string
+          error_samples_json: Json
+          failed_count: number
+          gradable_count: number
+          gradex_last_polled_at: string | null
+          gradex_run_id: string | null
+          gradex_status: string | null
+          gradex_submitted_at: string | null
+          id: string
+          lease_expires_at: string | null
+          lease_token: string | null
+          model: string | null
+          processed_count: number
+          requested_count: number
+          requested_student_ids_json: Json
+          selection_hash: string
+          skipped_empty_count: number
+          skipped_missing_count: number
+          started_at: string | null
+          status: string
+          triggered_by: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "assignment_ai_grading_runs"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      claim_due_classroom_archive_object_upload_cleanup: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_limit?: number
+        }
+        Returns: {
+          attempt_count: number
+          operation_id: string
+          storage_bucket: string
+          storage_path: string
+        }[]
+      }
+      claim_due_classroom_archive_source_object_cleanup: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_limit?: number
+          p_operation_id: string
+        }
+        Returns: {
+          archive_id: string
+          attempt_count: number
+          classroom_id: string
+          expected_byte_size: number
+          expected_sha256: string
+          operation_id: string
+          storage_bucket: string
+          storage_path: string
+        }[]
+      }
+      claim_due_classroom_gradex_extract_cleanup: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_limit?: number
+          p_operation_id: string
+        }
+        Returns: {
+          attempt_count: number
+          extract_id: string
+          storage_bucket: string
+          storage_path: string
+        }[]
+      }
+      claim_test_ai_grading_run: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_run_id: string
+        }
+        Returns: {
+          completed_at: string | null
+          completed_count: number
+          created_at: string
+          eligible_student_count: number
+          error_samples_json: Json
+          failed_count: number
+          id: string
+          lease_expires_at: string | null
+          lease_token: string | null
+          model: string | null
+          processed_count: number
+          prompt_guideline_override: string | null
+          queued_response_count: number
+          requested_count: number
+          requested_student_ids_json: Json
+          selection_hash: string
+          skipped_already_graded_count: number
+          skipped_unanswered_count: number
+          started_at: string | null
+          status: string
+          test_id: string
+          triggered_by: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "test_ai_grading_runs"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      cleanup_expired_classroom_archive_snapshots: {
+        Args: never
+        Returns: number
+      }
+      close_test_for_grading_atomic: {
+        Args: { p_closed_by: string; p_test_id: string }
+        Returns: Json
+      }
+      complete_classroom_archive_compaction: {
+        Args: {
+          p_actors: Json
+          p_operation_id: string
+          p_teacher_id: string
+          p_verification: Json
+        }
+        Returns: Json
+      }
+      complete_classroom_archive_export: {
+        Args: {
+          p_artifact_sha256: string
+          p_compressed_byte_size: number
+          p_content_sha256: string
+          p_operation_id: string
+          p_resource_counts: Json
+          p_storage_bucket: string
+          p_storage_object_counts: Json
+          p_storage_path: string
+          p_teacher_id: string
+          p_uncompressed_byte_size: number
+          p_verification: Json
+        }
+        Returns: Json
+      }
+      complete_classroom_archive_object_upload_cleanup: {
+        Args: {
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      complete_classroom_archive_restore: {
+        Args: {
+          p_operation_id: string
+          p_teacher_id: string
+          p_verification: Json
+        }
+        Returns: Json
+      }
+      complete_classroom_archive_source_object_cleanup: {
+        Args: {
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      complete_classroom_gradex_extract: {
+        Args: {
+          p_artifact_sha256: string
+          p_compressed_byte_size: number
+          p_content_sha256: string
+          p_operation_id: string
+          p_resource_counts: Json
+          p_teacher_id: string
+          p_uncompressed_byte_size: number
+          p_verification: Json
+        }
+        Returns: Json
+      }
+      complete_classroom_gradex_extract_cleanup: {
+        Args: { p_extract_id: string; p_lease_token: string }
+        Returns: boolean
+      }
+      create_assignment_ai_grading_run_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_gradable_count: number
+          p_item_rows: Json
+          p_model: string
+          p_now?: string
+          p_requested_student_ids: string[]
+          p_selection_hash: string
+          p_skipped_empty_count: number
+          p_skipped_missing_count: number
+          p_teacher_id: string
+        }
+        Returns: {
+          assignment_id: string
+          completed_at: string | null
+          completed_count: number
+          created_at: string
+          error_samples_json: Json
+          failed_count: number
+          gradable_count: number
+          gradex_last_polled_at: string | null
+          gradex_run_id: string | null
+          gradex_status: string | null
+          gradex_submitted_at: string | null
+          id: string
+          lease_expires_at: string | null
+          lease_token: string | null
+          model: string | null
+          processed_count: number
+          requested_count: number
+          requested_student_ids_json: Json
+          selection_hash: string
+          skipped_empty_count: number
+          skipped_missing_count: number
+          started_at: string | null
+          status: string
+          triggered_by: string
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "assignment_ai_grading_runs"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      create_course_blueprint_atomic: {
+        Args: {
+          p_expected_source_revision: number
+          p_operation_id: string
+          p_operation_type: string
+          p_plan: Json
+          p_request_sha256: string
+          p_source_classroom_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      delete_student_test_attempt_atomic: {
+        Args: { p_student_id: string; p_test_id: string }
+        Returns: Json
+      }
+      delete_student_test_attempts_atomic: {
+        Args: { p_student_ids: string[]; p_test_id: string }
+        Returns: Json
+      }
+      fail_classroom_archive_compaction: {
+        Args: {
+          p_error_code: string
+          p_operation_id: string
+          p_retryable: boolean
+          p_teacher_id: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_archive_export: {
+        Args: {
+          p_error_code: string
+          p_operation_id: string
+          p_retryable: boolean
+          p_teacher_id: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_archive_object_upload_cleanup: {
+        Args: {
+          p_error_code: string
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_archive_restore: {
+        Args: {
+          p_error_code: string
+          p_operation_id: string
+          p_retryable: boolean
+          p_teacher_id: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_archive_source_object_cleanup: {
+        Args: {
+          p_error_code: string
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_gradex_extract: {
+        Args: {
+          p_error_code: string
+          p_operation_id: string
+          p_retryable: boolean
+          p_teacher_id: string
+        }
+        Returns: boolean
+      }
+      fail_classroom_gradex_extract_cleanup: {
+        Args: {
+          p_error_code: string
+          p_extract_id: string
+          p_lease_token: string
+        }
+        Returns: boolean
+      }
+      finalize_test_attempts_for_grading_atomic: {
+        Args: {
+          p_closed_by: string
+          p_student_ids: string[]
+          p_test_id: string
+        }
+        Returns: Json
+      }
+      get_teacher_log_history_preview: {
+        Args: {
+          p_classroom_id: string
+          p_limit?: number
+          p_student_ids: string[]
+        }
+        Returns: {
+          classroom_id: string
+          created_at: string
+          date: string
+          id: string
+          minutes_reported: number
+          mood: string
+          on_time: boolean
+          rich_content: Json
+          student_id: string
+          text: string
+          updated_at: string
+          version: number
+        }[]
+      }
+      instantiate_course_blueprint_atomic: {
+        Args: {
+          p_blueprint_id: string
+          p_expected_content_revision: number
+          p_operation_id: string
+          p_plan: Json
+          p_request_sha256: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      remove_classroom_roster_entries_atomic: {
+        Args: { p_classroom_id: string; p_roster_ids: string[] }
+        Returns: Json
+      }
+      renew_classroom_archive_object_upload_cleanup_lease: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      renew_classroom_archive_source_object_cleanup_lease: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+        }
+        Returns: boolean
+      }
+      renew_classroom_gradex_extract_cleanup_lease: {
+        Args: {
+          p_extract_id: string
+          p_lease_seconds?: number
+          p_lease_token: string
+        }
+        Returns: boolean
+      }
+      reorder_assignments_preserve_materials: {
+        Args: { p_assignment_ids: Json; p_classroom_id: string }
+        Returns: undefined
+      }
+      reorder_classwork_items: {
+        Args: { p_classroom_id: string; p_items: Json }
+        Returns: undefined
+      }
+      replace_assignment_submission_requirements_atomic: {
+        Args: { p_assignment_id: string; p_requirements: Json }
+        Returns: {
+          assignment_id: string
+          created_at: string
+          id: string
+          instructions: string
+          label: string
+          position: number
+          required: boolean
+          type: string
+          updated_at: string
+          validation_policy_json: Json
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "assignment_submission_requirements"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      resolve_classroom_archive_resource_classroom_id: {
+        Args: { p_row_id: string; p_table_name: string }
+        Returns: string
+      }
+      return_assignment_docs_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_now?: string
+          p_student_ids: string[]
+          p_teacher_id: string
+        }
+        Returns: {
+          returned_count: number
+          skipped_count: number
+        }[]
+      }
+      return_test_attempts_atomic: {
+        Args: {
+          p_returned_by: string
+          p_student_ids: string[]
+          p_submitted_at_by_student?: Json
+          p_test_id: string
+        }
+        Returns: Json
+      }
+      stage_classroom_archive_compaction_objects: {
+        Args: { p_objects: Json; p_operation_id: string; p_teacher_id: string }
+        Returns: Json
+      }
+      stage_classroom_archive_object_upload: {
+        Args: {
+          p_expected_byte_size: number
+          p_expected_sha256: string
+          p_operation_id: string
+          p_storage_bucket: string
+          p_storage_path: string
+          p_teacher_id: string
+        }
+        Returns: boolean
+      }
+      stage_classroom_archive_restore_rows: {
+        Args: {
+          p_operation_id: string
+          p_rows: Json
+          p_table_name: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      unsubmit_test_attempts_atomic: {
+        Args: {
+          p_student_ids: string[]
+          p_test_id: string
+          p_updated_by: string
+        }
+        Returns: Json
+      }
+      update_test_student_access_atomic: {
+        Args: {
+          p_state: string
+          p_student_ids: string[]
+          p_test_id: string
+          p_updated_by: string
+        }
+        Returns: Json
+      }
+      upsert_developer_feedback_candidate: {
+        Args: {
+          p_affected_area: string
+          p_confidence: number
+          p_dedupe_key: string
+          p_implementation_hint: string
+          p_model: string
+          p_original_request: string
+          p_refined_request: string
+          p_source_classroom_id: string
+          p_source_date: string
+          p_source_entry_count: number
+          p_suggested_agent: string
+          p_title: string
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,324 @@
+import type {
+  AssignmentSubmissionRequirementDraft,
+  AssignmentSubmissionValidationPolicyJson,
+} from '@/lib/assignment-submission-requirements'
+import type { Database as GeneratedDatabase, Json } from '@/types/database.generated'
+import type {
+  ActualCourseSiteConfig,
+  AssessmentDraftContent,
+  AssessmentDraftType,
+  AssignmentAiGradingRunErrorSample,
+  AssignmentAiGradingRunStatus,
+  AuthenticityFlag,
+  PlannedCourseSiteConfig,
+  RepoReviewEvidenceItem,
+  RepoReviewSemanticBreakdown,
+  RepoReviewTimelinePoint,
+  RepoReviewWarning,
+  SurveyStatus,
+  TestAiGradingRunErrorSample,
+  TestAiGradingRunStatus,
+  TestDocument,
+  TestDraftContent,
+  TestFocusEventType,
+  TestQuestionType,
+  TiptapContent,
+  UserRole,
+} from '@/types'
+
+type Replace<Base, Changes> = Omit<Base, keyof Changes> & Changes
+type PublicSchema = GeneratedDatabase['public']
+type GeneratedTables = PublicSchema['Tables']
+type GeneratedFunctions = PublicSchema['Functions']
+
+type TableContract<
+  Name extends keyof GeneratedTables,
+  RowChanges,
+  InsertChanges = Partial<RowChanges>,
+  UpdateChanges = Partial<InsertChanges>,
+> = Replace<GeneratedTables[Name], {
+  Row: Replace<GeneratedTables[Name]['Row'], RowChanges>
+  Insert: Replace<GeneratedTables[Name]['Insert'], InsertChanges>
+  Update: Replace<GeneratedTables[Name]['Update'], UpdateChanges>
+}>
+
+type FunctionContract<
+  Name extends keyof GeneratedFunctions,
+  ReturnValue,
+  Args = GeneratedFunctions[Name]['Args'],
+> = Replace<GeneratedFunctions[Name], { Args: Args; Returns: ReturnValue }>
+
+type TestMutationCounts = {
+  deleted_attempts: number
+  deleted_responses: number
+  deleted_focus_events: number
+  deleted_ai_grading_items: number
+}
+
+type TestWorkDeletionCounts = TestMutationCounts & {
+  requested_count: number
+  deleted_student_count: number
+}
+
+type TestAccessMutationCounts = {
+  locked_count: number
+  unlocked_count: number
+  inserted_responses: number
+}
+
+type UnsubmittedAttempt = {
+  id: string
+  student_id: string
+  responses: Json
+}
+
+type RosterRemovalCounts = {
+  requested_count: number
+  deleted_roster_entries: number
+  deleted_entries: number
+  deleted_assignment_docs: number
+  deleted_enrollments: number
+}
+
+type TableOverrides = {
+  assessment_drafts: TableContract<
+    'assessment_drafts',
+    { assessment_type: AssessmentDraftType; content: AssessmentDraftContent | TestDraftContent },
+    { assessment_type: AssessmentDraftType; content: AssessmentDraftContent | TestDraftContent },
+    { assessment_type?: AssessmentDraftType; content?: AssessmentDraftContent | TestDraftContent }
+  >
+  assignment_ai_grading_runs: TableContract<
+    'assignment_ai_grading_runs',
+    {
+      error_samples_json: AssignmentAiGradingRunErrorSample[]
+      requested_student_ids_json: string[]
+      status: AssignmentAiGradingRunStatus
+    },
+    {
+      error_samples_json?: AssignmentAiGradingRunErrorSample[]
+      requested_student_ids_json?: string[]
+      status?: AssignmentAiGradingRunStatus
+    }
+  >
+  assignment_doc_history: TableContract<
+    'assignment_doc_history',
+    { snapshot: TiptapContent | null },
+    { snapshot?: TiptapContent | null }
+  >
+  assignment_docs: TableContract<
+    'assignment_docs',
+    { authenticity_flags: AuthenticityFlag[] | null; content: TiptapContent },
+    { authenticity_flags?: AuthenticityFlag[] | null; content?: TiptapContent }
+  >
+  assignment_repo_review_results: TableContract<
+    'assignment_repo_review_results',
+    {
+      evidence_json: RepoReviewEvidenceItem[]
+      semantic_breakdown_json: RepoReviewSemanticBreakdown
+      timeline_json: RepoReviewTimelinePoint[]
+    },
+    {
+      evidence_json?: RepoReviewEvidenceItem[]
+      semantic_breakdown_json?: RepoReviewSemanticBreakdown
+      timeline_json?: RepoReviewTimelinePoint[]
+    }
+  >
+  assignment_repo_review_runs: TableContract<
+    'assignment_repo_review_runs',
+    { warnings_json: RepoReviewWarning[] },
+    { warnings_json?: RepoReviewWarning[] }
+  >
+  assignment_submission_requirements: TableContract<
+    'assignment_submission_requirements',
+    { validation_policy_json: AssignmentSubmissionValidationPolicyJson },
+    { validation_policy_json?: AssignmentSubmissionValidationPolicyJson }
+  >
+  assignments: TableContract<
+    'assignments',
+    { rich_instructions: TiptapContent | null },
+    { rich_instructions?: TiptapContent | null }
+  >
+  classrooms: TableContract<
+    'classrooms',
+    { actual_site_config: ActualCourseSiteConfig },
+    { actual_site_config?: ActualCourseSiteConfig }
+  >
+  classroom_resources: TableContract<
+    'classroom_resources',
+    { content: TiptapContent },
+    { content?: TiptapContent }
+  >
+  classwork_materials: TableContract<
+    'classwork_materials',
+    { content: TiptapContent },
+    // The before-insert trigger assigns a position when compatibility code omits it.
+    { content?: TiptapContent; position?: number }
+  >
+  course_blueprint_assessments: TableContract<
+    'course_blueprint_assessments',
+    {
+      assessment_type: AssessmentDraftType
+      content: AssessmentDraftContent | TestDraftContent
+      documents: TestDocument[]
+    },
+    {
+      assessment_type: AssessmentDraftType
+      content?: AssessmentDraftContent | TestDraftContent
+      documents?: TestDocument[]
+    },
+    {
+      assessment_type?: AssessmentDraftType
+      content?: AssessmentDraftContent | TestDraftContent
+      documents?: TestDocument[]
+    }
+  >
+  course_blueprint_assignments: TableContract<
+    'course_blueprint_assignments',
+    { submission_requirements_json: AssignmentSubmissionRequirementDraft[] },
+    { submission_requirements_json?: AssignmentSubmissionRequirementDraft[] }
+  >
+  course_blueprints: TableContract<
+    'course_blueprints',
+    { planned_site_config: PlannedCourseSiteConfig },
+    { planned_site_config?: PlannedCourseSiteConfig }
+  >
+  entries: TableContract<
+    'entries',
+    { rich_content: TiptapContent | null },
+    { rich_content?: TiptapContent | null }
+  >
+  lesson_plans: TableContract<
+    'lesson_plans',
+    { content: TiptapContent },
+    { content?: TiptapContent }
+  >
+  surveys: TableContract<
+    'surveys',
+    { status: SurveyStatus },
+    { status?: SurveyStatus }
+  >
+  test_ai_grading_runs: TableContract<
+    'test_ai_grading_runs',
+    {
+      error_samples_json: TestAiGradingRunErrorSample[]
+      requested_student_ids_json: string[]
+      status: TestAiGradingRunStatus
+    },
+    {
+      error_samples_json?: TestAiGradingRunErrorSample[]
+      requested_student_ids_json?: string[]
+      status?: TestAiGradingRunStatus
+    }
+  >
+  test_attempts: TableContract<
+    'test_attempts',
+    { authenticity_flags: AuthenticityFlag[] | null },
+    { authenticity_flags?: AuthenticityFlag[] | null }
+  >
+  test_focus_events: TableContract<
+    'test_focus_events',
+    { event_type: TestFocusEventType },
+    { event_type: TestFocusEventType },
+    { event_type?: TestFocusEventType }
+  >
+  test_questions: TableContract<
+    'test_questions',
+    {
+      ai_reference_cache_answers: string[] | null
+      options: string[]
+      question_type: TestQuestionType
+    },
+    {
+      ai_reference_cache_answers?: string[] | null
+      options?: string[]
+      question_type?: TestQuestionType
+    }
+  >
+  tests: TableContract<
+    'tests',
+    { documents: TestDocument[]; status: 'draft' | 'active' | 'closed' },
+    { documents?: TestDocument[]; status?: 'draft' | 'active' | 'closed' }
+  >
+  users: TableContract<
+    'users',
+    { role: UserRole },
+    { role: UserRole },
+    { role?: UserRole }
+  >
+}
+
+type FunctionOverrides = {
+  claim_assignment_ai_grading_run: FunctionContract<
+    'claim_assignment_ai_grading_run',
+    TableOverrides['assignment_ai_grading_runs']['Row'][]
+  >
+  claim_test_ai_grading_run: FunctionContract<
+    'claim_test_ai_grading_run',
+    TableOverrides['test_ai_grading_runs']['Row'][]
+  >
+  close_test_for_grading_atomic: FunctionContract<
+    'close_test_for_grading_atomic',
+    { closed_count: number; finalized_attempts: number; inserted_responses: number }
+  >
+  create_assignment_ai_grading_run_atomic: FunctionContract<
+    'create_assignment_ai_grading_run_atomic',
+    TableOverrides['assignment_ai_grading_runs']['Row']
+  >
+  create_course_blueprint_atomic: FunctionContract<
+    'create_course_blueprint_atomic',
+    Json,
+    Replace<GeneratedFunctions['create_course_blueprint_atomic']['Args'], {
+      p_expected_source_revision: number | null
+      p_source_classroom_id: string | null
+    }>
+  >
+  delete_student_test_attempt_atomic: FunctionContract<
+    'delete_student_test_attempt_atomic',
+    TestMutationCounts
+  >
+  delete_student_test_attempts_atomic: FunctionContract<
+    'delete_student_test_attempts_atomic',
+    TestWorkDeletionCounts
+  >
+  finalize_test_attempts_for_grading_atomic: FunctionContract<
+    'finalize_test_attempts_for_grading_atomic',
+    { finalized_attempts: number; inserted_responses: number }
+  >
+  remove_classroom_roster_entries_atomic: FunctionContract<
+    'remove_classroom_roster_entries_atomic',
+    RosterRemovalCounts
+  >
+  return_test_attempts_atomic: FunctionContract<
+    'return_test_attempts_atomic',
+    { returned_count: number; updated_count: number; inserted_count: number }
+  >
+  unsubmit_test_attempts_atomic: FunctionContract<
+    'unsubmit_test_attempts_atomic',
+    { unsubmitted_count: number; deleted_responses: number; attempts: UnsubmittedAttempt[] }
+  >
+  upsert_developer_feedback_candidate: FunctionContract<
+    'upsert_developer_feedback_candidate',
+    Json,
+    Replace<GeneratedFunctions['upsert_developer_feedback_candidate']['Args'], {
+      p_affected_area: string | null
+      p_implementation_hint: string | null
+    }>
+  >
+  update_test_student_access_atomic: FunctionContract<
+    'update_test_student_access_atomic',
+    TestAccessMutationCounts
+  >
+}
+
+export type Database = Replace<GeneratedDatabase, {
+  public: Replace<PublicSchema, {
+    Tables: Omit<GeneratedTables, keyof TableOverrides> & TableOverrides
+    Functions: Omit<GeneratedFunctions, keyof FunctionOverrides> & FunctionOverrides
+  }>
+}>
+
+type Tables = Database['public']['Tables']
+
+export type TableRow<Name extends keyof Tables> = Tables[Name]['Row']
+export type TableInsert<Name extends keyof Tables> = Tables[Name]['Insert']
+export type TableUpdate<Name extends keyof Tables> = Tables[Name]['Update']

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -789,6 +789,47 @@ export type TestFocusEventType =
 export type TestQuestionType = 'multiple_choice' | 'open_response'
 export type TestDocumentSource = 'link' | 'upload' | 'text'
 
+export type AssessmentDraftType = 'quiz' | 'test'
+
+export type AssessmentDraftQuestion = {
+  id: string
+  question_text: string
+  options: string[]
+}
+
+export type QuizDraftQuestion = AssessmentDraftQuestion
+
+export type TestDraftQuestion = {
+  id: string
+  question_type: TestQuestionType
+  question_text: string
+  options: string[]
+  correct_option: number | null
+  answer_key: string | null
+  sample_solution: string | null
+  points: number
+  response_max_chars: number
+  response_monospace: boolean
+}
+
+export type AssessmentDraftContent = {
+  title: string
+  show_results: boolean
+  questions: AssessmentDraftQuestion[]
+  source_format?: 'markdown'
+  source_markdown?: string
+}
+
+export type QuizDraftContent = AssessmentDraftContent
+
+export type TestDraftContent = {
+  title: string
+  show_results: boolean
+  questions: TestDraftQuestion[]
+  source_format?: 'markdown'
+  source_markdown?: string
+}
+
 export interface TestDocument {
   id: string
   title: string

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -398,6 +398,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
       expect.objectContaining({
         assignment_id: 'assignment-1',
         student_id: 'student-4',
+        content: { type: 'doc', content: [] },
         is_submitted: false,
         submitted_at: null,
         score_completion: 0,

--- a/tests/unit/supabase-database-contract.test.ts
+++ b/tests/unit/supabase-database-contract.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { TiptapContent } from '@/types'
+import type { TableInsert, TableRow } from '@/types/database'
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+describe('generated Supabase database contract', () => {
+  it('types both central Supabase client factories', () => {
+    const source = readRepoFile('src/lib/supabase.ts')
+
+    expect(source).toContain("import type { Database } from '@/types/database'")
+    expect(source.match(/createClient<Database>/g)).toHaveLength(2)
+  })
+
+  it('refines generated JSON columns with application domain contracts', () => {
+    expectTypeOf<TableRow<'assignment_docs'>['content']>().toEqualTypeOf<TiptapContent>()
+    expectTypeOf<TableInsert<'test_ai_grading_runs'>['requested_student_ids_json']>()
+      .toEqualTypeOf<string[] | undefined>()
+    expectTypeOf<TableInsert<'classwork_materials'>['position']>()
+      .toEqualTypeOf<number | undefined>()
+  })
+
+  it('keeps generation and drift checks as explicit package commands', () => {
+    const packageJson = JSON.parse(readRepoFile('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['db:types:generate']).toBe(
+      'bash scripts/supabase-types.sh generate'
+    )
+    expect(packageJson.scripts?.['db:types:check']).toBe(
+      'bash scripts/supabase-types.sh check'
+    )
+    expect(readRepoFile('scripts/supabase-types.sh')).toContain(
+      'supabase migration list --local'
+    )
+  })
+
+  it('replays migrations in ephemeral CI before checking generated type drift', () => {
+    const workflow = readRepoFile('.github/workflows/ci.yml')
+    const databaseStartIndex = workflow.indexOf('supabase start ')
+    const typeCheckIndex = workflow.indexOf('pnpm run db:types:check')
+
+    expect(workflow).toContain('name: Architecture Database Contracts')
+    expect(databaseStartIndex).toBeGreaterThan(-1)
+    expect(typeCheckIndex).toBeGreaterThan(databaseStartIndex)
+  })
+})


### PR DESCRIPTION
## Summary

- generate and commit the public Supabase schema contract, then compose it with application-owned JSON, status, and RPC refinements
- type both central Supabase clients and replace exposed generic persisted payloads with table-specific row/insert/update contracts
- add reproducible generation/check commands and a CI job that replays migrations in an ephemeral database before rejecting type drift
- reject generation when a worktree's migration files and running local database have different migration histories
- preserve existing API response shapes while adapting legacy quiz field names at explicit boundaries
- fix blueprint instantiation when assignment points are null by allowing PostgreSQL to apply its 30-point default

## Why

Supabase query results and writes were effectively untyped at the shared client boundary. Schema drift, nullable blueprint fields, JSON payload assumptions, and RPC return shapes could therefore fail late or require broad casts. This slice makes the database schema a compiled contract without pretending generated PostgreSQL metadata can express every application domain type.

## Safety and rollout

- no migration files are added or changed
- no production access or mutation was performed
- no migration-application command was run locally
- CI starts an ephemeral local database and replays only the branch migrations before checking generated-type drift
- custom refinements remain separate from the generated file so regeneration is mechanical
- the shared local stack currently has migration `080` from another worktree, so the local preflight intentionally rejects generation on this `001-079` branch; the checked-in file is aligned to CI's clean branch replay

Risk profile: `runtime-platform`

## Validation

- `pnpm test` (311 files, 2785 tests)
- `pnpm build`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- local migration-history preflight rejects the mismatched shared stack (`database=080`, worktree missing `080`)
- focused contract, assignment, test, blueprint, grading, survey, resource, and material suites
- `bash .codex/skills/pika-audit/scripts/audit.sh`
