### PR TITLE
Add read-only archive production inventory

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,7 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Product status: core classroom, assignment, quiz/test, and auth flows are live.
 - Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
 - Feature inventory: `.ai/features.json` is the status authority for big epics; check it directly for current pass/fail state.
-- Classroom archives: migrations 082-086 cover export through cleanup. Restore is gated and idempotent. Compaction is server-only; source cleanup is hard-disabled pending ownership fencing. Abandoned uploads use separate, disabled-by-default leases. Production canaries remain.
+- Classroom archives: production migrations 082-086 are applied; read-only inventory passed for three hot archives. Direct PostgreSQL catalog audit and named canaries remain. Restore and compaction are gated; source cleanup is hard-disabled pending ownership fencing.
 
 ## Environment And Workflow Facts
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13473,3 +13473,21 @@
 - Playwright screenshots: `/tmp/pika-announcements-action-desktop-light-default.png`, `/tmp/pika-announcements-action-desktop-light-menu.png`, `/tmp/pika-announcements-action-mobile-light-default.png`, `/tmp/pika-announcements-action-mobile-light-menu.png`, `/tmp/pika-announcements-action-desktop-dark-default.png`, `/tmp/pika-announcements-action-desktop-dark-menu.png`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-06-23 — Student assignments cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a client read-cache consistency slice.
+- Replaced `StudentAssignmentsTab`'s three manual cached GET fetchers with the shared `fetchCachedJSON` helper for assignments, materials, and surveys.
+- Preserved existing cache keys, 20s TTLs, request-id stale response guard, classroom-change clearing, and optional survey fallback behavior.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,24 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-23 — Student assignments cached JSON
-
-**Completed:**
-- Continued the bounded architecture/UI improvement goal with a client read-cache consistency slice.
-- Replaced `StudentAssignmentsTab`'s three manual cached GET fetchers with the shared `fetchCachedJSON` helper for assignments, materials, and surveys.
-- Preserved existing cache keys, 20s TTLs, request-id stale response guard, classroom-change clearing, and optional survey fallback behavior.
-- Kept the slice non-visual: no layout, copy, or interaction changes.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `git diff --check`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-06-23 — Student calendar cached JSON
 
 **Completed:**
@@ -680,3 +662,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm run lint`
 - `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-07-14 — Read-only production classroom archive inventory
+
+**Risk profile:** runtime-platform
+
+**Model recommendation:** GPT-5 Codex - production verification crosses Supabase target safety, archive graph consistency, privacy-safe reporting, and fail-closed storage evidence.
+
+**Completed:**
+- Added a target-bound, read-only inventory command that requires the exact hosted Supabase project ref, validates deployed archive and Gradex contract rows, audits exposed PostgREST relationship metadata, and traverses the canonical 42-resource graph with exact-count pagination.
+- Bound the separately required direct PostgreSQL catalog audit to the same expected project ref for direct or Supabase pooler DSNs and required TLS.
+- Hardened the catalog runner against libpq DSN overrides and credential disclosure by allowlisting one TLS parameter, passing validated fields through `PG*` environment variables, sanitizing failures, and requiring either a hosted project ref or explicit loopback-only local mode.
+- Bracketed each hot archived classroom read with archive revisions, resolved managed objects through exact Storage metadata reads, and emitted only aggregate labels, counts, and byte sizes; missing referenced objects fail the command.
+- Ran the inventory against production after migrations 080-086 were applied: three hot archives, 44,813 relational rows, 42.2 MiB canonical relational payload, 165 referenced objects / 25.9 MiB, and zero missing objects or archive/restore/Gradex/cleanup operation rows.
+- Kept the archive epic unfinished. PostgREST metadata cannot prove hidden or stale catalog relationships, so the direct read-only PostgreSQL catalog audit remains required; no export, restore, Gradex, compaction, cleanup, row mutation, or Storage mutation was performed.
+
+**Validation:**
+- Final production read-only inventory passed after all review fixes
+- Full Vitest suite (345 files / 3,080 tests)
+- Focused inventory, catalog-runner, and service-client suites (35 tests)
+- Local read-only PostgreSQL catalog audit (117 foreign-key relationships)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture`
+- `pnpm build`
+- `git diff --check`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         run: pnpm exec tsx scripts/check-classroom-resource-schema.ts
         env:
           CLASSROOM_SCHEMA_AUDIT_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+          CLASSROOM_SCHEMA_AUDIT_LOCAL: "true"
 
       - name: Rehearse full classroom archive recovery on local Supabase
         run: pnpm verify:classroom-archive-recovery

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -87,6 +87,18 @@ service-role JWT and an exact destructive-operation acknowledgement, and rejects
 It creates and removes only a uniquely identified synthetic fixture. It must never be pointed at a
 hosted or production project.
 
+The production archive inventory is read-only and requires an exact expected project ref:
+
+```bash
+pnpm verify:classroom-archive-inventory -- \
+  --expected-project-ref "$(cat supabase/.temp/project-ref)"
+```
+
+It validates deployed archive/Gradex contracts and exposed PostgREST relationships, then reports
+privacy-safe row and managed-object sizing for hot archived classrooms. The direct database catalog
+audit documented in `docs/guidance/classroom-lifecycle-archives.md` remains separately required. The
+inventory does not create an archive or modify database or Storage state.
+
 ---
 
 ## Environment Variables (required)

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -140,9 +140,14 @@ Any migration that adds, removes, or changes a classroom-descendant foreign key 
 The read-only audit command compares PostgreSQL catalog relationships with the checked-in graph:
 
 ```bash
+CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF="$(cat supabase/.temp/project-ref)" \
 CLASSROOM_SCHEMA_AUDIT_DATABASE_URL="$DATABASE_URL" \
   pnpm exec tsx scripts/check-classroom-resource-schema.ts
 ```
+
+For a hosted audit, the command rejects local, mismatched, non-TLS, and unrelated database URLs.
+Use a direct `db.<project-ref>.supabase.co` URL or a Supabase pooler URL whose username is
+`postgres.<project-ref>`, and require `sslmode=require`, `verify-ca`, or `verify-full`.
 
 It fails for untracked or stale tables, missing restore dependencies, and invalid selection keys.
 Run it in database-backed CI after migrations are applied to the ephemeral database.
@@ -388,6 +393,39 @@ restore rollback, and archives without a successful read-back check.
 Production database access for inventory and verification is read-only unless a human explicitly
 approves a named canary operation. Migrations are applied by humans.
 
+Run the production inventory only after verifying the linked project. The command validates the
+expected project ref against `NEXT_PUBLIC_SUPABASE_URL`, compares the deployed 42-resource archive
+and 13-resource Gradex contracts with the checked-in definitions, audits exposed PostgREST
+primary/foreign key metadata, brackets each classroom read with its archive revision, and reports privacy-safe
+aggregate labels instead of classroom ids or content:
+
+```bash
+supabase projects list
+pnpm verify:classroom-archive-inventory -- \
+  --expected-project-ref "$(cat supabase/.temp/project-ref)"
+supabase inspect db db-stats --linked
+```
+
+The PostgREST schema check is privilege- and schema-cache-dependent, so it is not the authoritative
+catalog completeness check. Production verification must also run the direct `pg_constraint` and
+`pg_attribute` audit with a read-only database connection:
+
+```bash
+CLASSROOM_SCHEMA_AUDIT_DATABASE_URL="$DATABASE_URL" \
+CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF="$(cat supabase/.temp/project-ref)" \
+  pnpm exec tsx scripts/check-classroom-resource-schema.ts
+```
+
+`serialized_relational_bytes` is the canonical NDJSON payload size before tar/gzip compression. It
+is useful for comparing classrooms and estimating archive input, but it is not PostgreSQL disk usage
+and does not include indexes, tuple overhead, TOAST overhead, or reclaimable space. The Supabase
+database stats command reports database-wide physical usage separately. Managed-object bytes come
+from read-only Storage metadata. `estimated_uncompressed_archive_bytes` adds those object bytes to
+the relational payload only when every referenced object size is known; otherwise it is `null`.
+The final gzip size remains unknown until an export canary runs. A missing referenced object is
+reported directly and prevents a claim that all source objects are present;
+inventory alone does not claim that an export will succeed.
+
 ### Non-Production Recovery Rehearsal
 
 `pnpm verify:classroom-archive-recovery` exercises the complete runtime path against an already
@@ -437,6 +475,7 @@ Run the database-backed contract in an ephemeral Supabase instance:
 ```bash
 supabase db start
 bash scripts/check-classroom-archive-database.sh
+CLASSROOM_SCHEMA_AUDIT_LOCAL=true \
 CLASSROOM_SCHEMA_AUDIT_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres \
   pnpm exec tsx scripts/check-classroom-resource-schema.ts
 supabase stop --no-backup

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "verify:classroom-archive-recovery": "bash scripts/check-classroom-archive-recovery-drill.sh",
+    "verify:classroom-archive-inventory": "tsx scripts/inventory-classroom-archives.ts",
     "db:types:generate": "bash scripts/supabase-types.sh generate",
     "db:types:check": "bash scripts/supabase-types.sh check",
     "check:architecture": "tsx scripts/check-architecture.ts",

--- a/scripts/check-classroom-resource-schema.ts
+++ b/scripts/check-classroom-resource-schema.ts
@@ -4,6 +4,11 @@ import {
   type ClassroomSchemaPrimaryKey,
   type ClassroomSchemaRelationship,
 } from '../src/lib/contracts/classroom-data'
+import {
+  hostedSupabasePsqlEnvironment,
+  localSupabasePsqlEnvironment,
+  type PsqlConnectionEnvironment,
+} from '../src/lib/server/supabase-target'
 
 const schemaQuery = `
 with relationships as (
@@ -59,12 +64,44 @@ if (!databaseUrl) {
   process.stderr.write('CLASSROOM_SCHEMA_AUDIT_DATABASE_URL is required.\n')
   process.exit(2)
 }
+const expectedProjectRef = process.env.CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF
+const localMode = process.env.CLASSROOM_SCHEMA_AUDIT_LOCAL === 'true'
+if ((expectedProjectRef ? 1 : 0) + (localMode ? 1 : 0) !== 1) {
+  process.stderr.write(
+    'Set exactly one of CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF or CLASSROOM_SCHEMA_AUDIT_LOCAL=true.\n',
+  )
+  process.exit(2)
+}
+let connectionEnvironment: PsqlConnectionEnvironment
+try {
+  connectionEnvironment = expectedProjectRef
+    ? hostedSupabasePsqlEnvironment(databaseUrl, expectedProjectRef)
+    : localSupabasePsqlEnvironment(databaseUrl)
+} catch {
+  process.stderr.write('Classroom resource schema target validation failed.\n')
+  process.exit(2)
+}
+const childProcessEnvironment: NodeJS.ProcessEnv = {}
+for (const name of ['PATH', 'HOME', 'TMPDIR', 'LANG', 'LC_ALL'] as const) {
+  const value = process.env[name]
+  if (value !== undefined) childProcessEnvironment[name] = value
+}
 
-const output = execFileSync(
-  'psql',
-  ['--dbname', databaseUrl, '-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1', '-c', schemaQuery],
-  { encoding: 'utf8' },
-)
+let output: string
+try {
+  output = execFileSync(
+    'psql',
+    ['-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1', '-c', schemaQuery],
+    {
+      encoding: 'utf8',
+      env: { ...childProcessEnvironment, ...connectionEnvironment },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+} catch {
+  process.stderr.write('Classroom resource schema query failed for the validated target.\n')
+  process.exit(1)
+}
 const schema = JSON.parse(output.trim()) as {
   relationships: ClassroomSchemaRelationship[]
   primary_keys: ClassroomSchemaPrimaryKey[]
@@ -77,5 +114,6 @@ if (!audit.ok) {
 }
 
 process.stdout.write(
-  `Classroom resource schema contract passes (${schema.relationships.length} foreign-key relationships).\n`,
+  `Classroom resource schema contract passes (${schema.relationships.length} foreign-key relationships)` +
+  `${expectedProjectRef ? ` for project ${expectedProjectRef}` : ''}.\n`,
 )

--- a/scripts/inventory-classroom-archives.ts
+++ b/scripts/inventory-classroom-archives.ts
@@ -1,0 +1,98 @@
+import { config } from 'dotenv'
+import {
+  assertInventorySourceObjectsPresent,
+  createSupabaseClassroomArchiveInventoryReader,
+  inventoryArchivedClassrooms,
+  verifySupabaseInventoryTarget,
+} from '@/lib/server/classroom-archive-inventory'
+import { createTargetBoundFetch } from '@/lib/server/supabase-target'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+config({ path: process.env.ENV_FILE || '.env.local' })
+
+function readArgument(name: string): string | undefined {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return undefined
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`)
+  return value
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`
+}
+
+function formatKnownBytes(bytes: number | null): string {
+  return bytes === null ? 'unknown' : formatBytes(bytes)
+}
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const secretKey = process.env.SUPABASE_SECRET_KEY
+  const expectedProjectRef = readArgument('--expected-project-ref') ||
+    process.env.CLASSROOM_ARCHIVE_INVENTORY_EXPECTED_PROJECT_REF
+  if (!supabaseUrl || !secretKey) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SECRET_KEY are required')
+  }
+  if (!expectedProjectRef) {
+    throw new Error('--expected-project-ref is required')
+  }
+  const verifiedOrigin = verifySupabaseInventoryTarget(supabaseUrl, expectedProjectRef)
+  process.env.NEXT_PUBLIC_SUPABASE_URL = verifiedOrigin
+  const targetBoundFetch = createTargetBoundFetch(verifiedOrigin)
+  const reader = createSupabaseClassroomArchiveInventoryReader({
+    supabase: getServiceRoleClient({ fetch: targetBoundFetch }),
+    supabaseUrl: verifiedOrigin,
+    secretKey,
+  })
+  const inventory = await inventoryArchivedClassrooms(reader)
+  if (process.argv.includes('--json')) {
+    process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`)
+    assertInventorySourceObjectsPresent(inventory)
+    return
+  } else {
+    process.stdout.write('Classroom archive production inventory completed.\n')
+    process.stdout.write(
+      `Schema: ${inventory.schema.archive_resource_count} archive resources, ` +
+      `${inventory.schema.gradex_resource_count} Gradex resources, ` +
+      'PostgREST schema audit passed; direct database catalog audit remains required.\n',
+    )
+    for (const classroom of inventory.archived_hot) {
+      process.stdout.write(
+        `${classroom.label}: ${classroom.relational_row_count} rows, ` +
+        `${formatBytes(classroom.serialized_relational_bytes)} serialized relational data, ` +
+        `${classroom.storage_object_count} referenced objects / ` +
+        `${formatBytes(classroom.storage_metadata_bytes)}, ` +
+        `${formatKnownBytes(classroom.estimated_uncompressed_archive_bytes)} total uncompressed input, ` +
+        `${classroom.missing_storage_object_count} missing, ` +
+        `all source objects present=${classroom.source_objects_present}.\n`,
+      )
+    }
+    process.stdout.write(
+      `Totals: ${inventory.totals.archived_hot_count} hot archives, ` +
+      `${inventory.totals.relational_row_count} rows, ` +
+      `${formatBytes(inventory.totals.serialized_relational_bytes)} serialized relational data, ` +
+      `${inventory.totals.storage_object_count} referenced objects / ` +
+      `${formatBytes(inventory.totals.storage_metadata_bytes)}, ` +
+      `${formatKnownBytes(inventory.totals.estimated_uncompressed_archive_bytes)} total uncompressed input, ` +
+      `${inventory.totals.missing_storage_object_count} missing source objects.\n`,
+    )
+    process.stdout.write(
+      `Existing archive state: ${inventory.operations.verified_archives} verified archives, ` +
+      `${inventory.operations.cold_tombstones} cold tombstones, ` +
+      `${inventory.operations.archive_operations} operations, ` +
+      `${inventory.operations.gradex_extracts} Gradex extracts, ` +
+      `${inventory.operations.source_cleanup_rows} source-cleanup rows.\n`,
+    )
+  }
+  assertInventorySourceObjectsPresent(inventory)
+  process.stdout.write('Classroom archive production inventory passed.\n')
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : 'Unknown inventory failure'
+  process.stderr.write(`Classroom archive production inventory failed: ${message}\n`)
+  process.exitCode = 1
+})

--- a/src/lib/server/classroom-archive-inventory.ts
+++ b/src/lib/server/classroom-archive-inventory.ts
@@ -1,0 +1,582 @@
+import { z } from 'zod'
+import {
+  CLASSROOM_RELATIONAL_RESOURCES,
+  GRADEX_RESOURCE_TABLES,
+  auditClassroomResourceSchema,
+  getClassroomResourceOrder,
+  type ClassroomResourceTable,
+} from '@/lib/contracts/classroom-data'
+import {
+  canonicalJsonStringify,
+  discoverClassroomStorageReferences,
+} from '@/lib/server/classroom-archive-format'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { missingStorageObjectEvidence } from '@/lib/server/storage-object-evidence'
+import {
+  createTargetBoundFetch,
+  verifyHostedSupabaseApiOrigin,
+} from '@/lib/server/supabase-target'
+
+const uuidSchema = z.string().uuid()
+const jsonRowsSchema = z.array(z.record(z.string(), z.json()))
+const archivedClassroomsSchema = z.array(z.object({ id: uuidSchema }).strict())
+const revisionSchema = z.number().int().positive()
+
+const archiveContractRowSchema = z.object({
+  table_name: z.string().min(1),
+  primary_key_columns: z.array(z.string().min(1)).min(1),
+  parent_table: z.string().min(1).nullable(),
+  parent_column: z.string().min(1).nullable(),
+  actor_columns: z.array(z.string().min(1)),
+  restore_after: z.array(z.string().min(1)),
+  export_position: z.number().int().nonnegative(),
+}).strict()
+const archiveContractSchema = z.array(archiveContractRowSchema)
+const gradexContractSchema = z.array(z.object({ table_name: z.string().min(1) }).strict())
+
+const openApiPropertySchema = z.object({ description: z.string().optional() }).passthrough()
+const openApiSchema = z.object({
+  swagger: z.literal('2.0'),
+  definitions: z.record(z.string(), z.object({
+    properties: z.record(z.string(), openApiPropertySchema),
+  }).passthrough()),
+}).passthrough()
+
+const operationalCountsSchema = z.object({
+  verified_archives: z.number().int().nonnegative(),
+  cold_tombstones: z.number().int().nonnegative(),
+  archive_operations: z.number().int().nonnegative(),
+  gradex_extracts: z.number().int().nonnegative(),
+  source_cleanup_rows: z.number().int().nonnegative(),
+}).strict()
+
+const classroomInventorySchema = z.object({
+  label: z.string().regex(/^archived-hot-[1-9][0-9]*$/),
+  source_revision: revisionSchema,
+  relational_row_count: z.number().int().positive(),
+  serialized_relational_bytes: z.number().int().positive(),
+  storage_object_count: z.number().int().nonnegative(),
+  storage_metadata_bytes: z.number().int().nonnegative(),
+  estimated_uncompressed_archive_bytes: z.number().int().positive().nullable(),
+  missing_storage_object_count: z.number().int().nonnegative(),
+  source_objects_present: z.boolean(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+}).strict()
+
+const archiveInventorySchema = z.object({
+  generated_at: z.string().datetime({ offset: true }),
+  schema: z.object({
+    archive_resource_count: z.literal(42),
+    gradex_resource_count: z.literal(13),
+    postgrest_schema_audit_passed: z.literal(true),
+  }).strict(),
+  archived_hot: z.array(classroomInventorySchema),
+  totals: z.object({
+    archived_hot_count: z.number().int().nonnegative(),
+    relational_row_count: z.number().int().nonnegative(),
+    serialized_relational_bytes: z.number().int().nonnegative(),
+    storage_object_count: z.number().int().nonnegative(),
+    storage_metadata_bytes: z.number().int().nonnegative(),
+    estimated_uncompressed_archive_bytes: z.number().int().nonnegative().nullable(),
+    missing_storage_object_count: z.number().int().nonnegative(),
+  }).strict(),
+  operations: operationalCountsSchema,
+}).strict()
+
+export type ClassroomArchiveInventory = z.infer<typeof archiveInventorySchema>
+
+export type ResourceRead = {
+  table: ClassroomResourceTable
+  filterColumn: string
+  values: string[]
+  primaryKey: string
+}
+
+export interface ClassroomArchiveInventoryReader {
+  readonly supabaseUrl: string
+  readOpenApiSchema(): Promise<unknown>
+  readArchiveResourceContract(): Promise<unknown>
+  readGradexResourceContract(): Promise<unknown>
+  readArchivedClassrooms(): Promise<unknown>
+  readRevision(classroomId: string): Promise<unknown>
+  readResourceRows(query: ResourceRead): Promise<unknown>
+  readStorageObjectSize(bucket: string, path: string): Promise<unknown>
+  readOperationalCounts(): Promise<unknown>
+}
+
+export function verifySupabaseInventoryTarget(
+  supabaseUrl: string,
+  expectedProjectRef: string,
+): string {
+  return verifyHostedSupabaseApiOrigin(supabaseUrl, expectedProjectRef)
+}
+
+export function assertInventorySourceObjectsPresent(inventory: ClassroomArchiveInventory): void {
+  if (inventory.totals.missing_storage_object_count > 0) {
+    throw new Error(
+      `Read-only inventory found ${inventory.totals.missing_storage_object_count} missing source objects`,
+    )
+  }
+}
+
+export async function collectExactReadPages<T>(
+  readPage: (offset: number, requestedPageSize: number) => Promise<{
+    rows: T[]
+    count: number
+  }>,
+  requestedPageSize = 1000,
+): Promise<T[]> {
+  const rows: T[] = []
+  let expectedCount: number | null = null
+  while (expectedCount === null || rows.length < expectedCount) {
+    const page = await readPage(rows.length, requestedPageSize)
+    const count = z.number().int().nonnegative().parse(page.count)
+    if (expectedCount === null) expectedCount = count
+    if (count !== expectedCount) throw new Error('Exact count changed during paginated read')
+    if (page.rows.length === 0) {
+      if (rows.length === expectedCount) break
+      throw new Error('Paginated read ended before its exact count')
+    }
+    rows.push(...page.rows)
+    if (rows.length > expectedCount) throw new Error('Paginated read exceeded its exact count')
+  }
+  return rows
+}
+
+function expectedArchiveContract() {
+  const resources = new Map(
+    CLASSROOM_RELATIONAL_RESOURCES.map((resource) => [resource.table, resource]),
+  )
+  return getClassroomResourceOrder('export').map((table, exportPosition) => {
+    const resource = resources.get(table)
+    if (!resource) throw new Error('Classroom archive resource order is invalid')
+    return {
+      table_name: table,
+      primary_key_columns: [...resource.primary_key],
+      parent_table: resource.scope.kind === 'foreign_key' ? resource.scope.parent : null,
+      parent_column: resource.scope.kind === 'foreign_key' ? resource.scope.column : null,
+      actor_columns: [...resource.actor_columns],
+      restore_after: [...resource.restore_after],
+      export_position: exportPosition,
+    }
+  })
+}
+
+export function verifyRemoteClassroomContracts(
+  archiveContract: unknown,
+  gradexContract: unknown,
+): void {
+  const actualArchive = archiveContractSchema.parse(archiveContract)
+  const actualGradex = gradexContractSchema.parse(gradexContract)
+  if (canonicalJsonStringify(actualArchive) !== canonicalJsonStringify(expectedArchiveContract())) {
+    throw new Error('Remote archive resource contract does not match the checked-in contract')
+  }
+  const expectedGradex = GRADEX_RESOURCE_TABLES.map((table) => ({ table_name: table }))
+  if (canonicalJsonStringify(actualGradex) !== canonicalJsonStringify(expectedGradex)) {
+    throw new Error('Remote Gradex resource contract does not match the checked-in contract')
+  }
+}
+
+export function auditClassroomOpenApiSchema(document: unknown) {
+  const parsed = openApiSchema.parse(document)
+  const relationships: Array<{
+    child_table: string
+    parent_table: string
+    child_columns: string[]
+  }> = []
+  const primaryKeys: Array<{ table_name: string; columns: string[] }> = []
+
+  for (const [table, definition] of Object.entries(parsed.definitions)) {
+    const keyColumns: string[] = []
+    for (const [column, property] of Object.entries(definition.properties)) {
+      const description = property.description || ''
+      if (description.includes('<pk/>')) keyColumns.push(column)
+      for (const match of description.matchAll(/<fk table='([^']+)' column='([^']+)'\/>/g)) {
+        relationships.push({
+          child_table: table,
+          parent_table: match[1],
+          child_columns: [column],
+        })
+      }
+    }
+    if (keyColumns.length > 0) primaryKeys.push({ table_name: table, columns: keyColumns })
+  }
+  return auditClassroomResourceSchema(relationships, primaryKeys)
+}
+
+function comparePrimaryKey(left: Record<string, unknown>, right: Record<string, unknown>, key: string) {
+  const leftValue = String(left[key])
+  const rightValue = String(right[key])
+  return leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0
+}
+
+async function readClassroomResources(
+  reader: ClassroomArchiveInventoryReader,
+  classroomId: string,
+) {
+  const resources: Record<string, Array<Record<string, unknown>>> = {}
+  const contractByTable = new Map(
+    CLASSROOM_RELATIONAL_RESOURCES.map((resource) => [resource.table, resource]),
+  )
+  for (const table of getClassroomResourceOrder('export')) {
+    const resource = contractByTable.get(table)
+    if (!resource || resource.primary_key.length !== 1) {
+      throw new Error(`Inventory adapter is unavailable for classroom resource ${table}`)
+    }
+    const primaryKey = resource.primary_key[0]
+    let filterColumn = primaryKey
+    let values = [classroomId]
+    if (resource.scope.kind === 'foreign_key') {
+      filterColumn = resource.scope.column
+      const parent = contractByTable.get(resource.scope.parent as ClassroomResourceTable)
+      if (!parent || parent.primary_key.length !== 1) {
+        throw new Error(`Inventory parent adapter is unavailable for classroom resource ${table}`)
+      }
+      values = (resources[resource.scope.parent] || []).map((row) => {
+        const value = row[parent.primary_key[0]]
+        if (typeof value !== 'string') {
+          throw new Error(`Inventory parent key is invalid for classroom resource ${table}`)
+        }
+        return value
+      })
+    }
+    const rows = values.length === 0
+      ? []
+      : jsonRowsSchema.parse(await reader.readResourceRows({
+          table,
+          filterColumn,
+          values,
+          primaryKey,
+        }))
+    const uniqueKeys = new Set(rows.map((row) => String(row[primaryKey])))
+    if (uniqueKeys.size !== rows.length || rows.some((row) => typeof row[primaryKey] !== 'string')) {
+      throw new Error(`Inventory returned invalid primary keys for classroom resource ${table}`)
+    }
+    resources[table] = rows.sort((left, right) => comparePrimaryKey(left, right, primaryKey))
+  }
+  return resources
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  worker: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length)
+  let nextIndex = 0
+  async function run() {
+    while (nextIndex < values.length) {
+      const index = nextIndex++
+      results[index] = await worker(values[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, run))
+  return results
+}
+
+class ArchiveSetDriftError extends Error {}
+
+async function readStableClassroomInventory(
+  reader: ClassroomArchiveInventoryReader,
+  classroomId: string,
+  label: string,
+) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const revisionBefore = revisionSchema.parse(await reader.readRevision(classroomId))
+    const resources = await readClassroomResources(reader, classroomId)
+    const classroomRows = resources.classrooms || []
+    if (
+      classroomRows.length !== 1 ||
+      typeof classroomRows[0].archived_at !== 'string' ||
+      classroomRows[0].archived_at.length === 0
+    ) {
+      throw new ArchiveSetDriftError('Archived classroom root changed during inventory')
+    }
+    const references = discoverClassroomStorageReferences(
+      resources,
+      reader.supabaseUrl,
+    )
+    const sizes = await mapWithConcurrency(references, 4, async (reference) => {
+      const value = await reader.readStorageObjectSize(reference.bucket, reference.path)
+      return value === null ? null : z.number().int().nonnegative().parse(value)
+    })
+    const revisionAfter = revisionSchema.parse(await reader.readRevision(classroomId))
+    if (revisionBefore !== revisionAfter) continue
+
+    const resourceCounts: Record<string, number> = {}
+    let relationalRowCount = 0
+    let serializedRelationalBytes = 0
+    for (const resource of CLASSROOM_RELATIONAL_RESOURCES) {
+      const rows = resources[resource.table] || []
+      resourceCounts[resource.table] = rows.length
+      relationalRowCount += rows.length
+      for (const row of rows) {
+        serializedRelationalBytes += Buffer.byteLength(`${canonicalJsonStringify(row)}\n`, 'utf8')
+      }
+    }
+    const missingStorageObjectCount = sizes.filter((size) => size === null).length
+    let storageMetadataBytes = 0
+    for (const size of sizes) storageMetadataBytes += size || 0
+    return classroomInventorySchema.parse({
+      label,
+      source_revision: revisionAfter,
+      relational_row_count: relationalRowCount,
+      serialized_relational_bytes: serializedRelationalBytes,
+      storage_object_count: references.length,
+      storage_metadata_bytes: storageMetadataBytes,
+      estimated_uncompressed_archive_bytes: missingStorageObjectCount === 0
+        ? serializedRelationalBytes + storageMetadataBytes
+        : null,
+      missing_storage_object_count: missingStorageObjectCount,
+      source_objects_present: missingStorageObjectCount === 0,
+      resource_counts: resourceCounts,
+    })
+  }
+  throw new Error(`Archived classroom ${label} did not stabilize during read-only inventory`)
+}
+
+export async function inventoryArchivedClassrooms(
+  reader: ClassroomArchiveInventoryReader,
+): Promise<ClassroomArchiveInventory> {
+  const [openApi, archiveContract, gradexContract] = await Promise.all([
+    reader.readOpenApiSchema(),
+    reader.readArchiveResourceContract(),
+    reader.readGradexResourceContract(),
+  ])
+  verifyRemoteClassroomContracts(archiveContract, gradexContract)
+  const catalogAudit = auditClassroomOpenApiSchema(openApi)
+  if (!catalogAudit.ok) throw new Error('Remote classroom catalog does not match the checked-in contract')
+
+  let archivedHot: Array<z.infer<typeof classroomInventorySchema>> | null = null
+  let operationalCounts: z.infer<typeof operationalCountsSchema> | null = null
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const operationsBefore = operationalCountsSchema.parse(await reader.readOperationalCounts())
+    const archivedBefore = archivedClassroomsSchema.parse(await reader.readArchivedClassrooms())
+    const snapshot: Array<z.infer<typeof classroomInventorySchema>> = []
+    try {
+      for (const [index, classroom] of archivedBefore.entries()) {
+        snapshot.push(await readStableClassroomInventory(
+          reader,
+          classroom.id,
+          `archived-hot-${index + 1}`,
+        ))
+      }
+    } catch (error) {
+      if (error instanceof ArchiveSetDriftError) continue
+      throw error
+    }
+    const archivedAfter = archivedClassroomsSchema.parse(await reader.readArchivedClassrooms())
+    const operationsAfter = operationalCountsSchema.parse(await reader.readOperationalCounts())
+    if (
+      canonicalJsonStringify(archivedBefore) !== canonicalJsonStringify(archivedAfter) ||
+      canonicalJsonStringify(operationsBefore) !== canonicalJsonStringify(operationsAfter)
+    ) continue
+    archivedHot = snapshot
+    operationalCounts = operationsAfter
+    break
+  }
+  if (!archivedHot || !operationalCounts) {
+    throw new Error('Archived classroom set did not stabilize across the full inventory')
+  }
+  return archiveInventorySchema.parse({
+    generated_at: new Date().toISOString(),
+    schema: {
+      archive_resource_count: CLASSROOM_RELATIONAL_RESOURCES.length,
+      gradex_resource_count: GRADEX_RESOURCE_TABLES.length,
+      postgrest_schema_audit_passed: true,
+    },
+    archived_hot: archivedHot,
+    totals: {
+      archived_hot_count: archivedHot.length,
+      relational_row_count: archivedHot.reduce((total, item) => total + item.relational_row_count, 0),
+      serialized_relational_bytes: archivedHot.reduce(
+        (total, item) => total + item.serialized_relational_bytes,
+        0,
+      ),
+      storage_object_count: archivedHot.reduce((total, item) => total + item.storage_object_count, 0),
+      storage_metadata_bytes: archivedHot.reduce(
+        (total, item) => total + item.storage_metadata_bytes,
+        0,
+      ),
+      estimated_uncompressed_archive_bytes: archivedHot.every(
+        (item) => item.estimated_uncompressed_archive_bytes !== null,
+      )
+        ? archivedHot.reduce(
+            (total, item) => total + (item.estimated_uncompressed_archive_bytes || 0),
+            0,
+          )
+        : null,
+      missing_storage_object_count: archivedHot.reduce(
+        (total, item) => total + item.missing_storage_object_count,
+        0,
+      ),
+    },
+    operations: operationalCounts,
+  })
+}
+
+type SupabaseClient = ReturnType<typeof getServiceRoleClient>
+
+function throwReadError(resource: string, error: unknown) {
+  if (!error) return
+  const code = typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+    ? error.code
+    : 'unknown'
+  throw new Error(`Read-only inventory failed for ${resource} (${code})`)
+}
+
+export function createSupabaseClassroomArchiveInventoryReader(args: {
+  supabase: SupabaseClient
+  supabaseUrl: string
+  secretKey: string
+  fetchImpl?: typeof fetch
+}): ClassroomArchiveInventoryReader {
+  const expectedOrigin = new URL(args.supabaseUrl).origin
+  const fetchImpl = createTargetBoundFetch(expectedOrigin, args.fetchImpl || fetch)
+  return {
+    supabaseUrl: expectedOrigin,
+    async readOpenApiSchema() {
+      const response = await fetchImpl(`${expectedOrigin}/rest/v1/`, {
+        headers: {
+          apikey: args.secretKey,
+          Authorization: `Bearer ${args.secretKey}`,
+          Accept: 'application/openapi+json',
+        },
+      })
+      if (!response.ok) throw new Error(`Read-only inventory failed for PostgREST schema (${response.status})`)
+      return response.json()
+    },
+    async readArchiveResourceContract() {
+      return collectExactReadPages(async (offset, requestedPageSize) => {
+        const { data, error, count } = await args.supabase
+          .from('classroom_archive_resource_contract')
+          .select(
+            'table_name,primary_key_columns,parent_table,parent_column,actor_columns,restore_after,export_position',
+            { count: 'exact' },
+          )
+          .order('export_position', { ascending: true })
+          .range(offset, offset + requestedPageSize - 1)
+        throwReadError('archive resource contract', error)
+        return {
+          rows: archiveContractSchema.parse(data),
+          count: z.number().int().nonnegative().parse(count),
+        }
+      })
+    },
+    async readGradexResourceContract() {
+      return collectExactReadPages(async (offset, requestedPageSize) => {
+        const { data, error, count } = await args.supabase
+          .from('classroom_gradex_resource_contract')
+          .select('table_name', { count: 'exact' })
+          .order('table_name', { ascending: true })
+          .range(offset, offset + requestedPageSize - 1)
+        throwReadError('Gradex resource contract', error)
+        return {
+          rows: gradexContractSchema.parse(data),
+          count: z.number().int().nonnegative().parse(count),
+        }
+      })
+    },
+    async readArchivedClassrooms() {
+      const readSnapshot = async () => {
+        return collectExactReadPages(async (offset, requestedPageSize) => {
+          const { data, error, count } = await args.supabase
+            .from('classrooms')
+            .select('id', { count: 'exact' })
+            .not('archived_at', 'is', null)
+            .order('id', { ascending: true })
+            .range(offset, offset + requestedPageSize - 1)
+          throwReadError('archived classrooms', error)
+          return {
+            rows: archivedClassroomsSchema.parse(data),
+            count: z.number().int().nonnegative().parse(count),
+          }
+        })
+      }
+      const first = await readSnapshot()
+      const second = await readSnapshot()
+      if (canonicalJsonStringify(first) === canonicalJsonStringify(second)) return second
+      const third = await readSnapshot()
+      if (canonicalJsonStringify(second) === canonicalJsonStringify(third)) return third
+      throw new Error('Archived classroom list did not stabilize during read-only inventory')
+    },
+    async readRevision(classroomId) {
+      const { data, error } = await args.supabase
+        .from('classroom_archive_revisions')
+        .select('revision')
+        .eq('classroom_id', classroomId)
+        .single()
+      throwReadError('classroom archive revision', error)
+      return data?.revision
+    },
+    async readResourceRows({ table, filterColumn, values, primaryKey }) {
+      const rows: unknown[] = []
+      const valueChunkSize = 100
+      for (let valueOffset = 0; valueOffset < values.length; valueOffset += valueChunkSize) {
+        const chunk = values.slice(valueOffset, valueOffset + valueChunkSize)
+        const chunkRows = await collectExactReadPages(async (offset, requestedPageSize) => {
+          const query = args.supabase.from(table).select('*', { count: 'exact' }) as unknown as {
+            in(column: string, filterValues: string[]): {
+              order(column: string, options: { ascending: boolean }): {
+                range(from: number, to: number): PromiseLike<{
+                  data: unknown
+                  error: { code?: string } | null
+                  count: number | null
+                }>
+              }
+            }
+          }
+          const { data, error, count } = await query
+            .in(filterColumn, chunk)
+            .order(primaryKey, { ascending: true })
+            .range(offset, offset + requestedPageSize - 1)
+          throwReadError(table, error)
+          return {
+            rows: jsonRowsSchema.parse(data),
+            count: z.number().int().nonnegative().parse(count),
+          }
+        })
+        rows.push(...chunkRows)
+      }
+      return rows
+    },
+    async readStorageObjectSize(bucket, path) {
+      const { data, error } = await args.supabase.storage
+        .from(bucket)
+        .info(path)
+      if (error && missingStorageObjectEvidence(error)) return null
+      throwReadError('managed storage metadata', error)
+      return z.number().int().nonnegative().parse(data?.size)
+    },
+    async readOperationalCounts() {
+      type OperationalTable =
+        | 'classroom_archives'
+        | 'classroom_cold_tombstones'
+        | 'classroom_archive_operations'
+        | 'classroom_gradex_extracts'
+        | 'classroom_archive_source_object_cleanup'
+      const count = async (table: OperationalTable) => {
+        const { count: value, error } = await args.supabase
+          .from(table)
+          .select('*', { count: 'exact', head: true })
+        throwReadError(table, error)
+        return z.number().int().nonnegative().parse(value)
+      }
+      const [verifiedArchives, coldTombstones, archiveOperations, gradexExtracts, pendingCleanup] =
+        await Promise.all([
+          count('classroom_archives'),
+          count('classroom_cold_tombstones'),
+          count('classroom_archive_operations'),
+          count('classroom_gradex_extracts'),
+          count('classroom_archive_source_object_cleanup'),
+        ])
+      return {
+        verified_archives: verifiedArchives,
+        cold_tombstones: coldTombstones,
+        archive_operations: archiveOperations,
+        gradex_extracts: gradexExtracts,
+        source_cleanup_rows: pendingCleanup,
+      }
+    },
+  }
+}

--- a/src/lib/server/supabase-target.ts
+++ b/src/lib/server/supabase-target.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod'
+
+const projectRefSchema = z.string().regex(/^[a-z0-9]{20}$/)
+
+export function verifyHostedSupabaseApiOrigin(
+  supabaseUrl: string,
+  expectedProjectRef: string,
+): string {
+  const projectRef = projectRefSchema.parse(expectedProjectRef)
+  const parsed = new URL(z.url().parse(supabaseUrl))
+  const expectedOrigin = `https://${projectRef}.supabase.co`
+  if (
+    parsed.origin !== expectedOrigin ||
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    parsed.port !== '' ||
+    parsed.pathname !== '/' ||
+    parsed.search !== '' ||
+    parsed.hash !== ''
+  ) {
+    throw new Error('Supabase inventory target does not match the expected project ref')
+  }
+  return expectedOrigin
+}
+
+function fetchInputUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') return new URL(input)
+  if (input instanceof URL) return input
+  return new URL(input.url)
+}
+
+export function createTargetBoundFetch(
+  expectedOrigin: string,
+  fetchImpl: typeof fetch = fetch,
+): typeof fetch {
+  const origin = new URL(expectedOrigin).origin
+  return async (input, init) => {
+    if (fetchInputUrl(input).origin !== origin) {
+      throw new Error('Supabase request escaped the validated project origin')
+    }
+    const response = await fetchImpl(input, { ...init, redirect: 'manual' })
+    if (response.status >= 300 && response.status < 400) {
+      throw new Error('Supabase request redirect was rejected')
+    }
+    return response
+  }
+}
+
+export function verifyHostedSupabaseDatabaseUrl(
+  databaseUrl: string,
+  expectedProjectRef: string,
+): string {
+  const projectRef = projectRefSchema.parse(expectedProjectRef)
+  const parsed = new URL(databaseUrl)
+  const username = decodeURIComponent(parsed.username)
+  const isDirect =
+    parsed.hostname === `db.${projectRef}.supabase.co` &&
+    username === 'postgres' &&
+    (parsed.port === '' || parsed.port === '5432')
+  const isPooler =
+    parsed.hostname.endsWith('.pooler.supabase.com') &&
+    username === `postgres.${projectRef}` &&
+    (parsed.port === '5432' || parsed.port === '6543')
+  const queryParameters = [...parsed.searchParams.entries()]
+  const sslMode = queryParameters.length === 1 && queryParameters[0][0] === 'sslmode'
+    ? queryParameters[0][1]
+    : null
+  if (
+    !['postgres:', 'postgresql:'].includes(parsed.protocol) ||
+    (!isDirect && !isPooler) ||
+    parsed.password === '' ||
+    parsed.pathname !== '/postgres' ||
+    parsed.hash !== '' ||
+    !['require', 'verify-ca', 'verify-full'].includes(sslMode || '')
+  ) {
+    throw new Error('Supabase database target does not match the expected project ref')
+  }
+  return projectRef
+}
+
+export type PsqlConnectionEnvironment = {
+  PGHOST: string
+  PGPORT: string
+  PGUSER: string
+  PGPASSWORD: string
+  PGDATABASE: string
+  PGSSLMODE: string
+}
+
+function psqlEnvironment(parsed: URL, sslMode: string): PsqlConnectionEnvironment {
+  return {
+    PGHOST: parsed.hostname === '[::1]' ? '::1' : parsed.hostname,
+    PGPORT: parsed.port || '5432',
+    PGUSER: decodeURIComponent(parsed.username),
+    PGPASSWORD: decodeURIComponent(parsed.password),
+    PGDATABASE: decodeURIComponent(parsed.pathname.slice(1)),
+    PGSSLMODE: sslMode,
+  }
+}
+
+export function hostedSupabasePsqlEnvironment(
+  databaseUrl: string,
+  expectedProjectRef: string,
+): PsqlConnectionEnvironment {
+  verifyHostedSupabaseDatabaseUrl(databaseUrl, expectedProjectRef)
+  const parsed = new URL(databaseUrl)
+  return psqlEnvironment(parsed, parsed.searchParams.get('sslmode')!)
+}
+
+export function localSupabasePsqlEnvironment(databaseUrl: string): PsqlConnectionEnvironment {
+  const parsed = new URL(databaseUrl)
+  const loopbackHosts = new Set(['127.0.0.1', 'localhost', '[::1]'])
+  if (
+    !['postgres:', 'postgresql:'].includes(parsed.protocol) ||
+    !loopbackHosts.has(parsed.hostname) ||
+    parsed.username === '' ||
+    parsed.password === '' ||
+    parsed.pathname !== '/postgres' ||
+    parsed.search !== '' ||
+    parsed.hash !== ''
+  ) {
+    throw new Error('Local schema audit requires an exact loopback database URL')
+  }
+  return psqlEnvironment(parsed, 'disable')
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -13,7 +13,7 @@ export function getSupabaseClient() {
   return createClient<Database>(supabaseUrl, supabasePublishableKey)
 }
 
-export function getServiceRoleClient() {
+export function getServiceRoleClient(options: { fetch?: typeof fetch } = {}) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
   const secretKey = process.env.SUPABASE_SECRET_KEY
@@ -30,6 +30,7 @@ export function getServiceRoleClient() {
     auth: {
       autoRefreshToken: false,
       persistSession: false
-    }
+    },
+    ...(options.fetch ? { global: { fetch: options.fetch } } : {}),
   })
 }

--- a/tests/lib/server/classroom-archive-inventory.test.ts
+++ b/tests/lib/server/classroom-archive-inventory.test.ts
@@ -1,0 +1,516 @@
+import {
+  assertInventorySourceObjectsPresent,
+  auditClassroomOpenApiSchema,
+  collectExactReadPages,
+  createSupabaseClassroomArchiveInventoryReader,
+  inventoryArchivedClassrooms,
+  verifySupabaseInventoryTarget,
+  verifyRemoteClassroomContracts,
+  type ClassroomArchiveInventoryReader,
+} from '@/lib/server/classroom-archive-inventory'
+import {
+  CLASSROOM_RELATIONAL_RESOURCES,
+  GRADEX_RESOURCE_TABLES,
+  getClassroomResourceOrder,
+} from '@/lib/contracts/classroom-data'
+import {
+  createTargetBoundFetch,
+  hostedSupabasePsqlEnvironment,
+  localSupabasePsqlEnvironment,
+  verifyHostedSupabaseDatabaseUrl,
+} from '@/lib/server/supabase-target'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+const CLASSROOM_ID = '11111111-1111-4111-8111-111111111111'
+const ASSIGNMENT_ID = '22222222-2222-4222-8222-222222222222'
+
+function remoteArchiveContract() {
+  const resources = new Map(
+    CLASSROOM_RELATIONAL_RESOURCES.map((resource) => [resource.table, resource]),
+  )
+  return getClassroomResourceOrder('export').map((table, exportPosition) => {
+    const resource = resources.get(table)!
+    return {
+      table_name: table,
+      primary_key_columns: [...resource.primary_key],
+      parent_table: resource.scope.kind === 'foreign_key' ? resource.scope.parent : null,
+      parent_column: resource.scope.kind === 'foreign_key' ? resource.scope.column : null,
+      actor_columns: [...resource.actor_columns],
+      restore_after: [...resource.restore_after],
+      export_position: exportPosition,
+    }
+  })
+}
+
+function openApiDocument() {
+  const definitions: Record<string, { properties: Record<string, { description?: string }> }> = {}
+  for (const resource of CLASSROOM_RELATIONAL_RESOURCES) {
+    const properties: Record<string, { description?: string }> = {}
+    for (const column of resource.primary_key) {
+      properties[column] = { description: 'Note:\nThis is a Primary Key.<pk/>' }
+    }
+    if (resource.scope.kind === 'foreign_key') {
+      properties[resource.scope.column] = {
+        description: `${properties[resource.scope.column]?.description || 'Note:'}\nThis is a Foreign Key.<fk table='${resource.scope.parent}' column='id'/>`,
+      }
+    }
+    for (const column of resource.actor_columns) {
+      properties[column] = {
+        description: `${properties[column]?.description || 'Note:'}\nThis is a Foreign Key.<fk table='users' column='id'/>`,
+      }
+    }
+    definitions[resource.table] = { properties }
+  }
+  definitions.users = {
+    properties: { id: { description: 'Note:\nThis is a Primary Key.<pk/>' } },
+  }
+  return { swagger: '2.0', definitions }
+}
+
+function reader(overrides: Partial<ClassroomArchiveInventoryReader> = {}): ClassroomArchiveInventoryReader {
+  let revisionReads = 0
+  const rowsByTable: Record<string, Array<Record<string, unknown>>> = {
+    classrooms: [{ id: CLASSROOM_ID, archived_at: '2026-07-01T00:00:00Z' }],
+    assignments: [{
+      id: ASSIGNMENT_ID,
+      classroom_id: CLASSROOM_ID,
+      title: 'Private title must not appear in output',
+      description: 'http://inventory.invalid/storage/v1/object/public/submission-images/private/image.png',
+    }],
+    assignment_docs: [{
+      id: '44444444-4444-4444-8444-444444444444',
+      assignment_id: ASSIGNMENT_ID,
+      student_id: '55555555-5555-4555-8555-555555555555',
+    }],
+    assignment_submission_artifacts: [{
+      id: '33333333-3333-4333-8333-333333333333',
+      assignment_doc_id: '44444444-4444-4444-8444-444444444444',
+      storage_path: 'private/source.bin',
+    }],
+  }
+
+  return {
+    supabaseUrl: 'http://inventory.invalid',
+    readOpenApiSchema: async () => openApiDocument(),
+    readArchiveResourceContract: async () => remoteArchiveContract(),
+    readGradexResourceContract: async () => GRADEX_RESOURCE_TABLES.map((table) => ({ table_name: table })),
+    readArchivedClassrooms: async () => [{ id: CLASSROOM_ID }],
+    readRevision: async () => {
+      revisionReads += 1
+      return revisionReads <= 2 ? 7 : 8
+    },
+    readResourceRows: async ({ table, values }) => {
+      if (values.length === 0) return []
+      return rowsByTable[table] || []
+    },
+    readStorageObjectSize: async () => 17,
+    readOperationalCounts: async () => ({
+      verified_archives: 0,
+      cold_tombstones: 0,
+      archive_operations: 0,
+      gradex_extracts: 0,
+      source_cleanup_rows: 0,
+    }),
+    ...overrides,
+  }
+}
+
+describe('classroom archive production inventory', () => {
+  it('continues exact-count pagination when the server returns less than requested', async () => {
+    const source = ['a', 'b', 'c', 'd', 'e']
+    const reads: number[] = []
+    const rows = await collectExactReadPages(async (offset) => {
+      reads.push(offset)
+      return { rows: source.slice(offset, offset + 2), count: source.length }
+    })
+
+    expect(rows).toEqual(source)
+    expect(reads).toEqual([0, 2, 4])
+  })
+
+  it('rejects truncated and count-changing pagination', async () => {
+    await expect(collectExactReadPages(async () => ({ rows: [], count: 1 })))
+      .rejects.toThrow('ended before')
+    let reads = 0
+    await expect(collectExactReadPages(async () => {
+      reads += 1
+      return reads === 1
+        ? { rows: ['a'], count: 2 }
+        : { rows: ['b'], count: 3 }
+    })).rejects.toThrow('count changed')
+  })
+
+  it('paginates both deployed resource contracts through exact counts', async () => {
+    const archiveRows = remoteArchiveContract()
+    const gradexRows = GRADEX_RESOURCE_TABLES.map((table) => ({ table_name: table }))
+    const ranges: Array<{ table: string; from: number }> = []
+    const rowsByTable: Record<string, unknown[]> = {
+      classroom_archive_resource_contract: archiveRows,
+      classroom_gradex_resource_contract: gradexRows,
+    }
+    const supabase = {
+      from(table: string) {
+        return {
+          select(_columns: string, options: { count: string }) {
+            expect(options).toEqual({ count: 'exact' })
+            return {
+              order() {
+                return {
+                  range(from: number, to: number) {
+                    ranges.push({ table, from })
+                    const rows = rowsByTable[table]
+                    const cappedTo = Math.min(to + 1, from + 5)
+                    return Promise.resolve({
+                      data: rows.slice(from, cappedTo),
+                      error: null,
+                      count: rows.length,
+                    })
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as Parameters<typeof createSupabaseClassroomArchiveInventoryReader>[0]['supabase']
+    const inventoryReader = createSupabaseClassroomArchiveInventoryReader({
+      supabase,
+      supabaseUrl: 'https://abcdefghijklmnopqrst.supabase.co',
+      secretKey: 'secret',
+    })
+
+    await expect(inventoryReader.readArchiveResourceContract()).resolves.toEqual(archiveRows)
+    await expect(inventoryReader.readGradexResourceContract()).resolves.toEqual(gradexRows)
+    expect(ranges.filter(({ table }) => table === 'classroom_archive_resource_contract'))
+      .toHaveLength(9)
+    expect(ranges.filter(({ table }) => table === 'classroom_gradex_resource_contract'))
+      .toHaveLength(3)
+  })
+
+  it('requires the expected hosted Supabase project target', () => {
+    expect(verifySupabaseInventoryTarget(
+      'https://abcdefghijklmnopqrst.supabase.co',
+      'abcdefghijklmnopqrst',
+    )).toBe('https://abcdefghijklmnopqrst.supabase.co')
+    expect(() => verifySupabaseInventoryTarget(
+      'https://wrongprojectrefxxxxx.supabase.co',
+      'abcdefghijklmnopqrst',
+    )).toThrow('does not match')
+    for (const invalidUrl of [
+      'http://abcdefghijklmnopqrst.supabase.co',
+      'https://abcdefghijklmnopqrst.supabase.co:444',
+      'https://user:password@abcdefghijklmnopqrst.supabase.co',
+      'https://abcdefghijklmnopqrst.supabase.co/rest/v1',
+      'https://abcdefghijklmnopqrst.supabase.co?target=other',
+      'https://abcdefghijklmnopqrst.supabase.co#other',
+    ]) {
+      expect(() => verifySupabaseInventoryTarget(
+        invalidUrl,
+        'abcdefghijklmnopqrst',
+      )).toThrow('does not match')
+    }
+  })
+
+  it('rejects redirects and off-origin requests before service credentials can escape', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, {
+      status: 307,
+      headers: { location: 'https://attacker.invalid/collect' },
+    }))
+    const targetFetch = createTargetBoundFetch(
+      'https://abcdefghijklmnopqrst.supabase.co',
+      fetchImpl as unknown as typeof fetch,
+    )
+
+    await expect(targetFetch(
+      'https://abcdefghijklmnopqrst.supabase.co/rest/v1/',
+      { headers: { apikey: 'secret' } },
+    )).rejects.toThrow('redirect was rejected')
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://abcdefghijklmnopqrst.supabase.co/rest/v1/',
+      expect.objectContaining({ redirect: 'manual' }),
+    )
+
+    fetchImpl.mockClear()
+    await expect(targetFetch(
+      'https://attacker.invalid/collect',
+      { headers: { apikey: 'secret' } },
+    )).rejects.toThrow('escaped the validated project origin')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects redirects through the concrete OpenAPI reader path', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, {
+      status: 302,
+      headers: { location: 'https://attacker.invalid/collect' },
+    }))
+    const inventoryReader = createSupabaseClassroomArchiveInventoryReader({
+      supabase: {} as Parameters<typeof createSupabaseClassroomArchiveInventoryReader>[0]['supabase'],
+      supabaseUrl: 'https://abcdefghijklmnopqrst.supabase.co',
+      secretKey: 'service-secret',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    await expect(inventoryReader.readOpenApiSchema()).rejects.toThrow('redirect was rejected')
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://abcdefghijklmnopqrst.supabase.co/rest/v1/',
+      expect.objectContaining({
+        redirect: 'manual',
+        headers: expect.objectContaining({ apikey: 'service-secret' }),
+      }),
+    )
+  })
+
+  it('rejects redirects through a concrete Supabase SDK request', async () => {
+    const original = {
+      url: process.env.NEXT_PUBLIC_SUPABASE_URL,
+      publishableKey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+      secretKey: process.env.SUPABASE_SECRET_KEY,
+    }
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://abcdefghijklmnopqrst.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'publishable-key'
+    process.env.SUPABASE_SECRET_KEY = 'service-secret'
+    const fetchImpl = vi.fn(async () => new Response(null, {
+      status: 307,
+      headers: { location: 'https://attacker.invalid/collect' },
+    }))
+
+    try {
+      const client = getServiceRoleClient({
+        fetch: createTargetBoundFetch(
+          'https://abcdefghijklmnopqrst.supabase.co',
+          fetchImpl as unknown as typeof fetch,
+        ),
+      })
+      const { error } = await client.from('classrooms').select('id')
+
+      expect(error).not.toBeNull()
+      expect(fetchImpl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ redirect: 'manual' }),
+      )
+    } finally {
+      if (original.url === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL
+      else process.env.NEXT_PUBLIC_SUPABASE_URL = original.url
+      if (original.publishableKey === undefined) {
+        delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+      } else process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = original.publishableKey
+      if (original.secretKey === undefined) delete process.env.SUPABASE_SECRET_KEY
+      else process.env.SUPABASE_SECRET_KEY = original.secretKey
+    }
+  })
+
+  it('binds direct catalog audit URLs to the expected hosted project with TLS', () => {
+    expect(verifyHostedSupabaseDatabaseUrl(
+      'postgresql://postgres:secret@db.abcdefghijklmnopqrst.supabase.co:5432/postgres?sslmode=verify-full',
+      'abcdefghijklmnopqrst',
+    )).toBe('abcdefghijklmnopqrst')
+    expect(verifyHostedSupabaseDatabaseUrl(
+      'postgres://postgres.abcdefghijklmnopqrst:secret@aws-0-ca-central-1.pooler.supabase.com:6543/postgres?sslmode=require',
+      'abcdefghijklmnopqrst',
+    )).toBe('abcdefghijklmnopqrst')
+    for (const invalidUrl of [
+      'postgresql://postgres:secret@db.wrongprojectrefxxxxx.supabase.co:5432/postgres?sslmode=require',
+      'postgresql://postgres:secret@db.abcdefghijklmnopqrst.supabase.co:5432/postgres',
+      'postgresql://postgres:secret@localhost:5432/postgres?sslmode=require',
+      'postgresql://postgres:secret@db.abcdefghijklmnopqrst.supabase.co:5432/postgres?sslmode=require&hostaddr=127.0.0.1',
+      'postgresql://postgres:secret@db.abcdefghijklmnopqrst.supabase.co:5432/postgres?sslmode=require&sslmode=disable',
+    ]) {
+      expect(() => verifyHostedSupabaseDatabaseUrl(
+        invalidUrl,
+        'abcdefghijklmnopqrst',
+      )).toThrow('does not match')
+    }
+    expect(hostedSupabasePsqlEnvironment(
+      'postgresql://postgres:sentinel-password@db.abcdefghijklmnopqrst.supabase.co:5432/postgres?sslmode=require',
+      'abcdefghijklmnopqrst',
+    )).toEqual({
+      PGHOST: 'db.abcdefghijklmnopqrst.supabase.co',
+      PGPORT: '5432',
+      PGUSER: 'postgres',
+      PGPASSWORD: 'sentinel-password',
+      PGDATABASE: 'postgres',
+      PGSSLMODE: 'require',
+    })
+    expect(localSupabasePsqlEnvironment(
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+    )).toMatchObject({ PGHOST: '127.0.0.1', PGPORT: '54322', PGSSLMODE: 'disable' })
+    expect(() => localSupabasePsqlEnvironment(
+      'postgresql://postgres:postgres@staging.example.com:5432/postgres',
+    )).toThrow('loopback')
+  })
+
+  it('accepts the exact checked-in archive and Gradex database contracts', () => {
+    expect(() => verifyRemoteClassroomContracts(
+      remoteArchiveContract(),
+      GRADEX_RESOURCE_TABLES.map((table) => ({ table_name: table })),
+    )).not.toThrow()
+  })
+
+  it('rejects remote contract drift', () => {
+    const contract = remoteArchiveContract()
+    contract[0] = { ...contract[0], actor_columns: [] }
+
+    expect(() => verifyRemoteClassroomContracts(
+      contract,
+      GRADEX_RESOURCE_TABLES.map((table) => ({ table_name: table })),
+    )).toThrow('archive resource contract does not match')
+  })
+
+  it('audits primary keys and foreign keys from the validated PostgREST schema', () => {
+    expect(auditClassroomOpenApiSchema(openApiDocument())).toMatchObject({ ok: true })
+  })
+
+  it('fails the catalog audit when a classroom descendant is untracked', () => {
+    const document = openApiDocument()
+    document.definitions.untracked_child = {
+      properties: {
+        id: { description: 'Note:\nThis is a Primary Key.<pk/>' },
+        classroom_id: {
+          description: "Note:\nThis is a Foreign Key.<fk table='classrooms' column='id'/>",
+        },
+      },
+    }
+
+    expect(auditClassroomOpenApiSchema(document)).toMatchObject({
+      ok: false,
+      untracked_tables: ['untracked_child'],
+    })
+  })
+
+  it('reports stable aggregate inventory without classroom ids or source content', async () => {
+    const result = await inventoryArchivedClassrooms(reader())
+    const serialized = JSON.stringify(result)
+
+    expect(result.schema).toEqual({
+      archive_resource_count: 42,
+      gradex_resource_count: 13,
+      postgrest_schema_audit_passed: true,
+    })
+    expect(result.archived_hot).toHaveLength(1)
+    expect(result.archived_hot[0]).toMatchObject({
+      label: 'archived-hot-1',
+      source_revision: 7,
+      storage_object_count: 2,
+      storage_metadata_bytes: 34,
+      source_objects_present: true,
+      missing_storage_object_count: 0,
+    })
+    expect(result.archived_hot[0].relational_row_count).toBeGreaterThanOrEqual(2)
+    expect(result.archived_hot[0].serialized_relational_bytes).toBeGreaterThan(0)
+    expect(result.archived_hot[0].estimated_uncompressed_archive_bytes).toBe(
+      result.archived_hot[0].serialized_relational_bytes + 34,
+    )
+    expect(serialized).not.toContain(CLASSROOM_ID)
+    expect(serialized).not.toContain('Private title')
+    expect(serialized).not.toContain('private/source.bin')
+  })
+
+  it('retries one complete classroom read when the source revision moves', async () => {
+    const revisions = [7, 8, 8, 8]
+    const readResourceRows = vi.fn(reader().readResourceRows)
+    const result = await inventoryArchivedClassrooms(reader({
+      readRevision: async () => revisions.shift()!,
+      readResourceRows,
+    }))
+
+    expect(result.archived_hot[0].source_revision).toBe(8)
+    expect(readResourceRows.mock.calls.filter(([call]) => call.table === 'classrooms')).toHaveLength(2)
+  })
+
+  it('fails closed when the source revision changes twice', async () => {
+    const revisions = [7, 8, 9, 10]
+    await expect(inventoryArchivedClassrooms(reader({
+      readRevision: async () => revisions.shift()!,
+    }))).rejects.toThrow('did not stabilize')
+  })
+
+  it('retries the whole inventory when the archived classroom set changes', async () => {
+    const archivedSets = [
+      [{ id: CLASSROOM_ID }],
+      [],
+      [],
+      [],
+    ]
+    const readArchivedClassrooms = vi.fn(async () => archivedSets.shift()!)
+    const result = await inventoryArchivedClassrooms(reader({ readArchivedClassrooms }))
+
+    expect(result.archived_hot).toEqual([])
+    expect(readArchivedClassrooms).toHaveBeenCalledTimes(4)
+  })
+
+  it('fails closed when the archived classroom set changes across both full scans', async () => {
+    const archivedSets = [
+      [{ id: CLASSROOM_ID }],
+      [],
+      [{ id: CLASSROOM_ID }],
+      [],
+    ]
+    await expect(inventoryArchivedClassrooms(reader({
+      readArchivedClassrooms: async () => archivedSets.shift()!,
+    }))).rejects.toThrow('did not stabilize across the full inventory')
+  })
+
+  it('retries the whole inventory when the selected classroom root becomes active', async () => {
+    const base = reader()
+    let classroomReads = 0
+    const result = await inventoryArchivedClassrooms({
+      ...base,
+      readRevision: async () => 7,
+      readResourceRows: async (query) => {
+        if (query.table !== 'classrooms') return base.readResourceRows(query)
+        classroomReads += 1
+        if (classroomReads === 1) return [{ id: CLASSROOM_ID, archived_at: null }]
+        return base.readResourceRows(query)
+      },
+    })
+
+    expect(result.archived_hot).toHaveLength(1)
+    expect(classroomReads).toBe(2)
+  })
+
+  it('fails closed when the selected classroom root is active across both scans', async () => {
+    const base = reader()
+    await expect(inventoryArchivedClassrooms({
+      ...base,
+      readResourceRows: async (query) => query.table === 'classrooms'
+        ? [{ id: CLASSROOM_ID, archived_at: null }]
+        : base.readResourceRows(query),
+    })).rejects.toThrow('did not stabilize across the full inventory')
+  })
+
+  it('retries the whole inventory when operational counts change during a scan', async () => {
+    const counts = [0, 1, 1, 1]
+    const readOperationalCounts = vi.fn(async () => ({
+      verified_archives: counts.shift()!,
+      cold_tombstones: 0,
+      archive_operations: 0,
+      gradex_extracts: 0,
+      source_cleanup_rows: 0,
+    }))
+    const result = await inventoryArchivedClassrooms(reader({ readOperationalCounts }))
+
+    expect(result.operations.verified_archives).toBe(1)
+    expect(readOperationalCounts).toHaveBeenCalledTimes(4)
+  })
+
+  it('reports when a managed source object is missing', async () => {
+    const result = await inventoryArchivedClassrooms(reader({
+      readStorageObjectSize: async () => null,
+    }))
+
+    expect(result.archived_hot[0]).toMatchObject({
+      source_objects_present: false,
+      missing_storage_object_count: 2,
+      storage_metadata_bytes: 0,
+      estimated_uncompressed_archive_bytes: null,
+    })
+    expect(result.totals.estimated_uncompressed_archive_bytes).toBeNull()
+    expect(() => assertInventorySourceObjectsPresent(result)).toThrow('2 missing source objects')
+  })
+
+  it('rejects malformed data returned by the read boundary', async () => {
+    await expect(inventoryArchivedClassrooms(reader({
+      readArchivedClassrooms: async () => [{ id: 'not-a-uuid' }],
+    }))).rejects.toThrow()
+  })
+})

--- a/tests/unit/classroom-schema-audit-script.test.ts
+++ b/tests/unit/classroom-schema-audit-script.test.ts
@@ -1,0 +1,93 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const scriptPath = resolve(process.cwd(), 'scripts/check-classroom-resource-schema.ts')
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+describe('classroom resource schema audit script', () => {
+  it('keeps a hosted database password out of psql arguments and sanitized failures', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'pika-schema-audit-'))
+    const psqlPath = join(directory, 'psql')
+    const capturePath = join(directory, 'capture.txt')
+    writeFileSync(psqlPath, `#!/bin/sh
+printf 'args=%s\naudit_url=%s\npg_host=%s\npg_hostaddr=%s\npg_service=%s\npg_servicefile=%s\ndatabase_url=%s\n' "$*" "$CLASSROOM_SCHEMA_AUDIT_DATABASE_URL" "$PGHOST" "$PGHOSTADDR" "$PGSERVICE" "$PGSERVICEFILE" "$DATABASE_URL" > ${shellQuote(capturePath)}
+echo 'fake child error sentinel-password' >&2
+exit 1
+`)
+    chmodSync(psqlPath, 0o700)
+
+    try {
+      const result = spawnSync(
+        'pnpm',
+        ['exec', 'tsx', scriptPath],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${directory}:${process.env.PATH}`,
+            PGHOSTADDR: '127.0.0.1',
+            PGSERVICE: 'hostile-service',
+            PGSERVICEFILE: '/tmp/hostile-service-file',
+            DATABASE_URL:
+              'postgresql://postgres:ambient-password@attacker.invalid:5432/postgres',
+            CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF: 'abcdefghijklmnopqrst',
+            CLASSROOM_SCHEMA_AUDIT_DATABASE_URL:
+              'postgresql://postgres:sentinel-password@db.abcdefghijklmnopqrst.supabase.co:5432/postgres?sslmode=require',
+          },
+        },
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toBe(
+        'Classroom resource schema query failed for the validated target.\n',
+      )
+      expect(result.stderr).not.toContain('sentinel-password')
+      const capture = readFileSync(capturePath, 'utf8')
+      expect(capture).toContain('pg_host=db.abcdefghijklmnopqrst.supabase.co')
+      expect(capture).toContain('audit_url=\n')
+      expect(capture).toContain('pg_hostaddr=\n')
+      expect(capture).toContain('pg_service=\n')
+      expect(capture).toContain('pg_servicefile=\n')
+      expect(capture).toContain('database_url=\n')
+      expect(capture).not.toContain('sentinel-password')
+      expect(capture).not.toContain('ambient-password')
+      expect(capture).not.toContain('--dbname')
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('requires an explicit hosted or loopback-only mode without echoing the URL', () => {
+    const result = spawnSync(
+      'pnpm',
+      ['exec', 'tsx', scriptPath],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CLASSROOM_SCHEMA_AUDIT_EXPECTED_PROJECT_REF: '',
+          CLASSROOM_SCHEMA_AUDIT_LOCAL: '',
+          CLASSROOM_SCHEMA_AUDIT_DATABASE_URL:
+            'postgresql://postgres:sentinel-password@localhost:5432/postgres',
+        },
+      },
+    )
+
+    expect(result.status).toBe(2)
+    expect(result.stderr).toContain('Set exactly one of')
+    expect(result.stderr).not.toContain('sentinel-password')
+  })
+})

--- a/tests/unit/supabase.test.ts
+++ b/tests/unit/supabase.test.ts
@@ -133,6 +133,21 @@ describe('supabase utilities', () => {
       )
     })
 
+    it('should pass an optional target-bound fetch implementation to the service client', async () => {
+      const { getServiceRoleClient } = await import('@/lib/supabase')
+      const customFetch = vi.fn() as unknown as typeof fetch
+
+      getServiceRoleClient({ fetch: customFetch })
+
+      expect(mockCreateClient).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          global: { fetch: customFetch },
+        })
+      )
+    })
+
     it('should throw error when SUPABASE_SECRET_KEY is missing', async () => {
       delete process.env.SUPABASE_SECRET_KEY
       vi.resetModules()


### PR DESCRIPTION
## Summary
- add a target-bound, privacy-safe production inventory for hot archived classrooms
- harden the direct PostgreSQL catalog audit against target bypasses and credential disclosure
- verify exact archive/Gradex contracts, complete pagination, stable lifecycle snapshots, and exact Storage metadata
- document the production read-only workflow and local/hosted schema-audit modes

## Production safety
- the inventory performs only database and Storage reads
- no migration, export, restore, compaction, Gradex, cleanup, row mutation, or object mutation was performed
- the finalized read-only production run found 3 hot archives, 44,813 rows, 42.2 MiB relational payload, 165 objects / 25.9 MiB, and zero missing source objects

## Validation
- two independent review loops; final re-review reported no findings
- `pnpm test` (345 files, 3,080 tests)
- `pnpm build`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm check:architecture`
- local direct catalog audit (117 foreign-key relationships)
- finalized read-only production inventory
- Pika pre-commit audit