### PR TITLE
Extract assessment draft validation boundary

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13491,3 +13491,21 @@
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-06-23 — Student calendar cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with another client read-cache consistency slice.
+- Replaced `StudentLessonCalendarTab`'s manual cached GET fetchers with the shared `fetchCachedJSON` helper for lesson plans, assignments, and announcements.
+- Preserved existing cache keys, 20s TTLs, request-id/classroom stale response guard, and per-resource fallback behavior.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,24 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-23 — Student calendar cached JSON
-
-**Completed:**
-- Continued the bounded architecture/UI improvement goal with another client read-cache consistency slice.
-- Replaced `StudentLessonCalendarTab`'s manual cached GET fetchers with the shared `fetchCachedJSON` helper for lesson plans, assignments, and announcements.
-- Preserved existing cache keys, 20s TTLs, request-id/classroom stale response guard, and per-resource fallback behavior.
-- Kept the slice non-visual: no layout, copy, or interaction changes.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `git diff --check`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-06-23 — Announcements cached JSON
 
 **Completed:**
@@ -686,4 +668,30 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm check:architecture`
 - `pnpm build`
+- `git diff --check`
+
+## 2026-07-14 — Assessment draft validation boundary
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - cross-module boundary extraction benefits from repository-wide import analysis and behavior-parity verification.
+
+**Completed:**
+- Moved browser-safe assessment draft validation into the feature-owned `@/lib/validations/assessment-drafts` module while keeping persistence and database synchronization in `@/lib/server/assessment-drafts`.
+- Split browser, blueprint, route, and server imports so pure modules no longer reach through the server boundary for validation contracts or draft types.
+- Removed all four remaining deletion-only architecture allowances; the architecture check now covers 588 modules with zero allowances.
+- Removed stale route-test validator stubs so invalid draft payload tests exercise the real validation boundary.
+- Deleted the unused `syncAssessmentMetadataFromDraft` server export after CI coverage exposed that production performs the richer test metadata update directly in the route.
+- No behavior, UI, database schema, dependency, migration, or production changes.
+
+**Validation:**
+- Focused assessment draft, route, and architecture suites (4 files / 34 tests)
+- `pnpm test` (345 files / 3,081 tests)
+- `pnpm vitest run --coverage --maxWorkers=1` (server assessment drafts: 66.67% lines, 95% functions, 65.74% statements)
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture`
+- `node scripts/trim-session-log.mjs --check`
+- `node scripts/features.mjs validate`
 - `git diff --check`

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -193,7 +193,8 @@ Before changing remaining `quiz` / `quizzes` names, load
 [`docs/guidance/legacy-quiz-contract-cleanup.md`](../guidance/legacy-quiz-contract-cleanup.md).
 
 - **Test status**: `getStudentTestStatus()` from `@/lib/tests` — uses `returned_at` field
-- **Draft editing**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`
+- **Draft validation**: browser-safe draft contracts live in `@/lib/validations/assessment-drafts`
+- **Draft persistence**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`
 - **Scheduling**: `combineScheduleDateTimeToIso()` / `isScheduleIsoInFuture()` from `@/lib/scheduling`
 - **AI grading** (tests only): `src/lib/ai-test-grading.ts` — reference answer SHA-256 cached per question
 

--- a/scripts/architecture-baseline.json
+++ b/scripts/architecture-baseline.json
@@ -1,20 +1,3 @@
 {
-  "allowedViolations": [
-    {
-      "id": "browser-server:src/app/classrooms/[classroomId]/ClassroomPageClient.tsx->src/lib/server/assessment-drafts.ts",
-      "reason": "Legacy assessment markdown helpers import draft types from a server module. Remove after extracting the pure draft contract."
-    },
-    {
-      "id": "browser-server:src/app/classrooms/[classroomId]/TeacherTestsTab.tsx->src/lib/server/assessment-drafts.ts",
-      "reason": "Legacy assessment markdown helpers import draft types from a server module. Remove after extracting the pure draft contract."
-    },
-    {
-      "id": "browser-server:src/app/teacher/blueprints/page.tsx->src/lib/server/assessment-drafts.ts",
-      "reason": "Legacy assessment markdown helpers import draft types from a server module. Remove after extracting the pure draft contract."
-    },
-    {
-      "id": "browser-server:src/components/TestDetailPanel.tsx->src/lib/server/assessment-drafts.ts",
-      "reason": "Legacy assessment markdown helpers import draft types from a server module. Remove after extracting the pure draft contract."
-    }
-  ]
+  "allowedViolations": []
 }

--- a/src/app/api/teacher/tests/[id]/draft/route.ts
+++ b/src/app/api/teacher/tests/[id]/draft/route.ts
@@ -8,10 +8,10 @@ import {
   buildTestDraftContentFromRows,
   ensureAssessmentDraft,
   updateAssessmentDraft,
-  validateTestDraftContent,
-  type TestDraftContent,
 } from '@/lib/server/assessment-drafts'
+import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
+import type { TestDraftContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -10,12 +10,12 @@ import {
   isMissingAssessmentDraftsError,
   syncTestQuestionsFromDraft,
   updateAssessmentDraft,
-  validateTestDraftContent,
-  type TestDraftContent,
 } from '@/lib/server/assessment-drafts'
+import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
 import { withLegacyQuizKey } from '@/lib/test-api-contract'
 import type { TableRow } from '@/types/database'
+import type { TestDraftContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -12,16 +12,15 @@ import {
   buildTestDraftContentFromRows,
   createAssessmentDraft,
   isMissingAssessmentDraftsError,
-  validateTestDraftContent,
-  type TestDraftContent,
 } from '@/lib/server/assessment-drafts'
+import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import {
   getEffectiveStudentTestAccess,
   isMissingTestStudentAvailabilityError,
 } from '@/lib/server/tests'
 import { withErrorHandler } from '@/lib/api-handler'
 import { getFallbackAssessmentTitle } from '@/lib/assessment-titles'
-import type { TestStudentAvailabilityState } from '@/types'
+import type { TestDraftContent, TestStudentAvailabilityState } from '@/types'
 import { chunkValues, loadChunkedRows } from '@/lib/server/query-chunks'
 import { withLegacyQuizKey, withLegacyQuizListKey } from '@/lib/test-api-contract'
 

--- a/src/lib/course-blueprint-assessments-markdown.ts
+++ b/src/lib/course-blueprint-assessments-markdown.ts
@@ -1,6 +1,5 @@
 import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
-import type { TestDraftContent } from '@/lib/server/assessment-drafts'
-import type { TestDocument } from '@/types'
+import type { TestDocument, TestDraftContent } from '@/types'
 
 export interface CourseBlueprintAssessmentMarkdownRecord {
   id?: string

--- a/src/lib/course-blueprint-copilot.ts
+++ b/src/lib/course-blueprint-copilot.ts
@@ -10,9 +10,8 @@ import {
   courseBlueprintLessonTemplatesToMarkdown,
   type CourseBlueprintLessonTemplateMarkdownRecord,
 } from '@/lib/course-blueprint-lesson-templates'
-import type { CourseBlueprintDetail } from '@/types'
+import type { CourseBlueprintDetail, TestDraftContent } from '@/types'
 import { analyzeCourseBlueprintCompleteness } from '@/lib/course-blueprint-package'
-import type { TestDraftContent } from '@/lib/server/assessment-drafts'
 import { DEFAULT_OPEN_RESPONSE_MAX_CHARS } from '@/lib/test-attempts'
 
 type SuggestTarget =

--- a/src/lib/quiz-markdown.ts
+++ b/src/lib/quiz-markdown.ts
@@ -1,5 +1,5 @@
 import { validateAssessmentOptions } from '@/lib/assessments'
-import type { AssessmentDraftContent, AssessmentDraftQuestion } from '@/lib/server/assessment-drafts'
+import type { AssessmentDraftContent, AssessmentDraftQuestion } from '@/types'
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -1,29 +1,13 @@
 import { tryApplyJsonPatch } from '@/lib/json-patch'
-import { validateAssessmentOptions } from '@/lib/assessments'
-import { validateTestQuestionCreate } from '@/lib/test-questions'
+import type { AssessmentDraftValidationResult } from '@/lib/validations/assessment-drafts'
 import type {
   AssessmentDraftContent,
-  AssessmentDraftQuestion,
   AssessmentDraftType,
   JsonPatchOperation,
   TestDraftContent,
-  TestDraftQuestion,
-} from '@/types'
-
-export type {
-  AssessmentDraftContent,
-  AssessmentDraftQuestion,
-  AssessmentDraftType,
-  QuizDraftContent,
-  QuizDraftQuestion,
-  TestDraftContent,
-  TestDraftQuestion,
 } from '@/types'
 
 type SupabaseLike = any
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export type AssessmentDraftRow<TContent> = {
   id: string
@@ -38,25 +22,6 @@ export type AssessmentDraftRow<TContent> = {
   updated_at: string
 }
 
-type ValidationResult<TContent> =
-  | { valid: true; value: TContent }
-  | { valid: false; error: string }
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function parseUuid(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  return UUID_RE.test(value) ? value : null
-}
-
-function parseTitle(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : null
-}
-
 function parseStringArray(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null
 
@@ -69,27 +34,6 @@ function parseStringArray(value: unknown): string[] | null {
   }
 
   return next
-}
-
-function parseBoolean(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null
-}
-
-function parseOptionalMarkdown(value: unknown): string | undefined {
-  if (value === undefined || value === null) return undefined
-  if (typeof value !== 'string') return undefined
-  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-}
-
-function ensureUniqueQuestionIds<TQuestion extends { id: string }>(questions: TQuestion[]): string | null {
-  const ids = new Set<string>()
-  for (const question of questions) {
-    if (ids.has(question.id)) {
-      return `Duplicate question id: ${question.id}`
-    }
-    ids.add(question.id)
-  }
-  return null
 }
 
 // TODO(cleanup-045): Remove this function and all callsites once migration 045
@@ -112,147 +56,10 @@ export function isMissingAssessmentDraftsError(error: {
   return error.code === 'PGRST205' || error.code === '42P01' || combined.includes('table')
 }
 
-export function validateAssessmentDraftContent(
-  input: unknown
-): ValidationResult<AssessmentDraftContent> {
-  if (!isRecord(input)) return { valid: false, error: 'Invalid draft content' }
-
-  const title = parseTitle(input.title)
-  if (!title) return { valid: false, error: 'Title is required' }
-
-  const showResults = parseBoolean(input.show_results)
-  if (showResults === null) {
-    return { valid: false, error: 'show_results must be a boolean' }
-  }
-
-  if (!Array.isArray(input.questions)) {
-    return { valid: false, error: 'questions must be an array' }
-  }
-
-  const questions: AssessmentDraftQuestion[] = []
-
-  for (let index = 0; index < input.questions.length; index += 1) {
-    const rawQuestion = input.questions[index]
-    if (!isRecord(rawQuestion)) {
-      return { valid: false, error: `Q${index + 1}: Invalid question` }
-    }
-
-    const id = parseUuid(rawQuestion.id)
-    if (!id) {
-      return { valid: false, error: `Q${index + 1}: Invalid question id` }
-    }
-
-    const questionText = parseTitle(rawQuestion.question_text)
-    if (!questionText) {
-      return { valid: false, error: `Q${index + 1}: Question text is required` }
-    }
-
-    const options = parseStringArray(rawQuestion.options)
-    if (!options) {
-      return { valid: false, error: `Q${index + 1}: Options must be non-empty strings` }
-    }
-
-    const optionsValidation = validateAssessmentOptions(options)
-    if (!optionsValidation.valid) {
-      return { valid: false, error: `Q${index + 1}: ${optionsValidation.error}` }
-    }
-
-    questions.push({
-      id,
-      question_text: questionText,
-      options,
-    })
-  }
-
-  const duplicateError = ensureUniqueQuestionIds(questions)
-  if (duplicateError) {
-    return { valid: false, error: duplicateError }
-  }
-
-  return {
-    valid: true,
-    value: {
-      title,
-      show_results: showResults,
-      questions,
-      ...(input.source_format === 'markdown' ? { source_format: 'markdown' as const } : {}),
-      ...(parseOptionalMarkdown(input.source_markdown) !== undefined
-        ? { source_markdown: parseOptionalMarkdown(input.source_markdown) }
-        : {}),
-    },
-  }
-}
-
-export const validateQuizDraftContent = validateAssessmentDraftContent
-
-export function validateTestDraftContent(
-  input: unknown,
-  options?: { allowEmptyQuestionText?: boolean }
-): ValidationResult<TestDraftContent> {
-  if (!isRecord(input)) return { valid: false, error: 'Invalid draft content' }
-
-  const title = parseTitle(input.title)
-  if (!title) return { valid: false, error: 'Title is required' }
-
-  const showResults = parseBoolean(input.show_results)
-  if (showResults === null) {
-    return { valid: false, error: 'show_results must be a boolean' }
-  }
-
-  if (!Array.isArray(input.questions)) {
-    return { valid: false, error: 'questions must be an array' }
-  }
-
-  const questions: TestDraftQuestion[] = []
-
-  for (let index = 0; index < input.questions.length; index += 1) {
-    const rawQuestion = input.questions[index]
-    if (!isRecord(rawQuestion)) {
-      return { valid: false, error: `Q${index + 1}: Invalid question` }
-    }
-
-    const id = parseUuid(rawQuestion.id)
-    if (!id) {
-      return { valid: false, error: `Q${index + 1}: Invalid question id` }
-    }
-
-    const validation = validateTestQuestionCreate(rawQuestion, {
-      allowEmptyQuestionText: options?.allowEmptyQuestionText === true,
-    })
-
-    if (!validation.valid) {
-      return { valid: false, error: `Q${index + 1}: ${validation.error}` }
-    }
-
-    questions.push({
-      id,
-      ...validation.value,
-    })
-  }
-
-  const duplicateError = ensureUniqueQuestionIds(questions)
-  if (duplicateError) {
-    return { valid: false, error: duplicateError }
-  }
-
-  return {
-    valid: true,
-    value: {
-      title,
-      show_results: showResults,
-      questions,
-      ...(input.source_format === 'markdown' ? { source_format: 'markdown' as const } : {}),
-      ...(parseOptionalMarkdown(input.source_markdown) !== undefined
-        ? { source_markdown: parseOptionalMarkdown(input.source_markdown) }
-        : {}),
-    },
-  }
-}
-
 export function buildNextDraftContent<TContent extends object>(
   currentContent: TContent,
   payload: { patch?: JsonPatchOperation[]; content?: unknown },
-  validate: (input: unknown) => ValidationResult<TContent>
+  validate: (input: unknown) => AssessmentDraftValidationResult<TContent>
 ): { ok: true; content: TContent } | { ok: false; status: number; error: string } {
   let candidateContent: unknown
 
@@ -599,7 +406,10 @@ export type EnsureDraftConfig<TContent> = {
   /** Columns to select from the questions table */
   questionsSelect: string
   /** Validate draft content; extra options forwarded as `opts` */
-  validateContent: (input: unknown, opts?: { allowEmptyQuestionText?: boolean }) => ValidationResult<TContent>
+  validateContent: (
+    input: unknown,
+    opts?: { allowEmptyQuestionText?: boolean },
+  ) => AssessmentDraftValidationResult<TContent>
   validateOptions?: { allowEmptyQuestionText?: boolean }
   /** Build a fresh draft from the assessment + questions rows */
   buildFromRows: (
@@ -693,27 +503,4 @@ export async function ensureAssessmentDraft<TContent>(
   }
 
   return { ok: true, draft: createdDraft }
-}
-
-/**
- * Sync title and show_results from a saved draft back to the parent assessment table.
- * Used after PATCH in assessment draft routes.
- */
-export async function syncAssessmentMetadataFromDraft(
-  supabase: SupabaseLike,
-  parentTable: string,
-  id: string,
-  content: { title: string; show_results: boolean }
-): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-  const { error } = await supabase
-    .from(parentTable)
-    .update({ title: content.title, show_results: content.show_results })
-    .eq('id', id)
-
-  if (error) {
-    console.error(`Error syncing ${parentTable} metadata from draft:`, error)
-    return { ok: false, status: 500, error: 'Failed to sync assessment metadata' }
-  }
-
-  return { ok: true }
 }

--- a/src/lib/server/classroom-blueprint-source.ts
+++ b/src/lib/server/classroom-blueprint-source.ts
@@ -5,13 +5,13 @@ import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { tiptapToMarkdown } from '@/lib/limited-markdown'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { assertTeacherOwnsClassroom, hydrateClassroomRecord } from '@/lib/server/classrooms'
-import type { TestDraftContent } from '@/lib/server/assessment-drafts'
 import type {
   Announcement,
   AssignmentSubmissionRequirement,
   Classroom,
   ClassroomResources,
   TestDocument,
+  TestDraftContent,
 } from '@/types'
 
 export type ClassroomBlueprintSource = {

--- a/src/lib/server/course-blueprint-operations.ts
+++ b/src/lib/server/course-blueprint-operations.ts
@@ -17,8 +17,8 @@ import type {
   CourseBlueprintDetail,
   CreateClassroomFromBlueprintInput,
   Semester,
+  TestDraftContent,
 } from '@/types'
-import type { TestDraftContent } from '@/lib/server/assessment-drafts'
 import { parseDatabaseJson } from '@/lib/validations/database-json'
 import type { Database } from '@/types/database'
 

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/course-site-publishing'
 import { getDefaultClassroomThemeColor, normalizeClassroomThemeColor } from '@/lib/classroom-theme'
 import type {
+  AssessmentDraftContent,
   CourseBlueprint,
   CourseBlueprintAssignment,
   CourseBlueprintAssessment,
@@ -24,8 +25,8 @@ import type {
   CreateClassroomFromBlueprintInput,
   LinkedBlueprintClassroom,
   TestDocument,
+  TestDraftContent,
 } from '@/types'
-import type { AssessmentDraftContent, TestDraftContent } from '@/lib/server/assessment-drafts'
 import { normalizeAssignmentSubmissionRequirementDrafts } from '@/lib/assignment-submission-requirements'
 import {
   buildCreateBlueprintWritePlan,

--- a/src/lib/test-markdown.ts
+++ b/src/lib/test-markdown.ts
@@ -1,9 +1,9 @@
-import { validateTestDraftContent, type TestDraftContent, type TestDraftQuestion } from '@/lib/server/assessment-drafts'
+import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import { DEFAULT_OPEN_RESPONSE_MAX_CHARS } from '@/lib/test-attempts'
 import { TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown-schema'
 import { defaultPointsForQuestionType } from '@/lib/test-questions'
 import { validateTestDocumentsPayload } from '@/lib/test-documents'
-import type { TestDocument, TestQuestionType } from '@/types'
+import type { TestDocument, TestDraftContent, TestDraftQuestion, TestQuestionType } from '@/types'
 
 export { TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown-schema'
 

--- a/src/lib/validations/assessment-drafts.ts
+++ b/src/lib/validations/assessment-drafts.ts
@@ -1,0 +1,204 @@
+import { validateAssessmentOptions } from '@/lib/assessments'
+import { validateTestQuestionCreate } from '@/lib/test-questions'
+import type {
+  AssessmentDraftContent,
+  AssessmentDraftQuestion,
+  TestDraftContent,
+  TestDraftQuestion,
+} from '@/types'
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export type AssessmentDraftValidationResult<TContent> =
+  | { valid: true; value: TContent }
+  | { valid: false; error: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseUuid(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  return UUID_RE.test(value) ? value : null
+}
+
+function parseTitle(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+
+  const next: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string') return null
+    const trimmed = item.trim()
+    if (!trimmed) return null
+    next.push(trimmed)
+  }
+
+  return next
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function parseOptionalMarkdown(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') return undefined
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+}
+
+function ensureUniqueQuestionIds<TQuestion extends { id: string }>(
+  questions: TQuestion[],
+): string | null {
+  const ids = new Set<string>()
+  for (const question of questions) {
+    if (ids.has(question.id)) {
+      return `Duplicate question id: ${question.id}`
+    }
+    ids.add(question.id)
+  }
+  return null
+}
+
+export function validateAssessmentDraftContent(
+  input: unknown,
+): AssessmentDraftValidationResult<AssessmentDraftContent> {
+  if (!isRecord(input)) return { valid: false, error: 'Invalid draft content' }
+
+  const title = parseTitle(input.title)
+  if (!title) return { valid: false, error: 'Title is required' }
+
+  const showResults = parseBoolean(input.show_results)
+  if (showResults === null) {
+    return { valid: false, error: 'show_results must be a boolean' }
+  }
+
+  if (!Array.isArray(input.questions)) {
+    return { valid: false, error: 'questions must be an array' }
+  }
+
+  const questions: AssessmentDraftQuestion[] = []
+
+  for (let index = 0; index < input.questions.length; index += 1) {
+    const rawQuestion = input.questions[index]
+    if (!isRecord(rawQuestion)) {
+      return { valid: false, error: `Q${index + 1}: Invalid question` }
+    }
+
+    const id = parseUuid(rawQuestion.id)
+    if (!id) {
+      return { valid: false, error: `Q${index + 1}: Invalid question id` }
+    }
+
+    const questionText = parseTitle(rawQuestion.question_text)
+    if (!questionText) {
+      return { valid: false, error: `Q${index + 1}: Question text is required` }
+    }
+
+    const options = parseStringArray(rawQuestion.options)
+    if (!options) {
+      return { valid: false, error: `Q${index + 1}: Options must be non-empty strings` }
+    }
+
+    const optionsValidation = validateAssessmentOptions(options)
+    if (!optionsValidation.valid) {
+      return { valid: false, error: `Q${index + 1}: ${optionsValidation.error}` }
+    }
+
+    questions.push({
+      id,
+      question_text: questionText,
+      options,
+    })
+  }
+
+  const duplicateError = ensureUniqueQuestionIds(questions)
+  if (duplicateError) {
+    return { valid: false, error: duplicateError }
+  }
+
+  return {
+    valid: true,
+    value: {
+      title,
+      show_results: showResults,
+      questions,
+      ...(input.source_format === 'markdown' ? { source_format: 'markdown' as const } : {}),
+      ...(parseOptionalMarkdown(input.source_markdown) !== undefined
+        ? { source_markdown: parseOptionalMarkdown(input.source_markdown) }
+        : {}),
+    },
+  }
+}
+
+export const validateQuizDraftContent = validateAssessmentDraftContent
+
+export function validateTestDraftContent(
+  input: unknown,
+  options?: { allowEmptyQuestionText?: boolean },
+): AssessmentDraftValidationResult<TestDraftContent> {
+  if (!isRecord(input)) return { valid: false, error: 'Invalid draft content' }
+
+  const title = parseTitle(input.title)
+  if (!title) return { valid: false, error: 'Title is required' }
+
+  const showResults = parseBoolean(input.show_results)
+  if (showResults === null) {
+    return { valid: false, error: 'show_results must be a boolean' }
+  }
+
+  if (!Array.isArray(input.questions)) {
+    return { valid: false, error: 'questions must be an array' }
+  }
+
+  const questions: TestDraftQuestion[] = []
+
+  for (let index = 0; index < input.questions.length; index += 1) {
+    const rawQuestion = input.questions[index]
+    if (!isRecord(rawQuestion)) {
+      return { valid: false, error: `Q${index + 1}: Invalid question` }
+    }
+
+    const id = parseUuid(rawQuestion.id)
+    if (!id) {
+      return { valid: false, error: `Q${index + 1}: Invalid question id` }
+    }
+
+    const validation = validateTestQuestionCreate(rawQuestion, {
+      allowEmptyQuestionText: options?.allowEmptyQuestionText === true,
+    })
+
+    if (!validation.valid) {
+      return { valid: false, error: `Q${index + 1}: ${validation.error}` }
+    }
+
+    questions.push({
+      id,
+      ...validation.value,
+    })
+  }
+
+  const duplicateError = ensureUniqueQuestionIds(questions)
+  if (duplicateError) {
+    return { valid: false, error: duplicateError }
+  }
+
+  return {
+    valid: true,
+    value: {
+      title,
+      show_results: showResults,
+      questions,
+      ...(input.source_format === 'markdown' ? { source_format: 'markdown' as const } : {}),
+      ...(parseOptionalMarkdown(input.source_markdown) !== undefined
+        ? { source_markdown: parseOptionalMarkdown(input.source_markdown) }
+        : {}),
+    },
+  }
+}

--- a/src/lib/validations/course-blueprints.ts
+++ b/src/lib/validations/course-blueprints.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { CLASSROOM_THEME_COLORS } from '@/lib/classroom-theme'
-import { validateTestDraftContent } from '@/lib/server/assessment-drafts'
+import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import { validateTestDocumentsPayload } from '@/lib/test-documents'
 import {
   courseSiteSlugSchema,

--- a/tests/api/teacher/tests-draft-route.test.ts
+++ b/tests/api/teacher/tests-draft-route.test.ts
@@ -42,7 +42,6 @@ vi.mock('@/lib/server/assessment-drafts', () => ({
   })),
   ensureAssessmentDraft: vi.fn(),
   updateAssessmentDraft: vi.fn(),
-  validateTestDraftContent: vi.fn((content: any) => ({ valid: true, value: content })),
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -202,6 +201,33 @@ describe('PATCH /api/teacher/tests/[id]/draft', () => {
         userId: 'teacher-1',
       })
     )
+  })
+
+  it('validates draft content through the route-owned validation boundary', async () => {
+    vi.mocked(buildNextDraftContent).mockImplementationOnce(
+      ((_currentContent, payload, validate) => {
+        const validation = validate(payload.content)
+        return validation.valid
+          ? { ok: true, content: validation.value }
+          : { ok: false, status: 400, error: validation.error }
+      }) as typeof buildNextDraftContent
+    )
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/draft', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          version: 3,
+          content: { title: '  ', show_results: true, questions: [] },
+        }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Title is required')
+    expect(updateAssessmentDraft).not.toHaveBeenCalled()
   })
 
   it('returns 400 and blocks save when documents payload is invalid', async () => {

--- a/tests/api/teacher/tests-id-route.test.ts
+++ b/tests/api/teacher/tests-id-route.test.ts
@@ -41,7 +41,6 @@ vi.mock('@/lib/server/assessment-drafts', () => ({
   isMissingAssessmentDraftsError: vi.fn(() => false),
   syncTestQuestionsFromDraft: vi.fn(async () => ({ ok: true })),
   updateAssessmentDraft: vi.fn(async () => ({ draft: null, error: null })),
-  validateTestDraftContent: vi.fn((content: unknown) => ({ valid: true, value: content })),
 }))
 
 const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -11,10 +11,12 @@ import {
   syncQuizQuestionsFromDraft,
   syncTestQuestionsFromDraft,
   updateAssessmentDraft,
+} from '@/lib/server/assessment-drafts'
+import {
   validateAssessmentDraftContent,
   validateQuizDraftContent,
   validateTestDraftContent,
-} from '@/lib/server/assessment-drafts'
+} from '@/lib/validations/assessment-drafts'
 
 const QUIZ_ID_1 = '11111111-1111-4111-8111-111111111111'
 const QUIZ_ID_2 = '22222222-2222-4222-8222-222222222222'


### PR DESCRIPTION
## Summary
- move browser-safe assessment draft validation into a feature-owned validation module
- keep persistence and database synchronization behind the server boundary
- remove all four remaining architecture baseline allowances
- correct route tests and add route-level validation coverage

## Validation
- two independent review passes; no actionable findings remain
- `pnpm test` (345 files / 3,081 tests)
- `pnpm build`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm check:architecture` (588 modules, 0 allowances)
- continuity and feature validation
- Pika pre-commit audit

No UI, dependency, database schema, migration, or production changes.