### PR TITLE
Extract manual test grading workflow

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13544,3 +13544,21 @@
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `./node_modules/.bin/vitest run`
 - `pnpm test` was attempted but blocked before Vitest by pnpm ignored build-script approval (`@parcel/watcher`, `esbuild`, `unrs-resolver`).
+
+## 2026-06-23 — Teacher classroom cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a small client read-cache consistency slice in the teacher classroom assignments view.
+- Replaced the assignments, materials, and surveys summary GET loaders with `fetchCachedJSON`, preserving cache keys, 20s TTLs, error messages, survey fallback, and stale classroom/request guards.
+- Left selected-assignment detail loading on `fetchJSONWithCache` because its short TTL and refresh-counter key are intentional.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,24 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-23 — Teacher classroom cached JSON
-
-**Completed:**
-- Continued the bounded architecture/UI improvement goal with a small client read-cache consistency slice in the teacher classroom assignments view.
-- Replaced the assignments, materials, and surveys summary GET loaders with `fetchCachedJSON`, preserving cache keys, 20s TTLs, error messages, survey fallback, and stale classroom/request guards.
-- Left selected-assignment detail loading on `fetchJSONWithCache` because its short TTL and refresh-counter key are intentional.
-- Kept the slice non-visual: no layout, copy, or interaction changes.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `git diff --check`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-06-24 — Teacher lesson calendar cached JSON
 
 **Completed:**
@@ -709,4 +691,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm check:architecture` (592 modules / 0 allowances)
 - Pika pre-commit audit
 - `bash scripts/verify-env.sh`
+- `git diff --check`
+
+## 2026-07-14 — Manual test grading workflow boundary
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5 Codex - grading request compatibility and persistence extraction require exact cross-layer behavior analysis.
+
+**Completed:**
+- Replaced the handwritten manual test-grade decoder with a feature-owned Zod contract while preserving score coercion, rounding, trim behavior, clear semantics, AI audit metadata, and duplicate rejection.
+- Extracted teacher access, enrollment/question validation, existing-response preservation, grade row construction, and the legacy AI-column retry into `@/lib/server/test-grades`.
+- Kept the existing non-transactional persistence sequence unchanged for this behavior-preserving expand slice; atomic test grading remains a separately reviewed follow-up.
+- Made malformed JSON and JSON `null` fail deterministically with 400 responses instead of accidental internal errors.
+- Removed the route from the deletion-only API Zod baseline and added regressions for access arguments, archive protection, query failures, question scope, score caps, clear fields, timestamps, and failed compatibility retries.
+- Completed two independent review/fix rounds with no remaining findings. No UI, database schema, migration, dependency, or production changes.
+
+**Validation:**
+- Focused grading contract, route, and API architecture suites (3 files / 33 tests)
+- `pnpm test` (351 files / 3,186 tests)
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture` (594 modules / 0 allowances)
+- Pika pre-commit audit
 - `git diff --check`

--- a/src/app/api/teacher/tests/[id]/students/[studentId]/grades/route.ts
+++ b/src/app/api/teacher/tests/[id]/students/[studentId]/grades/route.ts
@@ -1,292 +1,40 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
-import { getServiceRoleClient } from '@/lib/supabase'
-import { assertTeacherOwnsTest, isMissingTestResponseAiColumnsError } from '@/lib/server/tests'
 import { withErrorHandler } from '@/lib/api-handler'
+import { saveStudentTestGrades } from '@/lib/server/test-grades'
+import { saveStudentTestGradesSchema } from '@/lib/validations/test-grading'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-
-type GradePayload = {
-  question_id: string
-  score: number | null
-  feedback: string | null
-  clear_grade: boolean
-  ai_grading_basis?: 'teacher_key' | 'generated_reference' | null
-  ai_reference_answers?: string[] | null
-  ai_model?: string | null
-}
-
-function normalizeGradePayload(raw: unknown): GradePayload | null {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
-  const record = raw as Record<string, unknown>
-  const questionId = typeof record.question_id === 'string' ? record.question_id.trim() : ''
-  const clearGrade = record.clear_grade === true
-  if (!questionId) return null
-  if (record.clear_grade !== undefined && typeof record.clear_grade !== 'boolean') return null
-
-  let score: number | null = null
-  let feedback: string | null = null
-  if (!clearGrade) {
-    const parsedScore = Number(record.score)
-    if (!Number.isFinite(parsedScore) || parsedScore < 0) return null
-    score = Math.round(parsedScore * 100) / 100
-    const normalizedFeedback = typeof record.feedback === 'string' ? record.feedback.trim() : ''
-    feedback = normalizedFeedback || null
-  }
-
-  let aiGradingBasis: 'teacher_key' | 'generated_reference' | null | undefined
-  if (record.ai_grading_basis !== undefined) {
-    if (record.ai_grading_basis === null) {
-      aiGradingBasis = null
-    } else if (
-      record.ai_grading_basis === 'teacher_key' ||
-      record.ai_grading_basis === 'generated_reference'
-    ) {
-      aiGradingBasis = record.ai_grading_basis
-    } else {
-      return null
-    }
-  }
-
-  let aiReferenceAnswers: string[] | null | undefined
-  if (record.ai_reference_answers !== undefined) {
-    if (record.ai_reference_answers === null) {
-      aiReferenceAnswers = null
-    } else if (Array.isArray(record.ai_reference_answers)) {
-      const normalized = record.ai_reference_answers
-        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-        .filter((value) => value.length > 0)
-      if (normalized.length === 0 || normalized.length > 3) return null
-      aiReferenceAnswers = normalized
-    } else {
-      return null
-    }
-  }
-
-  let aiModel: string | null | undefined
-  if (record.ai_model !== undefined) {
-    if (record.ai_model === null) {
-      aiModel = null
-    } else if (typeof record.ai_model === 'string') {
-      aiModel = record.ai_model.trim() || null
-    } else {
-      return null
-    }
-  }
-
-  if (aiGradingBasis === 'generated_reference' && (!aiReferenceAnswers || aiReferenceAnswers.length === 0)) {
-    return null
-  }
-  if (aiGradingBasis === 'teacher_key') {
-    aiReferenceAnswers = null
-  }
-
-  return {
-    question_id: questionId,
-    score,
-    feedback,
-    clear_grade: clearGrade,
-    ai_grading_basis: aiGradingBasis,
-    ai_reference_answers: aiReferenceAnswers,
-    ai_model: aiModel,
-  }
-}
 
 // PATCH /api/teacher/tests/[id]/students/[studentId]/grades - Save open-response grades for one student
 export const PATCH = withErrorHandler('BulkSaveTeacherTestGrades', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: testId, studentId } = await context.params
-  const body = (await request.json()) as Record<string, unknown>
-
-  if (!Array.isArray(body.grades) || body.grades.length === 0) {
-    return NextResponse.json({ error: 'grades array is required' }, { status: 400 })
+  let rawBody: unknown
+  try {
+    rawBody = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const grades: GradePayload[] = []
-  for (const raw of body.grades) {
-    const normalized = normalizeGradePayload(raw)
-    if (!normalized) {
-      return NextResponse.json({ error: 'Invalid grade payload' }, { status: 400 })
-    }
-    grades.push(normalized)
+  const parsed = saveStudentTestGradesSchema.safeParse(rawBody)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'Invalid grade payload' },
+      { status: 400 },
+    )
   }
 
-  const dedupedQuestionIds = new Set<string>()
-  for (const grade of grades) {
-    if (dedupedQuestionIds.has(grade.question_id)) {
-      return NextResponse.json({ error: 'Duplicate question_id in grades payload' }, { status: 400 })
-    }
-    dedupedQuestionIds.add(grade.question_id)
-  }
-
-  const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
-  if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status })
-  }
-
-  const supabase = getServiceRoleClient()
-
-  const { data: enrollment, error: enrollmentError } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id')
-    .eq('classroom_id', access.test.classroom_id)
-    .eq('student_id', studentId)
-    .maybeSingle()
-
-  if (enrollmentError) {
-    console.error('Error validating classroom enrollment for grade save:', enrollmentError)
-    return NextResponse.json({ error: 'Failed to validate student enrollment' }, { status: 500 })
-  }
-  if (!enrollment) {
-    return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
-  }
-
-  const questionIds = grades.map((grade) => grade.question_id)
-
-  const { data: questionRows, error: questionError } = await supabase
-    .from('test_questions')
-    .select('id, question_type, points')
-    .eq('test_id', testId)
-    .in('id', questionIds)
-
-  if (questionError) {
-    console.error('Error loading test questions for grade save:', questionError)
-    return NextResponse.json({ error: 'Failed to validate questions' }, { status: 500 })
-  }
-
-  if ((questionRows || []).length !== questionIds.length) {
-    return NextResponse.json({ error: 'One or more questions were not found for this test' }, { status: 400 })
-  }
-
-  const questionMap = new Map((questionRows || []).map((row) => [row.id, row]))
-  for (const grade of grades) {
-    const question = questionMap.get(grade.question_id)
-    if (!question) {
-      return NextResponse.json({ error: 'One or more questions were not found for this test' }, { status: 400 })
-    }
-    const maxScore = Number(question.points ?? 0)
-    if (grade.score != null && grade.score > maxScore) {
-      return NextResponse.json({ error: `score cannot exceed ${maxScore}` }, { status: 400 })
-    }
-    if (question.question_type !== 'open_response' && grade.ai_grading_basis !== undefined) {
-      return NextResponse.json(
-        { error: 'AI grading metadata is only supported for open-response questions' },
-        { status: 400 },
-      )
-    }
-  }
-
-  const { data: existingRows, error: existingRowsError } = await supabase
-    .from('test_responses')
-    .select('question_id, selected_option, response_text, submitted_at')
-    .eq('test_id', testId)
-    .eq('student_id', studentId)
-    .in('question_id', questionIds)
-
-  if (existingRowsError) {
-    console.error('Error loading existing responses for grade save:', existingRowsError)
-    return NextResponse.json({ error: 'Failed to save grades' }, { status: 500 })
-  }
-
-  const existingByQuestionId = new Map((existingRows || []).map((row) => [row.question_id, row]))
-  const gradedAt = new Date().toISOString()
-
-  const upsertRows = grades.map((grade) => {
-    const existing = existingByQuestionId.get(grade.question_id)
-    const question = questionMap.get(grade.question_id)!
-    const responseText =
-      typeof existing?.response_text === 'string'
-        ? existing.response_text
-        : question.question_type === 'open_response'
-          ? ''
-          : null
-    const submittedAt =
-      typeof existing?.submitted_at === 'string' && existing.submitted_at
-        ? existing.submitted_at
-        : gradedAt
-    const selectedOption =
-      typeof existing?.selected_option === 'number'
-        ? existing.selected_option
-        : null
-
-    if (grade.clear_grade) {
-      return {
-        test_id: testId,
-        question_id: grade.question_id,
-        student_id: studentId,
-        selected_option: selectedOption,
-        response_text: responseText,
-        score: null,
-        feedback: null,
-        graded_at: null,
-        graded_by: null,
-        submitted_at: submittedAt,
-        ai_grading_basis: null,
-        ai_reference_answers: null,
-        ai_model: null,
-      }
-    }
-
-    return {
-      test_id: testId,
-      question_id: grade.question_id,
-      student_id: studentId,
-      selected_option: selectedOption,
-      response_text: responseText,
-      score: grade.score,
-      feedback: question.question_type === 'open_response' ? grade.feedback : null,
-      graded_at: gradedAt,
-      graded_by: user.id,
-      submitted_at: submittedAt,
-      ai_grading_basis:
-        question.question_type === 'open_response'
-          ? (grade.ai_grading_basis ?? null)
-          : null,
-      ai_reference_answers:
-        question.question_type === 'open_response' && grade.ai_grading_basis === 'generated_reference'
-          ? (grade.ai_reference_answers ?? [])
-          : null,
-      ai_model: question.question_type === 'open_response' ? (grade.ai_model ?? null) : null,
-    }
+  const result = await saveStudentTestGrades({
+    teacherId: user.id,
+    testId,
+    studentId,
+    grades: parsed.data.grades,
   })
-
-  let upsertError: { code?: string; message?: string; details?: string; hint?: string } | null = null
-  {
-    const upsertWithAiResult = await supabase
-      .from('test_responses')
-      .upsert(upsertRows, { onConflict: 'question_id,student_id' })
-
-    upsertError = upsertWithAiResult.error
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status })
   }
 
-  if (upsertError && isMissingTestResponseAiColumnsError(upsertError)) {
-    const legacyUpsertRows = upsertRows.map((row) => ({
-      test_id: row.test_id,
-      question_id: row.question_id,
-      student_id: row.student_id,
-      selected_option: row.selected_option,
-      response_text: row.response_text,
-      score: row.score,
-      feedback: row.feedback,
-      graded_at: row.graded_at,
-      graded_by: row.graded_by,
-      submitted_at: row.submitted_at,
-    }))
-
-    const legacyUpsertResult = await supabase
-      .from('test_responses')
-      .upsert(legacyUpsertRows, { onConflict: 'question_id,student_id' })
-
-    upsertError = legacyUpsertResult.error
-  }
-
-  if (upsertError) {
-    console.error('Error upserting student grade set:', upsertError)
-    return NextResponse.json({ error: 'Failed to save grades' }, { status: 500 })
-  }
-
-  return NextResponse.json({
-    saved_count: upsertRows.length,
-  })
+  return NextResponse.json({ saved_count: result.savedCount })
 })

--- a/src/lib/server/test-grades.ts
+++ b/src/lib/server/test-grades.ts
@@ -1,0 +1,174 @@
+import { getServiceRoleClient } from '@/lib/supabase'
+import { assertTeacherOwnsTest, isMissingTestResponseAiColumnsError } from '@/lib/server/tests'
+import type { SaveStudentTestGradesInput } from '@/lib/validations/test-grading'
+
+type SaveStudentTestGradesResult =
+  | { ok: true; savedCount: number }
+  | { ok: false; status: number; error: string }
+
+export async function saveStudentTestGrades(input: {
+  teacherId: string
+  testId: string
+  studentId: string
+  grades: SaveStudentTestGradesInput['grades']
+}): Promise<SaveStudentTestGradesResult> {
+  const access = await assertTeacherOwnsTest(input.teacherId, input.testId, { checkArchived: true })
+  if (!access.ok) return access
+
+  const supabase = getServiceRoleClient()
+  const { data: enrollment, error: enrollmentError } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', access.test.classroom_id)
+    .eq('student_id', input.studentId)
+    .maybeSingle()
+
+  if (enrollmentError) {
+    console.error('Error validating classroom enrollment for grade save:', enrollmentError)
+    return { ok: false, status: 500, error: 'Failed to validate student enrollment' }
+  }
+  if (!enrollment) {
+    return { ok: false, status: 400, error: 'Student is not enrolled in this classroom' }
+  }
+
+  const questionIds = input.grades.map((grade) => grade.question_id)
+  const { data: questionRows, error: questionError } = await supabase
+    .from('test_questions')
+    .select('id, question_type, points')
+    .eq('test_id', input.testId)
+    .in('id', questionIds)
+
+  if (questionError) {
+    console.error('Error loading test questions for grade save:', questionError)
+    return { ok: false, status: 500, error: 'Failed to validate questions' }
+  }
+
+  if ((questionRows || []).length !== questionIds.length) {
+    return { ok: false, status: 400, error: 'One or more questions were not found for this test' }
+  }
+
+  const questionMap = new Map((questionRows || []).map((row) => [row.id, row]))
+  for (const grade of input.grades) {
+    const question = questionMap.get(grade.question_id)
+    if (!question) {
+      return { ok: false, status: 400, error: 'One or more questions were not found for this test' }
+    }
+    const maxScore = Number(question.points ?? 0)
+    if (grade.score != null && grade.score > maxScore) {
+      return { ok: false, status: 400, error: `score cannot exceed ${maxScore}` }
+    }
+    if (question.question_type !== 'open_response' && grade.ai_grading_basis !== undefined) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'AI grading metadata is only supported for open-response questions',
+      }
+    }
+  }
+
+  const { data: existingRows, error: existingRowsError } = await supabase
+    .from('test_responses')
+    .select('question_id, selected_option, response_text, submitted_at')
+    .eq('test_id', input.testId)
+    .eq('student_id', input.studentId)
+    .in('question_id', questionIds)
+
+  if (existingRowsError) {
+    console.error('Error loading existing responses for grade save:', existingRowsError)
+    return { ok: false, status: 500, error: 'Failed to save grades' }
+  }
+
+  const existingByQuestionId = new Map((existingRows || []).map((row) => [row.question_id, row]))
+  const gradedAt = new Date().toISOString()
+  const upsertRows = input.grades.map((grade) => {
+    const existing = existingByQuestionId.get(grade.question_id)
+    const question = questionMap.get(grade.question_id)!
+    const responseText =
+      typeof existing?.response_text === 'string'
+        ? existing.response_text
+        : question.question_type === 'open_response'
+          ? ''
+          : null
+    const submittedAt =
+      typeof existing?.submitted_at === 'string' && existing.submitted_at
+        ? existing.submitted_at
+        : gradedAt
+    const selectedOption =
+      typeof existing?.selected_option === 'number'
+        ? existing.selected_option
+        : null
+
+    if (grade.clear_grade) {
+      return {
+        test_id: input.testId,
+        question_id: grade.question_id,
+        student_id: input.studentId,
+        selected_option: selectedOption,
+        response_text: responseText,
+        score: null,
+        feedback: null,
+        graded_at: null,
+        graded_by: null,
+        submitted_at: submittedAt,
+        ai_grading_basis: null,
+        ai_reference_answers: null,
+        ai_model: null,
+      }
+    }
+
+    return {
+      test_id: input.testId,
+      question_id: grade.question_id,
+      student_id: input.studentId,
+      selected_option: selectedOption,
+      response_text: responseText,
+      score: grade.score,
+      feedback: question.question_type === 'open_response' ? grade.feedback : null,
+      graded_at: gradedAt,
+      graded_by: input.teacherId,
+      submitted_at: submittedAt,
+      ai_grading_basis:
+        question.question_type === 'open_response'
+          ? (grade.ai_grading_basis ?? null)
+          : null,
+      ai_reference_answers:
+        question.question_type === 'open_response' && grade.ai_grading_basis === 'generated_reference'
+          ? (grade.ai_reference_answers ?? [])
+          : null,
+      ai_model: question.question_type === 'open_response' ? (grade.ai_model ?? null) : null,
+    }
+  })
+
+  let upsertError: { code?: string; message?: string; details?: string; hint?: string } | null
+  const upsertWithAiResult = await supabase
+    .from('test_responses')
+    .upsert(upsertRows, { onConflict: 'question_id,student_id' })
+  upsertError = upsertWithAiResult.error
+
+  if (upsertError && isMissingTestResponseAiColumnsError(upsertError)) {
+    const legacyUpsertRows = upsertRows.map((row) => ({
+      test_id: row.test_id,
+      question_id: row.question_id,
+      student_id: row.student_id,
+      selected_option: row.selected_option,
+      response_text: row.response_text,
+      score: row.score,
+      feedback: row.feedback,
+      graded_at: row.graded_at,
+      graded_by: row.graded_by,
+      submitted_at: row.submitted_at,
+    }))
+
+    const legacyUpsertResult = await supabase
+      .from('test_responses')
+      .upsert(legacyUpsertRows, { onConflict: 'question_id,student_id' })
+    upsertError = legacyUpsertResult.error
+  }
+
+  if (upsertError) {
+    console.error('Error upserting student grade set:', upsertError)
+    return { ok: false, status: 500, error: 'Failed to save grades' }
+  }
+
+  return { ok: true, savedCount: upsertRows.length }
+}

--- a/src/lib/validations/test-grading.ts
+++ b/src/lib/validations/test-grading.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod'
+
+function invalidGrade(context: z.RefinementCtx): never {
+  context.addIssue({ code: 'custom', message: 'Invalid grade payload' })
+  return z.NEVER
+}
+
+const studentTestGradeSchema = z.unknown().transform((raw, context) => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return invalidGrade(context)
+  }
+
+  const record = raw as Record<string, unknown>
+  const questionId = typeof record.question_id === 'string' ? record.question_id.trim() : ''
+  const clearGrade = record.clear_grade === true
+  if (!questionId) return invalidGrade(context)
+  if (record.clear_grade !== undefined && typeof record.clear_grade !== 'boolean') {
+    return invalidGrade(context)
+  }
+
+  let score: number | null = null
+  let feedback: string | null = null
+  if (!clearGrade) {
+    let parsedScore: number
+    try {
+      parsedScore = Number(record.score)
+    } catch {
+      return invalidGrade(context)
+    }
+    if (!Number.isFinite(parsedScore) || parsedScore < 0) return invalidGrade(context)
+    score = Math.round(parsedScore * 100) / 100
+    const normalizedFeedback = typeof record.feedback === 'string' ? record.feedback.trim() : ''
+    feedback = normalizedFeedback || null
+  }
+
+  let aiGradingBasis: 'teacher_key' | 'generated_reference' | null | undefined
+  if (record.ai_grading_basis !== undefined) {
+    if (record.ai_grading_basis === null) {
+      aiGradingBasis = null
+    } else if (
+      record.ai_grading_basis === 'teacher_key' ||
+      record.ai_grading_basis === 'generated_reference'
+    ) {
+      aiGradingBasis = record.ai_grading_basis
+    } else {
+      return invalidGrade(context)
+    }
+  }
+
+  let aiReferenceAnswers: string[] | null | undefined
+  if (record.ai_reference_answers !== undefined) {
+    if (record.ai_reference_answers === null) {
+      aiReferenceAnswers = null
+    } else if (Array.isArray(record.ai_reference_answers)) {
+      const normalized = record.ai_reference_answers
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+      if (normalized.length === 0 || normalized.length > 3) return invalidGrade(context)
+      aiReferenceAnswers = normalized
+    } else {
+      return invalidGrade(context)
+    }
+  }
+
+  let aiModel: string | null | undefined
+  if (record.ai_model !== undefined) {
+    if (record.ai_model === null) {
+      aiModel = null
+    } else if (typeof record.ai_model === 'string') {
+      aiModel = record.ai_model.trim() || null
+    } else {
+      return invalidGrade(context)
+    }
+  }
+
+  if (
+    aiGradingBasis === 'generated_reference' &&
+    (!aiReferenceAnswers || aiReferenceAnswers.length === 0)
+  ) {
+    return invalidGrade(context)
+  }
+  if (aiGradingBasis === 'teacher_key') {
+    aiReferenceAnswers = null
+  }
+
+  return {
+    question_id: questionId,
+    score,
+    feedback,
+    clear_grade: clearGrade,
+    ai_grading_basis: aiGradingBasis,
+    ai_reference_answers: aiReferenceAnswers,
+    ai_model: aiModel,
+  }
+})
+
+export type StudentTestGradeInput = z.infer<typeof studentTestGradeSchema>
+
+export const saveStudentTestGradesSchema = z.unknown().transform((raw, context) => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    context.addIssue({ code: 'custom', message: 'grades array is required' })
+    return z.NEVER
+  }
+
+  const gradesValue = (raw as Record<string, unknown>).grades
+  if (!Array.isArray(gradesValue) || gradesValue.length === 0) {
+    context.addIssue({ code: 'custom', message: 'grades array is required' })
+    return z.NEVER
+  }
+
+  const grades: StudentTestGradeInput[] = []
+  for (const gradeValue of gradesValue) {
+    const parsed = studentTestGradeSchema.safeParse(gradeValue)
+    if (!parsed.success) {
+      context.addIssue({ code: 'custom', message: 'Invalid grade payload' })
+      return z.NEVER
+    }
+    grades.push(parsed.data)
+  }
+
+  const questionIds = new Set<string>()
+  for (const grade of grades) {
+    if (questionIds.has(grade.question_id)) {
+      context.addIssue({ code: 'custom', message: 'Duplicate question_id in grades payload' })
+      return z.NEVER
+    }
+    questionIds.add(grade.question_id)
+  }
+
+  return { grades }
+})
+
+export type SaveStudentTestGradesInput = z.infer<typeof saveStudentTestGradesSchema>

--- a/tests/api/teacher/tests-students-grades.test.ts
+++ b/tests/api/teacher/tests-students-grades.test.ts
@@ -32,6 +32,73 @@ vi.mock('@/lib/server/tests', async () => {
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function makeGradeRequest(body: unknown = {
+  grades: [{ question_id: 'question-open-1', score: 1 }],
+}) {
+  return new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/student-1/grades', {
+    method: 'PATCH',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+const gradeRouteContext = {
+  params: Promise.resolve({ id: 'test-1', studentId: 'student-1' }),
+}
+
+function configureGradeWorkflow(options: {
+  enrollmentError?: unknown
+  questionError?: unknown
+  responseError?: unknown
+  upsertErrors?: unknown[]
+} = {}) {
+  const upsert = vi.fn()
+  for (const error of options.upsertErrors || [null]) {
+    upsert.mockResolvedValueOnce({ error })
+  }
+
+  ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: options.enrollmentError ? null : { student_id: 'student-1' },
+            error: options.enrollmentError || null,
+          }),
+        })),
+      }
+    }
+    if (table === 'test_questions') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({
+            data: options.questionError
+              ? null
+              : [{ id: 'question-open-1', question_type: 'open_response', points: 5 }],
+            error: options.questionError || null,
+          }),
+        })),
+      }
+    }
+    if (table === 'test_responses') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({
+            data: options.responseError ? null : [],
+            error: options.responseError || null,
+          }),
+        })),
+        upsert,
+      }
+    }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return { upsert }
+}
+
 describe('PATCH /api/teacher/tests/[id]/students/[studentId]/grades', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -49,6 +116,171 @@ describe('PATCH /api/teacher/tests/[id]/students/[studentId]/grades', () => {
     const data = await response.json()
     expect(response.status).toBe(400)
     expect(data.error).toBe('grades array is required')
+  })
+
+  it.each([
+    ['{', 'Invalid JSON body'],
+    ['null', 'grades array is required'],
+  ])('returns a deterministic 400 for malformed body %s', async (body, expectedError) => {
+    const response = await PATCH(makeGradeRequest(body), gradeRouteContext)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: expectedError })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      [{ question_id: 'question-open-1', score: 1, ai_grading_basis: 'generated_reference' }],
+      'Invalid grade payload',
+    ],
+    [
+      [
+        { question_id: 'question-open-1', score: 1 },
+        { question_id: ' question-open-1 ', score: 2 },
+      ],
+      'Duplicate question_id in grades payload',
+    ],
+  ])('rejects invalid grade requests before access checks', async (grades, expectedError) => {
+    const { assertTeacherOwnsTest } = await import('@/lib/server/tests')
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/student-1/grades', {
+        method: 'PATCH',
+        body: JSON.stringify({ grades }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', studentId: 'student-1' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: expectedError })
+    expect(assertTeacherOwnsTest).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('stops archived-classroom saves before grade persistence', async () => {
+    const { assertTeacherOwnsTest } = await import('@/lib/server/tests')
+    vi.mocked(assertTeacherOwnsTest).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/student-1/grades', {
+        method: 'PATCH',
+        body: JSON.stringify({ grades: [{ question_id: 'question-open-1', score: 1 }] }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', studentId: 'student-1' }) }
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: 'Classroom is archived' })
+    expect(assertTeacherOwnsTest).toHaveBeenCalledWith('teacher-1', 'test-1', {
+      checkArchived: true,
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('rejects students who are not enrolled before loading questions', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table !== 'classroom_enrollments') throw new Error(`Unexpected table: ${table}`)
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      }
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/student-1/grades', {
+        method: 'PATCH',
+        body: JSON.stringify({ grades: [{ question_id: 'question-open-1', score: 1 }] }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', studentId: 'student-1' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Student is not enrolled in this classroom' })
+    expect(mockSupabaseClient.from).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [[], 'One or more questions were not found for this test'],
+    [[{ id: 'question-open-1', question_type: 'open_response', points: 2 }], 'score cannot exceed 2'],
+  ])('rejects invalid question scope before loading responses', async (questions, expectedError) => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { student_id: 'student-1' },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({ data: questions, error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/student-1/grades', {
+        method: 'PATCH',
+        body: JSON.stringify({ grades: [{ question_id: 'question-open-1', score: 3 }] }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', studentId: 'student-1' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: expectedError })
+    expect(mockSupabaseClient.from).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    [{ enrollmentError: { message: 'enrollment failed' } }, 'Failed to validate student enrollment'],
+    [{ questionError: { message: 'questions failed' } }, 'Failed to validate questions'],
+    [{ responseError: { message: 'responses failed' } }, 'Failed to save grades'],
+  ])('fails closed when a workflow query fails', async (options, expectedError) => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { upsert } = configureGradeWorkflow(options)
+
+    const response = await PATCH(makeGradeRequest(), gradeRouteContext)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: expectedError })
+    expect(upsert).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('returns 500 when the legacy compatibility upsert also fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { upsert } = configureGradeWorkflow({
+      upsertErrors: [
+        { code: '42703', message: 'column test_responses.ai_grading_basis does not exist' },
+        { code: 'XX000', message: 'legacy upsert failed' },
+      ],
+    })
+
+    const response = await PATCH(makeGradeRequest(), gradeRouteContext)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Failed to save grades' })
+    expect(upsert).toHaveBeenCalledTimes(2)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error upserting student grade set:',
+      expect.objectContaining({ message: 'legacy upsert failed' }),
+    )
+    consoleError.mockRestore()
   })
 
   it('upserts open-response grades, creating missing response rows with empty response_text', async () => {
@@ -323,6 +555,7 @@ describe('PATCH /api/teacher/tests/[id]/students/[studentId]/grades', () => {
         expect.objectContaining({
           question_id: 'question-mc-1',
           selected_option: 1,
+          submitted_at: '2026-03-08T12:00:00.000Z',
           score: 2,
           feedback: null,
           ai_grading_basis: null,
@@ -330,10 +563,14 @@ describe('PATCH /api/teacher/tests/[id]/students/[studentId]/grades', () => {
         expect.objectContaining({
           question_id: 'question-open-1',
           response_text: 'Original response',
+          submitted_at: '2026-03-08T12:00:00.000Z',
           score: null,
           feedback: null,
           graded_at: null,
           graded_by: null,
+          ai_grading_basis: null,
+          ai_reference_answers: null,
+          ai_model: null,
         }),
       ],
       { onConflict: 'question_id,student_id' }

--- a/tests/architecture/api-zod-boundary-baseline.json
+++ b/tests/architecture/api-zod-boundary-baseline.json
@@ -49,7 +49,6 @@
   "src/app/api/teacher/tests/[id]/return/route.ts",
   "src/app/api/teacher/tests/[id]/route.ts",
   "src/app/api/teacher/tests/[id]/student-access/route.ts",
-  "src/app/api/teacher/tests/[id]/students/[studentId]/grades/route.ts",
   "src/app/api/teacher/tests/[id]/students/attempts/bulk-delete/route.ts",
   "src/app/api/teacher/tests/[id]/unsubmit/route.ts",
   "src/app/api/teacher/tests/reorder/route.ts",

--- a/tests/lib/validations/test-grading.test.ts
+++ b/tests/lib/validations/test-grading.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { saveStudentTestGradesSchema } from '@/lib/validations/test-grading'
+
+describe('saveStudentTestGradesSchema', () => {
+  it('normalizes grade values and AI audit metadata', () => {
+    expect(saveStudentTestGradesSchema.parse({
+      grades: [
+        {
+          question_id: ' question-1 ',
+          score: '1.235',
+          feedback: ' Useful feedback ',
+          ai_grading_basis: 'generated_reference',
+          ai_reference_answers: [' Reference one ', '', 'Reference two'],
+          ai_model: ' gpt-5-nano ',
+        },
+      ],
+    })).toEqual({
+      grades: [
+        {
+          question_id: 'question-1',
+          score: 1.24,
+          feedback: 'Useful feedback',
+          clear_grade: false,
+          ai_grading_basis: 'generated_reference',
+          ai_reference_answers: ['Reference one', 'Reference two'],
+          ai_model: 'gpt-5-nano',
+        },
+      ],
+    })
+  })
+
+  it('normalizes clears without reading score or feedback', () => {
+    expect(saveStudentTestGradesSchema.parse({
+      grades: [
+        {
+          question_id: 'question-1',
+          clear_grade: true,
+          score: { malformed: true },
+          feedback: ['ignored'],
+          ai_grading_basis: 'teacher_key',
+          ai_reference_answers: ['ignored for teacher key'],
+          ai_model: '',
+        },
+      ],
+    })).toEqual({
+      grades: [
+        {
+          question_id: 'question-1',
+          score: null,
+          feedback: null,
+          clear_grade: true,
+          ai_grading_basis: 'teacher_key',
+          ai_reference_answers: null,
+          ai_model: null,
+        },
+      ],
+    })
+  })
+
+  it('preserves null and empty-string score coercion to zero', () => {
+    expect(saveStudentTestGradesSchema.parse({
+      grades: [
+        { question_id: 'question-1', score: null },
+        { question_id: 'question-2', score: '' },
+      ],
+    }).grades.map((grade) => grade.score)).toEqual([0, 0])
+  })
+
+  it.each([
+    [{}, 'grades array is required'],
+    [{ grades: [] }, 'grades array is required'],
+    [{ grades: [null] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: ' ', score: 1 }] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: -1 }] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: 'not-a-number' }] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: 1, clear_grade: 'yes' }] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: 1, ai_grading_basis: 'unknown' }] }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: 1, ai_grading_basis: 'generated_reference' }] }, 'Invalid grade payload'],
+    [{
+      grades: [{
+        question_id: 'q1',
+        score: 1,
+        ai_grading_basis: 'generated_reference',
+        ai_reference_answers: ['one', 'two', 'three', 'four'],
+      }],
+    }, 'Invalid grade payload'],
+    [{ grades: [{ question_id: 'q1', score: 1, ai_model: 5 }] }, 'Invalid grade payload'],
+  ])('rejects invalid request %#', (input, expectedMessage) => {
+    const result = saveStudentTestGradesSchema.safeParse(input)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(expectedMessage)
+    }
+  })
+
+  it('rejects duplicate question ids after trimming', () => {
+    const result = saveStudentTestGradesSchema.safeParse({
+      grades: [
+        { question_id: 'question-1', score: 1 },
+        { question_id: ' question-1 ', score: 2 },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Duplicate question_id in grades payload')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- replace the manual test-grade decoder with a feature-owned Zod contract
- extract authorization, enrollment/question checks, response preservation, and persistence into a focused server workflow
- preserve the existing AI-column compatibility retry and all current grade/clear semantics
- remove this route from the deletion-only API Zod baseline

## Behavior
The JSON-representable request contract remains compatible, including numeric coercion, two-decimal rounding, trimming, clear-grade behavior, generated-reference requirements, and duplicate rejection. Malformed JSON and JSON null now fail deterministically with 400 responses instead of accidental internal errors.

This is a behavior-preserving architecture slice. The existing multi-statement persistence sequence is intentionally unchanged; atomic test grading is a separate migration and concurrency-testing phase.

## Validation
- full Vitest suite: 351 files / 3,186 tests
- focused contract/route/architecture suite: 33 tests
- production build
- TypeScript and lint
- architecture check: 594 modules / 0 allowances
- Pika staged pre-commit audit
- two independent review/fix rounds with no remaining findings

No UI, schema, migration, dependency, Storage, or production changes.