### PR TITLE
Retire legacy quiz gradebook calculations

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13609,3 +13609,17 @@
 - `bash scripts/verify-env.sh`
 - `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
 - `corepack pnpm lint`
+
+## 2026-07-09 — Collaborator readiness: rulesets, CODEOWNERS, onboarding docs
+
+**Completed:**
+- Updated GitHub rulesets via API: `main` now requires a PR with 1 approving code-owner review plus the `Test & Build` status check (squash/rebase only); `production` mirrors the review + status-check requirements. Repo admins retain bypass.
+- Added `.github/CODEOWNERS` (`* @armorup`) and `CONTRIBUTING.md` (collaborator setup, PR workflow, contribution permission note).
+- README Getting Started rewritten: own-Supabase-per-developer with `supabase db push` (was stale "migrations 001–008 in dashboard"), required vs optional env split, seeded staging creds removed from docs.
+- Marked shared `.env.local` symlink convention as maintainer-specific in `.ai/START-HERE.md` and `docs/dev-workflow.md`.
+- Ran gitleaks over full history (1242 commits): no live secrets; flagged initial-commit README/tests 64-hex `SESSION_SECRET` example for precautionary rotation.
+- PR: https://github.com/codepetca/pika/pull/835
+
+**Validation:**
+- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
+- `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,20 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-09 — Collaborator readiness: rulesets, CODEOWNERS, onboarding docs
-
-**Completed:**
-- Updated GitHub rulesets via API: `main` now requires a PR with 1 approving code-owner review plus the `Test & Build` status check (squash/rebase only); `production` mirrors the review + status-check requirements. Repo admins retain bypass.
-- Added `.github/CODEOWNERS` (`* @armorup`) and `CONTRIBUTING.md` (collaborator setup, PR workflow, contribution permission note).
-- README Getting Started rewritten: own-Supabase-per-developer with `supabase db push` (was stale "migrations 001–008 in dashboard"), required vs optional env split, seeded staging creds removed from docs.
-- Marked shared `.env.local` symlink convention as maintainer-specific in `.ai/START-HERE.md` and `docs/dev-workflow.md`.
-- Ran gitleaks over full history (1242 commits): no live secrets; flagged initial-commit README/tests 64-hex `SESSION_SECRET` example for precautionary rotation.
-- PR: https://github.com/codepetca/pika/pull/835
-
-**Validation:**
-- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
-- `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active
-
 ## 2026-07-09 — Archive trimmed session-log entries instead of deleting
 
 **Completed:**
@@ -736,4 +722,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm vitest run` (361 files / 3,322 tests)
 - `pnpm build`
+- `git diff --check`
+
+## 2026-07-15 — Legacy quiz gradebook and archive compatibility decision
+
+**Completed:**
+- Removed the inactive quiz category from gradebook calculation inputs/results while retaining null/empty API response tombstones for older clients.
+- Added an architecture guard that allowlists gradebook dependencies and quiz tombstones, forbidding legacy quiz identifiers from active calculation and persistence code.
+- Classified legacy quiz gradebook rows as archival data and kept the version 3 course-package `quizzes` flag serialized but permanently normalized to `false`.
+- Removed dead quiz-table fixtures from gradebook tests and added encoded package compatibility regressions.
+- Expanded the archive database restore harness with non-empty quiz, question, response, and manual-override rows; the existing exact-table equality audit now proves they survive staging and final restore.
+- Documented that schema retirement remains blocked on an archive adapter, production inventory, and production verification. No production state or schema was changed.
+- Completed an independent review/fix loop; four guardrail findings were fixed and final rereview returned no findings.
+
+**Validation:**
+- Focused gradebook/package/archive suites (54 tests)
+- Classroom archive restore database contract harness
+- `pnpm vitest run` (361 files / 3,324 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (602 modules / 0 allowances)
+- `bash -n scripts/check-classroom-archive-restore-database.sh`
 - `git diff --check`

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -18,14 +18,17 @@ The current product contract is:
 
 Retain until an approved schema migration exists:
 
-- Legacy quiz tables and columns referenced by server routes and tests:
+- Legacy quiz tables and columns referenced by archive contracts, legacy-only
+  helpers, and tests:
   `quizzes`, `quiz_questions`, `quiz_responses`, `quiz_student_scores`,
   `quiz_id`, and quiz update functions/policies.
 - Historical migrations that created or hardened quiz tables, indexes, and RLS.
 - `assessment_drafts.assessment_type = 'quiz' | 'test'`, because historical or
   imported drafts may still carry `quiz`.
-- Gradebook quiz fields and settings, including `quizzes_weight`,
-  `quizzes_percent`, `GradebookQuizDetail`, and quiz override routes.
+- Gradebook database columns and response tombstones, including
+  `quizzes_weight`, `quizzes_percent`, and empty `quizzes` arrays. These remain
+  compatibility data only; active gradebook calculations and persistence must
+  not read legacy quiz tables.
 
 Do not rename these in app code as a cosmetic cleanup. They require a planned
 migration, deterministic backfill, compatibility reads, rollback notes, and
@@ -70,8 +73,12 @@ Retain for compatibility or schema-backed behavior:
 - `src/lib/server/assessments.ts` access aliases.
 - `src/lib/quiz-markdown.ts` and `tests/lib/quiz-markdown.test.ts`, which cover
   legacy quiz markdown import/export aliases.
-- Gradebook and notification server code that reads quiz tables separately from
-  active Tests.
+- Gradebook response tombstones for older clients. The active gradebook server
+  must never read quiz tables or include quiz rows in calculations.
+
+The active Tests, gradebook, and student-notification workflows do not query
+legacy quiz tables. Legacy-only server helpers and type aliases may be removed
+in isolated passes once an import audit proves they have no runtime callers.
 
 ### UI Compatibility Wrappers
 
@@ -94,7 +101,8 @@ Remaining quiz references usually fall into one of these groups:
 - Compatibility regressions for legacy response keys, props, route params, or
   helper aliases.
 - Database-shaped mocks that must still use `quiz_id` or legacy table names.
-- Gradebook tests that cover legacy quiz rows and quiz category behavior.
+- Gradebook tests that prove legacy quiz response fields remain inert and the
+  active server never queries quiz tables.
 - Course blueprint/package tests that cover persisted `quizzes` package fields.
 - UI absence tests that assert "Quizzes" is not visible.
 
@@ -175,12 +183,14 @@ Requires a follow-up design and approval:
    - Rollback: restore aliases; no data rollback required.
 
 5. **Gradebook and course package decision**
-   - Decide whether legacy quiz gradebook categories remain as archival data or
-     merge into Tests.
-   - Decide whether exported course packages keep `quizzes` for backward
-     compatibility or introduce a package format version bump.
-   - These decisions may need compatibility readers for old packages and
-     response payloads.
+   - Decision: legacy quiz gradebook rows are archival compatibility data, not
+     an active category. Keep database columns and null/empty response
+     tombstones until production verification permits their removal.
+   - Decision: version 3 course packages keep the `quizzes` site-config key for
+     backward compatibility, always normalized to `false`. Remove it only in a
+     future package version with an old-package reader.
+   - Executable architecture tests must prevent quiz-table reads from returning
+     to the gradebook workflow and package tests must keep the legacy flag off.
 
 6. **Schema migration**
    - Only after explicit approval, create migrations for table/column/function
@@ -189,6 +199,25 @@ Requires a follow-up design and approval:
    - Include deterministic backfill, compatibility views or aliases if needed,
      regression tests for pre/post shapes, and rollback notes.
    - Do not apply migrations as an AI agent.
+
+### Archive v1 gate
+
+The four legacy quiz tables cannot be dropped while classroom archive format
+v1 lists them as resources. Export and restore dynamically replay that resource
+contract, including `quiz_student_scores`; dropping a table or silently
+discarding those rows would break existing archives and can lose historical
+grades.
+
+Before any schema retirement:
+
+- Add a versioned archive adapter that preserves or maps all four quiz
+  resources for existing archives.
+- Prove a restore round trip with non-empty quiz, question, response, and manual
+  override rows.
+- Verify production row counts for all four tables, legacy quiz drafts and
+  blueprint assessments, plus non-empty quiz resource counts in stored archive
+  manifests.
+- Keep the existing archive-v1 reader after introducing any newer format.
 
 ## Validation Checklist
 
@@ -210,13 +239,16 @@ For each implementation pass:
 
 ## Next Implementation Pass
 
-The next safe pass should continue fixture-only cleanup in tests that still use
-arbitrary "Quiz" titles while not exercising a legacy fallback. Start with:
+The gradebook/course-package decision is complete. The next safe pass should
+continue fixture-only cleanup in tests that still use arbitrary "Quiz" titles
+while not exercising a legacy fallback. Start with:
 
 - `tests/lib/quiz-markdown.test.ts` only if the test is rewritten to clearly say
   it covers legacy quiz markdown compatibility.
-- Gradebook/course blueprint tests only after deciding whether their quiz rows
-  are archival compatibility data or active categories.
+- Gradebook tests may remove dead quiz-table mocks, but must retain assertions
+  for null/empty compatibility response fields.
+- Course blueprint tests must retain the version 3 `quizzes: false` package
+  contract.
 
-Do not start payload or schema removal until the payload deprecation and
-gradebook/course package decisions are approved.
+Payload and schema removal remain blocked until the deprecation window and
+production verification prove the compatibility aliases are no longer needed.

--- a/scripts/check-classroom-archive-restore-database.sh
+++ b/scripts/check-classroom-archive-restore-database.sh
@@ -58,6 +58,49 @@ values (
   clock_timestamp()
 );
 
+insert into public.quizzes (
+  id, classroom_id, title, status, show_results, created_by, points_possible
+) values (
+  '28000000-0000-4000-8000-000000000001',
+  '21000000-0000-4000-8000-000000000001',
+  'Historical restore quiz',
+  'closed',
+  true,
+  '11000000-0000-4000-8000-000000000001',
+  10
+);
+
+insert into public.quiz_questions (
+  id, quiz_id, question_text, options, correct_option, position
+) values (
+  '28000000-0000-4000-8000-000000000011',
+  '28000000-0000-4000-8000-000000000001',
+  'Historical restore question',
+  '["First", "Second"]'::jsonb,
+  1,
+  0
+);
+
+insert into public.quiz_responses (
+  id, quiz_id, question_id, student_id, selected_option
+) values (
+  '28000000-0000-4000-8000-000000000021',
+  '28000000-0000-4000-8000-000000000001',
+  '28000000-0000-4000-8000-000000000011',
+  '11000000-0000-4000-8000-000000000002',
+  1
+);
+
+insert into public.quiz_student_scores (
+  id, quiz_id, student_id, manual_override_score, graded_by
+) values (
+  '28000000-0000-4000-8000-000000000031',
+  '28000000-0000-4000-8000-000000000001',
+  '11000000-0000-4000-8000-000000000002',
+  9,
+  'teacher'
+);
+
 insert into public.tests (id, classroom_id, title, status, points_possible, created_by)
 values (
   '27000000-0000-4000-8000-000000000001',

--- a/src/lib/course-site-publishing.ts
+++ b/src/lib/course-site-publishing.ts
@@ -44,6 +44,7 @@ export function normalizePlannedCourseSiteConfig(value: unknown): PlannedCourseS
     outline: asBoolean(record.outline, DEFAULT_PLANNED_COURSE_SITE_CONFIG.outline),
     resources: asBoolean(record.resources, DEFAULT_PLANNED_COURSE_SITE_CONFIG.resources),
     assignments: asBoolean(record.assignments, DEFAULT_PLANNED_COURSE_SITE_CONFIG.assignments),
+    // Version 3 packages retain this serialized key, but quizzes are not an active surface.
     quizzes: false,
     tests: asBoolean(record.tests, DEFAULT_PLANNED_COURSE_SITE_CONFIG.tests),
     lesson_plans: asBoolean(record.lesson_plans, DEFAULT_PLANNED_COURSE_SITE_CONFIG.lesson_plans),

--- a/src/lib/gradebook.ts
+++ b/src/lib/gradebook.ts
@@ -7,16 +7,13 @@ export interface GradebookCategoryInput {
 export interface GradebookCalculationInput {
   useWeights: boolean
   assignmentsWeight: number
-  quizzesWeight: number
   testsWeight: number
   assignments: GradebookCategoryInput[]
-  quizzes: GradebookCategoryInput[]
   tests: GradebookCategoryInput[]
 }
 
 export interface GradebookCalculationResult {
   assignmentsPercent: number | null
-  quizzesPercent: number | null
   testsPercent: number | null
   finalPercent: number | null
 }
@@ -52,13 +49,11 @@ function toPercent(rows: GradebookCategoryInput[]): number | null {
 
 export function calculateFinalPercent(input: GradebookCalculationInput): GradebookCalculationResult {
   const assignmentsPercent = toPercent(input.assignments)
-  const quizzesPercent = toPercent(input.quizzes)
   const testsPercent = toPercent(input.tests)
 
-  if (assignmentsPercent == null && quizzesPercent == null && testsPercent == null) {
+  if (assignmentsPercent == null && testsPercent == null) {
     return {
       assignmentsPercent: null,
-      quizzesPercent: null,
       testsPercent: null,
       finalPercent: null,
     }
@@ -66,10 +61,9 @@ export function calculateFinalPercent(input: GradebookCalculationInput): Gradebo
 
   // Unweighted: blend all scored items by points.
   if (!input.useWeights) {
-    const all = [...input.assignments, ...input.quizzes, ...input.tests]
+    const all = [...input.assignments, ...input.tests]
     return {
       assignmentsPercent,
-      quizzesPercent,
       testsPercent,
       finalPercent: toPercent(all),
     }
@@ -80,17 +74,14 @@ export function calculateFinalPercent(input: GradebookCalculationInput): Gradebo
   if (assignmentsPercent != null && input.assignmentsWeight > 0) {
     components.push({ percent: assignmentsPercent, weight: input.assignmentsWeight })
   }
-  if (quizzesPercent != null && input.quizzesWeight > 0) {
-    components.push({ percent: quizzesPercent, weight: input.quizzesWeight })
-  }
   if (testsPercent != null && input.testsWeight > 0) {
     components.push({ percent: testsPercent, weight: input.testsWeight })
   }
 
   if (components.length === 0) {
     // fall back when scores exist but configured weights are zero
-    const fallback = assignmentsPercent ?? quizzesPercent ?? testsPercent
-    return { assignmentsPercent, quizzesPercent, testsPercent, finalPercent: fallback ?? null }
+    const fallback = assignmentsPercent ?? testsPercent
+    return { assignmentsPercent, testsPercent, finalPercent: fallback ?? null }
   }
 
   const weightTotal = components.reduce((sum, c) => sum + c.weight, 0)
@@ -98,7 +89,6 @@ export function calculateFinalPercent(input: GradebookCalculationInput): Gradebo
 
   return {
     assignmentsPercent,
-    quizzesPercent,
     testsPercent,
     finalPercent: round2(weighted),
   }

--- a/src/lib/server/gradebook.ts
+++ b/src/lib/server/gradebook.ts
@@ -771,10 +771,8 @@ export async function loadTeacherGradebook(opts: {
     const calc = calculateFinalPercent({
       useWeights: false,
       assignmentsWeight: DEFAULT_SETTINGS.assignments_weight,
-      quizzesWeight: DEFAULT_SETTINGS.quizzes_weight,
       testsWeight: DEFAULT_SETTINGS.tests_weight,
       assignments: assignmentRows,
-      quizzes: [],
       tests: testRows,
     })
     const assignmentTotals = assignmentRows.reduce(
@@ -803,7 +801,7 @@ export async function loadTeacherGradebook(opts: {
       assignments_percent: calc.assignmentsPercent,
       quizzes_earned: null,
       quizzes_possible: null,
-      quizzes_percent: calc.quizzesPercent,
+      quizzes_percent: null,
       tests_earned: testTotals.possible > 0 ? round2(testTotals.earned) : null,
       tests_possible: testTotals.possible > 0 ? round2(testTotals.possible) : null,
       tests_percent: calc.testsPercent,

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -17,14 +17,6 @@ type GradebookFixture = {
   docs?: Array<any>
   docsError?: SupabaseReadError | null
   docsTeacherClearedAtError?: SupabaseReadError | null
-  quizzes?: Array<any>
-  quizQuestions?: Array<any>
-  quizQuestionsCorrectOptionError?: SupabaseReadError | null
-  quizQuestionsError?: SupabaseReadError | null
-  quizResponses?: Array<any>
-  quizResponsesError?: SupabaseReadError | null
-  quizOverrides?: Array<any>
-  quizOverridesError?: SupabaseReadError | null
   tests?: Array<any>
   testsWithMetaError?: SupabaseReadError | null
   testsLegacyError?: SupabaseReadError | null
@@ -130,59 +122,6 @@ function buildMockFrom(fixture: GradebookFixture) {
             })),
           }
         }),
-      }
-    }
-
-    if (table === 'quizzes') {
-      return {
-        select: vi.fn(() => ({
-          eq: vi.fn().mockResolvedValue({
-            data: fixture.quizzes ?? [],
-            error: null,
-          }),
-        })),
-      }
-    }
-
-    if (table === 'quiz_questions') {
-      return {
-        select: vi.fn((selection: string) => {
-          const selectionError = fixture.quizQuestionsError ?? (
-            selection.includes('correct_option') ? fixture.quizQuestionsCorrectOptionError ?? null : null
-          )
-          return {
-            in: vi.fn().mockResolvedValue({
-              data: selectionError ? null : fixture.quizQuestions ?? [],
-              error: selectionError,
-            }),
-          }
-        }),
-      }
-    }
-
-    if (table === 'quiz_responses') {
-      return {
-        select: vi.fn(() => ({
-          in: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: fixture.quizResponsesError ? null : fixture.quizResponses ?? [],
-              error: fixture.quizResponsesError ?? null,
-            }),
-          })),
-        })),
-      }
-    }
-
-    if (table === 'quiz_student_scores') {
-      return {
-        select: vi.fn(() => ({
-          in: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: fixture.quizOverridesError ? null : fixture.quizOverrides ?? [],
-              error: fixture.quizOverridesError ?? null,
-            }),
-          })),
-        })),
       }
     }
 
@@ -337,18 +276,8 @@ describe('GET /api/teacher/gradebook', () => {
     vi.clearAllMocks()
   })
 
-  it('ignores legacy quiz rows in grade calculations', async () => {
-    ;(mockSupabaseClient.from as any) = buildMockFrom({
-      quizzes: [
-        { id: 'quiz-active', title: 'Active Quiz', status: 'active', points_possible: 10, include_in_final: true },
-        { id: 'quiz-draft', title: 'Draft Quiz', status: 'draft', points_possible: 10, include_in_final: true },
-      ],
-      quizQuestions: [
-        { id: 'q1', quiz_id: 'quiz-active', correct_option: 0 },
-        { id: 'q2', quiz_id: 'quiz-draft', correct_option: 0 },
-      ],
-      quizResponses: [{ quiz_id: 'quiz-active', question_id: 'q1', student_id: 'student-1', selected_option: 0 }],
-    })
+  it('returns inert legacy quiz response tombstones without querying quiz storage', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({})
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
     const response = await GET(request)
@@ -356,28 +285,16 @@ describe('GET /api/teacher/gradebook', () => {
 
     expect(response.status).toBe(200)
     expect(body.students).toHaveLength(1)
-
+    expect(body.students[0].quizzes_earned).toBeNull()
+    expect(body.students[0].quizzes_possible).toBeNull()
     expect(body.students[0].quizzes_percent).toBeNull()
     expect(body.students[0].final_percent).toBeNull()
-  })
-
-  it('does not count unattempted active quizzes as zero before they are closed', async () => {
-    ;(mockSupabaseClient.from as any) = buildMockFrom({
-      quizzes: [{ id: 'quiz-active', title: 'Active Quiz', status: 'active', points_possible: 10, include_in_final: true }],
-      quizQuestions: [{ id: 'q1', quiz_id: 'quiz-active', correct_option: 1 }],
-      quizResponses: [],
-    })
-
-    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
-    const response = await GET(request)
-    const body = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(body.students).toHaveLength(1)
-
-    // No attempt yet means no quiz mark in-progress.
-    expect(body.students[0].quizzes_percent).toBeNull()
-    expect(body.students[0].final_percent).toBeNull()
+    expect(body.class_summary.quizzes).toEqual([])
+    expect(body.totals.quizzes).toBe(0)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('quizzes')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('quiz_questions')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('quiz_responses')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('quiz_student_scores')
   })
 
   it('returns selected student assignment breakdown when student_id is provided', async () => {
@@ -539,9 +456,6 @@ describe('GET /api/teacher/gradebook', () => {
         { assignment_id: 'a-heavy-points', student_id: 'student-1', score_completion: 10, score_thinking: 10, score_workflow: 10 },
         { assignment_id: 'a-small-points', student_id: 'student-1', score_completion: 0, score_thinking: 0, score_workflow: 0 },
       ],
-      quizzes: [],
-      quizQuestions: [],
-      quizResponses: [],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
@@ -585,18 +499,6 @@ describe('GET /api/teacher/gradebook', () => {
       docs: [
         { assignment_id: 'a1', student_id: 'student-1', score_completion: 10, score_thinking: 10, score_workflow: 10 },
       ],
-      quizzes: [
-        {
-          id: 'q1',
-          title: 'Quiz 1',
-          status: 'closed',
-          points_possible: 1,
-          include_in_final: true,
-          gradebook_weight: 10,
-        },
-      ],
-      quizQuestions: [{ id: 'qq1', quiz_id: 'q1', correct_option: 0 }],
-      quizResponses: [{ quiz_id: 'q1', question_id: 'qq1', student_id: 'student-1', selected_option: 1 }],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
@@ -637,9 +539,6 @@ describe('GET /api/teacher/gradebook', () => {
         { id: 'a-draft', title: 'Draft Assignment', due_at: '2025-01-03T12:00:00.000Z', position: 4, is_draft: true, points_possible: 30, include_in_final: true },
       ],
       docs: [{ assignment_id: 'a-graded', student_id: 'student-1', score_completion: 10, score_thinking: 10, score_workflow: 10 }],
-      quizzes: [],
-      quizQuestions: [],
-      quizResponses: [],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1&student_id=student-1')
@@ -708,9 +607,6 @@ describe('GET /api/teacher/gradebook', () => {
         { assignment_id: 'a1', student_id: 'student-1', score_completion: 2, score_thinking: 2, score_workflow: 2 }, // 20%
         { assignment_id: 'a1', student_id: 'student-2', score_completion: 5, score_thinking: 5, score_workflow: 5 }, // 50%
       ],
-      quizzes: [],
-      quizQuestions: [],
-      quizResponses: [],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
@@ -738,9 +634,6 @@ describe('GET /api/teacher/gradebook', () => {
         { assignment_id: 'a1', student_id: 'student-1', score_completion: 3, score_thinking: 3, score_workflow: 3 }, // 30%
         { assignment_id: 'a1', student_id: 'withdrawn-student', score_completion: 10, score_thinking: 10, score_workflow: 10 }, // 100% (must be ignored)
       ],
-      quizzes: [],
-      quizQuestions: [],
-      quizResponses: [],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
@@ -768,16 +661,6 @@ describe('GET /api/teacher/gradebook', () => {
       position: index + 1,
       is_draft: false,
       points_possible: 30,
-      include_in_final: true,
-      gradebook_weight: 10,
-    }))
-    const quizzes = Array.from({ length: 51 }, (_, index) => ({
-      id: `quiz-${String(index + 1).padStart(2, '0')}`,
-      classroom_id: 'c1',
-      title: `Quiz ${index + 1}`,
-      status: 'closed',
-      position: index + 1,
-      points_possible: 10,
       include_in_final: true,
       gradebook_weight: 10,
     }))
@@ -831,18 +714,6 @@ describe('GET /api/teacher/gradebook', () => {
           score_thinking: 10,
           score_workflow: 10,
         },
-      ],
-      quizzes,
-      quiz_questions: [
-        { id: 'quiz-question-first', quiz_id: quizzes[0].id, correct_option: 1 },
-        { id: 'quiz-question-last', quiz_id: quizzes[50].id, correct_option: 1 },
-      ],
-      quiz_responses: [
-        { id: 'quiz-response-first', quiz_id: quizzes[0].id, question_id: 'quiz-question-first', student_id: studentIds[0], selected_option: 1 },
-        { id: 'quiz-response-last', quiz_id: quizzes[50].id, question_id: 'quiz-question-last', student_id: studentIds[50], selected_option: 1 },
-      ],
-      quiz_student_scores: [
-        { id: 'quiz-override-last', quiz_id: quizzes[50].id, student_id: studentIds[50], manual_override_score: 9 },
       ],
       tests,
       test_questions: [
@@ -915,10 +786,6 @@ describe('GET /api/teacher/gradebook', () => {
       student_profiles: [],
       assignments,
       assignment_docs: docs,
-      quizzes: [],
-      quiz_questions: [],
-      quiz_responses: [],
-      quiz_student_scores: [],
       tests: [],
       test_questions: [],
       test_responses: [],
@@ -957,10 +824,6 @@ describe('GET /api/teacher/gradebook', () => {
       student_profiles: [],
       assignments: [],
       assignment_docs: [],
-      quizzes: [],
-      quiz_questions: [],
-      quiz_responses: [],
-      quiz_student_scores: [],
       tests: [],
       test_questions: [],
       test_responses: [],
@@ -1069,7 +932,7 @@ describe('GET /api/teacher/gradebook', () => {
     consoleError.mockRestore()
   })
 
-  it('falls back to legacy assignment/quiz columns when gradebook metadata columns are unavailable', async () => {
+  it('falls back to legacy assignment columns when gradebook metadata columns are unavailable', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'classrooms') {
         return {
@@ -1149,46 +1012,6 @@ describe('GET /api/teacher/gradebook', () => {
                 }),
               }
             }),
-          })),
-        }
-      }
-
-      if (table === 'quizzes') {
-        return {
-          select: vi.fn((selection: string) => ({
-            eq: vi.fn().mockResolvedValue(
-              selection.includes('points_possible')
-                ? { data: null, error: { message: 'column quizzes.points_possible does not exist' } }
-                : { data: [], error: null }
-            ),
-          })),
-        }
-      }
-
-      if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
-      }
-
-      if (table === 'quiz_responses') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn(() => ({
-              in: vi.fn().mockResolvedValue({ data: [], error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'quiz_student_scores') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn(() => ({
-              in: vi.fn().mockResolvedValue({ data: [], error: null }),
-            })),
           })),
         }
       }

--- a/tests/architecture/gradebook-boundary.test.ts
+++ b/tests/architecture/gradebook-boundary.test.ts
@@ -25,4 +25,43 @@ describe('gradebook feature boundary', () => {
     expect(source).not.toContain('requireRole')
     expect(source).not.toContain("from '@/lib/api-handler'")
   })
+
+  it('keeps legacy quiz storage outside the active gradebook workflow', () => {
+    const serverSource = read('src/lib/server/gradebook.ts')
+    const calculationSource = read('src/lib/gradebook.ts')
+    const allowedServerQuizTombstones = [
+      'quizzes_weight: 20,',
+      'quizzes_earned: null,',
+      'quizzes_possible: null,',
+      'quizzes_percent: null,',
+      'quizzes: [],',
+      'quizzes: [],',
+      'quizzes: 0,',
+    ]
+    let activeServerSource = serverSource
+    for (const tombstone of allowedServerQuizTombstones) {
+      expect(activeServerSource).toContain(tombstone)
+      activeServerSource = activeServerSource.replace(tombstone, '')
+    }
+
+    const serverImports = [...serverSource.matchAll(/from ['"]([^'"]+)['"]/g)]
+      .map((match) => match[1])
+      .sort()
+
+    expect(serverImports).toEqual([
+      '@/lib/api-error',
+      '@/lib/assignments',
+      '@/lib/gradebook',
+      '@/lib/server/query-chunks',
+      '@/lib/supabase',
+      '@/lib/validations/gradebook',
+      '@/types',
+    ])
+    expect(serverSource).not.toMatch(/\bimport\s*\(/)
+    expect(serverSource).not.toMatch(/\bimport\s*['"]/)
+    expect(serverSource).not.toMatch(/\brequire\s*\(/)
+    expect(activeServerSource).not.toMatch(/quiz/i)
+    expect(calculationSource).not.toContain('quizzes')
+    expect(calculationSource).not.toContain('quiz')
+  })
 })

--- a/tests/lib/course-blueprint-package.test.ts
+++ b/tests/lib/course-blueprint-package.test.ts
@@ -172,6 +172,37 @@ describe('course blueprint package', () => {
     expect(parsed.lesson_templates).toHaveLength(1)
   })
 
+  it('keeps the version 3 quizzes site flag serialized but permanently disabled', () => {
+    const bundle = buildCourseBlueprintExportBundle({
+      ...DETAIL,
+      planned_site_config: {
+        ...DETAIL.planned_site_config,
+        quizzes: true,
+      },
+    })
+
+    expect(bundle.manifest.version).toBe('3')
+    expect(bundle.manifest.planned_site_config?.quizzes).toBe(false)
+
+    const archive = encodeCourseBlueprintPackageArchive(bundle)
+    const decoded = decodeCourseBlueprintPackageArchive(archive)
+    expect(decoded?.manifest.planned_site_config?.quizzes).toBe(false)
+
+    const legacyArchive = encodeCourseBlueprintPackageArchive({
+      ...bundle,
+      manifest: {
+        ...bundle.manifest,
+        planned_site_config: {
+          ...bundle.manifest.planned_site_config,
+          quizzes: true,
+        },
+      },
+    })
+    const parsed = parseCourseBlueprintImportArchive(legacyArchive)
+
+    expect(parsed.blueprint.planned_site_config.quizzes).toBe(false)
+  })
+
   it('analyzes missing blueprint areas', () => {
     const analysis = analyzeCourseBlueprintCompleteness({
       ...DETAIL,

--- a/tests/lib/server/classroom-archive-restore.test.ts
+++ b/tests/lib/server/classroom-archive-restore.test.ts
@@ -64,6 +64,30 @@ function verifiedFixture() {
           url: 'https://project.supabase.co/storage/v1/object/public/test-documents/teacher/test/source.pdf',
         }],
       }],
+      quizzes: [{
+        id: '60000000-0000-4000-8000-000000000001',
+        classroom_id: CLASSROOM_ID,
+        created_by: TEACHER_ID,
+        title: 'Historical quiz',
+      }],
+      quiz_questions: [{
+        id: '60000000-0000-4000-8000-000000000002',
+        quiz_id: '60000000-0000-4000-8000-000000000001',
+        question_text: 'Historical question',
+      }],
+      quiz_responses: [{
+        id: '60000000-0000-4000-8000-000000000003',
+        quiz_id: '60000000-0000-4000-8000-000000000001',
+        question_id: '60000000-0000-4000-8000-000000000002',
+        student_id: STUDENT_ID,
+        selected_option: 1,
+      }],
+      quiz_student_scores: [{
+        id: '60000000-0000-4000-8000-000000000004',
+        quiz_id: '60000000-0000-4000-8000-000000000001',
+        student_id: STUDENT_ID,
+        manual_override_score: 9,
+      }],
     },
     actors: [
       { id: TEACHER_ID, email: 'teacher@example.test', role: 'teacher', profile: null },
@@ -140,6 +164,17 @@ const currentActors = [
 ]
 
 describe('classroom archive restore planning', () => {
+  it('freezes the legacy quiz resources into the archive v1 contract', () => {
+    const resourceNames = CLASSROOM_RELATIONAL_RESOURCES.map((resource) => resource.table)
+
+    expect(resourceNames).toEqual(expect.arrayContaining([
+      'quizzes',
+      'quiz_questions',
+      'quiz_responses',
+      'quiz_student_scores',
+    ]))
+  })
+
   it('requires explicit outer artifact checksum evidence', () => {
     expect(() => buildClassroomArchiveRestorePlan({
       verified: verifiedFixture(),
@@ -179,6 +214,18 @@ describe('classroom archive restore planning', () => {
     expect(JSON.stringify(plan.resources.tests[0].documents)).not.toContain(
       'teacher/test/snapshot.html',
     )
+    expect(plan.resources.quizzes).toEqual([
+      expect.objectContaining({ title: 'Historical quiz' }),
+    ])
+    expect(plan.resources.quiz_questions).toEqual([
+      expect.objectContaining({ question_text: 'Historical question' }),
+    ])
+    expect(plan.resources.quiz_responses).toEqual([
+      expect.objectContaining({ student_id: STUDENT_ID, selected_option: 1 }),
+    ])
+    expect(plan.resources.quiz_student_scores).toEqual([
+      expect.objectContaining({ student_id: STUDENT_ID, manual_override_score: 9 }),
+    ])
   })
 
   it('fails closed when an archived actor cannot be reconciled', () => {

--- a/tests/unit/gradebook.test.ts
+++ b/tests/unit/gradebook.test.ts
@@ -6,16 +6,13 @@ describe('gradebook final percent', () => {
     const result = calculateFinalPercent({
       useWeights: false,
       assignmentsWeight: 50,
-      quizzesWeight: 20,
       testsWeight: 30,
       assignments: [],
-      quizzes: [],
       tests: [],
     })
 
     expect(result).toEqual({
       assignmentsPercent: null,
-      quizzesPercent: null,
       testsPercent: null,
       finalPercent: null,
     })
@@ -25,50 +22,42 @@ describe('gradebook final percent', () => {
     const result = calculateFinalPercent({
       useWeights: false,
       assignmentsWeight: 50,
-      quizzesWeight: 20,
       testsWeight: 30,
       assignments: [
         { earned: 24, possible: 30 },
         { earned: 18, possible: 20 },
       ],
-      quizzes: [{ earned: 8, possible: 10 }],
       tests: [{ earned: 45, possible: 50 }],
     })
 
     expect(result.assignmentsPercent).toBe(84)
-    expect(result.quizzesPercent).toBe(80)
     expect(result.testsPercent).toBe(90)
-    expect(result.finalPercent).toBe(86.36)
+    expect(result.finalPercent).toBe(87)
   })
 
   it('computes weighted percent when enabled', () => {
     const result = calculateFinalPercent({
       useWeights: true,
       assignmentsWeight: 50,
-      quizzesWeight: 20,
       testsWeight: 30,
       assignments: [{ earned: 24, possible: 30 }],
-      quizzes: [{ earned: 8, possible: 10 }],
       tests: [{ earned: 45, possible: 50 }],
     })
 
     expect(result.assignmentsPercent).toBe(80)
-    expect(result.quizzesPercent).toBe(80)
     expect(result.testsPercent).toBe(90)
-    expect(result.finalPercent).toBe(83)
+    expect(result.finalPercent).toBe(83.75)
   })
 
   it('uses assessment weights separately from points possible', () => {
     const result = calculateFinalPercent({
       useWeights: false,
       assignmentsWeight: 50,
-      quizzesWeight: 20,
       testsWeight: 30,
       assignments: [
         { earned: 100, possible: 100, weight: 10 },
         { earned: 0, possible: 10, weight: 10 },
       ],
-      quizzes: [],
       tests: [],
     })
 
@@ -80,15 +69,12 @@ describe('gradebook final percent', () => {
     const result = calculateFinalPercent({
       useWeights: true,
       assignmentsWeight: 50,
-      quizzesWeight: 20,
       testsWeight: 30,
       assignments: [{ earned: 27, possible: 30 }],
-      quizzes: [],
       tests: [],
     })
 
     expect(result.assignmentsPercent).toBe(90)
-    expect(result.quizzesPercent).toBeNull()
     expect(result.testsPercent).toBeNull()
     expect(result.finalPercent).toBe(90)
   })


### PR DESCRIPTION
## Summary
- remove the inactive quiz category from gradebook calculations while preserving compatibility tombstones
- freeze the course package v3 quizzes flag off and document archive/schema retirement gates
- prove non-empty legacy quiz resources survive the database restore round trip

## Validation
- pnpm vitest run (361 files / 3,324 tests)
- pnpm build
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm check:architecture
- bash scripts/check-classroom-archive-restore-database.sh
- shellcheck scripts/check-classroom-archive-restore-database.sh
- Pika pre-commit audit
- two independent review/fix loops, final rereviews clean

No production state or schema was changed.