### PR TITLE
Retire dead legacy quiz draft aliases

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13638,3 +13638,16 @@
 - `pnpm test tests/unit/ai-startup-docs.test.ts`
 - `node scripts/trim-session-log.mjs --check`
 - `pnpm lint`
+
+## 2026-07-09 — Remove stale staging environment references
+
+**Completed:**
+- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
+- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
+- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `grep -rni staging` (only seed-data classroom title and journal archive remain)
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,19 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-09 — Remove stale staging environment references
-
-**Completed:**
-- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
-- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
-- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `grep -rni staging` (only seed-data classroom title and journal archive remain)
-- `pnpm lint`
-- `pnpm exec tsc --noEmit`
-
 ## 2026-07-11 — Collaborator-local env startup guidance
 
 **Completed:**
@@ -743,6 +730,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - Focused assessment/access/architecture suites (4 files / 90 tests)
 - `pnpm vitest run` (361 files / 3,308 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (599 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-15 — Legacy quiz draft alias retirement
+
+**Completed:**
+- Removed the zero-caller `validateQuizDraftContent`, `buildQuizDraftContentFromRows`, and `syncQuizQuestionsFromDraft` wrapper exports and their identity-only assertions.
+- Preserved persisted `assessment_type = 'quiz'`, assessment-named legacy draft behavior, `quiz_questions`/`quiz_id` synchronization, archive resources, markdown compatibility, API aliases, and UI props.
+- Strengthened the legacy alias architecture regression to inspect resolved exports across every TypeScript module under `src`, preventing aliases from returning through unrelated re-exports.
+- Completed independent behavior and architecture review/fix loops; one guard bypass finding was fixed and final rereviews returned no findings. No UI, schema, dependency, or production changes.
+
+**Validation:**
+- Focused draft/architecture suites (2 files / 16 tests)
+- `pnpm vitest run` (361 files / 3,307 tests)
 - `pnpm build`
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -66,8 +66,9 @@ Retain for compatibility or schema-backed behavior:
 
 - `src/lib/assessments.ts` default handling for persisted legacy assessment
   types.
-- `src/lib/server/assessment-drafts.ts` quiz draft helpers and
-  `quiz_questions` sync for legacy rows.
+- `src/lib/server/assessment-drafts.ts` assessment-named draft helpers and their
+  `quiz_questions` sync behavior for legacy rows. The unused quiz-named wrapper
+  exports have been retired.
 - `src/lib/quiz-markdown.ts` and `tests/lib/quiz-markdown.test.ts`, which cover
   legacy quiz markdown import/export aliases.
 - Gradebook response tombstones for older clients. The active gradebook server
@@ -239,10 +240,11 @@ For each implementation pass:
 
 ## Next Implementation Pass
 
-The gradebook/course-package decision and dead alias retirement are complete.
-The next safe pass should remove test-only quiz draft aliases or continue
-fixture-only cleanup where no persisted/API/UI compatibility contract depends
-on the name. Start with:
+The gradebook/course-package decision and dead draft alias retirement are
+complete. The next safe pass should decide whether the test-only markdown
+aliases have completed their compatibility window or continue fixture-only
+cleanup where no persisted/API/UI compatibility contract depends on the name.
+Start with:
 
 - `tests/lib/quiz-markdown.test.ts` only if the test is rewritten to clearly say
   it covers legacy quiz markdown compatibility.

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -100,8 +100,6 @@ export function buildAssessmentDraftContentFromRows(
   }
 }
 
-export const buildQuizDraftContentFromRows = buildAssessmentDraftContentFromRows
-
 type TestQuestionRow = {
   id: string
   question_type: unknown
@@ -271,8 +269,6 @@ export async function syncAssessmentQuestionsFromDraft(
     },
   })
 }
-
-export const syncQuizQuestionsFromDraft = syncAssessmentQuestionsFromDraft
 
 export async function syncTestQuestionsFromDraft(
   supabase: SupabaseLike,

--- a/src/lib/validations/assessment-drafts.ts
+++ b/src/lib/validations/assessment-drafts.ts
@@ -137,8 +137,6 @@ export function validateAssessmentDraftContent(
   }
 }
 
-export const validateQuizDraftContent = validateAssessmentDraftContent
-
 export function validateTestDraftContent(
   input: unknown,
   options?: { allowEmptyQuestionText?: boolean },

--- a/tests/architecture/legacy-quiz-alias-retirement.test.ts
+++ b/tests/architecture/legacy-quiz-alias-retirement.test.ts
@@ -8,26 +8,26 @@ const retiredModules = [
   '@/lib/server/quizzes',
   '@/lib/quizzes',
 ]
-const exportModules = [
-  'src/types/index.ts',
-  'src/lib/assessments.ts',
-  'src/lib/quiz-markdown.ts',
-]
-
 const configFile = ts.readConfigFile(path.join(root, 'tsconfig.json'), ts.sys.readFile)
 const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, root)
-const program = ts.createProgram(
-  exportModules.map((file) => path.join(root, file)),
-  parsedConfig.options
-)
+const sourceRoot = `${path.join(root, 'src')}${path.sep}`
+const sourceFiles = parsedConfig.fileNames.filter((file) => file.startsWith(sourceRoot))
+const program = ts.createProgram(sourceFiles, parsedConfig.options)
 const checker = program.getTypeChecker()
 
-function exportedNames(file: string): Set<string> {
-  const source = program.getSourceFile(path.join(root, file))
-  if (!source) throw new Error(`TypeScript program did not load ${file}`)
-  const symbol = checker.getSymbolAtLocation(source)
-  if (!symbol) throw new Error(`TypeScript checker did not resolve ${file}`)
-  return new Set(checker.getExportsOfModule(symbol).map((entry) => entry.name))
+function exportedLocations(name: string): string[] {
+  const locations: string[] = []
+
+  for (const source of program.getSourceFiles()) {
+    if (!source.fileName.startsWith(sourceRoot)) continue
+    const symbol = checker.getSymbolAtLocation(source)
+    if (!symbol) continue
+    if (checker.getExportsOfModule(symbol).some((entry) => entry.name === name)) {
+      locations.push(path.relative(root, source.fileName))
+    }
+  }
+
+  return locations
 }
 
 describe('legacy quiz alias retirement', () => {
@@ -45,10 +45,7 @@ describe('legacy quiz alias retirement', () => {
     }
   })
 
-  it('keeps test-domain types and helpers on their current names', () => {
-    const typeExports = exportedNames('src/types/index.ts')
-    const assessmentExports = exportedNames('src/lib/assessments.ts')
-    const markdownExports = exportedNames('src/lib/quiz-markdown.ts')
+  it('does not expose retired quiz aliases from any source module', () => {
     const retiredTypeAliases = [
       'QuizDraftQuestion',
       'QuizDraftContent',
@@ -84,15 +81,19 @@ describe('legacy quiz alias retirement', () => {
       'emptyQuizFocusSummary',
       'summarizeQuizFocusEvents',
     ]
+    const retiredDraftAliases = [
+      'buildQuizDraftContentFromRows',
+      'syncQuizQuestionsFromDraft',
+      'validateQuizDraftContent',
+    ]
 
-    for (const alias of retiredTypeAliases) {
-      expect(typeExports).not.toContain(alias)
-    }
-    for (const alias of retiredHelperAliases) {
-      expect(assessmentExports).not.toContain(alias)
-    }
-    for (const alias of retiredMarkdownAliases) {
-      expect(markdownExports).not.toContain(alias)
+    for (const alias of [
+      ...retiredTypeAliases,
+      ...retiredHelperAliases,
+      ...retiredMarkdownAliases,
+      ...retiredDraftAliases,
+    ]) {
+      expect(exportedLocations(alias), `${alias} is exported`).toEqual([])
     }
   })
 })

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -2,19 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildAssessmentDraftContentFromRows,
   buildNextDraftContent,
-  buildQuizDraftContentFromRows,
   buildTestDraftContentFromRows,
   createAssessmentDraft,
   getAssessmentDraftByType,
   isMissingAssessmentDraftsError,
   syncAssessmentQuestionsFromDraft,
-  syncQuizQuestionsFromDraft,
   syncTestQuestionsFromDraft,
   updateAssessmentDraft,
 } from '@/lib/server/assessment-drafts'
 import {
   validateAssessmentDraftContent,
-  validateQuizDraftContent,
   validateTestDraftContent,
 } from '@/lib/validations/assessment-drafts'
 
@@ -278,12 +275,6 @@ describe('assessment drafts', () => {
     ).toBe(true)
 
     expect(isMissingAssessmentDraftsError({ code: '42703', message: 'column missing' })).toBe(false)
-  })
-
-  it('keeps legacy quiz helper exports as compatibility aliases', () => {
-    expect(validateQuizDraftContent).toBe(validateAssessmentDraftContent)
-    expect(buildQuizDraftContentFromRows).toBe(buildAssessmentDraftContentFromRows)
-    expect(syncQuizQuestionsFromDraft).toBe(syncAssessmentQuestionsFromDraft)
   })
 
   it('wraps draft fetch/create/update operations and normalizes thrown errors', async () => {


### PR DESCRIPTION
## Summary
- remove three zero-caller quiz-named draft wrapper exports
- preserve persisted legacy draft behavior and quiz question synchronization
- strengthen the alias retirement guard across all resolved `src` module exports

## Compatibility retained
- `assessment_type = 'quiz'`
- `quiz_questions` / `quiz_id` synchronization
- archive, markdown, API payload, gradebook, URL, and UI compatibility

## Validation
- focused draft/architecture suites (2 files / 16 tests)
- `pnpm vitest run` (361 files / 3,307 tests)
- `pnpm build`
- TypeScript, lint, architecture check, Pika audit
- independent review/fix loop; final rereviews clean

No UI, schema, dependency, or production changes.
