### PR TITLE
Harden classroom archive source cleanup

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,7 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Product status: core classroom, assignment, quiz/test, and auth flows are live.
 - Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
 - Feature inventory: `.ai/features.json` is the status authority for big epics; check it directly for current pass/fail state.
-- Classroom archives: production migrations 082-086 are applied; read-only inventory passed for three hot archives. Direct PostgreSQL catalog audit and named canaries remain. Restore and compaction are gated; source cleanup is hard-disabled pending ownership fencing.
+- Classroom archives: production 082-086 and read-only inventory are verified; hosted catalog/named canaries remain. Migration 096 locally fences assignment artifacts only; production is unchanged.
 
 ## Environment And Workflow Facts
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13651,3 +13651,16 @@
 - `grep -rni staging` (only seed-data classroom title and journal archive remain)
 - `pnpm lint`
 - `pnpm exec tsc --noEmit`
+
+## 2026-07-11 — Collaborator-local env startup guidance
+
+**Completed:**
+- Aligned the remaining startup/env guidance drift so collaborator-owned `.env.local` files are explicitly valid outside the maintainer symlink setup.
+- Updated `AGENTS.md`, `.ai/CURRENT.md`, `.codex/prompts/session-start.md`, `.claude/commands/session-start.md`, and `docs/core/project-context.md` to describe the maintainer symlink as the default on that machine, while allowing collaborators to copy `.env.example`.
+- Replaced the `ai-startup-docs` invariant that enforced a universal symlink requirement with a dual-path check that requires both the maintainer shared-env path and collaborator-local setup guidance.
+- No product code, runtime behavior, migrations, or dependencies changed.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,19 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-11 — Collaborator-local env startup guidance
-
-**Completed:**
-- Aligned the remaining startup/env guidance drift so collaborator-owned `.env.local` files are explicitly valid outside the maintainer symlink setup.
-- Updated `AGENTS.md`, `.ai/CURRENT.md`, `.codex/prompts/session-start.md`, `.claude/commands/session-start.md`, and `docs/core/project-context.md` to describe the maintainer symlink as the default on that machine, while allowing collaborators to copy `.env.example`.
-- Replaced the `ai-startup-docs` invariant that enforced a universal symlink requirement with a dual-path check that requires both the maintainer shared-env path and collaborator-local setup guidance.
-- No product code, runtime behavior, migrations, or dependencies changed.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
-- `git diff --check`
-
 ## 2026-07-10 — Bump GitHub Actions off deprecated Node 20
 
 **Completed:**
@@ -750,6 +737,33 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm vitest run` (361 files / 3,307 tests)
 - `pnpm build`
 - `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (599 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-15 — Classroom archive source ownership fence
+
+**Completed:**
+- Added migration 096 to make assignment-artifact source deletion require a bounded, transactional ownership verification and a permanent SHA-256 path reservation.
+- Serialized verification against artifact references, Storage writes, cleanup-ledger staging, and stale-worker deletion; reset pre-fence leases and rejected unreconciled historical deletions.
+- Restricted cleanup claims, lease transitions, and exact Storage presence checks to service-owned database contracts with explicit privilege tests.
+- Kept source cleanup manual, default-off, unscheduled, operation-scoped, and limited to one object per invocation; submission images and test documents remain preserved until they have authoritative relational registries.
+- Expanded the database harness with live multi-session races and the recovery drill with exact export, cleanup, byte-identical restore, replay, and deidentified-fence retention checks.
+- Completed repeated runtime and database review/fix rounds. No production state was read or modified by this phase.
+
+**Deployment obligation:**
+- Apply migration 096 before deploying this app version.
+- Run hosted catalog audit and named canaries read-only before enabling any source cleanup; keep cleanup disabled unless both explicit gates and an exact completed operation ID are supplied.
+
+**Validation:**
+- Classroom archive source-cleanup route/server/migration suites (33 tests)
+- `pnpm vitest run` (362 files / 3,317 tests)
+- Classroom archive compaction database contract harness, including concurrent verifier/reference/Storage/staging races
+- Classroom archive full recovery drill (42 resource tables; exact restore and replay)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm db:types:check`
 - `pnpm lint`
 - `pnpm check:architecture` (599 modules / 0 allowances)
 - Pika pre-commit audit

--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ CLASSROOM_ARCHIVE_RESTORE_DATABASE_BUDGET_BYTES=
 CLASSROOM_ARCHIVE_COMPACTION_ENABLED=false
 CLASSROOM_ARCHIVE_COMPACTION_TEACHER_IDS=
 CLASSROOM_ARCHIVE_COMPACTION_ARCHIVE_IDS=
-# Server-only source-object worker. Keep disabled until migration 086 is applied and recovery passes.
+# Server-only source-object worker. Keep disabled until migration 096 is applied and recovery passes.
 CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED=false
 # Manual CRON_SECRET-authenticated canary route. It is not scheduled in vercel.json.
 CLASSROOM_ARCHIVE_SOURCE_CLEANUP_TRIGGER_ENABLED=false

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -120,9 +120,10 @@ Classroom archive rollout controls are optional and disabled by default. Cold co
 coordinator is server-only and has no route or schedule; migration application and a named canary
 still require explicit human approval.
 
-Source-object deletion is separately hard-disabled. Its reserved manual route always returns `503`
-because transactional ownership verification and path reservation are not implemented. Environment
-flags cannot enable it, and it is not scheduled in `vercel.json`.
+Source-object deletion is separately disabled by default. Migration 096 transactionally fences
+`assignment-artifacts`; embedded-reference buckets remain ineligible. The manual route requires two
+independent gates plus one exact compaction operation UUID, and bounds both new reservations and
+claims to one object. It is not scheduled in `vercel.json`.
 
 Abandoned export/restore upload cleanup is independently disabled by default with
 `CLASSROOM_ARCHIVE_OBJECT_CLEANUP_ENABLED=false`. When enabled, the authenticated daily history cron

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -142,17 +142,24 @@ Test password-based flows:
   idempotent cleanup staging, atomic-finalization ordering, completed replay, and fail-closed handling
   when a completion response cannot prove its committed state. No route or schedule invokes it.
 - Source-object cleanup worker tests prove strict claim validation, full-byte checksum and size
-  verification before removal, authoritative exact-key absence afterward, stale-lease rejection,
-  durable retry evidence, independent claim containment, and privacy-safe metrics.
+  verification before removal, ownership reservation before v2 claims, authoritative exact-key
+  absence afterward through a definitive download response or exact database presence check,
+  stale-lease rejection, durable retry evidence, independent claim containment, and privacy-safe
+  metrics.
 - Source-object cleanup trigger tests prove cron-secret authentication, independent worker/trigger
-  gates, one-claim bounds, GET/POST parity, exact status propagation, and unhealthy batch signaling;
-  they also lock out automatic Vercel scheduling during the manual-canary stage.
+  gates, an exact operation canary, one-claim bounds, GET/POST parity, exact status propagation, and
+  unhealthy batch signaling; they also lock out automatic Vercel scheduling during the manual-canary
+  stage. The PostgreSQL contract proves bounded SHA-256 path reservations, separate relational and
+  Storage write races, concurrent cleanup-staging serialization, stale pre-fence lease and delete
+  rejection, exact presence-RPC semantics, boolean-only evidence rejection, and revocation of the
+  unfenced claim RPC.
 - Ephemeral full-stack CI starts local Supabase REST and Storage, creates a synthetic archived
   classroom with submitted work and a managed object, and invokes the real export, compaction,
   source-cleanup, and restore coordinators. The rehearsal proves representative row equality,
-  restored object-byte equality, cold tombstone removal, immutable archive retention, idempotent
-  replay, and complete synthetic-fixture teardown. Its guard rejects non-loopback targets and
-  non-local service-role credentials before any write.
+  fenced source deletion, restored object-byte equality, cold tombstone removal, immutable archive
+  retention, idempotent replay, fixture-row teardown, and clearing of the operation id from the
+  retained one-way path fence. Its guard rejects non-loopback targets and non-local service-role
+  credentials before any write.
 - Gradex runtime coordinator tests prove the internal feature gate, source archive identity/checksum
   binding, HMAC-key-bound idempotency, private no-overwrite upload, complete read-back verification,
   finalization ordering, deterministic retry reuse, and terminal-versus-retryable object cleanup.

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -32,20 +32,32 @@ archive UUID must be explicitly allowlisted and `CLASSROOM_ARCHIVE_COMPACTION_EN
 settings default off. There is no route, UI, schedule, or production caller, so deployment alone
 cannot compact a classroom.
 
-Migration `086_classroom_archive_source_object_cleanup.sql` and
+Migrations `086_classroom_archive_source_object_cleanup.sql` and
+`096_classroom_archive_source_ownership_fence.sql`, together with
 `src/lib/server/classroom-archive-source-cleanup.ts` define the separate deletion boundary. The
-runtime is hard-disabled until a transactional ownership verifier and path reservation fence exist;
-environment flags alone cannot enable source deletion. Once that prerequisite is implemented, the
-worker will lease at most 10 rows from completed
+fence initially supports only `assignment-artifacts`, whose exact relational reference is
+`assignment_submission_artifacts.storage_path`. It atomically reserves only the bounded candidate
+set the worker can claim, stores only a SHA-256 path fingerprint, rejects future relational
+references and Storage writes to that permanent identity, and uses a versioned claim RPC that cannot
+be bypassed through migration 086's original claim function. Embedded
+`submission-images` and `test-documents` references remain ineligible and are preserved until they
+have an equivalent authoritative registry. The worker leases at most 10 rows from completed
 compactions with matching cold tombstones, reads each exact source key, and verifies its complete
 bytes against the archived SHA-256 and byte count before removal. It completes a lease only after an
-exact-key read authoritatively reports absence. Mismatches, missing buckets, uncertain reads,
-unconfirmed deletion, and stale leases fail closed with durable retry evidence.
+exact-key read or service-only exact `storage.objects` lookup authoritatively reports absence.
+Mismatches, missing buckets, uncertain reads, unconfirmed deletion, and stale leases fail closed with
+durable retry evidence.
 
-`/api/cron/classroom-archive-source-cleanup` is reserved for a future manual deletion canary, but it
-currently always returns `503` even when its environment flags are set. The route is absent from
-`vercel.json` and has no UI caller. It must not be enabled until the transactional ownership verifier
-and path reservation fence are implemented and reviewed.
+During rollout, migration 096 invalidates every processing lease created under migration 086 and
+requires timestamped evidence plus a matching reservation in renew, complete, and fail transitions.
+Storage deletes for inventoried but unreserved paths are blocked, and cleanup staging takes the same
+exact-path lock as verification. The migration refuses to apply if an earlier unfenced worker
+recorded any deleted row, because that history requires explicit operator reconciliation rather than
+an inferred backfill.
+
+`/api/cron/classroom-archive-source-cleanup` is a manual, one-operation deletion canary. Both cleanup
+gates and an exact compaction operation UUID are required, all settings default off, and the route is
+absent from `vercel.json` with no UI caller. Applying migration 096 does not schedule or invoke it.
 
 The export endpoint accepts an optional UUID `Idempotency-Key` and an optional strict retention policy.
 It also requires `CLASSROOM_ARCHIVE_EXPORT_ENABLED=true` and the teacher UUID in the server-only
@@ -251,8 +263,8 @@ Cold compaction starts only from `archived_hot`, where mutation is already block
 6. Recheck the source revision and every ownership count, then remove classroom-owned rows
    child-first in the same transaction that creates the tombstone.
 7. Transition the staged cleanup rows to retryable `pending` work only after relational commit.
-8. Keep every source object ineligible by default. A separate ownership verifier must prove that one
-   archive operation exclusively owns a path before the cleanup worker may claim it.
+8. Keep every source object ineligible by default. Migration 096 can verify and permanently reserve
+   only exact `assignment-artifacts` paths; embedded-reference buckets remain preserved.
 9. Delete ownership-verified source objects as retryable cleanup; a cleanup failure does not
    invalidate the verified archive.
 
@@ -270,9 +282,12 @@ in bounded batches and finalization is attempted only after the aggregate count 
 match immutable archive metadata. A completed replay does not reread Storage. An unknown completion
 response is never reported as success because the database transaction may already have committed.
 The pending cleanup rows are deliberately left for a separate lease-based deletion worker. Migration
-086 requires an exact operation canary and `ownership_verified = true`; no runtime in this phase sets
-that evidence, and the worker gate is hard-disabled, so source-object deletion remains fail-closed
-while relational compaction is usable.
+096 requires timestamped ownership evidence plus a matching permanent reservation, revokes the old
+unfenced claim capability, and exposes a service-role-only v2 claim. The runtime verifier sets that
+evidence only for the bounded assignment-artifact candidates the invocation may claim. Reservations
+retain the bucket and a SHA-256 path fingerprint rather than the raw path; deleting the operation
+clears its identifier but intentionally preserves the reuse fence. Both runtime gates and an exact
+operation canary remain required, so relational compaction does not automatically delete objects.
 
 ## Gradex Extract
 
@@ -431,9 +446,10 @@ inventory alone does not claim that an export will succeed.
 `pnpm verify:classroom-archive-recovery` exercises the complete runtime path against an already
 started local Supabase stack. It creates a unique synthetic archived classroom with a submission and
 one private source object, then calls the real export, compaction, ownership-gated source cleanup,
-and restore coordinators. It verifies representative relational equality, restored object bytes,
-source-object retention while ownership is unverified, cold tombstone removal, immutable archive
-retention, completed-work replay, and fixture teardown.
+and restore coordinators. It verifies representative relational equality, fenced source-object
+deletion, restoration of the deleted bytes from the immutable archive, cold tombstone removal,
+immutable archive retention, completed-work replay, fixture-row teardown, and removal of the
+operation identifier from the retained one-way path fence.
 
 The command has no hosted-project mode. Before constructing a client it requires an exact local
 destructive-operation acknowledgement, an HTTP loopback Supabase origin, and the Supabase local-demo

--- a/scripts/check-classroom-archive-compaction-database.sh
+++ b/scripts/check-classroom-archive-compaction-database.sh
@@ -69,6 +69,43 @@ values
     '{"type":"doc","content":[]}'::jsonb
   );
 
+insert into public.assignment_submission_requirements (
+  id,
+  assignment_id,
+  type,
+  label
+) values (
+  '27000000-0000-4000-8000-000000000022',
+  '22000000-0000-4000-8000-000000000022',
+  'image',
+  'Compaction evidence'
+);
+
+insert into public.assignment_submission_artifacts (
+  id,
+  assignment_doc_id,
+  requirement_id,
+  student_id,
+  type,
+  storage_path,
+  validation_status
+) values (
+  '28000000-0000-4000-8000-000000000022',
+  '23000000-0000-4000-8000-000000000022',
+  '27000000-0000-4000-8000-000000000022',
+  '11000000-0000-4000-8000-000000000022',
+  'image',
+  'teacher/classroom/success.txt',
+  'valid'
+);
+
+insert into storage.objects (bucket_id, name, metadata)
+values (
+  'assignment-artifacts',
+  'teacher/classroom/success.txt',
+  '{"size":10}'::jsonb
+);
+
 create function public.reject_test_classroom_archive_compaction()
 returns trigger
 language plpgsql
@@ -442,7 +479,7 @@ begin
     }]'::jsonb
   );
   select count(*) into v_claim_count
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000030',
     v_success_compaction_id,
     1,
@@ -515,10 +552,164 @@ $contract$;
 reset role;
 
 update public.classroom_archive_source_object_cleanup
-set ownership_verified = true
+set status = 'processing',
+    lease_token = '26000000-0000-4000-8000-000000000030'::uuid,
+    lease_expires_at = clock_timestamp() + interval '5 minutes',
+    last_error_code = null
 where operation_id = '25000000-0000-4000-8000-000000000022'::uuid;
 
 set local role service_role;
+
+do $stale_lease_transition$
+begin
+  if public.complete_classroom_archive_source_object_cleanup(
+    '25000000-0000-4000-8000-000000000022'::uuid,
+    'assignment-artifacts',
+    'teacher/classroom/success.txt',
+    '26000000-0000-4000-8000-000000000030'::uuid
+  ) then
+    raise exception 'Pre-fence source cleanup lease completed without a reservation';
+  end if;
+end;
+$stale_lease_transition$;
+
+reset role;
+
+update public.classroom_archive_source_object_cleanup
+set status = 'pending',
+    lease_token = null,
+    lease_expires_at = null,
+    last_error_code = null
+where operation_id = '25000000-0000-4000-8000-000000000022'::uuid;
+
+do $stale_worker_delete$
+begin
+  perform set_config('storage.allow_delete_query', 'true', true);
+  begin
+    delete from storage.objects
+    where bucket_id = 'assignment-artifacts'
+      and name = 'teacher/classroom/success.txt';
+    raise exception 'Pre-fence source cleanup worker deleted without a reservation';
+  exception when object_not_in_prerequisite_state then null;
+  end;
+  if not exists (
+    select 1
+    from storage.objects
+    where bucket_id = 'assignment-artifacts'
+      and name = 'teacher/classroom/success.txt'
+  ) then
+    raise exception 'Blocked pre-fence deletion removed the source object';
+  end if;
+end;
+$stale_worker_delete$;
+
+do $cleanup_ownership_evidence$
+begin
+  begin
+    update public.classroom_archive_source_object_cleanup
+    set ownership_verified = true
+    where operation_id = '25000000-0000-4000-8000-000000000022'::uuid;
+    raise exception 'Boolean-only source ownership evidence was accepted';
+  exception when check_violation then null;
+  end;
+end;
+$cleanup_ownership_evidence$;
+
+set local role service_role;
+
+do $source_object_presence$
+declare
+  v_present jsonb;
+  v_absent jsonb;
+begin
+  v_present := public.get_classroom_archive_source_object_presence(
+    'assignment-artifacts',
+    'teacher/classroom/success.txt'
+  );
+  if coalesce((v_present->>'bucket_exists')::boolean, false) is not true
+    or coalesce((v_present->>'object_exists')::boolean, false) is not true
+  then
+    raise exception 'Exact source-object presence lookup missed an existing object: %', v_present;
+  end if;
+
+  v_absent := public.get_classroom_archive_source_object_presence(
+    'assignment-artifacts',
+    'teacher/classroom/absent.txt'
+  );
+  if coalesce((v_absent->>'bucket_exists')::boolean, false) is not true
+    or coalesce((v_absent->>'object_exists')::boolean, true) is not false
+  then
+    raise exception 'Exact source-object presence lookup invented an absent object: %', v_absent;
+  end if;
+
+  begin
+    perform public.get_classroom_archive_source_object_presence(
+      'assignment-artifacts',
+      '../outside'
+    );
+    raise exception 'Malformed source-object presence path was accepted';
+  exception when invalid_parameter_value then null;
+  end;
+end;
+$source_object_presence$;
+
+do $cleanup_reservation$
+declare
+  v_result jsonb;
+begin
+  v_result := public.verify_and_reserve_classroom_archive_source_objects(
+    '25000000-0000-4000-8000-000000000022'::uuid,
+    1
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or (v_result->>'verified')::integer <> 1
+    or (v_result->>'preserved')::integer <> 0
+  then
+    raise exception 'Source-object ownership reservation failed: %', v_result;
+  end if;
+  v_result := public.verify_and_reserve_classroom_archive_source_objects(
+    '25000000-0000-4000-8000-000000000022'::uuid,
+    1
+  );
+  if coalesce((v_result->>'replayed')::boolean, false) is not true then
+    raise exception 'Source-object ownership reservation did not replay: %', v_result;
+  end if;
+
+  begin
+    insert into public.assignment_submission_artifacts (
+      assignment_doc_id,
+      requirement_id,
+      student_id,
+      type,
+      storage_path
+    ) values (
+      '23000000-0000-4000-8000-000000000099',
+      '27000000-0000-4000-8000-000000000099',
+      '11000000-0000-4000-8000-000000000022',
+      'image',
+      'teacher/classroom/success.txt'
+    );
+    raise exception 'Reserved source path was attached to hot relational data';
+  exception when object_not_in_prerequisite_state then null;
+  end;
+
+  begin
+    update storage.objects
+    set metadata = '{"size":11}'::jsonb
+    where bucket_id = 'assignment-artifacts'
+      and name = 'teacher/classroom/success.txt';
+    raise exception 'Reserved source object was overwritten';
+  exception when object_not_in_prerequisite_state then null;
+  end;
+
+  begin
+    insert into storage.objects (bucket_id, name)
+    values ('assignment-artifacts', 'teacher/classroom/success.txt');
+    raise exception 'Reserved source object path was reused';
+  exception when object_not_in_prerequisite_state then null;
+  end;
+end;
+$cleanup_reservation$;
 
 do $cleanup_claim$
 declare
@@ -526,7 +717,7 @@ declare
   v_claim_count integer;
 begin
   begin
-    perform public.claim_due_classroom_archive_source_object_cleanup(
+    perform public.claim_due_classroom_archive_source_object_cleanup_v2(
       '26000000-0000-4000-8000-000000000031',
       '25000000-0000-4000-8000-000000000022',
       0,
@@ -537,7 +728,7 @@ begin
   end;
 
   select * into v_claim
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000031',
     '25000000-0000-4000-8000-000000000022',
     1,
@@ -557,7 +748,7 @@ begin
   end if;
 
   select count(*) into v_claim_count
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000032',
     '25000000-0000-4000-8000-000000000022',
     1,
@@ -583,7 +774,7 @@ declare
   v_claim_count integer;
 begin
   select * into v_claim
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000032',
     '25000000-0000-4000-8000-000000000022',
     1,
@@ -610,7 +801,7 @@ begin
     raise exception 'Current source-object cleanup lease could not record failure';
   end if;
   select count(*) into v_claim_count
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000033',
     '25000000-0000-4000-8000-000000000022',
     1,
@@ -635,7 +826,7 @@ declare
   v_claim record;
 begin
   select * into v_claim
-  from public.claim_due_classroom_archive_source_object_cleanup(
+  from public.claim_due_classroom_archive_source_object_cleanup_v2(
     '26000000-0000-4000-8000-000000000033',
     '25000000-0000-4000-8000-000000000022',
     1,
@@ -691,6 +882,18 @@ begin
   ) then
     raise exception 'Source-object cleanup completion did not preserve audit evidence';
   end if;
+  if not exists (
+    select 1
+    from public.classroom_archive_source_object_reservations reservation
+    where reservation.operation_id = v_claim.operation_id
+      and reservation.storage_bucket = v_claim.storage_bucket
+      and reservation.storage_path_sha256 =
+        public.classroom_archive_source_object_path_sha256(
+          v_claim.storage_bucket, v_claim.storage_path
+        )
+  ) then
+    raise exception 'Source-object cleanup completion released its permanent reservation';
+  end if;
 end;
 $cleanup_complete$;
 
@@ -715,7 +918,15 @@ begin
   end if;
   if has_function_privilege(
     'authenticated',
-    'public.claim_due_classroom_archive_source_object_cleanup(uuid,uuid,integer,integer)',
+    'public.verify_and_reserve_classroom_archive_source_objects(uuid,integer)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.get_classroom_archive_source_object_presence(text,text)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.claim_due_classroom_archive_source_object_cleanup_v2(uuid,uuid,integer,integer)',
     'EXECUTE'
   ) or has_function_privilege(
     'authenticated',
@@ -727,10 +938,17 @@ begin
     'EXECUTE'
   ) or has_function_privilege(
     'anon',
-    'public.claim_due_classroom_archive_source_object_cleanup(uuid,uuid,integer,integer)',
+    'public.claim_due_classroom_archive_source_object_cleanup_v2(uuid,uuid,integer,integer)',
     'EXECUTE'
   ) then
     raise exception 'Authenticated role can execute source-object cleanup RPCs';
+  end if;
+  if has_function_privilege(
+    'service_role',
+    'public.claim_due_classroom_archive_source_object_cleanup(uuid,uuid,integer,integer)',
+    'EXECUTE'
+  ) then
+    raise exception 'Service role can bypass the source-object ownership fence';
   end if;
   if has_table_privilege(
     'authenticated',
@@ -739,10 +957,278 @@ begin
   ) then
     raise exception 'Authenticated role can read source-object cleanup rows';
   end if;
+  if has_table_privilege(
+    'authenticated',
+    'public.classroom_archive_source_object_reservations',
+    'SELECT'
+  ) then
+    raise exception 'Authenticated role can read source-object reservations';
+  end if;
+  if has_table_privilege(
+    'service_role',
+    'public.classroom_archive_source_object_cleanup',
+    'UPDATE'
+  ) or has_table_privilege(
+    'service_role',
+    'public.classroom_archive_source_object_reservations',
+    'INSERT'
+  ) or has_table_privilege(
+    'service_role',
+    'public.classroom_archive_source_object_reservations',
+    'DELETE'
+  ) then
+    raise exception 'Service role can mutate source ownership evidence directly';
+  end if;
 end;
 $security$;
 
 rollback;
 SQL
+
+RACE_OPERATION_ID="25000000-0000-4000-8000-000000000029"
+RACE_STAGING_OPERATION_ID="25000000-0000-4000-8000-000000000028"
+RACE_ARCHIVE_ID="24000000-0000-4000-8000-000000000029"
+RACE_CLASSROOM_ID="21000000-0000-4000-8000-000000000029"
+RACE_PATH="teacher/classroom/concurrent-race.txt"
+RACE_STORAGE_PATH="zz-unreserved-canary-path.txt"
+RACE_STAGING_PATH="zzzz-concurrent-staging-path.txt"
+RACE_OUTPUT="$(mktemp)"
+
+cleanup_race_fixture() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+    -v operation_id="$RACE_OPERATION_ID" \
+    -v staging_operation_id="$RACE_STAGING_OPERATION_ID" \
+    -v archive_id="$RACE_ARCHIVE_ID" \
+    -v classroom_id="$RACE_CLASSROOM_ID" \
+    -v storage_path="$RACE_PATH" \
+    -v storage_race_path="$RACE_STORAGE_PATH" \
+    -v staging_race_path="$RACE_STAGING_PATH" >/dev/null <<'SQL'
+delete from public.classroom_cold_tombstones where classroom_id = :'classroom_id'::uuid;
+delete from public.classroom_archive_source_object_cleanup
+where operation_id in (:'operation_id'::uuid, :'staging_operation_id'::uuid);
+delete from public.classroom_archives where id = :'archive_id'::uuid;
+delete from public.classroom_archive_operations where id = :'operation_id'::uuid;
+delete from public.classroom_archive_operations where id = :'staging_operation_id'::uuid;
+delete from public.classroom_archive_source_object_reservations
+where storage_bucket = 'assignment-artifacts'
+  and storage_path_sha256 in (
+    public.classroom_archive_source_object_path_sha256(
+      'assignment-artifacts', :'storage_path'
+    ),
+    public.classroom_archive_source_object_path_sha256(
+      'assignment-artifacts', :'storage_race_path'
+    ),
+    public.classroom_archive_source_object_path_sha256(
+      'assignment-artifacts', :'staging_race_path'
+    )
+  );
+SQL
+  rm -f "$RACE_OUTPUT"
+}
+trap cleanup_race_fixture EXIT
+cleanup_race_fixture
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -v operation_id="$RACE_OPERATION_ID" \
+  -v staging_operation_id="$RACE_STAGING_OPERATION_ID" \
+  -v archive_id="$RACE_ARCHIVE_ID" \
+  -v classroom_id="$RACE_CLASSROOM_ID" \
+  -v storage_path="$RACE_PATH" \
+  -v storage_race_path="$RACE_STORAGE_PATH" \
+  -v staging_race_path="$RACE_STAGING_PATH" <<'SQL' >/dev/null
+insert into public.classroom_archive_operations (
+  id, teacher_id, classroom_id, operation_type, request_sha256, status,
+  source_revision, source_schema_migration, source_app_commit, retention,
+  archive_id, storage_bucket, storage_path, artifact_sha256, content_sha256,
+  compressed_byte_size, uncompressed_byte_size, verification,
+  snapshot_created_at, snapshot_expires_at, completed_at,
+  source_object_cleanup_staged_at
+) values (
+  :'operation_id'::uuid,
+  '11000000-0000-4000-8000-000000000029'::uuid,
+  :'classroom_id'::uuid,
+  'compact', repeat('1', 64), 'completed', 1, '096_race_fixture', 'fixture',
+  '{}'::jsonb, :'archive_id'::uuid, 'classroom-archives',
+  'race/archive.tar.gz', repeat('2', 64), repeat('3', 64), 1, 1,
+  '{}'::jsonb, clock_timestamp() - interval '2 minutes',
+  clock_timestamp() + interval '1 hour', clock_timestamp() - interval '1 minute',
+  clock_timestamp() - interval '1 minute'
+);
+insert into public.classroom_archive_operations (
+  id, teacher_id, classroom_id, operation_type, request_sha256, status,
+  source_revision, source_schema_migration, source_app_commit, retention,
+  archive_id, storage_bucket, storage_path, artifact_sha256, content_sha256,
+  compressed_byte_size, uncompressed_byte_size, verification,
+  snapshot_created_at, snapshot_expires_at
+) values (
+  :'staging_operation_id'::uuid,
+  '11000000-0000-4000-8000-000000000029'::uuid,
+  :'classroom_id'::uuid,
+  'compact', repeat('6', 64), 'snapshot_ready', 1, '096_race_fixture', 'fixture',
+  '{}'::jsonb, :'archive_id'::uuid, 'classroom-archives',
+  'race/staging-archive.tar.gz', repeat('7', 64), repeat('8', 64), 1, 1,
+  '{}'::jsonb, clock_timestamp() - interval '1 minute',
+  clock_timestamp() + interval '1 hour'
+);
+insert into public.classroom_archives (
+  id, operation_id, classroom_id, teacher_id, format, format_version,
+  source_revision, source_schema_migration, source_app_commit, storage_bucket,
+  storage_path, artifact_sha256, content_sha256, compressed_byte_size,
+  uncompressed_byte_size, resource_counts, storage_object_counts, verification,
+  retention, created_at, verified_at
+) values (
+  :'archive_id'::uuid, :'operation_id'::uuid, :'classroom_id'::uuid,
+  '11000000-0000-4000-8000-000000000029'::uuid,
+  'pika.classroom-archive', 1, 1, '096_race_fixture', 'fixture',
+  'classroom-archives', 'race/archive.tar.gz', repeat('2', 64), repeat('3', 64),
+  1, 1, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+  clock_timestamp() - interval '2 minutes', clock_timestamp() - interval '1 minute'
+);
+insert into public.classroom_cold_tombstones (
+  classroom_id, teacher_id, archive_id, title, archived_at, compacted_at,
+  source_revision
+) values (
+  :'classroom_id'::uuid,
+  '11000000-0000-4000-8000-000000000029'::uuid,
+  :'archive_id'::uuid, 'Race fixture', clock_timestamp() - interval '3 minutes',
+  clock_timestamp() - interval '1 minute', 1
+);
+insert into public.classroom_archive_source_object_cleanup (
+  operation_id, archive_id, classroom_id, storage_bucket, storage_path,
+  expected_sha256, expected_byte_size, status
+) values
+(
+  :'operation_id'::uuid, :'archive_id'::uuid, :'classroom_id'::uuid,
+  'assignment-artifacts', :'storage_path', repeat('4', 64), 1, 'pending'
+), (
+  :'operation_id'::uuid, :'archive_id'::uuid, :'classroom_id'::uuid,
+  'assignment-artifacts', :'storage_race_path', repeat('5', 64), 1, 'pending'
+), (
+  :'operation_id'::uuid, :'archive_id'::uuid, :'classroom_id'::uuid,
+  'assignment-artifacts', :'staging_race_path', repeat('9', 64), 1, 'pending'
+);
+SQL
+
+docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "begin; set local role service_role; select public.verify_and_reserve_classroom_archive_source_objects('$RACE_OPERATION_ID'::uuid, 1); select pg_sleep(3); commit;" \
+  >"$RACE_OUTPUT" 2>&1 &
+RACE_VERIFIER_PID=$!
+
+for _ in {1..40}; do
+  LOCK_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+    "select count(*) from pg_locks locks join pg_stat_activity activity using (pid) where locks.locktype = 'advisory' and locks.granted and activity.query like '%verify_and_reserve_classroom_archive_source_objects%pg_sleep(3)%';")"
+  [[ "$LOCK_COUNT" -gt 0 ]] && break
+  sleep 0.1
+done
+if [[ "${LOCK_COUNT:-0}" -eq 0 ]]; then
+  wait "$RACE_VERIFIER_PID" || true
+  cat "$RACE_OUTPUT" >&2
+  echo "Verifier did not acquire the expected advisory lock." >&2
+  exit 1
+fi
+
+RACE_WRITE_OUTPUT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "set statement_timeout = '10s'; insert into public.assignment_submission_artifacts (assignment_doc_id, requirement_id, student_id, type, storage_path) values ('23000000-0000-4000-8000-000000000029', '27000000-0000-4000-8000-000000000029', '11000000-0000-4000-8000-000000000029', 'image', '$RACE_PATH');" 2>&1)" && RACE_WRITE_STATUS=0 || RACE_WRITE_STATUS=$?
+wait "$RACE_VERIFIER_PID"
+
+RACE_BOUND_COUNTS="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  "select (select count(*) from public.classroom_archive_source_object_reservations where operation_id = '$RACE_OPERATION_ID'::uuid), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_OPERATION_ID'::uuid and ownership_verified), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_OPERATION_ID'::uuid and not ownership_verified);")"
+
+if [[ "$RACE_WRITE_STATUS" -eq 0 ]] \
+  || [[ "$RACE_WRITE_OUTPUT" != *"Assignment artifact storage path is reserved"* ]]; then
+  printf '%s\n' "$RACE_WRITE_OUTPUT" >&2
+  echo "Concurrent hot reference write was not serialized behind the reservation." >&2
+  exit 1
+fi
+if [[ "$RACE_BOUND_COUNTS" != "1|1|2" ]]; then
+  echo "One-claim verification fenced more than one source path: $RACE_BOUND_COUNTS" >&2
+  exit 1
+fi
+
+RACE_CLAIM_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  "select count(*) from public.claim_due_classroom_archive_source_object_cleanup_v2('26000000-0000-4000-8000-000000000039'::uuid, '$RACE_OPERATION_ID'::uuid, 1, 300);")"
+if [[ "$RACE_CLAIM_COUNT" != "1" ]]; then
+  echo "Relational race fixture could not claim its first bounded reservation." >&2
+  exit 1
+fi
+
+docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "begin; set local role service_role; select public.verify_and_reserve_classroom_archive_source_objects('$RACE_OPERATION_ID'::uuid, 1); select pg_sleep(3); commit;" \
+  >"$RACE_OUTPUT" 2>&1 &
+RACE_VERIFIER_PID=$!
+
+LOCK_COUNT=0
+for _ in {1..40}; do
+  LOCK_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+    "select count(*) from pg_locks locks join pg_stat_activity activity using (pid) where locks.locktype = 'advisory' and locks.granted and activity.query like '%verify_and_reserve_classroom_archive_source_objects%pg_sleep(3)%';")"
+  [[ "$LOCK_COUNT" -gt 0 ]] && break
+  sleep 0.1
+done
+if [[ "$LOCK_COUNT" -eq 0 ]]; then
+  wait "$RACE_VERIFIER_PID" || true
+  cat "$RACE_OUTPUT" >&2
+  echo "Storage verifier did not acquire the expected advisory lock." >&2
+  exit 1
+fi
+
+RACE_STORAGE_OUTPUT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "set statement_timeout = '10s'; insert into storage.objects (bucket_id, name) values ('assignment-artifacts', '$RACE_STORAGE_PATH');" 2>&1)" && RACE_STORAGE_STATUS=0 || RACE_STORAGE_STATUS=$?
+wait "$RACE_VERIFIER_PID"
+
+RACE_FINAL_COUNTS="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  "select (select count(*) from public.classroom_archive_source_object_reservations where operation_id = '$RACE_OPERATION_ID'::uuid), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_OPERATION_ID'::uuid and ownership_verified), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_OPERATION_ID'::uuid and not ownership_verified);")"
+if [[ "$RACE_STORAGE_STATUS" -eq 0 ]] \
+  || [[ "$RACE_STORAGE_OUTPUT" != *"Storage path is reserved by a classroom archive"* ]]; then
+  printf '%s\n' "$RACE_STORAGE_OUTPUT" >&2
+  echo "Concurrent Storage write was not serialized behind the reservation." >&2
+  exit 1
+fi
+if [[ "$RACE_FINAL_COUNTS" != "2|2|1" ]]; then
+  echo "Bounded Storage-race verification produced unexpected evidence: $RACE_FINAL_COUNTS" >&2
+  exit 1
+fi
+
+RACE_SECOND_CLAIM_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  "select count(*) from public.claim_due_classroom_archive_source_object_cleanup_v2('26000000-0000-4000-8000-000000000038'::uuid, '$RACE_OPERATION_ID'::uuid, 1, 300);")"
+if [[ "$RACE_SECOND_CLAIM_COUNT" != "1" ]]; then
+  echo "Storage race fixture could not claim its bounded reservation." >&2
+  exit 1
+fi
+
+docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "begin; set local role service_role; select public.verify_and_reserve_classroom_archive_source_objects('$RACE_OPERATION_ID'::uuid, 1); select pg_sleep(3); commit;" \
+  >"$RACE_OUTPUT" 2>&1 &
+RACE_VERIFIER_PID=$!
+
+LOCK_COUNT=0
+for _ in {1..40}; do
+  LOCK_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+    "select count(*) from pg_locks locks join pg_stat_activity activity using (pid) where locks.locktype = 'advisory' and locks.granted and activity.query like '%verify_and_reserve_classroom_archive_source_objects%pg_sleep(3)%';")"
+  [[ "$LOCK_COUNT" -gt 0 ]] && break
+  sleep 0.1
+done
+if [[ "$LOCK_COUNT" -eq 0 ]]; then
+  wait "$RACE_VERIFIER_PID" || true
+  cat "$RACE_OUTPUT" >&2
+  echo "Staging verifier did not acquire the expected advisory lock." >&2
+  exit 1
+fi
+
+RACE_STAGING_OUTPUT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  -c "set statement_timeout = '10s'; select public.stage_classroom_archive_compaction_objects('$RACE_STAGING_OPERATION_ID'::uuid, '11000000-0000-4000-8000-000000000029'::uuid, jsonb_build_array(jsonb_build_object('storage_bucket', 'assignment-artifacts', 'storage_path', '$RACE_STAGING_PATH', 'sha256', repeat('a', 64), 'byte_size', 1)));" 2>&1)" && RACE_STAGING_STATUS=0 || RACE_STAGING_STATUS=$?
+wait "$RACE_VERIFIER_PID"
+
+RACE_STAGING_COUNTS="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  "select (select count(*) from public.classroom_archive_source_object_reservations where operation_id = '$RACE_OPERATION_ID'::uuid), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_OPERATION_ID'::uuid and ownership_verified), (select count(*) from public.classroom_archive_source_object_cleanup where operation_id = '$RACE_STAGING_OPERATION_ID'::uuid);")"
+if [[ "$RACE_STAGING_STATUS" -eq 0 ]] \
+  || [[ "$RACE_STAGING_OUTPUT" != *"Classroom archive source cleanup path is already reserved"* ]]; then
+  printf '%s\n' "$RACE_STAGING_OUTPUT" >&2
+  echo "Concurrent cleanup staging was not serialized behind the reservation." >&2
+  exit 1
+fi
+if [[ "$RACE_STAGING_COUNTS" != "3|3|0" ]]; then
+  echo "Concurrent staging race produced unexpected evidence: $RACE_STAGING_COUNTS" >&2
+  exit 1
+fi
 
 echo "Classroom archive compaction database contract passed."

--- a/scripts/run-classroom-archive-recovery-drill.ts
+++ b/scripts/run-classroom-archive-recovery-drill.ts
@@ -19,6 +19,10 @@ const archiveMetadataSchema = z.object({
   storage_bucket: z.literal('classroom-archives'),
   storage_path: z.string().min(1),
 }).passthrough()
+const sourceObjectPresenceSchema = z.object({
+  bucket_exists: z.boolean(),
+  object_exists: z.boolean(),
+}).strict()
 
 const fixtureTables = [
   'classrooms',
@@ -106,6 +110,29 @@ async function readStorageBytes(
     throw new Error(`Recovery drill object is unavailable in ${bucket}`)
   }
   return new Uint8Array(await response.data.arrayBuffer())
+}
+
+async function assertStorageObjectAbsent(
+  supabase: SupabaseClient,
+  bucket: string,
+  path: string,
+) {
+  const response = await supabase.storage.from(bucket).download(path)
+  if (response.data) {
+    throw new Error(`Recovery drill expected no object in ${bucket}`)
+  }
+  const presenceResponse = await supabase.rpc(
+    'get_classroom_archive_source_object_presence',
+    { p_storage_bucket: bucket, p_storage_path: path },
+  )
+  const presence = sourceObjectPresenceSchema.safeParse(presenceResponse.data)
+  if (
+    !presenceResponse.error
+    && presence.success
+    && presence.data.bucket_exists
+    && !presence.data.object_exists
+  ) return
+  throw new Error(`Recovery drill could not verify object absence in ${bucket}`)
 }
 
 async function assertRowAbsent(
@@ -215,6 +242,18 @@ async function removeFixture(args: {
   archiveObjectPath?: string
 }) {
   const failures: string[] = []
+  const pathHashResponse = await args.supabase.rpc(
+    'classroom_archive_source_object_path_sha256',
+    {
+      p_storage_bucket: 'assignment-artifacts',
+      p_storage_path: args.sourceObjectPath,
+    },
+  )
+  const sourcePathHash = typeof pathHashResponse.data === 'string'
+    ? pathHashResponse.data
+    : null
+  if (pathHashResponse.error || !sourcePathHash) failures.push('reservation:path-hash')
+
   const removeObjects = async (bucket: string, paths: string[]) => {
     const response = await args.supabase.storage.from(bucket).remove(paths)
     if (response.error) failures.push(`storage:${bucket}`)
@@ -228,11 +267,6 @@ async function removeFixture(args: {
     const response = await args.supabase.from(table).delete().in(column, values)
     if (response.error) failures.push(`table:${table}:${response.error.code}`)
   }
-  await deleteRows(
-    'classroom_archive_source_object_cleanup',
-    'operation_id',
-    [args.ids.compactionOperation],
-  )
   await deleteRows('classroom_cold_tombstones', 'classroom_id', [args.ids.classrooms])
   await deleteRows(
     'classroom_archive_operations',
@@ -243,6 +277,22 @@ async function removeFixture(args: {
   await deleteRows('classroom_archive_operations', 'id', [args.ids.exportOperation])
   await deleteRows('classrooms', 'id', [args.ids.classrooms])
   await deleteRows('users', 'id', [args.ids.student, args.ids.teacher])
+
+  if (sourcePathHash) {
+    const reservation = await args.supabase
+      .from('classroom_archive_source_object_reservations')
+      .select('storage_bucket,storage_path_sha256,operation_id')
+      .eq('storage_bucket', 'assignment-artifacts')
+      .eq('storage_path_sha256', sourcePathHash)
+      .maybeSingle()
+    if (
+      reservation.error
+      || reservation.data?.storage_path_sha256 !== sourcePathHash
+      || reservation.data.operation_id !== null
+    ) {
+      failures.push('reservation:deidentified-fence')
+    }
+  }
 
   for (const [table, column, value] of [
     ['classroom_archive_operations', 'id', args.ids.exportOperation],
@@ -343,17 +393,14 @@ async function runRecoveryDrill() {
       leaseSeconds: 300,
     })
     if (!cleaned.ok) operationFailure('Archive source cleanup', cleaned)
-    if (cleaned.claimed !== 0 || cleaned.deleted !== 0 || cleaned.failed !== 0) {
-      throw new Error('Unverified archive source ownership became cleanup-eligible')
+    if (cleaned.claimed !== 1 || cleaned.deleted !== 1 || cleaned.failed !== 0) {
+      throw new Error('Ownership-fenced archive source cleanup did not delete exactly one object')
     }
-    const retainedSourceBytes = await readStorageBytes(
+    await assertStorageObjectAbsent(
       supabase,
       'assignment-artifacts',
       sourceObjectPath,
     )
-    if (sha256Bytes(retainedSourceBytes) !== sourceObjectSha256) {
-      throw new Error('Ownership-gated archive source object changed')
-    }
 
     const restored = await restoreClassroomArchive({
       supabase,
@@ -448,7 +495,8 @@ async function runRecoveryDrill() {
       resource_table_count: Object.keys(exported.resource_counts).length,
       representative_rows_verified: fixtureTables.length,
       storage_objects_verified: 1,
-      source_cleanup_ownership_gate_verified: true,
+      source_cleanup_deletion_verified: true,
+      deidentified_source_fence_retained: true,
       immutable_archive_retained: true,
       cold_tombstone_removed: true,
       idempotent_replays_verified: 4,

--- a/src/app/api/cron/classroom-archive-source-cleanup/route.ts
+++ b/src/app/api/cron/classroom-archive-source-cleanup/route.ts
@@ -14,7 +14,6 @@ export const revalidate = 0
 export const maxDuration = 60
 
 const CLEANUP_CANARY_LIMIT = 1
-const OWNERSHIP_VERIFIER_IMPLEMENTED = false
 
 function getCronAuthHeader(request: NextRequest): string | null {
   return request.headers.get('authorization') ?? request.headers.get('Authorization')
@@ -43,17 +42,6 @@ async function handle(request: NextRequest) {
       error_code: 'classroom_archive_source_cleanup_trigger_not_enabled',
       error: 'Classroom archive source cleanup trigger is not enabled',
       retryable: true,
-    }, { status: 503 })
-  }
-
-  if (!OWNERSHIP_VERIFIER_IMPLEMENTED) {
-    return NextResponse.json({
-      ok: false,
-      status: 503,
-      lease_token: leaseToken,
-      error_code: 'classroom_archive_source_cleanup_ownership_verifier_required',
-      error: 'Classroom archive source cleanup ownership verification is not implemented',
-      retryable: false,
     }, { status: 503 })
   }
 

--- a/src/lib/server/classroom-archive-source-cleanup.ts
+++ b/src/lib/server/classroom-archive-source-cleanup.ts
@@ -7,11 +7,7 @@ export const CLASSROOM_ARCHIVE_SOURCE_CLEANUP_MAX_CLAIMS = 10
 export const CLASSROOM_ARCHIVE_SOURCE_CLEANUP_DEFAULT_LEASE_SECONDS = 300
 
 const uuidSchema = z.string().uuid()
-const storageBucketSchema = z.enum([
-  'assignment-artifacts',
-  'submission-images',
-  'test-documents',
-])
+const storageBucketSchema = z.literal('assignment-artifacts')
 const storagePathSchema = z.string().min(1).superRefine((path, context) => {
   if (
     path.startsWith('/')
@@ -41,6 +37,32 @@ const runOptionsSchema = z.object({
   leaseSeconds: z.number().int().min(30).max(1800).optional(),
 }).strict()
 const booleanRpcSchema = z.boolean()
+const objectPresenceSchema = z.object({
+  bucket_exists: z.boolean(),
+  object_exists: z.boolean(),
+}).strict()
+const ownershipVerificationSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    status: z.literal(200),
+    operation_id: uuidSchema,
+    verified: z.number().int().nonnegative(),
+    preserved: z.number().int().nonnegative(),
+    replayed: z.boolean(),
+  }).strict(),
+  z.object({
+    ok: z.literal(false),
+    status: z.literal(409),
+    operation_id: uuidSchema,
+    error_code: z.enum([
+      'classroom_archive_source_ownership_not_compacted',
+      'classroom_archive_source_object_still_referenced',
+      'classroom_archive_source_object_competing_claim',
+      'classroom_archive_source_object_already_reserved',
+    ]),
+    error: z.string().min(1),
+  }).strict(),
+])
 
 type SupabaseClient = ReturnType<typeof getServiceRoleClient>
 type CleanupClaim = z.infer<typeof claimSchema>
@@ -66,7 +88,7 @@ export type ClassroomArchiveSourceCleanupResult =
     }
   | {
       ok: false
-      status: 500 | 503
+      status: 409 | 500 | 503
       lease_token: string
       error_code: string
       error: string
@@ -77,6 +99,29 @@ type ObjectReadResult =
   | { status: 'present'; bytes: Uint8Array }
   | { status: 'absent' }
   | { status: 'uncertain' }
+
+async function confirmExactObjectAbsence(
+  supabase: SupabaseClient,
+  bucketName: CleanupClaim['storage_bucket'],
+  path: string,
+): Promise<boolean> {
+  try {
+    const response = await supabase.rpc(
+      'get_classroom_archive_source_object_presence',
+      {
+        p_storage_bucket: bucketName,
+        p_storage_path: path,
+      },
+    )
+    if (response.error) return false
+    const presence = objectPresenceSchema.safeParse(response.data)
+    return presence.success
+      && presence.data.bucket_exists
+      && !presence.data.object_exists
+  } catch {
+    return false
+  }
+}
 
 export function isClassroomArchiveSourceCleanupEnabled(): boolean {
   return process.env.CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED?.trim().toLowerCase() === 'true'
@@ -102,7 +147,9 @@ function isMissingCleanupRpc(error: { code?: string; message?: string } | null |
   if (!error) return false
   const message = (error.message || '').toLowerCase()
   return error.code === '42883' || error.code === 'PGRST202' || (
-    message.includes('claim_due_classroom_archive_source_object_cleanup')
+    message.includes('claim_due_classroom_archive_source_object_cleanup_v2')
+    || message.includes('verify_and_reserve_classroom_archive_source_objects')
+    || message.includes('get_classroom_archive_source_object_presence')
     || message.includes('renew_classroom_archive_source_object_cleanup_lease')
     || message.includes('complete_classroom_archive_source_object_cleanup')
     || message.includes('fail_classroom_archive_source_object_cleanup')
@@ -168,25 +215,15 @@ async function readObject(
     }
     const evidence = missingStorageObjectEvidence(response.error)
     if (evidence === 'object') return { status: 'absent' }
-    if (evidence === 'generic') {
-      const bucketResponse = await supabase.storage.getBucket(bucketName)
-      if (!bucketResponse.error && bucketResponse.data?.id === bucketName) {
-        return { status: 'absent' }
-      }
+    if (await confirmExactObjectAbsence(supabase, bucketName, path)) {
+      return { status: 'absent' }
     }
     return { status: 'uncertain' }
   } catch (error) {
     const evidence = missingStorageObjectEvidence(error)
     if (evidence === 'object') return { status: 'absent' }
-    if (evidence === 'generic') {
-      try {
-        const bucketResponse = await supabase.storage.getBucket(bucketName)
-        if (!bucketResponse.error && bucketResponse.data?.id === bucketName) {
-          return { status: 'absent' }
-        }
-      } catch {
-        // A missing or unreadable bucket is not evidence that the exact key was deleted.
-      }
+    if (await confirmExactObjectAbsence(supabase, bucketName, path)) {
+      return { status: 'absent' }
     }
     return { status: 'uncertain' }
   }
@@ -429,8 +466,56 @@ export async function runClassroomArchiveSourceCleanup(args: {
   }
 
   try {
+    const verificationResponse = await args.supabase.rpc(
+      'verify_and_reserve_classroom_archive_source_objects',
+      { p_operation_id: operationId, p_limit: limit },
+    )
+    if (verificationResponse.error) {
+      const migrationRequired = isMissingCleanupRpc(verificationResponse.error)
+      const result: ClassroomArchiveSourceCleanupResult = {
+        ok: false,
+        status: 503,
+        lease_token: leaseToken,
+        error_code: migrationRequired
+          ? 'classroom_archive_source_ownership_fence_migration_required'
+          : 'archive_source_ownership_verification_failed',
+        error: migrationRequired
+          ? 'Classroom archive source cleanup requires migration 096'
+          : 'Classroom archive source ownership could not be verified',
+        retryable: true,
+      }
+      emitCleanupMetric(result, startedAt)
+      return result
+    }
+
+    const verification = ownershipVerificationSchema.safeParse(verificationResponse.data)
+    if (!verification.success || verification.data.operation_id !== operationId) {
+      const result: ClassroomArchiveSourceCleanupResult = {
+        ok: false,
+        status: 500,
+        lease_token: leaseToken,
+        error_code: 'archive_source_ownership_verification_contract_invalid',
+        error: 'Classroom archive source ownership verification returned an invalid contract',
+        retryable: false,
+      }
+      emitCleanupMetric(result, startedAt)
+      return result
+    }
+    if (!verification.data.ok) {
+      const result: ClassroomArchiveSourceCleanupResult = {
+        ok: false,
+        status: verification.data.status,
+        lease_token: leaseToken,
+        error_code: verification.data.error_code,
+        error: verification.data.error,
+        retryable: false,
+      }
+      emitCleanupMetric(result, startedAt)
+      return result
+    }
+
     const response = await args.supabase.rpc(
-      'claim_due_classroom_archive_source_object_cleanup',
+      'claim_due_classroom_archive_source_object_cleanup_v2',
       {
         p_lease_token: leaseToken,
         p_operation_id: operationId,
@@ -445,10 +530,10 @@ export async function runClassroomArchiveSourceCleanup(args: {
         status: 503,
         lease_token: leaseToken,
         error_code: migrationRequired
-          ? 'classroom_archive_source_cleanup_migration_required'
+          ? 'classroom_archive_source_ownership_fence_migration_required'
           : 'archive_source_cleanup_claim_failed',
         error: migrationRequired
-          ? 'Classroom archive source cleanup requires migration 086'
+          ? 'Classroom archive source cleanup requires migration 096'
           : 'Classroom archive source cleanup work could not be claimed',
         retryable: true,
       }

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1356,6 +1356,7 @@ export type Database = {
           next_attempt_at: string
           operation_id: string
           ownership_verified: boolean
+          ownership_verified_at: string | null
           status: string
           storage_bucket: string
           storage_path: string
@@ -1375,6 +1376,7 @@ export type Database = {
           next_attempt_at?: string
           operation_id: string
           ownership_verified?: boolean
+          ownership_verified_at?: string | null
           status?: string
           storage_bucket: string
           storage_path: string
@@ -1394,6 +1396,7 @@ export type Database = {
           next_attempt_at?: string
           operation_id?: string
           ownership_verified?: boolean
+          ownership_verified_at?: string | null
           status?: string
           storage_bucket?: string
           storage_path?: string
@@ -1409,6 +1412,35 @@ export type Database = {
           },
           {
             foreignKeyName: "classroom_archive_source_object_cleanup_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "classroom_archive_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      classroom_archive_source_object_reservations: {
+        Row: {
+          operation_id: string | null
+          reserved_at: string
+          storage_bucket: string
+          storage_path_sha256: string
+        }
+        Insert: {
+          operation_id?: string | null
+          reserved_at?: string
+          storage_bucket: string
+          storage_path_sha256: string
+        }
+        Update: {
+          operation_id?: string | null
+          reserved_at?: string
+          storage_bucket?: string
+          storage_path_sha256?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "classroom_archive_source_object_reservations_operation_id_fkey"
             columns: ["operation_id"]
             isOneToOne: false
             referencedRelation: "classroom_archive_operations"
@@ -3970,6 +4002,24 @@ export type Database = {
           storage_path: string
         }[]
       }
+      claim_due_classroom_archive_source_object_cleanup_v2: {
+        Args: {
+          p_lease_seconds?: number
+          p_lease_token: string
+          p_limit?: number
+          p_operation_id: string
+        }
+        Returns: {
+          archive_id: string
+          attempt_count: number
+          classroom_id: string
+          expected_byte_size: number
+          expected_sha256: string
+          operation_id: string
+          storage_bucket: string
+          storage_path: string
+        }[]
+      }
       claim_due_classroom_gradex_extract_cleanup: {
         Args: {
           p_lease_seconds?: number
@@ -4021,6 +4071,10 @@ export type Database = {
           isOneToOne: false
           isSetofReturn: true
         }
+      }
+      classroom_archive_source_object_path_sha256: {
+        Args: { p_storage_bucket: string; p_storage_path: string }
+        Returns: string
       }
       cleanup_expired_classroom_archive_snapshots: {
         Args: never
@@ -4314,6 +4368,10 @@ export type Database = {
           p_student_ids: string[]
           p_test_id: string
         }
+        Returns: Json
+      }
+      get_classroom_archive_source_object_presence: {
+        Args: { p_storage_bucket: string; p_storage_path: string }
         Returns: Json
       }
       get_teacher_log_history_preview: {
@@ -4618,6 +4676,10 @@ export type Database = {
           p_suggested_agent: string
           p_title: string
         }
+        Returns: Json
+      }
+      verify_and_reserve_classroom_archive_source_objects: {
+        Args: { p_limit: number; p_operation_id: string }
         Returns: Json
       }
     }

--- a/supabase/migrations/096_classroom_archive_source_ownership_fence.sql
+++ b/supabase/migrations/096_classroom_archive_source_ownership_fence.sql
@@ -1,0 +1,957 @@
+-- Transactional ownership fencing for compacted classroom source objects.
+--
+-- Only assignment-artifacts are eligible in this rollout. Their authoritative
+-- reference is assignment_submission_artifacts.storage_path, so PostgreSQL can
+-- serialize reference writes with reservation creation. Buckets referenced from
+-- embedded rich content remain preserved until they have an equivalent registry.
+
+alter table public.classroom_archive_source_object_cleanup
+  add column if not exists ownership_verified_at timestamptz;
+
+-- A deleted row from the unfenced migration 086 contract cannot be proven safe
+-- retroactively. Refuse rollout until an operator reconciles any such row.
+do $$
+begin
+  if exists (
+    select 1
+    from public.classroom_archive_source_object_cleanup
+    where status = 'deleted'
+  ) then
+    raise exception 'Migration 096 requires reconciliation of previously deleted source objects'
+      using errcode = '55000';
+  end if;
+end;
+$$;
+
+-- Invalidate every pre-096 lease before revoking the old claim capability.
+update public.classroom_archive_source_object_cleanup
+set status = 'failed',
+    lease_token = null,
+    lease_expires_at = null,
+    last_error_code = 'ownership_fence_migration_required',
+    next_attempt_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+where status = 'processing';
+
+-- Migration 086 deliberately had no verifier. Discard any manual boolean-only
+-- marks before requiring durable evidence from this migration.
+update public.classroom_archive_source_object_cleanup
+set ownership_verified = false,
+    ownership_verified_at = null,
+    updated_at = clock_timestamp()
+where ownership_verified is true
+   or ownership_verified_at is not null;
+
+alter table public.classroom_archive_source_object_cleanup
+  drop constraint if exists classroom_archive_source_object_cleanup_ownership_check;
+alter table public.classroom_archive_source_object_cleanup
+  add constraint classroom_archive_source_object_cleanup_ownership_check check (
+    ownership_verified = (ownership_verified_at is not null)
+  );
+
+create or replace function public.classroom_archive_source_object_path_sha256(
+  p_storage_bucket text,
+  p_storage_path text
+)
+returns text
+language sql
+immutable
+strict
+set search_path = public, extensions, pg_temp
+as $$
+  select encode(
+    extensions.digest(
+      convert_to(jsonb_build_array(p_storage_bucket, p_storage_path)::text, 'UTF8'),
+      'sha256'
+    ),
+    'hex'
+  )
+$$;
+
+revoke all on function public.classroom_archive_source_object_path_sha256(text, text)
+  from public, anon, authenticated;
+grant execute on function public.classroom_archive_source_object_path_sha256(text, text)
+  to service_role;
+
+create table if not exists public.classroom_archive_source_object_reservations (
+  storage_bucket text not null,
+  storage_path_sha256 text not null,
+  operation_id uuid references public.classroom_archive_operations(id) on delete set null,
+  reserved_at timestamptz not null default clock_timestamp(),
+  primary key (storage_bucket, storage_path_sha256),
+  unique (operation_id, storage_bucket, storage_path_sha256),
+  constraint classroom_archive_source_object_reservations_bucket_check check (
+    storage_bucket = 'assignment-artifacts'
+  ),
+  constraint classroom_archive_source_object_reservations_path_sha256_check check (
+    storage_path_sha256 ~ '^[a-f0-9]{64}$'
+  )
+);
+
+create index if not exists idx_classroom_archive_source_object_reservations_operation
+  on public.classroom_archive_source_object_reservations (operation_id);
+
+alter table public.classroom_archive_source_object_reservations enable row level security;
+revoke all on table public.classroom_archive_source_object_reservations
+  from public, anon, authenticated, service_role;
+grant select on table public.classroom_archive_source_object_reservations to service_role;
+
+revoke all on table public.classroom_archive_source_object_cleanup from service_role;
+grant select on table public.classroom_archive_source_object_cleanup to service_role;
+
+-- Compaction owns cleanup-ledger staging and state transitions. Preserve those
+-- existing RPC contracts while removing service_role's direct table writes.
+alter function public.begin_classroom_archive_compaction(
+  uuid, uuid, uuid, uuid, text
+) security definer;
+alter function public.stage_classroom_archive_compaction_objects(
+  uuid, uuid, jsonb
+) security definer;
+alter function public.complete_classroom_archive_compaction(
+  uuid, uuid, jsonb, jsonb
+) security definer;
+alter function public.fail_classroom_archive_compaction(
+  uuid, uuid, text, boolean
+) security definer;
+alter function public.cleanup_expired_classroom_archive_snapshots()
+  security definer;
+
+alter function public.begin_classroom_archive_compaction(
+  uuid, uuid, uuid, uuid, text
+) set search_path = public, pg_temp;
+alter function public.stage_classroom_archive_compaction_objects(
+  uuid, uuid, jsonb
+) set search_path = public, pg_temp;
+alter function public.complete_classroom_archive_compaction(
+  uuid, uuid, jsonb, jsonb
+) set search_path = public, pg_temp;
+alter function public.fail_classroom_archive_compaction(
+  uuid, uuid, text, boolean
+) set search_path = public, pg_temp;
+alter function public.cleanup_expired_classroom_archive_snapshots()
+  set search_path = public, pg_temp;
+
+-- A permanent reservation is intentional. Reusing a deleted source path could
+-- otherwise attach new classroom data to an object identity already retired by
+-- a completed archive operation.
+create or replace function public.guard_classroom_archive_source_cleanup_path()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_bucket text;
+  v_path text;
+begin
+  for v_bucket, v_path in
+    select distinct candidate.bucket, candidate.path
+    from (values
+      (
+        case when tg_op <> 'INSERT' then old.storage_bucket end,
+        case when tg_op <> 'INSERT' then old.storage_path end
+      ),
+      (
+        case when tg_op <> 'DELETE' then new.storage_bucket end,
+        case when tg_op <> 'DELETE' then new.storage_path end
+      )
+    ) as candidate(bucket, path)
+    where candidate.bucket = 'assignment-artifacts'
+      and candidate.path is not null
+    order by candidate.bucket, candidate.path
+  loop
+    perform pg_advisory_xact_lock(
+      hashtextextended(jsonb_build_array(v_bucket, v_path)::text, 0)
+    );
+  end loop;
+
+  if tg_op <> 'DELETE'
+    and new.storage_bucket = 'assignment-artifacts'
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_reservations reservation
+      where reservation.storage_bucket = new.storage_bucket
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            new.storage_bucket, new.storage_path
+          )
+    )
+  then
+    raise exception 'Classroom archive source cleanup path is already reserved'
+      using errcode = '55000';
+  end if;
+
+  if tg_op = 'DELETE' then return old; end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.guard_classroom_archive_source_cleanup_path()
+  from public, anon, authenticated;
+
+drop trigger if exists guard_classroom_archive_source_cleanup_path
+  on public.classroom_archive_source_object_cleanup;
+create trigger guard_classroom_archive_source_cleanup_path
+  before insert or update of storage_bucket, storage_path or delete
+  on public.classroom_archive_source_object_cleanup
+  for each row
+  execute function public.guard_classroom_archive_source_cleanup_path();
+
+create or replace function public.reject_reserved_assignment_artifact_path()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_path text;
+begin
+  for v_path in
+    select distinct candidate.path
+    from (values
+      (case when tg_op <> 'INSERT' then old.storage_path end),
+      (case when tg_op <> 'DELETE' then new.storage_path end)
+    ) as candidate(path)
+    where candidate.path is not null
+    order by candidate.path
+  loop
+    perform pg_advisory_xact_lock(
+      hashtextextended(jsonb_build_array('assignment-artifacts', v_path)::text, 0)
+    );
+  end loop;
+
+  if tg_op <> 'DELETE'
+    and new.storage_path is not null
+    and exists (
+    select 1
+    from public.classroom_archive_source_object_reservations reservation
+    where reservation.storage_bucket = 'assignment-artifacts'
+      and reservation.storage_path_sha256 =
+        public.classroom_archive_source_object_path_sha256(
+          'assignment-artifacts', new.storage_path
+        )
+  ) then
+    raise exception 'Assignment artifact storage path is reserved by a classroom archive'
+      using errcode = '55000';
+  end if;
+
+  if tg_op = 'DELETE' then return old; end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_reserved_assignment_artifact_path()
+  from public, anon, authenticated;
+
+drop trigger if exists reject_reserved_assignment_artifact_path
+  on public.assignment_submission_artifacts;
+create trigger reject_reserved_assignment_artifact_path
+  before insert or update of storage_path or delete
+  on public.assignment_submission_artifacts
+  for each row
+  execute function public.reject_reserved_assignment_artifact_path();
+
+create or replace function public.reject_reserved_classroom_archive_storage_path()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, storage, pg_temp
+as $$
+declare
+  v_bucket text;
+  v_path text;
+begin
+  for v_bucket, v_path in
+    select distinct candidate.bucket, candidate.path
+    from (values
+      (
+        case when tg_op <> 'INSERT' then old.bucket_id end,
+        case when tg_op <> 'INSERT' then old.name end
+      ),
+      (
+        case when tg_op <> 'DELETE' then new.bucket_id end,
+        case when tg_op <> 'DELETE' then new.name end
+      )
+    ) as candidate(bucket, path)
+    where candidate.bucket = 'assignment-artifacts'
+      and candidate.path is not null
+    order by candidate.bucket, candidate.path
+  loop
+    perform pg_advisory_xact_lock(
+      hashtextextended(jsonb_build_array(v_bucket, v_path)::text, 0)
+    );
+  end loop;
+
+  if tg_op <> 'DELETE'
+    and new.bucket_id = 'assignment-artifacts'
+    and exists (
+    select 1
+    from public.classroom_archive_source_object_reservations reservation
+    where reservation.storage_bucket = new.bucket_id
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            new.bucket_id, new.name
+          )
+    )
+  then
+    raise exception 'Storage path is reserved by a classroom archive'
+      using errcode = '55000';
+  end if;
+
+  if tg_op = 'DELETE'
+    and old.bucket_id = 'assignment-artifacts'
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_cleanup cleanup
+      where cleanup.storage_bucket = old.bucket_id
+        and cleanup.storage_path = old.name
+        and cleanup.status <> 'deleted'
+        and not exists (
+          select 1
+          from public.classroom_archive_source_object_reservations reservation
+          where reservation.storage_bucket = cleanup.storage_bucket
+            and reservation.storage_path_sha256 =
+              public.classroom_archive_source_object_path_sha256(
+                cleanup.storage_bucket, cleanup.storage_path
+              )
+        )
+    )
+  then
+    raise exception 'Storage deletion requires a classroom archive source reservation'
+      using errcode = '55000';
+  end if;
+
+  if tg_op = 'DELETE' then return old; end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.reject_reserved_classroom_archive_storage_path()
+  from public, anon, authenticated;
+
+drop trigger if exists reject_reserved_classroom_archive_storage_path
+  on storage.objects;
+create trigger reject_reserved_classroom_archive_storage_path
+  before insert or update or delete
+  on storage.objects
+  for each row
+  execute function public.reject_reserved_classroom_archive_storage_path();
+
+create or replace function public.verify_and_reserve_classroom_archive_source_objects(
+  p_operation_id uuid,
+  p_limit integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_operation public.classroom_archive_operations%rowtype;
+  v_eligible_count integer;
+  v_preserved_count integer;
+  v_verified_count integer;
+  v_previously_verified_count integer;
+  v_deleted_verified_count integer;
+  v_selected_paths text[];
+  v_selected_count integer;
+begin
+  if p_operation_id is null
+    or p_limit is null
+    or p_limit < 1
+    or p_limit > 100
+  then
+    raise exception 'Invalid classroom archive source ownership verification request'
+      using errcode = '22023';
+  end if;
+
+  select operation.* into v_operation
+  from public.classroom_archive_operations operation
+  where operation.id = p_operation_id
+  for update;
+
+  if not found
+    or v_operation.operation_type <> 'compact'
+    or v_operation.status <> 'completed'
+    or v_operation.archive_id is null
+  then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', 'classroom_archive_source_ownership_not_compacted',
+      'error', 'Source ownership can only be verified for a completed cold compaction'
+    );
+  end if;
+
+  select
+    count(*) filter (where cleanup.storage_bucket = 'assignment-artifacts'),
+    count(*) filter (where cleanup.storage_bucket <> 'assignment-artifacts'),
+    count(*) filter (
+      where cleanup.storage_bucket = 'assignment-artifacts'
+        and cleanup.ownership_verified is true
+        and cleanup.ownership_verified_at is not null
+    ),
+    count(*) filter (
+      where cleanup.storage_bucket = 'assignment-artifacts'
+        and cleanup.status = 'deleted'
+        and cleanup.ownership_verified is true
+        and cleanup.ownership_verified_at is not null
+        and exists (
+          select 1
+          from public.classroom_archive_source_object_reservations reservation
+          where reservation.operation_id = cleanup.operation_id
+            and reservation.storage_bucket = cleanup.storage_bucket
+            and reservation.storage_path_sha256 =
+              public.classroom_archive_source_object_path_sha256(
+                cleanup.storage_bucket, cleanup.storage_path
+              )
+        )
+    )
+  into
+    v_eligible_count,
+    v_preserved_count,
+    v_previously_verified_count,
+    v_deleted_verified_count
+  from public.classroom_archive_source_object_cleanup cleanup
+  where cleanup.operation_id = p_operation_id;
+
+  -- Restore removes the cold tombstone. A later cleanup replay may report only
+  -- already-completed work; it can never create reservations or claim new work.
+  if v_deleted_verified_count = v_eligible_count then
+    return jsonb_build_object(
+      'ok', true,
+      'status', 200,
+      'operation_id', p_operation_id,
+      'verified', v_deleted_verified_count,
+      'preserved', v_preserved_count,
+      'replayed', true
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from public.classroom_cold_tombstones tombstone
+    where tombstone.classroom_id = v_operation.classroom_id
+      and tombstone.archive_id = v_operation.archive_id
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', 'classroom_archive_source_ownership_not_compacted',
+      'error', 'Source ownership can only be verified for a completed cold compaction'
+    );
+  end if;
+
+  select array_agg(candidate.storage_path order by candidate.storage_path)
+  into v_selected_paths
+  from (
+    select cleanup.storage_path
+    from public.classroom_archive_source_object_cleanup cleanup
+    where cleanup.operation_id = p_operation_id
+      and cleanup.storage_bucket = 'assignment-artifacts'
+      and cleanup.next_attempt_at <= clock_timestamp()
+      and (
+        cleanup.status in ('pending', 'failed')
+        or (
+          cleanup.status = 'processing'
+          and cleanup.lease_expires_at <= clock_timestamp()
+        )
+      )
+    order by cleanup.next_attempt_at, cleanup.created_at, cleanup.storage_path
+    for update skip locked
+    limit p_limit
+  ) candidate;
+
+  v_selected_paths := coalesce(v_selected_paths, array[]::text[]);
+  v_selected_count := cardinality(v_selected_paths);
+
+  select count(*) into v_previously_verified_count
+  from public.classroom_archive_source_object_cleanup cleanup
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = 'assignment-artifacts'
+    and cleanup.storage_path = any(v_selected_paths)
+    and cleanup.ownership_verified is true
+    and cleanup.ownership_verified_at is not null;
+
+  -- Both this verifier and the authoritative reference trigger take the same
+  -- exact-path lock. Sorted acquisition also prevents verifier/verifier deadlocks.
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      jsonb_build_array(cleanup.storage_bucket, cleanup.storage_path)::text,
+      0
+    )
+  )
+  from public.classroom_archive_source_object_cleanup cleanup
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = 'assignment-artifacts'
+    and cleanup.storage_path = any(v_selected_paths)
+  order by cleanup.storage_path;
+
+  if exists (
+    select 1
+    from public.classroom_archive_source_object_cleanup cleanup
+    join public.assignment_submission_artifacts artifact
+      on artifact.storage_path = cleanup.storage_path
+    where cleanup.operation_id = p_operation_id
+      and cleanup.storage_bucket = 'assignment-artifacts'
+      and cleanup.storage_path = any(v_selected_paths)
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', 'classroom_archive_source_object_still_referenced',
+      'error', 'An assignment artifact source path is still referenced by hot classroom data'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from public.classroom_archive_source_object_cleanup cleanup
+    join public.classroom_archive_source_object_cleanup competing
+      on competing.storage_bucket = cleanup.storage_bucket
+      and competing.storage_path = cleanup.storage_path
+      and competing.operation_id <> cleanup.operation_id
+    where cleanup.operation_id = p_operation_id
+      and cleanup.storage_bucket = 'assignment-artifacts'
+      and cleanup.storage_path = any(v_selected_paths)
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', 'classroom_archive_source_object_competing_claim',
+      'error', 'An assignment artifact source path is present in another cleanup inventory'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from public.classroom_archive_source_object_cleanup cleanup
+    join public.classroom_archive_source_object_reservations reservation
+      on reservation.storage_bucket = cleanup.storage_bucket
+      and reservation.storage_path_sha256 =
+        public.classroom_archive_source_object_path_sha256(
+          cleanup.storage_bucket, cleanup.storage_path
+        )
+      and reservation.operation_id is distinct from cleanup.operation_id
+    where cleanup.operation_id = p_operation_id
+      and cleanup.storage_bucket = 'assignment-artifacts'
+      and cleanup.storage_path = any(v_selected_paths)
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', 'classroom_archive_source_object_already_reserved',
+      'error', 'An assignment artifact source path belongs to another archive operation'
+    );
+  end if;
+
+  insert into public.classroom_archive_source_object_reservations (
+    storage_bucket,
+    storage_path_sha256,
+    operation_id
+  )
+  select
+    cleanup.storage_bucket,
+    public.classroom_archive_source_object_path_sha256(
+      cleanup.storage_bucket, cleanup.storage_path
+    ),
+    cleanup.operation_id
+  from public.classroom_archive_source_object_cleanup cleanup
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = 'assignment-artifacts'
+    and cleanup.storage_path = any(v_selected_paths)
+  on conflict (storage_bucket, storage_path_sha256) do nothing;
+
+  update public.classroom_archive_source_object_cleanup cleanup
+  set ownership_verified = true,
+      ownership_verified_at = coalesce(cleanup.ownership_verified_at, clock_timestamp()),
+      updated_at = clock_timestamp()
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = 'assignment-artifacts'
+    and cleanup.storage_path = any(v_selected_paths)
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_reservations reservation
+      where reservation.storage_bucket = cleanup.storage_bucket
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            cleanup.storage_bucket, cleanup.storage_path
+          )
+        and reservation.operation_id = cleanup.operation_id
+    );
+
+  select count(*) into v_verified_count
+  from public.classroom_archive_source_object_cleanup cleanup
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = 'assignment-artifacts'
+    and cleanup.storage_path = any(v_selected_paths)
+    and cleanup.ownership_verified is true;
+
+  if v_verified_count <> v_selected_count then
+    raise exception 'Classroom archive source ownership reservation was incomplete'
+      using errcode = '40001';
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'status', 200,
+    'operation_id', p_operation_id,
+    'verified', v_verified_count,
+    'preserved', v_preserved_count,
+    'replayed', v_previously_verified_count = v_selected_count
+  );
+end;
+$$;
+
+revoke all on function public.verify_and_reserve_classroom_archive_source_objects(uuid, integer)
+  from public, anon, authenticated;
+grant execute on function public.verify_and_reserve_classroom_archive_source_objects(uuid, integer)
+  to service_role;
+
+create or replace function public.claim_due_classroom_archive_source_object_cleanup_v2(
+  p_lease_token uuid,
+  p_operation_id uuid,
+  p_limit integer default 25,
+  p_lease_seconds integer default 300
+)
+returns table (
+  operation_id uuid,
+  archive_id uuid,
+  classroom_id uuid,
+  storage_bucket text,
+  storage_path text,
+  expected_sha256 text,
+  expected_byte_size bigint,
+  attempt_count integer
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if p_lease_token is null
+    or p_operation_id is null
+    or p_limit is null
+    or p_limit < 1
+    or p_limit > 100
+    or p_lease_seconds is null
+    or p_lease_seconds < 30
+    or p_lease_seconds > 1800
+  then
+    raise exception 'Invalid classroom archive source cleanup claim'
+      using errcode = '22023';
+  end if;
+
+  return query
+  with candidates as (
+    select cleanup.operation_id, cleanup.storage_bucket, cleanup.storage_path
+    from public.classroom_archive_source_object_cleanup cleanup
+    join public.classroom_archive_source_object_reservations reservation
+      on reservation.operation_id = cleanup.operation_id
+      and reservation.storage_bucket = cleanup.storage_bucket
+      and reservation.storage_path_sha256 =
+        public.classroom_archive_source_object_path_sha256(
+          cleanup.storage_bucket, cleanup.storage_path
+        )
+    join public.classroom_archive_operations operation
+      on operation.id = cleanup.operation_id
+      and operation.operation_type = 'compact'
+      and operation.status = 'completed'
+      and operation.archive_id = cleanup.archive_id
+      and operation.classroom_id = cleanup.classroom_id
+    join public.classroom_cold_tombstones tombstone
+      on tombstone.classroom_id = cleanup.classroom_id
+      and tombstone.archive_id = cleanup.archive_id
+    where cleanup.next_attempt_at <= clock_timestamp()
+      and cleanup.operation_id = p_operation_id
+      and cleanup.storage_bucket = 'assignment-artifacts'
+      and cleanup.ownership_verified is true
+      and cleanup.ownership_verified_at is not null
+      and (
+        cleanup.status in ('pending', 'failed')
+        or (
+          cleanup.status = 'processing'
+          and cleanup.lease_expires_at <= clock_timestamp()
+        )
+      )
+    order by cleanup.next_attempt_at, cleanup.created_at,
+      cleanup.operation_id, cleanup.storage_bucket, cleanup.storage_path
+    for update of cleanup skip locked
+    limit p_limit
+  ), claimed as (
+    update public.classroom_archive_source_object_cleanup cleanup
+    set
+      status = 'processing',
+      attempt_count = cleanup.attempt_count + 1,
+      lease_token = p_lease_token,
+      lease_expires_at = clock_timestamp() + make_interval(secs => p_lease_seconds),
+      last_error_code = null,
+      updated_at = clock_timestamp()
+    from candidates
+    where cleanup.operation_id = candidates.operation_id
+      and cleanup.storage_bucket = candidates.storage_bucket
+      and cleanup.storage_path = candidates.storage_path
+    returning cleanup.*
+  )
+  select
+    claimed.operation_id,
+    claimed.archive_id,
+    claimed.classroom_id,
+    claimed.storage_bucket,
+    claimed.storage_path,
+    claimed.expected_sha256,
+    claimed.expected_byte_size,
+    claimed.attempt_count
+  from claimed;
+end;
+$$;
+
+revoke execute on function public.claim_due_classroom_archive_source_object_cleanup(
+  uuid, uuid, integer, integer
+) from service_role;
+
+revoke all on function public.claim_due_classroom_archive_source_object_cleanup_v2(
+  uuid, uuid, integer, integer
+) from public, anon, authenticated;
+grant execute on function public.claim_due_classroom_archive_source_object_cleanup_v2(
+  uuid, uuid, integer, integer
+) to service_role;
+
+-- Every lease transition repeats the ownership-evidence and reservation check.
+-- This invalidates a pre-096 worker even if it retained an old lease token.
+create or replace function public.renew_classroom_archive_source_object_cleanup_lease(
+  p_operation_id uuid,
+  p_storage_bucket text,
+  p_storage_path text,
+  p_lease_token uuid,
+  p_lease_seconds integer default 300
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_updated boolean;
+begin
+  if p_operation_id is null
+    or p_lease_token is null
+    or p_storage_bucket <> 'assignment-artifacts'
+    or p_storage_path is null
+    or p_storage_path = ''
+    or p_storage_path like '/%'
+    or p_storage_path like '%/'
+    or p_storage_path like '%//%'
+    or strpos(p_storage_path, E'\\') > 0
+    or p_storage_path ~ '(^|/)\.{1,2}(/|$)'
+    or p_lease_seconds is null
+    or p_lease_seconds < 30
+    or p_lease_seconds > 1800
+  then
+    raise exception 'Invalid classroom archive source cleanup lease renewal'
+      using errcode = '22023';
+  end if;
+
+  update public.classroom_archive_source_object_cleanup cleanup
+  set lease_expires_at = clock_timestamp() + make_interval(secs => p_lease_seconds),
+      updated_at = clock_timestamp()
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = p_storage_bucket
+    and cleanup.storage_path = p_storage_path
+    and cleanup.ownership_verified is true
+    and cleanup.ownership_verified_at is not null
+    and cleanup.status = 'processing'
+    and cleanup.lease_token = p_lease_token
+    and cleanup.lease_expires_at > clock_timestamp()
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_reservations reservation
+      where reservation.operation_id = cleanup.operation_id
+        and reservation.storage_bucket = cleanup.storage_bucket
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            cleanup.storage_bucket, cleanup.storage_path
+          )
+    );
+  v_updated := found;
+  return v_updated;
+end;
+$$;
+
+create or replace function public.complete_classroom_archive_source_object_cleanup(
+  p_operation_id uuid,
+  p_storage_bucket text,
+  p_storage_path text,
+  p_lease_token uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_updated boolean;
+begin
+  if p_operation_id is null
+    or p_lease_token is null
+    or p_storage_bucket <> 'assignment-artifacts'
+    or p_storage_path is null
+    or p_storage_path = ''
+    or p_storage_path like '/%'
+    or p_storage_path like '%/'
+    or p_storage_path like '%//%'
+    or strpos(p_storage_path, E'\\') > 0
+    or p_storage_path ~ '(^|/)\.{1,2}(/|$)'
+  then
+    raise exception 'Invalid classroom archive source cleanup completion'
+      using errcode = '22023';
+  end if;
+
+  update public.classroom_archive_source_object_cleanup cleanup
+  set status = 'deleted',
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = null,
+      deleted_at = clock_timestamp(),
+      updated_at = clock_timestamp()
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = p_storage_bucket
+    and cleanup.storage_path = p_storage_path
+    and cleanup.ownership_verified is true
+    and cleanup.ownership_verified_at is not null
+    and cleanup.status = 'processing'
+    and cleanup.lease_token = p_lease_token
+    and cleanup.lease_expires_at > clock_timestamp()
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_reservations reservation
+      where reservation.operation_id = cleanup.operation_id
+        and reservation.storage_bucket = cleanup.storage_bucket
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            cleanup.storage_bucket, cleanup.storage_path
+          )
+    );
+  v_updated := found;
+  return v_updated;
+end;
+$$;
+
+create or replace function public.fail_classroom_archive_source_object_cleanup(
+  p_operation_id uuid,
+  p_storage_bucket text,
+  p_storage_path text,
+  p_lease_token uuid,
+  p_error_code text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_updated boolean;
+begin
+  if p_operation_id is null
+    or p_lease_token is null
+    or p_storage_bucket <> 'assignment-artifacts'
+    or p_storage_path is null
+    or p_storage_path = ''
+    or p_storage_path like '/%'
+    or p_storage_path like '%/'
+    or p_storage_path like '%//%'
+    or strpos(p_storage_path, E'\\') > 0
+    or p_storage_path ~ '(^|/)\.{1,2}(/|$)'
+    or p_error_code is null
+    or p_error_code !~ '^[a-z0-9_]{3,80}$'
+  then
+    raise exception 'Invalid classroom archive source cleanup failure'
+      using errcode = '22023';
+  end if;
+
+  update public.classroom_archive_source_object_cleanup cleanup
+  set status = 'failed',
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = p_error_code,
+      next_attempt_at = clock_timestamp() + make_interval(
+        mins => least(
+          1440,
+          greatest(1, power(2, least(cleanup.attempt_count, 10))::integer)
+        )
+      ),
+      updated_at = clock_timestamp()
+  where cleanup.operation_id = p_operation_id
+    and cleanup.storage_bucket = p_storage_bucket
+    and cleanup.storage_path = p_storage_path
+    and cleanup.ownership_verified is true
+    and cleanup.ownership_verified_at is not null
+    and cleanup.status = 'processing'
+    and cleanup.lease_token = p_lease_token
+    and cleanup.lease_expires_at > clock_timestamp()
+    and exists (
+      select 1
+      from public.classroom_archive_source_object_reservations reservation
+      where reservation.operation_id = cleanup.operation_id
+        and reservation.storage_bucket = cleanup.storage_bucket
+        and reservation.storage_path_sha256 =
+          public.classroom_archive_source_object_path_sha256(
+            cleanup.storage_bucket, cleanup.storage_path
+          )
+    );
+  v_updated := found;
+  return v_updated;
+end;
+$$;
+
+create or replace function public.get_classroom_archive_source_object_presence(
+  p_storage_bucket text,
+  p_storage_path text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, storage, pg_temp
+as $$
+begin
+  if p_storage_bucket <> 'assignment-artifacts'
+    or p_storage_path is null
+    or p_storage_path = ''
+    or p_storage_path like '/%'
+    or p_storage_path like '%/'
+    or p_storage_path like '%//%'
+    or strpos(p_storage_path, E'\\') > 0
+    or p_storage_path ~ '(^|/)\.{1,2}(/|$)'
+  then
+    raise exception 'Invalid classroom archive source object identity'
+      using errcode = '22023';
+  end if;
+
+  return jsonb_build_object(
+    'bucket_exists', exists (
+      select 1 from storage.buckets bucket where bucket.id = p_storage_bucket
+    ),
+    'object_exists', exists (
+      select 1
+      from storage.objects object
+      where object.bucket_id = p_storage_bucket
+        and object.name = p_storage_path
+    )
+  );
+end;
+$$;
+
+revoke all on function public.get_classroom_archive_source_object_presence(text, text)
+  from public, anon, authenticated;
+grant execute on function public.get_classroom_archive_source_object_presence(text, text)
+  to service_role;
+
+comment on table public.classroom_archive_source_object_reservations is
+  'Permanent de-identified exact-path reservations that fence verified classroom archive source deletion.';
+comment on function public.verify_and_reserve_classroom_archive_source_objects(uuid, integer) is
+  'Atomically reserves a bounded set of exclusively-owned assignment artifact paths for one completed cold compaction.';

--- a/tests/api/cron/classroom-archive-source-cleanup.test.ts
+++ b/tests/api/cron/classroom-archive-source-cleanup.test.ts
@@ -111,25 +111,83 @@ describe('classroom archive source cleanup cron route', () => {
   })
 
   it.each(['GET', 'POST'] as const)(
-    'keeps destructive cleanup unavailable through %s until ownership fencing exists',
+    'runs the one-operation canary through %s after both gates pass',
     async (method) => {
       const response = method === 'GET'
         ? await GET(request(method))
         : await POST(request(method))
 
-      expect(response.status).toBe(503)
-      await expect(response.json()).resolves.toEqual({
-        ok: false,
-        status: 503,
-        lease_token: LEASE_TOKEN,
-        error_code: 'classroom_archive_source_cleanup_ownership_verifier_required',
-        error: 'Classroom archive source cleanup ownership verification is not implemented',
-        retryable: false,
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual(successfulResult())
+      expect(mocks.getServiceRoleClient).toHaveBeenCalledOnce()
+      expect(mocks.resolveOperationId).toHaveBeenCalledWith(OPERATION_ID)
+      expect(mocks.runCleanup).toHaveBeenCalledWith({
+        supabase,
+        leaseToken: LEASE_TOKEN,
+        operationId: OPERATION_ID,
+        limit: 1,
+        leaseSeconds: 300,
       })
-      expect(mocks.getServiceRoleClient).not.toHaveBeenCalled()
-      expect(mocks.runCleanup).not.toHaveBeenCalled()
     },
   )
+
+  it('fails closed when no exact canary operation is configured', async () => {
+    vi.stubEnv('CLASSROOM_ARCHIVE_SOURCE_CLEANUP_OPERATION_ID', '')
+
+    const response = await POST(request('POST'))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({
+      error_code: 'classroom_archive_source_cleanup_operation_not_configured',
+    }))
+    expect(mocks.getServiceRoleClient).not.toHaveBeenCalled()
+    expect(mocks.runCleanup).not.toHaveBeenCalled()
+  })
+
+  it('propagates an exact worker failure status and contract', async () => {
+    const workerFailure = {
+      ok: false,
+      status: 409,
+      lease_token: LEASE_TOKEN,
+      error_code: 'classroom_archive_source_object_still_referenced',
+      error: 'Source path is still referenced',
+      retryable: false,
+    }
+    mocks.runCleanup.mockResolvedValue(workerFailure)
+
+    const response = await POST(request('POST'))
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual(workerFailure)
+  })
+
+  it('fails closed when a batch lacks durable retry evidence', async () => {
+    const unhealthyBatch = successfulResult({
+      claimed: 1,
+      failed: 1,
+      retry_recording_failed: 1,
+      results: [{
+        object_ref: 'opaque-ref',
+        attempt_count: 1,
+        status: 'failed',
+        error_code: 'archive_source_object_read_failed',
+        retry_recorded: false,
+      }],
+    })
+    mocks.runCleanup.mockResolvedValue(unhealthyBatch)
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      status: 503,
+      error_code: 'archive_source_cleanup_batch_unhealthy',
+      error: 'Classroom archive source cleanup completed without durable evidence for every claim',
+      retryable: true,
+      batch: unhealthyBatch,
+    })
+  })
 
   it('is not registered for automatic invocation in Vercel', () => {
     const config = JSON.parse(readFileSync('vercel.json', 'utf8'))

--- a/tests/lib/server/classroom-archive-source-cleanup.test.ts
+++ b/tests/lib/server/classroom-archive-source-cleanup.test.ts
@@ -50,6 +50,8 @@ function claim(
 function createSupabaseMock(options: {
   claims?: Claim[]
   claimError?: { code?: string; message?: string }
+  verificationError?: { code?: string; message?: string }
+  verificationResult?: Record<string, unknown>
   completeResult?: boolean
   failResult?: boolean
   renewResult?: boolean
@@ -61,6 +63,7 @@ function createSupabaseMock(options: {
   noSuchBucketPaths?: string[]
   useLocalNotFoundShape?: boolean
   bucketLookupError?: boolean
+  existenceProbeErrorPaths?: string[]
   unwrappedBadRequestPaths?: string[]
 } = {}) {
   const claims = options.claims ?? [claim()]
@@ -73,7 +76,35 @@ function createSupabaseMock(options: {
 
   const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
     calls.push(`rpc:${name}`)
-    if (name === 'claim_due_classroom_archive_source_object_cleanup') {
+    if (name === 'verify_and_reserve_classroom_archive_source_objects') {
+      return options.verificationError
+        ? { data: null, error: options.verificationError }
+        : {
+            data: options.verificationResult ?? {
+              ok: true,
+              status: 200,
+              operation_id: OPERATION_ID,
+              verified: claims.length,
+              preserved: 0,
+              replayed: false,
+            },
+            error: null,
+          }
+    }
+    if (name === 'get_classroom_archive_source_object_presence') {
+      const path = String(args.p_storage_path)
+      if (options.existenceProbeErrorPaths?.includes(path)) {
+        return { data: null, error: { status: 503, message: 'Presence lookup failed' } }
+      }
+      return {
+        data: {
+          bucket_exists: !(options.bucketLookupError || options.noSuchBucketPaths?.includes(path)),
+          object_exists: objects.has(path),
+        },
+        error: null,
+      }
+    }
+    if (name === 'claim_due_classroom_archive_source_object_cleanup_v2') {
       return options.claimError
         ? { data: null, error: options.claimError }
         : { data: claims, error: null }
@@ -140,8 +171,17 @@ function createSupabaseMock(options: {
     }
     return { data: [{ name: path }], error: null }
   })
-  const storageFrom = vi.fn(() => ({ download, remove }))
-  const getBucket = vi.fn(async () => options.bucketLookupError
+  const exists = vi.fn(async (path: string) => {
+    if (options.existenceProbeErrorPaths?.includes(path)) {
+      throw new Error('Existence probe failed')
+    }
+    return {
+      data: objects.has(path),
+      error: objects.has(path) ? null : { name: 'StorageUnknownError' },
+    }
+  })
+  const storageFrom = vi.fn(() => ({ download, exists, remove }))
+  const getBucket = vi.fn(async () => options.bucketLookupError || options.noSuchBucketPaths?.length
     ? { data: null, error: { status: 404, statusCode: 'NoSuchBucket' } }
     : { data: { id: 'assignment-artifacts' }, error: null })
 
@@ -149,6 +189,7 @@ function createSupabaseMock(options: {
     calls,
     client: { rpc, storage: { from: storageFrom, getBucket } } as any,
     download,
+    exists,
     getBucket,
     objects,
     remove,
@@ -216,7 +257,15 @@ describe('classroom archive source-object cleanup', () => {
     }))
     expect(mock.rpc).toHaveBeenNthCalledWith(
       1,
-      'claim_due_classroom_archive_source_object_cleanup',
+      'verify_and_reserve_classroom_archive_source_objects',
+      {
+        p_operation_id: OPERATION_ID,
+        p_limit: CLASSROOM_ARCHIVE_SOURCE_CLEANUP_MAX_CLAIMS,
+      },
+    )
+    expect(mock.rpc).toHaveBeenNthCalledWith(
+      2,
+      'claim_due_classroom_archive_source_object_cleanup_v2',
       {
         p_lease_token: LEASE_TOKEN,
         p_operation_id: OPERATION_ID,
@@ -225,7 +274,8 @@ describe('classroom archive source-object cleanup', () => {
       },
     )
     expect(mock.calls).toEqual([
-      'rpc:claim_due_classroom_archive_source_object_cleanup',
+      'rpc:verify_and_reserve_classroom_archive_source_objects',
+      'rpc:claim_due_classroom_archive_source_object_cleanup_v2',
       `download:${PATH}`,
       'rpc:renew_classroom_archive_source_object_cleanup_lease',
       `remove:${PATH}`,
@@ -255,8 +305,25 @@ describe('classroom archive source-object cleanup', () => {
     )
   })
 
-  it('does not treat a wrapped Storage 400 as authoritative absence', async () => {
+  it('confirms wrapped Storage 400 absence with an exact database presence lookup', async () => {
     const mock = createSupabaseMock({ useLocalNotFoundShape: true })
+    const result = await run(mock)
+
+    expect(result).toEqual(expect.objectContaining({ deleted: 1, failed: 0 }))
+    expect(mock.rpc).toHaveBeenCalledWith(
+      'get_classroom_archive_source_object_presence',
+      {
+        p_storage_bucket: 'assignment-artifacts',
+        p_storage_path: PATH,
+      },
+    )
+  })
+
+  it('does not trust a wrapped Storage 400 when the exact existence probe fails', async () => {
+    const mock = createSupabaseMock({
+      useLocalNotFoundShape: true,
+      existenceProbeErrorPaths: [PATH],
+    })
     const result = await run(mock)
 
     expect(result).toEqual(expect.objectContaining({ deleted: 0, failed: 1 }))
@@ -264,7 +331,10 @@ describe('classroom archive source-object cleanup', () => {
       'fail_classroom_archive_source_object_cleanup',
       expect.objectContaining({ p_storage_path: PATH }),
     )
-    expect(mock.getBucket).not.toHaveBeenCalled()
+    expect(mock.rpc).not.toHaveBeenCalledWith(
+      'complete_classroom_archive_source_object_cleanup',
+      expect.anything(),
+    )
   })
 
   it('does not treat an unwrapped generic 400 as object absence', async () => {
@@ -275,7 +345,10 @@ describe('classroom archive source-object cleanup', () => {
       status: 'failed',
       error_code: 'archive_source_object_read_failed',
     }))
-    expect(mock.getBucket).not.toHaveBeenCalled()
+    expect(mock.rpc).toHaveBeenCalledWith(
+      'get_classroom_archive_source_object_presence',
+      expect.objectContaining({ p_storage_path: PATH }),
+    )
     expect(mock.rpc).not.toHaveBeenCalledWith(
       'complete_classroom_archive_source_object_cleanup',
       expect.anything(),
@@ -408,11 +481,15 @@ describe('classroom archive source-object cleanup', () => {
     const oversized = createSupabaseMock({
       claims: [claim(), claim(OPERATION_ID, PATH_TWO)],
     })
+    const unsupportedBucket = createSupabaseMock({
+      claims: [claim(OPERATION_ID, PATH, { storage_bucket: 'submission-images' })],
+    })
 
     for (const [mock, overrides] of [
       [malformed, {}],
       [duplicate, { limit: 2 }],
       [oversized, { limit: 1 }],
+      [unsupportedBucket, {}],
     ] as const) {
       const result = await run(mock, overrides)
       expect(result).toEqual(expect.objectContaining({
@@ -423,19 +500,45 @@ describe('classroom archive source-object cleanup', () => {
     }
   })
 
-  it('maps missing cleanup RPCs to migration 086 and validates runtime bounds', async () => {
+  it('maps a missing ownership fence to migration 096 and validates runtime bounds', async () => {
     const mock = createSupabaseMock({
-      claimError: { code: 'PGRST202', message: 'Function was not found' },
+      verificationError: {
+        code: 'PGRST202',
+        message: 'verify_and_reserve_classroom_archive_source_objects was not found',
+      },
     })
     const result = await run(mock)
 
     expect(result).toEqual(expect.objectContaining({
       ok: false,
-      error_code: 'classroom_archive_source_cleanup_migration_required',
-      error: 'Classroom archive source cleanup requires migration 086',
+      error_code: 'classroom_archive_source_ownership_fence_migration_required',
+      error: 'Classroom archive source cleanup requires migration 096',
     }))
     await expect(run(createSupabaseMock(), { limit: 0 })).rejects.toThrow()
     await expect(run(createSupabaseMock(), { leaseSeconds: 29 })).rejects.toThrow()
+  })
+
+  it('does not claim or touch storage when ownership verification rejects the operation', async () => {
+    const mock = createSupabaseMock({
+      verificationResult: {
+        ok: false,
+        status: 409,
+        operation_id: OPERATION_ID,
+        error_code: 'classroom_archive_source_object_still_referenced',
+        error: 'Source path is still referenced',
+      },
+    })
+
+    const result = await run(mock)
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      status: 409,
+      error_code: 'classroom_archive_source_object_still_referenced',
+      retryable: false,
+    }))
+    expect(mock.rpc).toHaveBeenCalledTimes(1)
+    expect(mock.storageFrom).not.toHaveBeenCalled()
   })
 
   it('keeps paths, checksums, and classroom identity out of results and metrics', async () => {

--- a/tests/unit/classroom-archive-source-ownership-fence-migration.test.ts
+++ b/tests/unit/classroom-archive-source-ownership-fence-migration.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/096_classroom_archive_source_ownership_fence.sql',
+  ),
+  'utf8',
+)
+const databaseContract = readFileSync(
+  resolve(process.cwd(), 'scripts/check-classroom-archive-compaction-database.sh'),
+  'utf8',
+)
+
+describe('classroom archive source ownership fence migration', () => {
+  it('ties ownership evidence to a permanent exact-path reservation', () => {
+    expect(migration).toContain('ownership_verified_at timestamptz')
+    expect(migration).toContain(
+      'ownership_verified = (ownership_verified_at is not null)',
+    )
+    expect(migration).toContain(
+      'create table if not exists public.classroom_archive_source_object_reservations',
+    )
+    expect(migration).toContain('primary key (storage_bucket, storage_path_sha256)')
+    expect(migration).toContain(
+      'public.classroom_archive_source_object_path_sha256(',
+    )
+    expect(migration).not.toContain('storage_path text not null,\n  operation_id uuid')
+    expect(migration).toContain(
+      'references public.classroom_archive_operations(id) on delete set null',
+    )
+    expect(migration).toContain(
+      'Migration 096 requires reconciliation of previously deleted source objects',
+    )
+    expect(migration).toContain("last_error_code = 'ownership_fence_migration_required'")
+  })
+
+  it('limits initial verification and claims to relational assignment artifacts', () => {
+    expect(migration).toContain("storage_bucket = 'assignment-artifacts'")
+    expect(migration).toContain(
+      'public.verify_and_reserve_classroom_archive_source_objects(',
+    )
+    expect(migration).toContain(
+      'join public.assignment_submission_artifacts artifact',
+    )
+    expect(migration).toContain(
+      'public.claim_due_classroom_archive_source_object_cleanup_v2(',
+    )
+    expect(migration).toContain('cleanup.ownership_verified_at is not null')
+    expect(migration).toContain(
+      'join public.classroom_archive_source_object_reservations reservation',
+    )
+    expect(migration).toContain(
+      'create or replace function public.get_classroom_archive_source_object_presence(',
+    )
+  })
+
+  it('serializes and rejects future relational and storage writes to reserved paths', () => {
+    expect(migration).toContain('pg_advisory_xact_lock(')
+    expect(migration).toContain(
+      'public.reject_reserved_assignment_artifact_path()',
+    )
+    expect(migration).toContain(
+      'public.reject_reserved_classroom_archive_storage_path()',
+    )
+    expect(migration).toContain(
+      'public.guard_classroom_archive_source_cleanup_path()',
+    )
+    expect(migration).toContain('on storage.objects')
+    expect(migration).toContain(
+      'Storage deletion requires a classroom archive source reservation',
+    )
+    expect(migration).toContain("using errcode = '55000'")
+  })
+
+  it('removes the unfenced claim capability and keeps new contracts service-only', () => {
+    expect(migration).toMatch(
+      /revoke all on table public\.classroom_archive_source_object_cleanup from service_role;/,
+    )
+    expect(migration).toMatch(
+      /revoke all on table public\.classroom_archive_source_object_reservations[\s\S]*?service_role;/,
+    )
+    expect(migration).toMatch(
+      /revoke execute on function public\.claim_due_classroom_archive_source_object_cleanup\([\s\S]*?from service_role;/,
+    )
+    expect(migration).toMatch(
+      /grant execute on function public\.verify_and_reserve_classroom_archive_source_objects\(uuid, integer\)[\s\S]*?to service_role;/,
+    )
+    expect(migration).toMatch(
+      /grant execute on function public\.claim_due_classroom_archive_source_object_cleanup_v2\([\s\S]*?to service_role;/,
+    )
+    expect(migration).toMatch(
+      /revoke all on table public\.classroom_archive_source_object_reservations[\s\S]*?from public, anon, authenticated;/,
+    )
+  })
+
+  it('exercises evidence, reservation replay, v2 claims, and bypass revocation in PostgreSQL', () => {
+    expect(databaseContract).toContain(
+      'Boolean-only source ownership evidence was accepted',
+    )
+    expect(databaseContract).toContain(
+      'verify_and_reserve_classroom_archive_source_objects',
+    )
+    expect(databaseContract).toContain(
+      'claim_due_classroom_archive_source_object_cleanup_v2',
+    )
+    expect(databaseContract).toContain(
+      'Service role can bypass the source-object ownership fence',
+    )
+    expect(databaseContract).toContain('Concurrent hot reference write was not serialized')
+    expect(databaseContract).toContain(
+      'Pre-fence source cleanup lease completed without a reservation',
+    )
+    expect(databaseContract).toContain(
+      'Pre-fence source cleanup worker deleted without a reservation',
+    )
+    expect(databaseContract).toContain(
+      'Concurrent cleanup staging was not serialized',
+    )
+    expect(databaseContract).toContain(
+      'Exact source-object presence lookup missed an existing object',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- require bounded transactional ownership verification before assignment-artifact source deletion
- serialize cleanup against artifact references, Storage writes, cleanup staging, and stale workers
- preserve a deidentified path fence and prove exact deletion, restore, replay, and concurrency behavior

## Why

The existing compaction cleanup ledger could identify candidate source objects, but it did not provide a durable database-owned proof that deletion remained safe across concurrent references, staged compactions, Storage writes, or pre-migration worker leases. This phase makes those invariants enforceable before any manual cleanup canary can claim work.

## Rollout

- migration 096 must be applied before this app version is deployed
- source cleanup remains manual, unscheduled, default-off, operation-scoped, and limited to one object
- production was not modified; hosted catalog audit and named canaries remain explicit follow-up obligations

## Validation

- 33 focused source-cleanup and migration tests
- full Vitest suite: 362 files / 3,317 tests
- database contract harness with live verifier/reference/Storage/staging races
- full local recovery drill across 42 resource tables
- production build, TypeScript, generated database types, lint, architecture checks, Pika audit, and diff checks
- independent runtime and SQL review rounds: clean
