### PR TITLE
Add production classroom archive canary runner

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,9 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Product status: core classroom, assignment, quiz/test, and auth flows are live.
 - Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
 - Feature inventory: `.ai/features.json` is the status authority for big epics; check it directly for current pass/fail state.
-- Classroom archives: production 082-086 and read-only inventory are verified; hosted catalog/named canaries remain. Migration 096 locally fences assignment artifacts only; production is unchanged.
+- Classroom archives: production migrations 001-096, the read-only inventory, and the hosted catalog
+  audit are verified. Source and Gradex cleanup remain disabled. The named export/compact/immediate-
+  restore production canary and its post-run verification remain before rollout completion.
 
 ## Environment And Workflow Facts
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13664,3 +13664,12 @@
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
 - `git diff --check`
+
+## 2026-07-10 — Bump GitHub Actions off deprecated Node 20
+
+**Completed:**
+- Bumped pinned action majors in ci.yml and ui-policy.yml to clear the "Node.js 20 is deprecated" runner warning: checkout v4→v7, setup-node v4→v6, pnpm/action-setup v4→v6, cache v4→v6, upload-artifact v4→v7.
+- All step inputs used are stable across these majors (no removed inputs); relying on CI to validate.
+
+**Validation:**
+- CI `Test & Build` on the PR (self-validating workflow change)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,15 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-10 — Bump GitHub Actions off deprecated Node 20
-
-**Completed:**
-- Bumped pinned action majors in ci.yml and ui-policy.yml to clear the "Node.js 20 is deprecated" runner warning: checkout v4→v7, setup-node v4→v6, pnpm/action-setup v4→v6, cache v4→v6, upload-artifact v4→v7.
-- All step inputs used are stable across these majors (no removed inputs); relying on CI to validate.
-
-**Validation:**
-- CI `Test & Build` on the PR (self-validating workflow change)
-
 ## 2026-07-10 — Repo cleanup and /repo-tidy skill
 
 **Completed:**
@@ -285,6 +276,36 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm build`
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-15 — Production classroom archive canary runner
+
+**Completed:**
+- Added a production-only prepare/execute/resume CLI bound to one hosted project, teacher,
+  archived-hot classroom, immutable mode-0600 plan, clean deployed commit, exact acknowledgement,
+  and deterministic export/compact/restore operation UUIDs.
+- Added exact pre/archive/restored-projection evidence across all 42 classroom resources and every
+  source object, full manifest and operation metadata auditing, original/restored object byte checks,
+  source-revision equality, pre/post database sizing, and a conservative restore safety margin.
+- Kept every source/Gradex cleanup gate disabled and proved cleanup rows, reservations, restore
+  staging, and upload-cleanup state remain untouched or empty after immediate restore.
+- Added crash recovery for cold state, transient state/archive reads, ambiguous coordinator results,
+  journal failure, and hot state after restore completion. Evidence files reject symlink traversal and
+  unsafe permissions.
+- Updated lifecycle/testing/operator documentation and current context. Production migrations 001-096,
+  read-only inventory, and hosted catalog audit were previously verified; no mutation canary ran in
+  this branch.
+- Completed repeated independent production-safety/data-integrity review and fix rounds.
+
+**Validation:**
+- Production canary contract suite (14 tests)
+- `pnpm vitest run` (363 files / 3,329 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm db:types:check`
+- `pnpm lint`
+- `pnpm check:architecture` (600 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
 

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -99,6 +99,18 @@ privacy-safe row and managed-object sizing for hot archived classrooms. The dire
 audit documented in `docs/guidance/classroom-lifecycle-archives.md` remains separately required. The
 inventory does not create an archive or modify database or Storage state.
 
+The named production round-trip runner has separate read-only preparation and explicitly
+acknowledged mutation/resume modes:
+
+```bash
+pnpm canary:classroom-archive-production -- prepare --plan "$HOME/.pika/archive-canary.json"
+pnpm canary:classroom-archive-production -- execute --plan "$HOME/.pika/archive-canary.json"
+pnpm canary:classroom-archive-production -- resume --plan "$HOME/.pika/archive-canary.json"
+```
+
+Use it only under the migration, catalog, deployment, headroom, named-target, immutable-plan, and
+cleanup-disabled procedure in `docs/guidance/classroom-lifecycle-archives.md`.
+
 ---
 
 ## Environment Variables (required)
@@ -113,12 +125,15 @@ inventory does not create an archive or modify database or Storage state.
 - `CRON_SECRET` (required for protected cron endpoints; Vercel sends `Authorization: Bearer <CRON_SECRET>`; cron schedules are configured in `vercel.json` or the Vercel dashboard; on the Hobby plan, schedules must run at most once per day)
 - `OPENAI_API_KEY` (optional; required for AI grading, nightly log summaries, and developer feedback extraction)
 - `OPENAI_SUMMARY_MODEL` / `OPENAI_DEVELOPER_FEEDBACK_MODEL` (optional model overrides)
+- `SUPABASE_ACCESS_TOKEN` (operator-only; required by the named production archive canary for
+  read-only pre/post database-size evidence)
 
 Classroom archive rollout controls are optional and disabled by default. Cold compaction requires
 `CLASSROOM_ARCHIVE_COMPACTION_ENABLED=true` plus exact UUID matches in both
 `CLASSROOM_ARCHIVE_COMPACTION_TEACHER_IDS` and `CLASSROOM_ARCHIVE_COMPACTION_ARCHIVE_IDS`. The
 coordinator is server-only and has no route or schedule; migration application and a named canary
-still require explicit human approval.
+still require explicit human approval. The named round-trip canary keeps every source and Gradex
+cleanup gate disabled and immediately restores the classroom after cold compaction.
 
 Source-object deletion is separately disabled by default. Migration 096 transactionally fences
 `assignment-artifacts`; embedded-reference buckets remain ineligible. The manual route requires two

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -132,6 +132,14 @@ Test password-based flows:
   forced transactional rollback, idempotent replay, concurrency rejection, strict verification,
   durable-but-ineligible cleanup staging, lease reclaim/backoff/completion, and service-role
   isolation.
+- Production canary contract tests prove immutable plan digests, deterministic and distinct phase
+  operation UUIDs, exact hosted target/credential/acknowledgement binding, cleanup-gate rejection,
+  complete 42-resource evidence, exact aggregate-digest validation, hot and cold crash resumption,
+  journal-failure-tolerant cold recovery, ambiguous export/compaction/restore reconciliation,
+  same-operation restore retry, deterministic restored-path projection, and post-restore row,
+  revision, and source-object drift rejection. The operator runner additionally verifies actual tar
+  bytes, full manifest identity, retained archive bytes, complete operation evidence, pre/post database
+  size, no tombstone, no ownership reservations, and the exact untouched cleanup descriptor set.
 - Teacher recovery-list tests prove tombstone queries are teacher-scoped, response rows are
   Zod-validated, missing migrations preserve the hot-archive response, unexpected failures fail
   closed, tombstone changes around the hot query trigger a bounded stable-read retry, restore remains

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -12,8 +12,9 @@ Migration `082_verified_classroom_archive_exports.sql` and
 `POST /api/teacher/classrooms/[id]/archives` implement the export-only rollout stage. They create a
 private, read-back-verified archive while retaining every hot relational row and source object.
 They do not enable cold compaction, Gradex generation, or automatic export on the existing
-archive toggle. Current production behavior remains unchanged until a human applies the migration;
-`classrooms.archived_at` continues to make a classroom read-only while relational data stays hot.
+archive toggle. Applying or deploying the migration does not invoke an archive operation;
+`classrooms.archived_at` continues to make a classroom read-only while relational data stays hot
+until an explicitly authorized lifecycle operation runs.
 
 Migration `083_resumable_classroom_archive_restore.sql` and
 `POST /api/teacher/classrooms/[id]/archives/[archiveId]/restore` add the canary-only restore
@@ -221,6 +222,65 @@ headroom for indexes, MVCC, and vacuum; a refusal leaves the cold archive unchan
 On failure, roll back relational writes, remove operation-scoped temporary objects, retain the cold
 tombstone and original archive, and store a retryable error code. Never mark the classroom hot or
 active after a partial restore.
+
+### Named Production Round-Trip Canary
+
+`pnpm canary:classroom-archive-production` is the only supported operator runner for the first named
+production export, cold-compaction, and immediate restore. It is not a route, schedule, or general
+classroom command. Before use, migrations 082 through 096, the direct catalog audit, the read-only
+inventory, database headroom, and deployment of the exact runner commit must be independently
+verified.
+
+Preparation is read-only and writes a new mode-0600 plan outside the repository:
+
+```bash
+pnpm canary:classroom-archive-production -- prepare --plan "$HOME/.pika/archive-canary.json"
+```
+
+The environment must provide the exact hosted project ref, one teacher UUID, one archived-hot
+classroom UUID with no prior lifecycle operation, and the actual database quota as
+`CLASSROOM_ARCHIVE_PRODUCTION_CANARY_EXPECTED_PROJECT_REF`,
+`CLASSROOM_ARCHIVE_PRODUCTION_CANARY_TEACHER_ID`,
+`CLASSROOM_ARCHIVE_PRODUCTION_CANARY_CLASSROOM_ID`, and
+`CLASSROOM_ARCHIVE_PRODUCTION_CANARY_DATABASE_BUDGET_BYTES`. The ordinary hosted Supabase URL and
+matching service-role JWT are also required. Preparation captures the clean git commit, stable source
+revision, all 42 canonical resource row/byte/SHA-256 descriptors, every referenced source object's
+byte/SHA-256 descriptor, the Management API's current database size, deterministic phase operation
+UUIDs, and a digest over the complete plan. `SUPABASE_ACCESS_TOKEN` is required for the read-only
+pre/post `pg_database_size` evidence. Paths and classroom content are not printed.
+
+Execution requires the same clean deployed commit and the exact target-specific acknowledgement
+printed by preparation:
+
+```bash
+pnpm canary:classroom-archive-production -- execute --plan "$HOME/.pika/archive-canary.json"
+```
+
+The runner exports, verifies the immutable archive, compacts, and immediately restores with the
+plan's same operation UUIDs. It rereads database size immediately before execution and again before
+compaction, requiring at least 100 MB of quota headroom and at least four times the actual
+uncompressed archive size when that is larger. It appends a mode-0600 JSONL event journal and
+atomically replaces a mode-0600 state file beside the plan. If the process ends after compaction or
+during restore, rerun
+`resume` with the same plan and acknowledgement; it reconciles hot/cold state and durable archive
+evidence before reusing the same operation UUIDs:
+
+```bash
+pnpm canary:classroom-archive-production -- resume --plan "$HOME/.pika/archive-canary.json"
+```
+
+Every source cleanup, staging cleanup, object cleanup, and Gradex cleanup gate must remain disabled.
+The runner sets them false in its own process and rejects an environment where any is enabled. It
+never calls a cleanup coordinator. Restore intentionally rewrites managed references to deterministic
+operation-scoped paths, so post-restore equality is checked against the archive-derived restore
+projection while every original source object is separately reread and byte-verified. Success also
+requires the exact archived source revision, a full canonical manifest digest, actual decompressed tar
+size, a restored archived-hot classroom, no cold tombstone, three identity- and verification-checked
+completed lifecycle operation rows, retained immutable archive bytes, database size below the plan's
+budget, no ownership reservation, and the exact cleanup descriptor set remaining unleased `pending`
+with zero attempts and zero deletions. Once cold state is durable, local journal write failure is
+non-blocking so immediate restore still runs. A failed run must be resumed until the classroom is
+confirmed hot; cleanup must not be used as recovery.
 
 ### Teacher Recovery Surface
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "vitest run --coverage",
     "verify:classroom-archive-recovery": "bash scripts/check-classroom-archive-recovery-drill.sh",
     "verify:classroom-archive-inventory": "tsx scripts/inventory-classroom-archives.ts",
+    "canary:classroom-archive-production": "tsx scripts/run-classroom-archive-production-canary.ts",
     "db:types:generate": "bash scripts/supabase-types.sh generate",
     "db:types:check": "bash scripts/supabase-types.sh check",
     "check:architecture": "tsx scripts/check-architecture.ts",

--- a/scripts/run-classroom-archive-production-canary.ts
+++ b/scripts/run-classroom-archive-production-canary.ts
@@ -1,0 +1,1108 @@
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { constants as fsConstants } from 'node:fs'
+import {
+  link,
+  open,
+  rename,
+  unlink,
+} from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createInterface } from 'node:readline/promises'
+import { gunzipSync } from 'node:zlib'
+import { config as loadEnvironment } from 'dotenv'
+import { z } from 'zod'
+import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
+import {
+  assertClassroomArchiveProductionCanaryEvidenceEqual,
+  assertClassroomArchiveProductionCanaryExecution,
+  assertClassroomArchiveProductionCanaryTarget,
+  classroomArchiveProductionCanaryAcknowledgement,
+  classroomArchiveProductionCanaryEvidenceDigest,
+  classroomArchiveStorageIdentitySha256,
+  createClassroomArchiveProductionCanaryPlan,
+  runClassroomArchiveProductionCanary,
+  verifyClassroomArchiveProductionCanaryPlan,
+  type ClassroomArchiveProductionArchiveEvidence,
+  type ClassroomArchiveProductionCanaryEvent,
+  type ClassroomArchiveProductionCanaryEvidence,
+  type ClassroomArchiveProductionCanaryFinalEvidence,
+  type ClassroomArchiveProductionCanaryPlan,
+  type ClassroomArchiveProductionCanaryState,
+} from '@/lib/server/classroom-archive-production-canary'
+import { compactClassroomArchive } from '@/lib/server/classroom-archive-compaction'
+import {
+  canonicalJsonStringify,
+  decodeClassroomArchiveData,
+  discoverClassroomStorageReferences,
+  sha256Bytes,
+  verifyClassroomArchiveBundle,
+} from '@/lib/server/classroom-archive-format'
+import {
+  buildClassroomArchiveRestorePlan,
+  CLASSROOM_ARCHIVE_RESTORE_TARGET_MIGRATION,
+} from '@/lib/server/classroom-archive-restore'
+import {
+  createSupabaseClassroomArchiveInventoryReader,
+  readClassroomArchiveResourceGraph,
+} from '@/lib/server/classroom-archive-inventory'
+import {
+  classroomArchiveStoragePath,
+  exportClassroomArchive,
+} from '@/lib/server/classroom-archive-operations'
+import { restoreClassroomArchive } from '@/lib/server/classroom-archive-restore-operations'
+import { createTargetBoundFetch } from '@/lib/server/supabase-target'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+loadEnvironment({ path: process.env.ENV_FILE || '.env.local' })
+
+const uuidSchema = z.string().uuid()
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/)
+const commandSchema = z.enum(['prepare', 'execute', 'resume'])
+const projectRefSchema = z.string().regex(/^[a-z0-9]{20}$/)
+const commitSchema = z.string().regex(/^[a-f0-9]{40}$/)
+const planFileSchema = z.string().min(1).transform((value) => resolve(value))
+const MINIMUM_DATABASE_SAFETY_MARGIN_BYTES = 100_000_000
+
+type SupabaseClient = ReturnType<typeof getServiceRoleClient>
+
+async function readProductionDatabaseSizeBytes(projectRef: string): Promise<number> {
+  const accessToken = z.string().min(1).parse(process.env.SUPABASE_ACCESS_TOKEN)
+  const endpoint = `https://api.supabase.com/v1/projects/${projectRefSchema.parse(projectRef)}/database/query`
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    redirect: 'error',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: 'select pg_database_size(current_database())::bigint as database_size_bytes',
+    }),
+  })
+  if (!response.ok) throw new Error('Production archive canary database size could not be read')
+  const rows = z.array(z.object({
+    database_size_bytes: z.union([z.number().int().positive(), z.string().regex(/^\d+$/)]),
+  }).passthrough()).parse(await response.json())
+  if (rows.length !== 1) throw new Error('Production archive canary database size evidence is invalid')
+  return z.coerce.number().int().positive().parse(rows[0].database_size_bytes)
+}
+
+const classroomStateRowSchema = z.object({
+  id: uuidSchema,
+  teacher_id: uuidSchema,
+  archived_at: z.string().datetime({ offset: true }),
+}).strict()
+
+const tombstoneRowSchema = z.object({
+  classroom_id: uuidSchema,
+  teacher_id: uuidSchema,
+  archive_id: uuidSchema,
+}).strict()
+
+const archiveRowSchema = z.object({
+  id: uuidSchema,
+  operation_id: uuidSchema,
+  classroom_id: uuidSchema,
+  teacher_id: uuidSchema,
+  format: z.literal('pika.classroom-archive'),
+  format_version: z.literal(1),
+  storage_bucket: z.literal('classroom-archives'),
+  storage_path: z.string().min(1),
+  artifact_sha256: sha256Schema,
+  compressed_byte_size: z.number().int().positive(),
+  uncompressed_byte_size: z.number().int().positive(),
+  source_revision: z.number().int().positive(),
+  source_schema_migration: z.string().min(1),
+  source_app_commit: commitSchema,
+  content_sha256: sha256Schema,
+  retention: z.object({ mode: z.literal('teacher_managed'), delete_after: z.null() }).strict(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+  storage_object_counts: z.record(z.string(), z.unknown()),
+  verification: z.record(z.string(), z.unknown()),
+  verified_at: z.string().datetime({ offset: true }),
+}).strict()
+
+const operationRowSchema = z.object({
+  id: uuidSchema,
+  teacher_id: uuidSchema,
+  classroom_id: uuidSchema,
+  operation_type: z.enum(['export', 'compact', 'restore']),
+  status: z.literal('completed'),
+  request_sha256: sha256Schema,
+  source_revision: z.number().int().positive(),
+  source_schema_migration: z.string().min(1),
+  source_app_commit: commitSchema,
+  archive_id: uuidSchema,
+  retention: z.object({ mode: z.literal('teacher_managed'), delete_after: z.null() }).strict(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+  storage_object_counts: z.record(z.string(), z.unknown()),
+  storage_bucket: z.literal('classroom-archives'),
+  storage_path: z.string().min(1),
+  artifact_sha256: sha256Schema,
+  content_sha256: sha256Schema,
+  compressed_byte_size: z.number().int().positive(),
+  uncompressed_byte_size: z.number().int().positive(),
+  target_schema_migration: z.string().nullable(),
+  adapter_chain: z.array(z.string()).nullable(),
+  completed_at: z.string().datetime({ offset: true }),
+  error_code: z.null(),
+  retryable: z.null(),
+  verification: z.record(z.string(), z.unknown()),
+}).strict()
+
+const cleanupRowSchema = z.object({
+  storage_bucket: z.string().min(1),
+  storage_path: z.string().min(1),
+  expected_sha256: sha256Schema,
+  expected_byte_size: z.number().int().nonnegative(),
+  attempt_count: z.number().int().nonnegative(),
+  status: z.string().min(1),
+  lease_token: z.string().nullable(),
+  lease_expires_at: z.string().nullable(),
+  deleted_at: z.string().nullable(),
+  ownership_verified: z.boolean(),
+  ownership_verified_at: z.string().nullable(),
+}).strict()
+
+const completedRestoreIdentitySchema = z.object({
+  id: uuidSchema,
+  teacher_id: uuidSchema,
+  classroom_id: uuidSchema,
+  archive_id: uuidSchema,
+  operation_type: z.literal('restore'),
+  status: z.literal('completed'),
+}).strict()
+
+function currentCommit(): string {
+  return commitSchema.parse(execFileSync('git', ['rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim())
+}
+
+function assertCleanCheckout(expectedCommit?: string) {
+  const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim()
+  if (status) throw new Error('Production archive canary requires a clean checkout')
+  const commit = currentCommit()
+  if (expectedCommit && commit !== expectedCommit) {
+    throw new Error('Production archive canary checkout does not match the approved runner commit')
+  }
+  return commit
+}
+
+function parseArguments() {
+  const command = commandSchema.parse(process.argv[2])
+  const planIndex = process.argv.indexOf('--plan')
+  if (planIndex < 0 || !process.argv[planIndex + 1]) {
+    throw new Error('--plan is required')
+  }
+  return { command, planPath: planFileSchema.parse(process.argv[planIndex + 1]) }
+}
+
+async function writeImmutablePlan(path: string, plan: ClassroomArchiveProductionCanaryPlan) {
+  try {
+    const existing = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+    await existing.close()
+    throw new Error('Production archive canary plan already exists')
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Production archive canary plan already exists') {
+      throw error
+    }
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  const temporaryPath = `${path}.${process.pid}.tmp`
+  const handle = await open(temporaryPath, 'wx', 0o600)
+  try {
+    await handle.writeFile(`${JSON.stringify(plan, null, 2)}\n`, 'utf8')
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  try {
+    await link(temporaryPath, path)
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined)
+  }
+}
+
+async function readPlan(path: string): Promise<ClassroomArchiveProductionCanaryPlan> {
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+  try {
+    const metadata = await handle.stat()
+    if (!metadata.isFile() || (metadata.mode & 0o077) !== 0) {
+      throw new Error('Production archive canary plan must be a mode-0600 regular file')
+    }
+    return verifyClassroomArchiveProductionCanaryPlan(
+      JSON.parse(await handle.readFile('utf8')),
+    )
+  } finally {
+    await handle.close()
+  }
+}
+
+async function writeAtomicJson(path: string, value: unknown) {
+  const temporaryPath = `${path}.${process.pid}.tmp`
+  const handle = await open(
+    temporaryPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o600,
+  )
+  try {
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, 'utf8')
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  try {
+    await rename(temporaryPath, path)
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined)
+    throw error
+  }
+}
+
+function createEventRecorder(planPath: string, plan: ClassroomArchiveProductionCanaryPlan) {
+  const journalPath = `${planPath}.events.jsonl`
+  const statePath = `${planPath}.state.json`
+  return async (event: ClassroomArchiveProductionCanaryEvent) => {
+    const record = {
+      format: 'pika.classroom-archive-production-canary-event',
+      version: 1,
+      plan_sha256: plan.plan_sha256,
+      recorded_at: new Date().toISOString(),
+      ...event,
+    }
+    const handle = await open(
+      journalPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND | fsConstants.O_NOFOLLOW,
+      0o600,
+    )
+    try {
+      const metadata = await handle.stat()
+      if (!metadata.isFile() || (metadata.mode & 0o077) !== 0) {
+        throw new Error('Production archive canary evidence files must be mode-0600 regular files')
+      }
+      await handle.writeFile(`${JSON.stringify(record)}\n`, 'utf8')
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await writeAtomicJson(statePath, record)
+  }
+}
+
+function createProductionClient(args: {
+  expectedProjectRef: string
+  plan?: ClassroomArchiveProductionCanaryPlan
+  acknowledgement?: string
+}) {
+  const supabaseUrl = args.plan && args.acknowledgement !== undefined
+    ? assertClassroomArchiveProductionCanaryExecution({
+        plan: args.plan,
+        acknowledgement: args.acknowledgement,
+        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+        serviceRoleKey: process.env.SUPABASE_SECRET_KEY,
+        environment: process.env,
+      })
+    : assertClassroomArchiveProductionCanaryTarget({
+        expectedProjectRef: args.expectedProjectRef,
+        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+        serviceRoleKey: process.env.SUPABASE_SECRET_KEY,
+        environment: process.env,
+      })
+  const targetFetch = createTargetBoundFetch(supabaseUrl)
+  return {
+    supabaseUrl,
+    supabase: getServiceRoleClient({ fetch: targetFetch }),
+  }
+}
+
+async function readLifecycleState(
+  supabase: SupabaseClient,
+  classroomId: string,
+): Promise<ClassroomArchiveProductionCanaryState> {
+  const [classroomResponse, tombstoneResponse] = await Promise.all([
+    supabase.from('classrooms')
+      .select('id,teacher_id,archived_at')
+      .eq('id', classroomId)
+      .maybeSingle(),
+    supabase.from('classroom_cold_tombstones')
+      .select('classroom_id,teacher_id,archive_id')
+      .eq('classroom_id', classroomId)
+      .maybeSingle(),
+  ])
+  if (classroomResponse.error || tombstoneResponse.error) {
+    throw new Error('Production archive canary lifecycle state could not be read')
+  }
+  if (classroomResponse.data && tombstoneResponse.data) {
+    throw new Error('Production archive canary found conflicting hot and cold lifecycle state')
+  }
+  if (classroomResponse.data) {
+    const classroom = classroomStateRowSchema.parse(classroomResponse.data)
+    return { phase: 'hot', teacherId: classroom.teacher_id, archivedAt: classroom.archived_at }
+  }
+  if (tombstoneResponse.data) {
+    const tombstone = tombstoneRowSchema.parse(tombstoneResponse.data)
+    return {
+      phase: 'cold',
+      teacherId: tombstone.teacher_id,
+      archiveId: tombstone.archive_id,
+    }
+  }
+  throw new Error('Production archive canary target has no hot classroom or cold tombstone')
+}
+
+async function readRestoreCompleted(
+  supabase: SupabaseClient,
+  plan: ClassroomArchiveProductionCanaryPlan,
+): Promise<boolean> {
+  const response = await supabase.from('classroom_archive_operations')
+    .select('id,teacher_id,classroom_id,archive_id,operation_type,status')
+    .eq('id', plan.operation_ids.restore)
+    .maybeSingle()
+  if (response.error) throw new Error('Production archive canary restore state could not be read')
+  if (!response.data) return false
+  const operation = completedRestoreIdentitySchema.parse(response.data)
+  return operation.teacher_id === plan.teacher_id &&
+    operation.classroom_id === plan.classroom_id &&
+    operation.archive_id === plan.operation_ids.export
+}
+
+function resourceBytes(rows: Array<Record<string, unknown>>): Uint8Array {
+  return Buffer.from(rows.map((row) => `${canonicalJsonStringify(row)}\n`).join(''), 'utf8')
+}
+
+function canonicalSha256(value: unknown): string {
+  return createHash('sha256').update(canonicalJsonStringify(value)).digest('hex')
+}
+
+async function downloadExactStorageBytes(
+  supabase: SupabaseClient,
+  bucket: string,
+  path: string,
+): Promise<Uint8Array> {
+  const response = await supabase.storage.from(bucket).download(path)
+  if (response.error || !response.data) {
+    throw new Error('Production archive canary source object could not be read exactly')
+  }
+  return new Uint8Array(await response.data.arrayBuffer())
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  worker: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length)
+  let nextIndex = 0
+  async function run() {
+    while (nextIndex < values.length) {
+      const index = nextIndex++
+      results[index] = await worker(values[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, run))
+  return results
+}
+
+async function readCurrentEvidence(args: {
+  supabase: SupabaseClient
+  supabaseUrl: string
+  databaseSizeBytesBefore: number
+  serviceRoleKey: string
+  classroomId: string
+}): Promise<ClassroomArchiveProductionCanaryEvidence> {
+  const reader = createSupabaseClassroomArchiveInventoryReader({
+    supabase: args.supabase,
+    supabaseUrl: args.supabaseUrl,
+    secretKey: args.serviceRoleKey,
+  })
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const revisionBefore = z.number().int().positive().parse(
+      await reader.readRevision(args.classroomId),
+    )
+    const resources = await readClassroomArchiveResourceGraph(reader, args.classroomId)
+    const root = resources.classrooms || []
+    if (root.length !== 1 || typeof root[0].archived_at !== 'string') {
+      throw new Error('Production archive canary target is not an archived hot classroom')
+    }
+    const resourceDigests = CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => {
+      const rows = resources[table] || []
+      const bytes = resourceBytes(rows)
+      return {
+        table,
+        row_count: rows.length,
+        byte_size: bytes.byteLength,
+        sha256: sha256Bytes(bytes),
+      }
+    })
+    const references = discoverClassroomStorageReferences(resources, args.supabaseUrl)
+    const storageDigests = await mapWithConcurrency(references, 4, async (reference) => {
+      const bytes = await downloadExactStorageBytes(
+        args.supabase,
+        reference.bucket,
+        reference.path,
+      )
+      return {
+        identity_sha256: classroomArchiveStorageIdentitySha256(
+          reference.bucket,
+          reference.path,
+        ),
+        byte_size: bytes.byteLength,
+        sha256: sha256Bytes(bytes),
+      }
+    })
+    const revisionAfter = z.number().int().positive().parse(
+      await reader.readRevision(args.classroomId),
+    )
+    if (revisionBefore !== revisionAfter) continue
+    return classroomArchiveProductionCanaryEvidenceDigest({
+      sourceRevision: revisionAfter,
+      resources: resourceDigests,
+      storageObjects: storageDigests,
+    })
+  }
+  throw new Error('Production archive canary target changed during exact evidence capture')
+}
+
+async function readArchiveEvidence(args: {
+  supabase: SupabaseClient
+  archiveId: string
+  classroomId: string
+  teacherId: string
+  restoreOperationId: string
+  sourceAppCommit: string
+  supabaseUrl: string
+  verifyOriginalSourceObjects?: boolean
+}): Promise<ClassroomArchiveProductionArchiveEvidence | null> {
+  const metadataResponse = await args.supabase.from('classroom_archives')
+    .select([
+      'id',
+      'operation_id',
+      'classroom_id',
+      'teacher_id',
+      'format',
+      'format_version',
+      'storage_bucket',
+      'storage_path',
+      'artifact_sha256',
+      'compressed_byte_size',
+      'uncompressed_byte_size',
+      'source_revision',
+      'source_schema_migration',
+      'source_app_commit',
+      'content_sha256',
+      'retention',
+      'resource_counts',
+      'storage_object_counts',
+      'verification',
+      'verified_at',
+    ].join(','))
+    .eq('id', args.archiveId)
+    .eq('classroom_id', args.classroomId)
+    .eq('teacher_id', args.teacherId)
+    .maybeSingle()
+  if (metadataResponse.error) {
+    throw new Error('Production archive canary metadata could not be read')
+  }
+  if (!metadataResponse.data) return null
+  const metadata = archiveRowSchema.parse(metadataResponse.data)
+  const bytes = await downloadExactStorageBytes(
+    args.supabase,
+    metadata.storage_bucket,
+    metadata.storage_path,
+  )
+  if (
+    bytes.byteLength !== metadata.compressed_byte_size ||
+    sha256Bytes(bytes) !== metadata.artifact_sha256 ||
+    gunzipSync(bytes).byteLength !== metadata.uncompressed_byte_size
+  ) {
+    throw new Error('Production archive canary immutable archive bytes do not match metadata')
+  }
+  const verified = verifyClassroomArchiveBundle(bytes)
+  if (!verified.ok) throw new Error('Production archive canary immutable archive is invalid')
+  if (
+    verified.manifest.archive_id !== metadata.id ||
+    verified.manifest.classroom_id !== metadata.classroom_id ||
+    verified.manifest.teacher_id !== metadata.teacher_id
+  ) {
+    throw new Error('Production archive canary immutable archive identity is invalid')
+  }
+  const manifestResourceCounts = Object.fromEntries(
+    verified.manifest.resources.map((resource) => [resource.table, resource.row_count]),
+  )
+  const manifestStorageCounts = {
+    total_count: verified.manifest.storage_objects.length,
+    total_bytes: verified.manifest.storage_objects.reduce((sum, object) => sum + object.byte_size, 0),
+    by_bucket: Object.fromEntries([...new Set(
+      verified.manifest.storage_objects.map((object) => object.bucket),
+    )].sort().map((bucket) => {
+      const objects = verified.manifest.storage_objects.filter((object) => object.bucket === bucket)
+      return [bucket, {
+        count: objects.length,
+        bytes: objects.reduce((sum, object) => sum + object.byte_size, 0),
+      }]
+    })),
+  }
+  if (
+    metadata.operation_id !== args.archiveId ||
+    metadata.storage_path !== classroomArchiveStoragePath({
+      teacherId: args.teacherId,
+      classroomId: args.classroomId,
+      archiveId: args.archiveId,
+    }) ||
+    canonicalJsonStringify(metadata.resource_counts) !== canonicalJsonStringify(manifestResourceCounts) ||
+    canonicalJsonStringify(metadata.storage_object_counts) !== canonicalJsonStringify(manifestStorageCounts) ||
+    [
+      'read_back_verified', 'artifact_checksum_verified', 'manifest_verified',
+      'resource_checksums_verified', 'resource_counts_verified',
+      'storage_objects_verified', 'actor_snapshots_verified',
+    ].some((key) => metadata.verification[key] !== true) ||
+    verified.manifest.source.app_commit !== args.sourceAppCommit ||
+    verified.manifest.source.schema_migration !== metadata.source_schema_migration ||
+    verified.manifest.content_sha256 !== metadata.content_sha256 ||
+    metadata.source_app_commit !== args.sourceAppCommit ||
+    canonicalJsonStringify(verified.manifest.retention) !== canonicalJsonStringify(metadata.retention) ||
+    verified.manifest.retention.mode !== 'teacher_managed' ||
+    verified.manifest.retention.delete_after !== null
+  ) {
+    throw new Error('Production archive canary immutable archive source or retention is invalid')
+  }
+  if (args.verifyOriginalSourceObjects) {
+    await mapWithConcurrency(verified.manifest.storage_objects, 4, async (object) => {
+      const sourceBytes = await downloadExactStorageBytes(
+        args.supabase,
+        object.bucket,
+        object.source_path,
+      )
+      if (sourceBytes.byteLength !== object.byte_size || sha256Bytes(sourceBytes) !== object.sha256) {
+        throw new Error('Production archive canary original source object changed after restore')
+      }
+    })
+  }
+  const evidence = classroomArchiveProductionCanaryEvidenceDigest({
+    sourceRevision: metadata.source_revision,
+    resources: verified.manifest.resources.map((resource) => ({
+      table: resource.table,
+      row_count: resource.row_count,
+      byte_size: resource.byte_size,
+      sha256: resource.sha256,
+    })),
+    storageObjects: verified.manifest.storage_objects.map((object) => ({
+      identity_sha256: classroomArchiveStorageIdentitySha256(
+        object.bucket,
+        object.source_path,
+      ),
+      byte_size: object.byte_size,
+      sha256: object.sha256,
+    })),
+  })
+  const decoded = decodeClassroomArchiveData(verified)
+  const restorePlan = buildClassroomArchiveRestorePlan({
+    verified,
+    operationId: args.restoreOperationId,
+    supabaseUrl: args.supabaseUrl,
+    artifactChecksumVerified: true,
+    currentActors: decoded.actors.map((actor) => ({
+      id: actor.id,
+      email: actor.email,
+      role: actor.role,
+    })),
+  })
+  const restoredEvidence = classroomArchiveProductionCanaryEvidenceDigest({
+    sourceRevision: metadata.source_revision,
+    resources: CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => {
+      const rows = restorePlan.resources[table] || []
+      const resource = resourceBytes(rows)
+      return {
+        table,
+        row_count: rows.length,
+        byte_size: resource.byteLength,
+        sha256: sha256Bytes(resource),
+      }
+    }),
+    storageObjects: restorePlan.storageObjects.map((object) => ({
+      identity_sha256: classroomArchiveStorageIdentitySha256(
+        object.bucket,
+        object.restorePath,
+      ),
+      byte_size: object.bytes.byteLength,
+      sha256: object.sha256,
+    })),
+  })
+  const restoredStorageDescriptors = restorePlan.storageObjects.map((object) => ({
+    storage_bucket: object.bucket,
+    storage_path: object.restorePath,
+    expected_sha256: object.sha256,
+    expected_byte_size: object.bytes.byteLength,
+  })).sort((left, right) => (
+    left.storage_bucket.localeCompare(right.storage_bucket) ||
+    left.storage_path.localeCompare(right.storage_path)
+  ))
+  return {
+    archiveId: metadata.id,
+    classroomId: metadata.classroom_id,
+    teacherId: metadata.teacher_id,
+    artifactSha256: metadata.artifact_sha256,
+    contentSha256: metadata.content_sha256,
+    compressedByteSize: metadata.compressed_byte_size,
+    uncompressedByteSize: metadata.uncompressed_byte_size,
+    manifestSha256: sha256Bytes(Buffer.from(canonicalJsonStringify(verified.manifest), 'utf8')),
+    operationRequestSha256: {
+      export: canonicalSha256({
+        format: 'pika.classroom-archive',
+        version: 1,
+        classroom_id: args.classroomId,
+        retention: metadata.retention,
+      }),
+      compact: canonicalSha256({
+        format: 'pika.classroom-archive',
+        version: 1,
+        transition: 'archived_hot:archived_cold',
+        classroom_id: args.classroomId,
+        archive_id: args.archiveId,
+      }),
+      restore: canonicalSha256({
+        operation: 'classroom_archive_restore',
+        archive_id: args.archiveId,
+        classroom_id: args.classroomId,
+        target_schema_migration: CLASSROOM_ARCHIVE_RESTORE_TARGET_MIGRATION,
+        storage_objects: restoredStorageDescriptors,
+      }),
+    },
+    storageObjectCounts: metadata.storage_object_counts,
+    restoreAdapterChain: restorePlan.adapterChain,
+    evidence,
+    restoredEvidence,
+  }
+}
+
+function configureCoordinatorGates(plan: ClassroomArchiveProductionCanaryPlan) {
+  process.env.CLASSROOM_ARCHIVE_EXPORT_ENABLED = 'true'
+  process.env.CLASSROOM_ARCHIVE_EXPORT_TEACHER_IDS = plan.teacher_id
+  process.env.CLASSROOM_ARCHIVE_COMPACTION_ENABLED = 'true'
+  process.env.CLASSROOM_ARCHIVE_COMPACTION_TEACHER_IDS = plan.teacher_id
+  process.env.CLASSROOM_ARCHIVE_COMPACTION_ARCHIVE_IDS = plan.operation_ids.export
+  process.env.CLASSROOM_ARCHIVE_RESTORE_ENABLED = 'true'
+  process.env.CLASSROOM_ARCHIVE_RESTORE_TEACHER_IDS = plan.teacher_id
+  process.env.CLASSROOM_ARCHIVE_RESTORE_DATABASE_BUDGET_BYTES =
+    String(plan.database_budget_bytes)
+  process.env.PIKA_APP_COMMIT = plan.source_app_commit
+  for (const name of [
+    'CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED',
+    'CLASSROOM_ARCHIVE_SOURCE_CLEANUP_TRIGGER_ENABLED',
+    'CLASSROOM_ARCHIVE_STAGING_CLEANUP_ENABLED',
+    'CLASSROOM_ARCHIVE_OBJECT_CLEANUP_ENABLED',
+    'CLASSROOM_GRADEX_CLEANUP_ENABLED',
+    'CLASSROOM_GRADEX_CLEANUP_TRIGGER_ENABLED',
+  ]) process.env[name] = 'false'
+}
+
+async function verifyFinalEvidence(args: {
+  supabase: SupabaseClient
+  supabaseUrl: string
+  databaseSizeBytesBefore: number
+  plan: ClassroomArchiveProductionCanaryPlan
+  archive: ClassroomArchiveProductionArchiveEvidence
+}): Promise<ClassroomArchiveProductionCanaryFinalEvidence> {
+  const state = await readLifecycleState(args.supabase, args.plan.classroom_id)
+  if (state.phase !== 'hot' || state.teacherId !== args.plan.teacher_id) {
+    throw new Error('Production archive canary did not restore the archived hot classroom')
+  }
+  const retainedArchive = await readArchiveEvidence({
+    supabase: args.supabase,
+    archiveId: args.plan.operation_ids.export,
+    classroomId: args.plan.classroom_id,
+    teacherId: args.plan.teacher_id,
+    restoreOperationId: args.plan.operation_ids.restore,
+    sourceAppCommit: args.plan.source_app_commit,
+    supabaseUrl: args.supabaseUrl,
+    verifyOriginalSourceObjects: true,
+  })
+  if (
+    !retainedArchive ||
+    retainedArchive.artifactSha256 !== args.archive.artifactSha256 ||
+    retainedArchive.manifestSha256 !== args.archive.manifestSha256
+  ) {
+    throw new Error('Production archive canary immutable archive was not retained exactly')
+  }
+
+  const operationsResponse = await args.supabase.from('classroom_archive_operations')
+    .select([
+      'id',
+      'teacher_id',
+      'classroom_id',
+      'operation_type',
+      'status',
+      'request_sha256',
+      'source_revision',
+      'source_schema_migration',
+      'source_app_commit',
+      'archive_id',
+      'retention',
+      'resource_counts',
+      'storage_object_counts',
+      'storage_bucket',
+      'storage_path',
+      'artifact_sha256',
+      'content_sha256',
+      'compressed_byte_size',
+      'uncompressed_byte_size',
+      'target_schema_migration',
+      'adapter_chain',
+      'completed_at',
+      'error_code',
+      'retryable',
+      'verification',
+    ].join(','))
+    .in('id', Object.values(args.plan.operation_ids))
+  if (operationsResponse.error) {
+    throw new Error('Production archive canary operation evidence could not be read')
+  }
+  const operations = z.array(operationRowSchema).parse(operationsResponse.data || [])
+  const expectedTypes = new Map([
+    [args.plan.operation_ids.export, 'export'],
+    [args.plan.operation_ids.compact, 'compact'],
+    [args.plan.operation_ids.restore, 'restore'],
+  ])
+  const requiredVerificationKeys = {
+    export: [
+      'read_back_verified', 'artifact_checksum_verified', 'manifest_verified',
+      'resource_checksums_verified', 'resource_counts_verified',
+      'storage_objects_verified', 'actor_snapshots_verified',
+    ],
+    compact: [
+      'read_back_verified', 'artifact_checksum_verified', 'manifest_verified',
+      'resource_checksums_verified', 'resource_counts_verified',
+      'storage_objects_verified', 'actor_snapshots_verified', 'schema_adapter_verified',
+      'actor_references_resolved', 'source_object_cleanup_staged',
+      'source_revision_verified', 'resource_ownership_verified',
+      'relational_deletion_verified', 'tombstone_verified',
+    ],
+    restore: [
+      'archive_checksum_verified', 'manifest_verified', 'resource_checksums_verified',
+      'resource_counts_verified', 'storage_objects_verified', 'actor_snapshots_verified',
+      'schema_adapter_available', 'restored_storage_objects_verified',
+      'referential_integrity_verified',
+    ],
+  } as const
+  const expectedResourceCounts = Object.fromEntries(
+    args.plan.pre_evidence.resources.map((resource) => [resource.table, resource.row_count]),
+  )
+  const expectedRequestHashes = args.archive.operationRequestSha256
+  if (
+    operations.length !== 3 ||
+    operations.some((operation) => (
+      expectedTypes.get(operation.id) !== operation.operation_type ||
+      operation.teacher_id !== args.plan.teacher_id ||
+      operation.classroom_id !== args.plan.classroom_id ||
+      operation.archive_id !== args.plan.operation_ids.export ||
+      operation.request_sha256 !== expectedRequestHashes[operation.operation_type] ||
+      operation.source_revision !== args.plan.pre_evidence.source_revision ||
+      operation.source_app_commit !== args.plan.source_app_commit ||
+      operation.source_schema_migration !== '082_verified_classroom_archive_exports' ||
+      canonicalJsonStringify(operation.retention) !== canonicalJsonStringify(args.plan.retention) ||
+      canonicalJsonStringify(operation.resource_counts) !== canonicalJsonStringify(expectedResourceCounts) ||
+      canonicalJsonStringify(operation.storage_object_counts) !==
+        canonicalJsonStringify(args.archive.storageObjectCounts) ||
+      operation.storage_bucket !== 'classroom-archives' ||
+      operation.storage_path !== classroomArchiveStoragePath({
+        teacherId: args.plan.teacher_id,
+        classroomId: args.plan.classroom_id,
+        archiveId: args.plan.operation_ids.export,
+      }) ||
+      operation.artifact_sha256 !== args.archive.artifactSha256 ||
+      operation.content_sha256 !== args.archive.contentSha256 ||
+      operation.compressed_byte_size !== args.archive.compressedByteSize ||
+      operation.uncompressed_byte_size !== args.archive.uncompressedByteSize ||
+      (operation.operation_type === 'restore'
+        ? operation.target_schema_migration !== CLASSROOM_ARCHIVE_RESTORE_TARGET_MIGRATION ||
+          canonicalJsonStringify(operation.adapter_chain) !==
+            canonicalJsonStringify(args.archive.restoreAdapterChain)
+        : operation.target_schema_migration !== null || operation.adapter_chain !== null) ||
+      requiredVerificationKeys[operation.operation_type]
+        .some((key) => operation.verification[key] !== true)
+    ))
+  ) {
+    throw new Error('Production archive canary completed operation evidence is invalid')
+  }
+
+  const cleanupResponse = await args.supabase
+    .from('classroom_archive_source_object_cleanup')
+    .select([
+      'storage_bucket',
+      'storage_path',
+      'expected_sha256',
+      'expected_byte_size',
+      'attempt_count',
+      'status',
+      'lease_token',
+      'lease_expires_at',
+      'deleted_at',
+      'ownership_verified',
+      'ownership_verified_at',
+    ].join(','))
+    .eq('operation_id', args.plan.operation_ids.compact)
+  if (cleanupResponse.error) {
+    throw new Error('Production archive canary cleanup evidence could not be read')
+  }
+  const cleanupRows = z.array(cleanupRowSchema).parse(cleanupResponse.data || [])
+  const cleanupDescriptors = cleanupRows.map((row) => ({
+    identity_sha256: classroomArchiveStorageIdentitySha256(row.storage_bucket, row.storage_path),
+    byte_size: row.expected_byte_size,
+    sha256: row.expected_sha256,
+  })).sort((left, right) => left.identity_sha256.localeCompare(right.identity_sha256))
+  if (
+    canonicalJsonStringify(cleanupDescriptors) !==
+      canonicalJsonStringify(args.plan.pre_evidence.storage_objects) ||
+    cleanupRows.some((row) => (
+    row.attempt_count !== 0 ||
+    row.status !== 'pending' ||
+    row.lease_token !== null ||
+    row.lease_expires_at !== null ||
+    row.deleted_at !== null ||
+    row.ownership_verified ||
+    row.ownership_verified_at !== null
+    ))
+  ) {
+    throw new Error('Production archive canary source cleanup did not remain untouched')
+  }
+  const reservationsResponse = await args.supabase
+    .from('classroom_archive_source_object_reservations')
+    .select('operation_id', { count: 'exact', head: true })
+    .eq('operation_id', args.plan.operation_ids.compact)
+  if (reservationsResponse.error || reservationsResponse.count !== 0) {
+    throw new Error('Production archive canary unexpectedly reserved source object ownership')
+  }
+  const [stagingResponse, uploadCleanupResponse] = await Promise.all([
+    args.supabase.from('classroom_archive_restore_staging')
+      .select('operation_id', { count: 'exact', head: true })
+      .eq('operation_id', args.plan.operation_ids.restore),
+    args.supabase.from('classroom_archive_object_upload_cleanup')
+      .select('operation_id', { count: 'exact', head: true })
+      .eq('operation_id', args.plan.operation_ids.restore),
+  ])
+  if (
+    stagingResponse.error || stagingResponse.count !== 0 ||
+    uploadCleanupResponse.error || uploadCleanupResponse.count !== 0
+  ) {
+    throw new Error('Production archive canary restore staging cleanup is incomplete')
+  }
+  const databaseSizeBytesAfter = await readProductionDatabaseSizeBytes(
+    args.plan.expected_project_ref,
+  )
+  if (databaseSizeBytesAfter >= args.plan.database_budget_bytes) {
+    throw new Error('Production archive canary database size reached or exceeded its budget')
+  }
+
+  return {
+    archiveRetained: true,
+    archiveBytesVerified: true,
+    hotClassroomRestored: true,
+    coldTombstoneRemoved: true,
+    operationsCompleted: true,
+    sourceCleanupDeletedCount: 0,
+    sourceCleanupOwnershipVerifiedCount: 0,
+    sourceCleanupAttemptCount: 0,
+    databaseWithinBudget: true,
+    databaseSizeBytesBefore: args.databaseSizeBytesBefore,
+    databaseSizeBytesAfter,
+  }
+}
+
+async function assertPreparePreconditions(args: {
+  supabase: SupabaseClient
+  teacherId: string
+  classroomId: string
+}) {
+  const state = await readLifecycleState(args.supabase, args.classroomId)
+  if (state.phase !== 'hot' || state.teacherId !== args.teacherId) {
+    throw new Error('Production archive canary prepare target is not the approved hot classroom')
+  }
+  const operations = await args.supabase.from('classroom_archive_operations')
+    .select('id', { count: 'exact', head: true })
+    .eq('classroom_id', args.classroomId)
+  if (operations.error || operations.count !== 0) {
+    throw new Error('Production archive canary prepare target already has lifecycle operations')
+  }
+}
+
+async function readAcknowledgement(plan: ClassroomArchiveProductionCanaryPlan): Promise<string> {
+  const expected = classroomArchiveProductionCanaryAcknowledgement(plan)
+  process.stderr.write(`Type the exact acknowledgement to continue:\n${expected}\n> `)
+  const readline = createInterface({ input: process.stdin, output: process.stderr })
+  try {
+    return await readline.question('')
+  } finally {
+    readline.close()
+  }
+}
+
+async function prepare(planPath: string) {
+  const commit = assertCleanCheckout()
+  const expectedProjectRef = projectRefSchema.parse(
+    process.env.CLASSROOM_ARCHIVE_PRODUCTION_CANARY_EXPECTED_PROJECT_REF,
+  )
+  const teacherId = uuidSchema.parse(
+    process.env.CLASSROOM_ARCHIVE_PRODUCTION_CANARY_TEACHER_ID,
+  )
+  const classroomId = uuidSchema.parse(
+    process.env.CLASSROOM_ARCHIVE_PRODUCTION_CANARY_CLASSROOM_ID,
+  )
+  const databaseBudgetBytes = z.coerce.number().int().positive().parse(
+    process.env.CLASSROOM_ARCHIVE_PRODUCTION_CANARY_DATABASE_BUDGET_BYTES,
+  )
+  const { supabase, supabaseUrl } = createProductionClient({ expectedProjectRef })
+  await assertPreparePreconditions({ supabase, teacherId, classroomId })
+  const preEvidence = await readCurrentEvidence({
+    supabase,
+    supabaseUrl,
+    serviceRoleKey: z.string().min(1).parse(process.env.SUPABASE_SECRET_KEY),
+    classroomId,
+  })
+  const databaseSizeBytesBefore = await readProductionDatabaseSizeBytes(expectedProjectRef)
+  if (databaseSizeBytesBefore >= databaseBudgetBytes) {
+    throw new Error('Production archive canary database is already at or above its budget')
+  }
+  const plan = createClassroomArchiveProductionCanaryPlan({
+    approvedRunnerCommit: commit,
+    expectedProjectRef,
+    supabaseUrl,
+    teacherId,
+    classroomId,
+    sourceAppCommit: commit,
+    databaseBudgetBytes,
+    databaseSizeBytesBefore,
+    preEvidence,
+  })
+  await writeImmutablePlan(planPath, plan)
+  process.stdout.write(`${JSON.stringify({
+    status: 'prepared',
+    plan_sha256: plan.plan_sha256,
+    resource_table_count: plan.pre_evidence.resources.length,
+    storage_object_count: plan.pre_evidence.storage_objects.length,
+    evidence_sha256: plan.pre_evidence.evidence_sha256,
+    acknowledgement: classroomArchiveProductionCanaryAcknowledgement(plan),
+  }, null, 2)}\n`)
+}
+
+async function execute(planPath: string) {
+  const plan = await readPlan(planPath)
+  assertCleanCheckout(plan.approved_runner_commit)
+  const acknowledgement = await readAcknowledgement(plan)
+  const { supabase, supabaseUrl } = createProductionClient({
+    expectedProjectRef: plan.expected_project_ref,
+    plan,
+    acknowledgement,
+  })
+  const databaseSizeBytesBefore = await readProductionDatabaseSizeBytes(
+    plan.expected_project_ref,
+  )
+  if (
+    databaseSizeBytesBefore + MINIMUM_DATABASE_SAFETY_MARGIN_BYTES >=
+      plan.database_budget_bytes
+  ) {
+    throw new Error('Production archive canary lacks the minimum database safety margin')
+  }
+  configureCoordinatorGates(plan)
+  const serviceRoleKey = z.string().min(1).parse(process.env.SUPABASE_SECRET_KEY)
+  const archiveReader = () => readArchiveEvidence({
+    supabase,
+    archiveId: plan.operation_ids.export,
+    classroomId: plan.classroom_id,
+    teacherId: plan.teacher_id,
+    restoreOperationId: plan.operation_ids.restore,
+    sourceAppCommit: plan.source_app_commit,
+    supabaseUrl,
+  })
+  const result = await runClassroomArchiveProductionCanary({
+    plan,
+    dependencies: {
+      readState: () => readLifecycleState(supabase, plan.classroom_id),
+      readCurrentEvidence: () => readCurrentEvidence({
+        supabase,
+        supabaseUrl,
+        serviceRoleKey,
+        classroomId: plan.classroom_id,
+      }),
+      readArchiveEvidence: archiveReader,
+      readRestoreCompleted: () => readRestoreCompleted(supabase, plan),
+      exportArchive: () => exportClassroomArchive({
+        supabase,
+        operationId: plan.operation_ids.export,
+        teacherId: plan.teacher_id,
+        classroomId: plan.classroom_id,
+        retention: plan.retention,
+        sourceAppCommit: plan.source_app_commit,
+        supabaseUrl,
+      }),
+      compactArchive: async () => {
+        const archive = await archiveReader()
+        if (!archive) throw new Error('Production archive canary archive is unavailable before compaction')
+        const databaseSize = await readProductionDatabaseSizeBytes(plan.expected_project_ref)
+        const safetyMargin = Math.max(
+          MINIMUM_DATABASE_SAFETY_MARGIN_BYTES,
+          archive.uncompressedByteSize * 4,
+        )
+        if (databaseSize + safetyMargin >= plan.database_budget_bytes) {
+          throw new Error('Production archive canary database safety margin is insufficient')
+        }
+        return compactClassroomArchive({
+          supabase,
+          operationId: plan.operation_ids.compact,
+          teacherId: plan.teacher_id,
+          classroomId: plan.classroom_id,
+          archiveId: plan.operation_ids.export,
+          supabaseUrl,
+        })
+      },
+      restoreArchive: () => restoreClassroomArchive({
+        supabase,
+        operationId: plan.operation_ids.restore,
+        archiveId: plan.operation_ids.export,
+        teacherId: plan.teacher_id,
+        classroomId: plan.classroom_id,
+        databaseBudgetBytes: plan.database_budget_bytes,
+        supabaseUrl,
+      }),
+      verifyFinal: async ({ archive }) => verifyFinalEvidence({
+        supabase,
+        supabaseUrl,
+        databaseSizeBytesBefore,
+        plan,
+        archive,
+      }),
+      recordEvent: createEventRecorder(planPath, plan),
+    },
+  })
+  const archive = await archiveReader()
+  if (!archive) throw new Error('Production archive canary final archive evidence is unavailable')
+  assertClassroomArchiveProductionCanaryEvidenceEqual({
+    expected: plan.pre_evidence,
+    actual: archive.evidence,
+    compareRevision: true,
+  })
+  process.stdout.write(`${JSON.stringify({
+    format: 'pika.classroom-archive-production-canary-result',
+    version: 1,
+    status: 'passed',
+    target_project_ref: plan.expected_project_ref,
+    ...result,
+  }, null, 2)}\n`)
+}
+
+async function main() {
+  const { command, planPath } = parseArguments()
+  if (command === 'prepare') await prepare(planPath)
+  else await execute(planPath)
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : 'Unknown production archive canary failure'
+  process.stderr.write(`Production classroom archive canary failed: ${message}\n`)
+  process.exitCode = 1
+})

--- a/src/lib/server/classroom-archive-inventory.ts
+++ b/src/lib/server/classroom-archive-inventory.ts
@@ -210,7 +210,7 @@ function comparePrimaryKey(left: Record<string, unknown>, right: Record<string, 
   return leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0
 }
 
-async function readClassroomResources(
+export async function readClassroomArchiveResourceGraph(
   reader: ClassroomArchiveInventoryReader,
   classroomId: string,
 ) {
@@ -283,7 +283,7 @@ async function readStableClassroomInventory(
 ) {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const revisionBefore = revisionSchema.parse(await reader.readRevision(classroomId))
-    const resources = await readClassroomResources(reader, classroomId)
+    const resources = await readClassroomArchiveResourceGraph(reader, classroomId)
     const classroomRows = resources.classrooms || []
     if (
       classroomRows.length !== 1 ||

--- a/src/lib/server/classroom-archive-production-canary.ts
+++ b/src/lib/server/classroom-archive-production-canary.ts
@@ -1,0 +1,655 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
+import { canonicalJsonStringify } from '@/lib/server/classroom-archive-format'
+import type { ClassroomArchiveCompactionResult } from '@/lib/server/classroom-archive-compaction'
+import type { ClassroomArchiveExportResult } from '@/lib/server/classroom-archive-operations'
+import type { ClassroomArchiveRestoreResult } from '@/lib/server/classroom-archive-restore-operations'
+import { verifyHostedSupabaseApiOrigin } from '@/lib/server/supabase-target'
+
+export const CLASSROOM_ARCHIVE_PRODUCTION_CANARY_PLAN_VERSION = 1 as const
+export const CLASSROOM_ARCHIVE_PRODUCTION_CANARY_ACK_PREFIX = 'COMPACT_AND_RESTORE'
+
+const uuidSchema = z.string().uuid()
+const projectRefSchema = z.string().regex(/^[a-z0-9]{20}$/)
+const commitSchema = z.string().regex(/^[a-f0-9]{40}$/)
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/)
+
+const cleanupGateNames = [
+  'CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED',
+  'CLASSROOM_ARCHIVE_SOURCE_CLEANUP_TRIGGER_ENABLED',
+  'CLASSROOM_ARCHIVE_STAGING_CLEANUP_ENABLED',
+  'CLASSROOM_ARCHIVE_OBJECT_CLEANUP_ENABLED',
+  'CLASSROOM_GRADEX_CLEANUP_ENABLED',
+  'CLASSROOM_GRADEX_CLEANUP_TRIGGER_ENABLED',
+] as const
+
+const hostedServiceRoleClaimsSchema = z.object({
+  role: z.literal('service_role'),
+  ref: projectRefSchema,
+}).passthrough()
+
+const resourceDigestSchema = z.object({
+  table: z.string().min(1),
+  row_count: z.number().int().nonnegative(),
+  byte_size: z.number().int().nonnegative(),
+  sha256: sha256Schema,
+}).strict()
+
+const storageDigestSchema = z.object({
+  identity_sha256: sha256Schema,
+  byte_size: z.number().int().nonnegative(),
+  sha256: sha256Schema,
+}).strict()
+
+export const classroomArchiveProductionCanaryEvidenceSchema = z.object({
+  source_revision: z.number().int().positive(),
+  resources: z.array(resourceDigestSchema),
+  storage_objects: z.array(storageDigestSchema),
+  evidence_sha256: sha256Schema,
+}).strict().superRefine((evidence, context) => {
+  const computedDigest = createHash('sha256').update(canonicalJsonStringify({
+    resources: [...evidence.resources].sort((left, right) => left.table.localeCompare(right.table)),
+    storage_objects: [...evidence.storage_objects]
+      .sort((left, right) => left.identity_sha256.localeCompare(right.identity_sha256)),
+  })).digest('hex')
+  if (computedDigest !== evidence.evidence_sha256) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Production canary evidence digest does not match its contents',
+      path: ['evidence_sha256'],
+    })
+  }
+  const expectedTables = CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => table).sort()
+  const actualTables = evidence.resources.map(({ table }) => table).sort()
+  if (canonicalJsonStringify(actualTables) !== canonicalJsonStringify(expectedTables)) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Production canary evidence does not cover the exact classroom resource contract',
+      path: ['resources'],
+    })
+  }
+  if (new Set(actualTables).size !== actualTables.length) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Production canary evidence contains duplicate classroom resources',
+      path: ['resources'],
+    })
+  }
+  const identities = evidence.storage_objects.map(({ identity_sha256 }) => identity_sha256)
+  if (new Set(identities).size !== identities.length) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Production canary evidence contains duplicate storage identities',
+      path: ['storage_objects'],
+    })
+  }
+})
+
+const operationIdsSchema = z.object({
+  export: uuidSchema,
+  compact: uuidSchema,
+  restore: uuidSchema,
+}).strict().refine((ids) => new Set(Object.values(ids)).size === 3, {
+  message: 'Production canary operation IDs must be distinct',
+})
+
+const planPayloadSchema = z.object({
+  format: z.literal('pika.classroom-archive-production-canary-plan'),
+  version: z.literal(CLASSROOM_ARCHIVE_PRODUCTION_CANARY_PLAN_VERSION),
+  prepared_at: z.string().datetime({ offset: true }),
+  approved_runner_commit: commitSchema,
+  expected_project_ref: projectRefSchema,
+  supabase_origin: z.string().url(),
+  run_id: uuidSchema,
+  teacher_id: uuidSchema,
+  classroom_id: uuidSchema,
+  operation_ids: operationIdsSchema,
+  source_app_commit: commitSchema,
+  database_budget_bytes: z.number().int().positive(),
+  database_size_bytes_before: z.number().int().positive(),
+  retention: z.object({
+    mode: z.literal('teacher_managed'),
+    delete_after: z.null(),
+  }).strict(),
+  pre_evidence: classroomArchiveProductionCanaryEvidenceSchema,
+}).strict()
+
+export const classroomArchiveProductionCanaryPlanSchema = planPayloadSchema.extend({
+  plan_sha256: sha256Schema,
+}).strict()
+
+export type ClassroomArchiveProductionCanaryEvidence = z.infer<
+  typeof classroomArchiveProductionCanaryEvidenceSchema
+>
+export type ClassroomArchiveProductionCanaryPlan = z.infer<
+  typeof classroomArchiveProductionCanaryPlanSchema
+>
+
+export type ClassroomArchiveProductionCanaryState =
+  | { phase: 'hot'; teacherId: string; archivedAt: string }
+  | { phase: 'cold'; teacherId: string; archiveId: string }
+
+export type ClassroomArchiveProductionArchiveEvidence = {
+  archiveId: string
+  teacherId: string
+  classroomId: string
+  artifactSha256: string
+  contentSha256: string
+  compressedByteSize: number
+  uncompressedByteSize: number
+  manifestSha256: string
+  operationRequestSha256: { export: string; compact: string; restore: string }
+  storageObjectCounts: Record<string, unknown>
+  restoreAdapterChain: string[]
+  evidence: ClassroomArchiveProductionCanaryEvidence
+  restoredEvidence: ClassroomArchiveProductionCanaryEvidence
+}
+
+export type ClassroomArchiveProductionCanaryFinalEvidence = {
+  archiveRetained: true
+  archiveBytesVerified: true
+  hotClassroomRestored: true
+  coldTombstoneRemoved: true
+  operationsCompleted: true
+  sourceCleanupDeletedCount: 0
+  sourceCleanupOwnershipVerifiedCount: 0
+  sourceCleanupAttemptCount: 0
+  databaseWithinBudget: true
+  databaseSizeBytesBefore: number
+  databaseSizeBytesAfter: number
+}
+
+export type ClassroomArchiveProductionCanaryResult = {
+  ok: true
+  runId: string
+  resumedFromCold: boolean
+  exportReplayed: boolean
+  compactionReplayed: boolean
+  restoreReplayed: boolean
+  restoreAttempts: number
+  compressedByteSize: number
+  uncompressedByteSize: number
+  resourceTableCount: number
+  storageObjectCount: number
+  evidenceSha256: string
+  finalEvidence: ClassroomArchiveProductionCanaryFinalEvidence
+}
+
+export type ClassroomArchiveProductionCanaryEvent = {
+  phase: 'preflight' | 'export' | 'compact' | 'restore' | 'verify'
+  status: 'started' | 'completed' | 'reconciled' | 'failed'
+  errorCode?: string
+}
+
+export type ClassroomArchiveProductionCanaryDependencies = {
+  readState(): Promise<ClassroomArchiveProductionCanaryState>
+  readCurrentEvidence(): Promise<ClassroomArchiveProductionCanaryEvidence>
+  readArchiveEvidence(): Promise<ClassroomArchiveProductionArchiveEvidence | null>
+  readRestoreCompleted(): Promise<boolean>
+  exportArchive(): Promise<ClassroomArchiveExportResult>
+  compactArchive(): Promise<ClassroomArchiveCompactionResult>
+  restoreArchive(): Promise<ClassroomArchiveRestoreResult>
+  verifyFinal(args: {
+    archive: ClassroomArchiveProductionArchiveEvidence
+    operationIds: ClassroomArchiveProductionCanaryPlan['operation_ids']
+  }): Promise<ClassroomArchiveProductionCanaryFinalEvidence>
+  recordEvent(event: ClassroomArchiveProductionCanaryEvent): Promise<void>
+}
+
+function sha256(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function decodeJwtClaims(value: string): unknown {
+  const segments = value.split('.')
+  if (segments.length !== 3) return null
+  try {
+    return JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8'))
+  } catch {
+    return null
+  }
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === 'true'
+}
+
+export function deriveClassroomArchiveProductionCanaryOperationId(
+  runId: string,
+  phase: 'export' | 'compact' | 'restore',
+): string {
+  const parsedRunId = uuidSchema.parse(runId)
+  const bytes = createHash('sha256')
+    .update(`pika.classroom-archive-production-canary:v1:${parsedRunId}:${phase}`)
+    .digest()
+    .subarray(0, 16)
+  bytes[6] = (bytes[6] & 0x0f) | 0x50
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = bytes.toString('hex')
+  return uuidSchema.parse([
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join('-'))
+}
+
+export function classroomArchiveProductionCanaryEvidenceDigest(args: {
+  sourceRevision: number
+  resources: Array<z.infer<typeof resourceDigestSchema>>
+  storageObjects: Array<z.infer<typeof storageDigestSchema>>
+}): ClassroomArchiveProductionCanaryEvidence {
+  const payload = {
+    source_revision: z.number().int().positive().parse(args.sourceRevision),
+    resources: z.array(resourceDigestSchema).parse(args.resources)
+      .sort((left, right) => left.table.localeCompare(right.table)),
+    storage_objects: z.array(storageDigestSchema).parse(args.storageObjects)
+      .sort((left, right) => left.identity_sha256.localeCompare(right.identity_sha256)),
+  }
+  return classroomArchiveProductionCanaryEvidenceSchema.parse({
+    ...payload,
+    evidence_sha256: sha256(canonicalJsonStringify({
+      resources: payload.resources,
+      storage_objects: payload.storage_objects,
+    })),
+  })
+}
+
+export function classroomArchiveStorageIdentitySha256(bucket: string, path: string): string {
+  return sha256(`${z.string().min(1).parse(bucket)}\0${z.string().min(1).parse(path)}`)
+}
+
+export function createClassroomArchiveProductionCanaryPlan(args: {
+  preparedAt?: string
+  approvedRunnerCommit: string
+  expectedProjectRef: string
+  supabaseUrl: string
+  runId?: string
+  teacherId: string
+  classroomId: string
+  sourceAppCommit: string
+  databaseBudgetBytes: number
+  databaseSizeBytesBefore: number
+  preEvidence: ClassroomArchiveProductionCanaryEvidence
+}): ClassroomArchiveProductionCanaryPlan {
+  const expectedProjectRef = projectRefSchema.parse(args.expectedProjectRef)
+  const runId = uuidSchema.parse(args.runId || randomUUID())
+  const payload = planPayloadSchema.parse({
+    format: 'pika.classroom-archive-production-canary-plan',
+    version: CLASSROOM_ARCHIVE_PRODUCTION_CANARY_PLAN_VERSION,
+    prepared_at: args.preparedAt || new Date().toISOString(),
+    approved_runner_commit: args.approvedRunnerCommit,
+    expected_project_ref: expectedProjectRef,
+    supabase_origin: verifyHostedSupabaseApiOrigin(args.supabaseUrl, expectedProjectRef),
+    run_id: runId,
+    teacher_id: args.teacherId,
+    classroom_id: args.classroomId,
+    operation_ids: {
+      export: deriveClassroomArchiveProductionCanaryOperationId(runId, 'export'),
+      compact: deriveClassroomArchiveProductionCanaryOperationId(runId, 'compact'),
+      restore: deriveClassroomArchiveProductionCanaryOperationId(runId, 'restore'),
+    },
+    source_app_commit: args.sourceAppCommit,
+    database_budget_bytes: args.databaseBudgetBytes,
+    database_size_bytes_before: args.databaseSizeBytesBefore,
+    retention: { mode: 'teacher_managed', delete_after: null },
+    pre_evidence: args.preEvidence,
+  })
+  return classroomArchiveProductionCanaryPlanSchema.parse({
+    ...payload,
+    plan_sha256: sha256(canonicalJsonStringify(payload)),
+  })
+}
+
+export function verifyClassroomArchiveProductionCanaryPlan(
+  value: unknown,
+): ClassroomArchiveProductionCanaryPlan {
+  const plan = classroomArchiveProductionCanaryPlanSchema.parse(value)
+  const { plan_sha256: digest, ...payload } = plan
+  if (sha256(canonicalJsonStringify(payload)) !== digest) {
+    throw new Error('Production archive canary plan digest does not match its contents')
+  }
+  verifyHostedSupabaseApiOrigin(plan.supabase_origin, plan.expected_project_ref)
+  return plan
+}
+
+export function classroomArchiveProductionCanaryAcknowledgement(
+  plan: ClassroomArchiveProductionCanaryPlan,
+): string {
+  return `${CLASSROOM_ARCHIVE_PRODUCTION_CANARY_ACK_PREFIX} ${plan.expected_project_ref} ${plan.plan_sha256}`
+}
+
+export function assertClassroomArchiveProductionCanaryExecution(args: {
+  plan: ClassroomArchiveProductionCanaryPlan
+  acknowledgement: string
+  supabaseUrl: string | undefined
+  serviceRoleKey: string | undefined
+  environment: NodeJS.ProcessEnv
+}): string {
+  const plan = verifyClassroomArchiveProductionCanaryPlan(args.plan)
+  if (args.acknowledgement.trim() !== classroomArchiveProductionCanaryAcknowledgement(plan)) {
+    throw new Error('Production archive canary target-specific acknowledgement is invalid')
+  }
+  return assertClassroomArchiveProductionCanaryTarget({
+    expectedProjectRef: plan.expected_project_ref,
+    supabaseUrl: args.supabaseUrl,
+    serviceRoleKey: args.serviceRoleKey,
+    environment: args.environment,
+  })
+}
+
+export function assertClassroomArchiveProductionCanaryTarget(args: {
+  expectedProjectRef: string
+  supabaseUrl: string | undefined
+  serviceRoleKey: string | undefined
+  environment: NodeJS.ProcessEnv
+}): string {
+  const expectedProjectRef = projectRefSchema.parse(args.expectedProjectRef)
+  for (const name of cleanupGateNames) {
+    if (isEnabled(args.environment[name])) {
+      throw new Error('Production archive canary requires every cleanup gate to remain disabled')
+    }
+  }
+  const supabaseUrl = verifyHostedSupabaseApiOrigin(
+    z.url().parse(args.supabaseUrl),
+    expectedProjectRef,
+  )
+  const serviceRoleKey = z.string().min(1).parse(args.serviceRoleKey)
+  const claims = hostedServiceRoleClaimsSchema.safeParse(decodeJwtClaims(serviceRoleKey))
+  if (!claims.success || claims.data.ref !== expectedProjectRef) {
+    throw new Error('Production archive canary requires the exact hosted service-role key')
+  }
+  return supabaseUrl
+}
+
+export function assertClassroomArchiveProductionCanaryEvidenceEqual(args: {
+  expected: ClassroomArchiveProductionCanaryEvidence
+  actual: ClassroomArchiveProductionCanaryEvidence
+  compareRevision: boolean
+}) {
+  const expected = classroomArchiveProductionCanaryEvidenceSchema.parse(args.expected)
+  const actual = classroomArchiveProductionCanaryEvidenceSchema.parse(args.actual)
+  if (args.compareRevision && expected.source_revision !== actual.source_revision) {
+    throw new Error('Production archive canary source revision changed after preparation')
+  }
+  if (expected.evidence_sha256 !== actual.evidence_sha256) {
+    throw new Error('Production archive canary exact resource or storage evidence differs')
+  }
+}
+
+function assertStateIdentity(
+  state: ClassroomArchiveProductionCanaryState,
+  plan: ClassroomArchiveProductionCanaryPlan,
+) {
+  if (state.teacherId !== plan.teacher_id) {
+    throw new Error('Production archive canary lifecycle identity does not match the plan')
+  }
+  if (state.phase === 'cold' && state.archiveId !== plan.operation_ids.export) {
+    throw new Error('Production archive canary cold tombstone does not match the plan')
+  }
+}
+
+function assertArchiveIdentity(
+  archive: ClassroomArchiveProductionArchiveEvidence,
+  plan: ClassroomArchiveProductionCanaryPlan,
+) {
+  if (
+    archive.archiveId !== plan.operation_ids.export ||
+    archive.teacherId !== plan.teacher_id ||
+    archive.classroomId !== plan.classroom_id
+  ) {
+    throw new Error('Production archive canary archive identity does not match the plan')
+  }
+  assertClassroomArchiveProductionCanaryEvidenceEqual({
+    expected: plan.pre_evidence,
+    actual: archive.evidence,
+    compareRevision: true,
+  })
+}
+
+function operationFailure(label: string, result: {
+  error_code: string
+  retryable: boolean
+}): Error {
+  return new Error(`${label} failed with ${result.error_code}; retryable=${String(result.retryable)}`)
+}
+
+function sameResourceCounts(
+  counts: Record<string, number>,
+  evidence: ClassroomArchiveProductionCanaryEvidence,
+): boolean {
+  const expected = Object.fromEntries(evidence.resources.map((item) => [item.table, item.row_count]))
+  return canonicalJsonStringify(counts) === canonicalJsonStringify(expected)
+}
+
+export async function runClassroomArchiveProductionCanary(args: {
+  plan: ClassroomArchiveProductionCanaryPlan
+  dependencies: ClassroomArchiveProductionCanaryDependencies
+}): Promise<ClassroomArchiveProductionCanaryResult> {
+  const plan = verifyClassroomArchiveProductionCanaryPlan(args.plan)
+  const { dependencies } = args
+  const readStateWithRetry = async () => {
+    let lastError: unknown
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await dependencies.readState()
+      } catch (error) {
+        lastError = error
+      }
+    }
+    throw lastError
+  }
+  let initialEventError: unknown
+  try {
+    await dependencies.recordEvent({ phase: 'preflight', status: 'started' })
+  } catch (error) {
+    initialEventError = error
+  }
+  const initialState = await readStateWithRetry()
+  assertStateIdentity(initialState, plan)
+  if (initialEventError && initialState.phase !== 'cold') throw initialEventError
+  let coldRecoveryRequired = initialState.phase === 'cold'
+  const recordEvent = async (event: ClassroomArchiveProductionCanaryEvent) => {
+    try {
+      await dependencies.recordEvent(event)
+    } catch (error) {
+      if (!coldRecoveryRequired) throw error
+    }
+  }
+  const resumedFromCold = initialState.phase === 'cold'
+  let exportReplayed = resumedFromCold
+  let compactionReplayed = resumedFromCold
+  const readArchiveWithRetry = async () => {
+    let lastError: unknown
+    const attempts = coldRecoveryRequired ? 3 : 1
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        return await dependencies.readArchiveEvidence()
+      } catch (error) {
+        lastError = error
+      }
+    }
+    throw lastError
+  }
+  let archive = await readArchiveWithRetry()
+
+  if (initialState.phase === 'hot') {
+    const completedArchive = archive !== null && await dependencies.readRestoreCompleted()
+      ? archive
+      : null
+    const currentEvidence = await dependencies.readCurrentEvidence()
+    assertClassroomArchiveProductionCanaryEvidenceEqual({
+      expected: completedArchive?.restoredEvidence || plan.pre_evidence,
+      actual: currentEvidence,
+      compareRevision: true,
+    })
+    if (completedArchive) {
+      await recordEvent({ phase: 'preflight', status: 'reconciled' })
+      await recordEvent({ phase: 'restore', status: 'reconciled' })
+      await recordEvent({ phase: 'verify', status: 'started' })
+      const finalEvidence = await dependencies.verifyFinal({
+        archive: completedArchive,
+        operationIds: plan.operation_ids,
+      })
+      await recordEvent({ phase: 'verify', status: 'completed' })
+      return {
+        ok: true,
+        runId: plan.run_id,
+        resumedFromCold: false,
+        exportReplayed: true,
+        compactionReplayed: true,
+        restoreReplayed: true,
+        restoreAttempts: 0,
+        compressedByteSize: completedArchive.compressedByteSize,
+        uncompressedByteSize: completedArchive.uncompressedByteSize,
+        resourceTableCount: plan.pre_evidence.resources.length,
+        storageObjectCount: plan.pre_evidence.storage_objects.length,
+        evidenceSha256: plan.pre_evidence.evidence_sha256,
+        finalEvidence,
+      }
+    }
+    await recordEvent({ phase: 'preflight', status: 'completed' })
+
+    await recordEvent({ phase: 'export', status: 'started' })
+    const exported = await dependencies.exportArchive()
+    if (exported.operation_id !== plan.operation_ids.export) {
+      throw new Error('Production archive export operation identity does not match the plan')
+    }
+    archive = await dependencies.readArchiveEvidence()
+    if (!exported.ok && !archive) {
+      await recordEvent({
+        phase: 'export', status: 'failed', errorCode: exported.error_code,
+      })
+      throw operationFailure('Production archive export', exported)
+    }
+    if (exported.ok) {
+      if (
+        exported.operation_id !== plan.operation_ids.export ||
+        exported.archive_id !== plan.operation_ids.export ||
+        !sameResourceCounts(exported.resource_counts, plan.pre_evidence)
+      ) {
+        throw new Error('Production archive export evidence does not match the plan')
+      }
+      exportReplayed = exported.replayed
+    }
+    if (!archive) throw new Error('Production archive metadata is unavailable after export')
+    assertArchiveIdentity(archive, plan)
+    await recordEvent({
+      phase: 'export', status: exported.ok ? 'completed' : 'reconciled',
+    })
+
+    await recordEvent({ phase: 'compact', status: 'started' })
+    const compacted = await dependencies.compactArchive()
+    if (compacted.operation_id !== plan.operation_ids.compact) {
+      throw new Error('Production archive compaction operation identity does not match the plan')
+    }
+    let stateAfterCompaction: ClassroomArchiveProductionCanaryState | null = null
+    try {
+      stateAfterCompaction = await readStateWithRetry()
+      assertStateIdentity(stateAfterCompaction, plan)
+      coldRecoveryRequired = stateAfterCompaction.phase === 'cold'
+    } catch {
+      // Compaction may have committed despite an unreadable response. Prioritize restore.
+      coldRecoveryRequired = true
+    }
+    if (!compacted.ok && stateAfterCompaction?.phase !== 'cold' && stateAfterCompaction !== null) {
+      await recordEvent({
+        phase: 'compact', status: 'failed', errorCode: compacted.error_code,
+      })
+      throw operationFailure('Production archive compaction', compacted)
+    }
+    if (compacted.ok) {
+      if (
+        compacted.operation_id !== plan.operation_ids.compact ||
+        compacted.archive_id !== plan.operation_ids.export ||
+        !sameResourceCounts(compacted.resource_counts, plan.pre_evidence)
+      ) {
+        throw new Error('Production archive compaction evidence does not match the plan')
+      }
+      compactionReplayed = compacted.replayed
+      if (stateAfterCompaction?.phase === 'hot' && !compacted.replayed) {
+        throw new Error('Production archive compaction completed without a cold tombstone')
+      }
+    }
+    await recordEvent({
+      phase: 'compact', status: compacted.ok ? 'completed' : 'reconciled',
+    })
+  } else {
+    await recordEvent({ phase: 'preflight', status: 'reconciled' })
+  }
+
+  archive ??= await readArchiveWithRetry()
+  if (!archive) throw new Error('Production archive metadata is unavailable for restore')
+  assertArchiveIdentity(archive, plan)
+
+  await recordEvent({ phase: 'restore', status: 'started' })
+  let restored: ClassroomArchiveRestoreResult | null = null
+  let restoreReconciled = false
+  let restoreAttempts = 0
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    restoreAttempts = attempt
+    restored = await dependencies.restoreArchive()
+    if (restored.operation_id !== plan.operation_ids.restore) {
+      throw new Error('Production archive restore operation identity does not match the plan')
+    }
+    if (restored.ok || !restored.retryable) break
+  }
+  if (!restored || !restored.ok) {
+    const errorCode = restored?.error_code || 'restore_result_missing'
+    const stateAfterRestore = await readStateWithRetry()
+    assertStateIdentity(stateAfterRestore, plan)
+    if (stateAfterRestore.phase !== 'hot') {
+      await recordEvent({ phase: 'restore', status: 'failed', errorCode })
+      if (!restored) throw new Error('Production archive restore did not return a result')
+      throw operationFailure('Production archive restore', restored)
+    }
+    const reconciledEvidence = await dependencies.readCurrentEvidence()
+    assertClassroomArchiveProductionCanaryEvidenceEqual({
+      expected: archive.restoredEvidence,
+      actual: reconciledEvidence,
+      compareRevision: true,
+    })
+    restoreReconciled = true
+    await recordEvent({ phase: 'restore', status: 'reconciled', errorCode })
+  } else {
+    if (
+      restored.operation_id !== plan.operation_ids.restore ||
+      restored.archive_id !== plan.operation_ids.export ||
+      !sameResourceCounts(restored.resource_counts, plan.pre_evidence)
+    ) {
+      throw new Error('Production archive restore evidence does not match the plan')
+    }
+    await recordEvent({ phase: 'restore', status: 'completed' })
+  }
+
+  await recordEvent({ phase: 'verify', status: 'started' })
+  const postEvidence = await dependencies.readCurrentEvidence()
+  assertClassroomArchiveProductionCanaryEvidenceEqual({
+    expected: archive.restoredEvidence,
+    actual: postEvidence,
+    compareRevision: true,
+  })
+  const finalEvidence = await dependencies.verifyFinal({
+    archive,
+    operationIds: plan.operation_ids,
+  })
+  await recordEvent({ phase: 'verify', status: 'completed' })
+
+  return {
+    ok: true,
+    runId: plan.run_id,
+    resumedFromCold,
+    exportReplayed,
+    compactionReplayed,
+    restoreReplayed: restored?.ok ? restored.replayed : restoreReconciled,
+    restoreAttempts,
+    compressedByteSize: archive.compressedByteSize,
+    uncompressedByteSize: archive.uncompressedByteSize,
+    resourceTableCount: plan.pre_evidence.resources.length,
+    storageObjectCount: plan.pre_evidence.storage_objects.length,
+    evidenceSha256: plan.pre_evidence.evidence_sha256,
+    finalEvidence,
+  }
+}

--- a/tests/lib/server/classroom-archive-production-canary.test.ts
+++ b/tests/lib/server/classroom-archive-production-canary.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
+import {
+  assertClassroomArchiveProductionCanaryExecution,
+  classroomArchiveProductionCanaryAcknowledgement,
+  classroomArchiveProductionCanaryEvidenceDigest,
+  createClassroomArchiveProductionCanaryPlan,
+  deriveClassroomArchiveProductionCanaryOperationId,
+  runClassroomArchiveProductionCanary,
+  verifyClassroomArchiveProductionCanaryPlan,
+  type ClassroomArchiveProductionCanaryDependencies,
+  type ClassroomArchiveProductionCanaryEvidence,
+  type ClassroomArchiveProductionCanaryFinalEvidence,
+  type ClassroomArchiveProductionCanaryPlan,
+  type ClassroomArchiveProductionCanaryState,
+} from '@/lib/server/classroom-archive-production-canary'
+
+const PROJECT_REF = 'abcdefghijklmnopqrst'
+const TEACHER_ID = '00000000-0000-4000-8000-000000000001'
+const CLASSROOM_ID = '00000000-0000-4000-8000-000000000002'
+const RUN_ID = '00000000-0000-4000-8000-000000000003'
+const COMMIT = 'a'.repeat(40)
+const SHA = 'b'.repeat(64)
+
+function jwt(payload: Record<string, unknown>): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify(payload)).toString('base64url'),
+    'signature',
+  ].join('.')
+}
+
+function evidence(
+  sourceRevision = 7,
+  resourceSha = SHA,
+): ClassroomArchiveProductionCanaryEvidence {
+  return classroomArchiveProductionCanaryEvidenceDigest({
+    sourceRevision,
+    resources: CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => ({
+      table,
+      row_count: table === 'classrooms' ? 1 : 0,
+      byte_size: table === 'classrooms' ? 123 : 0,
+      sha256: resourceSha,
+    })),
+    storageObjects: [{ identity_sha256: 'c'.repeat(64), byte_size: 5, sha256: SHA }],
+  })
+}
+
+function plan(): ClassroomArchiveProductionCanaryPlan {
+  return createClassroomArchiveProductionCanaryPlan({
+    preparedAt: '2026-07-15T12:00:00.000Z',
+    approvedRunnerCommit: COMMIT,
+    expectedProjectRef: PROJECT_REF,
+    supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    runId: RUN_ID,
+    teacherId: TEACHER_ID,
+    classroomId: CLASSROOM_ID,
+    sourceAppCommit: COMMIT,
+    databaseBudgetBytes: 500_000_000,
+    databaseSizeBytesBefore: 57_000_000,
+    preEvidence: evidence(),
+  })
+}
+
+const finalEvidence: ClassroomArchiveProductionCanaryFinalEvidence = {
+  archiveRetained: true,
+  archiveBytesVerified: true,
+  hotClassroomRestored: true,
+  coldTombstoneRemoved: true,
+  operationsCompleted: true,
+  sourceCleanupDeletedCount: 0,
+  sourceCleanupOwnershipVerifiedCount: 0,
+  sourceCleanupAttemptCount: 0,
+  databaseWithinBudget: true,
+  databaseSizeBytesBefore: 57_000_000,
+  databaseSizeBytesAfter: 58_000_000,
+}
+
+function counts(value: ClassroomArchiveProductionCanaryEvidence) {
+  return Object.fromEntries(value.resources.map((item) => [item.table, item.row_count]))
+}
+
+function dependencies(options: {
+  states?: ClassroomArchiveProductionCanaryState[]
+  initialArchive?: boolean
+  exportFailure?: boolean
+  compactFailure?: boolean
+  retryRestore?: boolean
+  restoreFailure?: boolean
+  initialEvidence?: ClassroomArchiveProductionCanaryEvidence
+  postEvidence?: ClassroomArchiveProductionCanaryEvidence
+  restoredEvidence?: ClassroomArchiveProductionCanaryEvidence
+  journalFailure?: boolean
+  stateFailuresAtCalls?: number[]
+  restoreCompleted?: boolean
+  archiveFailures?: number
+} = {}): ClassroomArchiveProductionCanaryDependencies & {
+  calls: string[]
+  events: Array<{ phase: string; status: string }>
+} {
+  const approvedPlan = plan()
+  const calls: string[] = []
+  const events: Array<{ phase: string; status: string }> = []
+  const stateQueue = [...(options.states || [
+    { phase: 'hot' as const, teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+    { phase: 'cold' as const, teacherId: TEACHER_ID, archiveId: approvedPlan.operation_ids.export },
+  ])]
+  let archiveAvailable = options.initialArchive || false
+  let evidenceReads = 0
+  let restoreCalls = 0
+  let stateCalls = 0
+  let archiveReads = 0
+  const archive = {
+    archiveId: approvedPlan.operation_ids.export,
+    teacherId: TEACHER_ID,
+    classroomId: CLASSROOM_ID,
+    artifactSha256: 'd'.repeat(64),
+    contentSha256: SHA,
+    compressedByteSize: 100,
+    uncompressedByteSize: 500,
+    manifestSha256: SHA,
+    operationRequestSha256: { export: SHA, compact: SHA, restore: SHA },
+    storageObjectCounts: {},
+    restoreAdapterChain: ['classroom-archive-v1-082-to-083'],
+    evidence: approvedPlan.pre_evidence,
+    restoredEvidence: options.restoredEvidence || approvedPlan.pre_evidence,
+  }
+  return {
+    calls,
+    events,
+    readState: vi.fn(async () => {
+      calls.push('state')
+      stateCalls += 1
+      if (options.stateFailuresAtCalls?.includes(stateCalls)) {
+        throw new Error('transient lifecycle read failure')
+      }
+      return stateQueue.shift() || {
+        phase: 'hot' as const,
+        teacherId: TEACHER_ID,
+        archivedAt: '2026-07-01T00:00:00.000Z',
+      }
+    }),
+    readCurrentEvidence: vi.fn(async () => {
+      calls.push('evidence')
+      evidenceReads += 1
+      return evidenceReads > 1 && options.postEvidence
+        ? options.postEvidence
+        : options.initialEvidence || approvedPlan.pre_evidence
+    }),
+    readArchiveEvidence: vi.fn(async () => {
+      calls.push('archive')
+      archiveReads += 1
+      if (archiveReads <= (options.archiveFailures || 0)) {
+        throw new Error('transient archive read failure')
+      }
+      return archiveAvailable ? archive : null
+    }),
+    readRestoreCompleted: vi.fn(async () => options.restoreCompleted || false),
+    exportArchive: vi.fn(async () => {
+      calls.push('export')
+      archiveAvailable = true
+      if (options.exportFailure) {
+        return {
+          ok: false as const,
+          status: 500,
+          operation_id: approvedPlan.operation_ids.export,
+          error_code: 'ambiguous_export',
+          error: 'ambiguous export response',
+          retryable: true,
+        }
+      }
+      return {
+        ok: true as const,
+        status: 201 as const,
+        operation_id: approvedPlan.operation_ids.export,
+        archive_id: approvedPlan.operation_ids.export,
+        replayed: false,
+        artifact_sha256: archive.artifactSha256,
+        content_sha256: SHA,
+        compressed_byte_size: 100,
+        uncompressed_byte_size: 500,
+        resource_counts: counts(approvedPlan.pre_evidence),
+        storage_object_counts: {},
+        verification: {} as never,
+      }
+    }),
+    compactArchive: vi.fn(async () => {
+      calls.push('compact')
+      if (options.compactFailure) {
+        return {
+          ok: false as const,
+          status: 500,
+          operation_id: approvedPlan.operation_ids.compact,
+          error_code: 'ambiguous_compaction',
+          error: 'ambiguous compaction response',
+          retryable: true,
+        }
+      }
+      return {
+        ok: true as const,
+        status: 201 as const,
+        operation_id: approvedPlan.operation_ids.compact,
+        archive_id: approvedPlan.operation_ids.export,
+        replayed: false,
+        resource_counts: counts(approvedPlan.pre_evidence),
+        storage_object_counts: { total_count: 1, total_bytes: 5, by_bucket: {} },
+        cleanup_object_count: 1,
+        cleanup_object_bytes: 5,
+        verification: {} as never,
+      }
+    }),
+    restoreArchive: vi.fn(async () => {
+      calls.push('restore')
+      restoreCalls += 1
+      if (options.restoreFailure || (options.retryRestore && restoreCalls === 1)) {
+        return {
+          ok: false as const,
+          status: 503,
+          operation_id: approvedPlan.operation_ids.restore,
+          error_code: 'restore_busy',
+          error: 'retry restore',
+          retryable: true,
+        }
+      }
+      return {
+        ok: true as const,
+        status: 201 as const,
+        operation_id: approvedPlan.operation_ids.restore,
+        archive_id: approvedPlan.operation_ids.export,
+        replayed: false,
+        resource_counts: counts(approvedPlan.pre_evidence),
+        verification: {} as never,
+      }
+    }),
+    verifyFinal: vi.fn(async () => {
+      calls.push('verify')
+      return finalEvidence
+    }),
+    recordEvent: vi.fn(async (event) => {
+      if (options.journalFailure) throw new Error('journal unavailable')
+      events.push(event)
+    }),
+  }
+}
+
+describe('production classroom archive canary contract', () => {
+  it('derives stable, distinct operation IDs and verifies the immutable plan digest', () => {
+    const ids = ['export', 'compact', 'restore'].map((phase) =>
+      deriveClassroomArchiveProductionCanaryOperationId(
+        RUN_ID,
+        phase as 'export' | 'compact' | 'restore',
+      ),
+    )
+    expect(new Set(ids).size).toBe(3)
+    expect(ids[0]).toBe(deriveClassroomArchiveProductionCanaryOperationId(RUN_ID, 'export'))
+    expect(verifyClassroomArchiveProductionCanaryPlan(plan())).toEqual(plan())
+  })
+
+  it('rejects incomplete evidence and a tampered plan', () => {
+    expect(() => classroomArchiveProductionCanaryEvidenceDigest({
+      sourceRevision: 1,
+      resources: [],
+      storageObjects: [],
+    })).toThrow('exact classroom resource contract')
+    const tampered = { ...plan(), database_budget_bytes: 1 }
+    expect(() => verifyClassroomArchiveProductionCanaryPlan(tampered))
+      .toThrow('plan digest does not match')
+  })
+
+  it('requires exact target acknowledgement, credential, and disabled cleanup gates', () => {
+    const approvedPlan = plan()
+    const valid = {
+      plan: approvedPlan,
+      acknowledgement: classroomArchiveProductionCanaryAcknowledgement(approvedPlan),
+      supabaseUrl: approvedPlan.supabase_origin,
+      serviceRoleKey: jwt({ role: 'service_role', ref: PROJECT_REF }),
+      environment: {} as NodeJS.ProcessEnv,
+    }
+    expect(assertClassroomArchiveProductionCanaryExecution(valid))
+      .toBe(`https://${PROJECT_REF}.supabase.co`)
+    expect(() => assertClassroomArchiveProductionCanaryExecution({
+      ...valid,
+      acknowledgement: 'yes',
+    })).toThrow('acknowledgement')
+    expect(() => assertClassroomArchiveProductionCanaryExecution({
+      ...valid,
+      serviceRoleKey: jwt({ role: 'service_role', ref: 'zyxwvutsrqponmlkjihg' }),
+    })).toThrow('exact hosted service-role key')
+    expect(() => assertClassroomArchiveProductionCanaryExecution({
+      ...valid,
+      environment: { CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED: 'true' },
+    })).toThrow('cleanup gate')
+  })
+})
+
+describe('production classroom archive canary orchestration', () => {
+  it('exports, compacts, restores, and verifies exact evidence', async () => {
+    const deps = dependencies()
+    const result = await runClassroomArchiveProductionCanary({ plan: plan(), dependencies: deps })
+    expect(result).toMatchObject({
+      ok: true,
+      resumedFromCold: false,
+      restoreAttempts: 1,
+      resourceTableCount: CLASSROOM_RELATIONAL_RESOURCES.length,
+      storageObjectCount: 1,
+    })
+    expect(deps.calls).toEqual([
+      'state', 'archive', 'evidence', 'export', 'archive', 'compact', 'state',
+      'restore', 'evidence', 'verify',
+    ])
+  })
+
+  it('resumes a cold canary without rerunning export or compaction', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      initialArchive: true,
+      states: [{
+        phase: 'cold',
+        teacherId: TEACHER_ID,
+        archiveId: approvedPlan.operation_ids.export,
+      }],
+    })
+    const result = await runClassroomArchiveProductionCanary({ plan: approvedPlan, dependencies: deps })
+    expect(result.resumedFromCold).toBe(true)
+    expect(deps.calls).not.toContain('export')
+    expect(deps.calls).not.toContain('compact')
+    expect(deps.calls).toContain('restore')
+  })
+
+  it('does not let journal failure prevent restore once durable state is cold', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      initialArchive: true,
+      journalFailure: true,
+      states: [{
+        phase: 'cold',
+        teacherId: TEACHER_ID,
+        archiveId: approvedPlan.operation_ids.export,
+      }],
+    })
+    await expect(runClassroomArchiveProductionCanary({ plan: approvedPlan, dependencies: deps }))
+      .resolves.toMatchObject({ ok: true, resumedFromCold: true })
+    expect(deps.calls).toContain('restore')
+  })
+
+  it('retries archive evidence before restoring a cold classroom', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      initialArchive: true,
+      archiveFailures: 2,
+      states: [{
+        phase: 'cold',
+        teacherId: TEACHER_ID,
+        archiveId: approvedPlan.operation_ids.export,
+      }],
+    })
+    await expect(runClassroomArchiveProductionCanary({ plan: approvedPlan, dependencies: deps }))
+      .resolves.toMatchObject({ ok: true, resumedFromCold: true })
+    expect(deps.calls.filter((call) => call === 'archive')).toHaveLength(3)
+  })
+
+  it('prioritizes restore when state reconciliation is transiently unreadable after compaction', async () => {
+    const deps = dependencies({ stateFailuresAtCalls: [2, 3, 4] })
+    await expect(runClassroomArchiveProductionCanary({ plan: plan(), dependencies: deps }))
+      .resolves.toMatchObject({ ok: true })
+    expect(deps.calls).toContain('restore')
+  })
+
+  it('reconciles ambiguous export and compaction responses from durable evidence', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      exportFailure: true,
+      compactFailure: true,
+      states: [
+        { phase: 'hot', teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+        { phase: 'cold', teacherId: TEACHER_ID, archiveId: approvedPlan.operation_ids.export },
+      ],
+    })
+    await expect(runClassroomArchiveProductionCanary({ plan: approvedPlan, dependencies: deps }))
+      .resolves.toMatchObject({ ok: true })
+    expect(deps.events).toContainEqual({ phase: 'export', status: 'reconciled' })
+    expect(deps.events).toContainEqual({ phase: 'compact', status: 'reconciled' })
+  })
+
+  it('retries restore with the same planned operation and rejects post-restore drift', async () => {
+    const retrying = dependencies({ retryRestore: true })
+    const result = await runClassroomArchiveProductionCanary({ plan: plan(), dependencies: retrying })
+    expect(result.restoreAttempts).toBe(2)
+    expect(retrying.calls.filter((call) => call === 'restore')).toHaveLength(2)
+
+    const changed = evidence(7, 'e'.repeat(64))
+    const drifting = dependencies({ postEvidence: changed })
+    await expect(runClassroomArchiveProductionCanary({ plan: plan(), dependencies: drifting }))
+      .rejects.toThrow('exact resource or storage evidence differs')
+  })
+
+  it('reconciles an ambiguous restore response only from exact durable hot state', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      restoreFailure: true,
+      states: [
+        { phase: 'hot', teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+        { phase: 'cold', teacherId: TEACHER_ID, archiveId: approvedPlan.operation_ids.export },
+        { phase: 'hot', teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+      ],
+    })
+    const result = await runClassroomArchiveProductionCanary({
+      plan: approvedPlan,
+      dependencies: deps,
+    })
+    expect(result).toMatchObject({ ok: true, restoreReplayed: true, restoreAttempts: 3 })
+    expect(deps.events).toContainEqual({
+      phase: 'restore',
+      status: 'reconciled',
+      errorCode: 'restore_busy',
+    })
+  })
+
+  it('rejects an already restored hot resume with a mismatched source revision', async () => {
+    const restoredEvidence = evidence(99)
+    const deps = dependencies({
+      initialArchive: true,
+      initialEvidence: restoredEvidence,
+      postEvidence: restoredEvidence,
+    })
+    await expect(runClassroomArchiveProductionCanary({ plan: plan(), dependencies: deps }))
+      .rejects.toThrow('source revision changed')
+  })
+
+  it('compares post-restore evidence to the deterministic rewritten storage projection', async () => {
+    const restoredEvidence = evidence(7, 'f'.repeat(64))
+    const deps = dependencies({ restoredEvidence, postEvidence: restoredEvidence })
+    await expect(runClassroomArchiveProductionCanary({ plan: plan(), dependencies: deps }))
+      .resolves.toMatchObject({ ok: true })
+  })
+
+  it('finalizes a hot resume after restore without replaying lifecycle mutations', async () => {
+    const restoredEvidence = evidence(7, 'f'.repeat(64))
+    const deps = dependencies({
+      initialArchive: true,
+      initialEvidence: restoredEvidence,
+      restoredEvidence,
+      restoreCompleted: true,
+    })
+    const result = await runClassroomArchiveProductionCanary({ plan: plan(), dependencies: deps })
+    expect(result).toMatchObject({ ok: true, restoreReplayed: true, restoreAttempts: 0 })
+    expect(deps.calls).not.toContain('export')
+    expect(deps.calls).not.toContain('compact')
+    expect(deps.calls).not.toContain('restore')
+    expect(deps.calls).toContain('verify')
+  })
+})


### PR DESCRIPTION
## Summary
- add immutable prepare/execute/resume runner for one named hosted classroom archive round trip
- prove exact 42-resource, original/restored object, manifest, operation, cleanup, staging, and database-budget evidence
- keep all source and Gradex cleanup gates disabled and add crash/ambiguity recovery coverage

## Validation
- pnpm test (363 files, 3,329 tests)
- pnpm build
- pnpm exec tsc --noEmit
- pnpm db:types:check
- pnpm lint
- pnpm check:architecture
- Pika audit
- repeated independent review/fix loops; final review clean

No production mutation was executed by this PR.