### PR TITLE
Accept pnpm separator in archive canary CLI

### DIFF
--- a/scripts/run-classroom-archive-production-canary.ts
+++ b/scripts/run-classroom-archive-production-canary.ts
@@ -21,6 +21,7 @@ import {
   classroomArchiveProductionCanaryEvidenceDigest,
   classroomArchiveStorageIdentitySha256,
   createClassroomArchiveProductionCanaryPlan,
+  normalizeClassroomArchiveProductionCanaryCliArguments,
   runClassroomArchiveProductionCanary,
   verifyClassroomArchiveProductionCanaryPlan,
   type ClassroomArchiveProductionArchiveEvidence,
@@ -195,12 +196,13 @@ function assertCleanCheckout(expectedCommit?: string) {
 }
 
 function parseArguments() {
-  const command = commandSchema.parse(process.argv[2])
-  const planIndex = process.argv.indexOf('--plan')
-  if (planIndex < 0 || !process.argv[planIndex + 1]) {
+  const args = normalizeClassroomArchiveProductionCanaryCliArguments(process.argv.slice(2))
+  const command = commandSchema.parse(args[0])
+  const planIndex = args.indexOf('--plan')
+  if (planIndex < 0 || !args[planIndex + 1]) {
     throw new Error('--plan is required')
   }
-  return { command, planPath: planFileSchema.parse(process.argv[planIndex + 1]) }
+  return { command, planPath: planFileSchema.parse(args[planIndex + 1]) }
 }
 
 async function writeImmutablePlan(path: string, plan: ClassroomArchiveProductionCanaryPlan) {

--- a/src/lib/server/classroom-archive-production-canary.ts
+++ b/src/lib/server/classroom-archive-production-canary.ts
@@ -10,6 +10,12 @@ import { verifyHostedSupabaseApiOrigin } from '@/lib/server/supabase-target'
 export const CLASSROOM_ARCHIVE_PRODUCTION_CANARY_PLAN_VERSION = 1 as const
 export const CLASSROOM_ARCHIVE_PRODUCTION_CANARY_ACK_PREFIX = 'COMPACT_AND_RESTORE'
 
+export function normalizeClassroomArchiveProductionCanaryCliArguments(
+  args: string[],
+): string[] {
+  return args[0] === '--' ? args.slice(1) : args
+}
+
 const uuidSchema = z.string().uuid()
 const projectRefSchema = z.string().regex(/^[a-z0-9]{20}$/)
 const commitSchema = z.string().regex(/^[a-f0-9]{40}$/)

--- a/tests/lib/server/classroom-archive-production-canary.test.ts
+++ b/tests/lib/server/classroom-archive-production-canary.test.ts
@@ -6,6 +6,7 @@ import {
   classroomArchiveProductionCanaryEvidenceDigest,
   createClassroomArchiveProductionCanaryPlan,
   deriveClassroomArchiveProductionCanaryOperationId,
+  normalizeClassroomArchiveProductionCanaryCliArguments,
   runClassroomArchiveProductionCanary,
   verifyClassroomArchiveProductionCanaryPlan,
   type ClassroomArchiveProductionCanaryDependencies,
@@ -244,6 +245,12 @@ function dependencies(options: {
 }
 
 describe('production classroom archive canary contract', () => {
+  it('accepts pnpm argument forwarding with or without its separator', () => {
+    const args = ['prepare', '--plan', '/private/plan.json']
+    expect(normalizeClassroomArchiveProductionCanaryCliArguments(args)).toEqual(args)
+    expect(normalizeClassroomArchiveProductionCanaryCliArguments(['--', ...args])).toEqual(args)
+  })
+
   it('derives stable, distinct operation IDs and verifies the immutable plan digest', () => {
     const ids = ['export', 'compact', 'restore'].map((phase) =>
       deriveClassroomArchiveProductionCanaryOperationId(


### PR DESCRIPTION
Fix the documented production canary command so pnpm's forwarded separator is normalized before strict command parsing. Adds a regression for both invocation forms. No production mutation occurred.\n\nValidation: focused canary suite, TypeScript, lint, Pika audit.