### PR TITLE
Harden production archive canary recovery

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13673,3 +13673,17 @@
 
 **Validation:**
 - CI `Test & Build` on the PR (self-validating workflow change)
+
+## 2026-07-10 — Repo cleanup and /repo-tidy skill
+
+**Completed:**
+- Deleted 101 stale remote branches (95 merged/closed-PR + 6 from closing stalled PRs) and ~140 local branches; pruned phantom `origin/pr/672` ref.
+- Removed 20 stale worktrees and 2 orphan directories; tagged 9 scratch-branch tips as `rescue/*` (local-only) before deleting.
+- Closed stalled PRs #298, #323, #328, #341, #568, #739. Rescued uncommitted work from an unattended worktree into PR #838.
+- Enabled `delete_branch_on_merge` on the repo so merged PR branches self-clean.
+- Added `scripts/repo-tidy.sh` (read-only hygiene report) plus `/repo-tidy` command in `.claude/commands/` and `.codex/prompts/`, and documented it in `docs/dev-workflow.md`.
+
+**Validation:**
+- `bash scripts/repo-tidy.sh` (clean run against the tidied repo)
+- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
+- `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,20 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-10 — Repo cleanup and /repo-tidy skill
-
-**Completed:**
-- Deleted 101 stale remote branches (95 merged/closed-PR + 6 from closing stalled PRs) and ~140 local branches; pruned phantom `origin/pr/672` ref.
-- Removed 20 stale worktrees and 2 orphan directories; tagged 9 scratch-branch tips as `rescue/*` (local-only) before deleting.
-- Closed stalled PRs #298, #323, #328, #341, #568, #739. Rescued uncommitted work from an unattended worktree into PR #838.
-- Enabled `delete_branch_on_merge` on the repo so merged PR branches self-clean.
-- Added `scripts/repo-tidy.sh` (read-only hygiene report) plus `/repo-tidy` command in `.claude/commands/` and `.codex/prompts/`, and documented it in `docs/dev-workflow.md`.
-
-**Validation:**
-- `bash scripts/repo-tidy.sh` (clean run against the tidied repo)
-- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
-- `pnpm lint`
-
 ## 2026-07-10 — Issue backlog triage + CONTRIBUTING "Finding work" section
 
 **Completed:**
@@ -789,3 +775,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm check:architecture` (599 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
+
+## 2026-07-15 — Production archive canary retry and recovery hardening
+
+**Completed:**
+- Hardened restore storage read-back, unexpected transport failures, durable failure recording, and terminal best-effort cleanup so retries retain the fixed operation ID without deleting reused objects.
+- Added an independent archive-to-restored evidence oracle covering all resource rows, nested storage references, canonical public URLs, object identity, byte size, and SHA-256 bindings; the production canary no longer verifies restore output from its own restore plan.
+- Made the canary reconcile thrown restore calls against durable hot/cold state and retry the fixed operation ID up to three times.
+- Added migration 097 to preserve concurrent retryable restore failures and safely rearm exact expired requests. Expiry recovery now fences active cleanup leases, rolls back transient rearm state when delegated begin fails, and recovers a naturally expired snapshot in one call.
+- Expanded the database contract drill for same-ID finalization races, active cleanup leases, delegated-failure rollback, and expiry recovery. Completed repeated independent review/fix loops covering restore safety, equality evidence, SQL concurrency, privilege boundaries, and cleanup ownership.
+- No production canary, source cleanup, Gradex cleanup, or migration application was performed.
+
+**Deployment obligation:**
+- Apply migration 097 before deploying or running the production canary.
+- Keep source cleanup and Gradex cleanup disabled. Prepare a fresh named canary plan after production is on the reviewed commit; do not reuse the obsolete local plan.
+
+**Validation:**
+- Focused archive restore/canary/migration suites (4 files / 37 tests)
+- `pnpm vitest run` (364 files / 3,345 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- Bash syntax validation for the restore database contract drill
+- Pika pre-commit audit
+- `git diff --check`
+- `pnpm db:types:check` intentionally blocked because local database history remains at 096 and AI did not apply migration 097

--- a/scripts/check-classroom-archive-restore-database.sh
+++ b/scripts/check-classroom-archive-restore-database.sh
@@ -451,20 +451,37 @@ begin
   end if;
 
   update public.classroom_archive_operations
-  set snapshot_expires_at = clock_timestamp() - interval '1 second'
+  set status = 'failed', error_code = 'restore_transport_failure', retryable = true
   where id = v_restore_id;
+  v_result := public.complete_classroom_archive_restore(
+    v_restore_id,
+    v_teacher_id,
+    '{}'::jsonb
+  );
+  if coalesce((v_result->>'retryable')::boolean, false) is not true
+    or v_result->>'error_code' <> 'restore_transport_failure'
+  then
+    raise exception 'Concurrent retryable restore failure became terminal: %', v_result;
+  end if;
+  if not exists (
+    select 1 from public.classroom_archive_operations
+    where id = v_restore_id and status = 'failed' and retryable is true
+  ) then
+    raise exception 'Concurrent finalization overwrote retryable restore state';
+  end if;
+
   v_result := public.begin_classroom_archive_restore(
-    v_concurrent_id,
+    v_restore_id,
     v_teacher_id,
     v_classroom_id,
     v_archive_id,
-    repeat('f', 64),
+    repeat('e', 64),
     '083_resumable_classroom_archive_restore',
     '["classroom-archive-v1-082-to-083"]'::jsonb,
     v_counts,
     jsonb_build_array(jsonb_build_object(
       'storage_bucket', 'assignment-artifacts',
-      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_concurrent_id, repeat('a', 64), repeat('c', 64)),
+      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_restore_id, repeat('a', 64), repeat('c', 64)),
       'expected_sha256', repeat('c', 64),
       'expected_byte_size', 10
     )),
@@ -473,22 +490,203 @@ begin
   if coalesce((v_result->>'ok')::boolean, false) is not true
     or v_result->>'operation_status' <> 'snapshot_ready'
   then
-    raise exception 'Expired restore operation still blocked a replacement: %', v_result;
+    raise exception 'Retryable restore operation did not replay: %', v_result;
   end if;
-  if not public.fail_classroom_archive_restore(
-    v_concurrent_id,
+
+  if not public.stage_classroom_archive_object_upload(
+    v_restore_id,
     v_teacher_id,
-    'restore_canary_replacement_complete',
-    false
+    'assignment-artifacts',
+    format(
+      'restores/%s/%s/%s-%s',
+      v_classroom_id,
+      v_restore_id,
+      repeat('a', 64),
+      repeat('c', 64)
+    ),
+    repeat('c', 64),
+    10
   ) then
-    raise exception 'Replacement restore operation could not be closed';
+    raise exception 'Expiry recovery upload intent could not be staged';
   end if;
   update public.classroom_archive_operations
-  set status = 'snapshot_ready',
-      error_code = null,
-      retryable = null,
-      snapshot_expires_at = clock_timestamp() + interval '24 hours'
+  set snapshot_expires_at = now() - interval '1 second'
   where id = v_restore_id;
+  perform public.cleanup_expired_classroom_archive_snapshots();
+  if not exists (
+    select 1 from public.classroom_archive_operations
+    where id = v_restore_id
+      and status = 'failed'
+      and retryable is false
+      and error_code = 'archive_snapshot_expired'
+  ) then
+    raise exception 'Restore expiry did not become durable';
+  end if;
+  if not exists (
+    select 1 from public.classroom_archive_object_upload_cleanup
+    where operation_id = v_restore_id and status = 'pending'
+  ) then
+    raise exception 'Restore expiry did not preserve cleanup authority';
+  end if;
+
+  update public.classroom_archive_object_upload_cleanup
+  set
+    status = 'processing',
+    lease_token = '88000000-0000-4000-8000-000000000008'::uuid,
+    lease_expires_at = clock_timestamp() + interval '5 minutes'
+  where operation_id = v_restore_id;
+
+  v_result := public.begin_classroom_archive_restore(
+    v_restore_id,
+    v_teacher_id,
+    v_classroom_id,
+    v_archive_id,
+    repeat('e', 64),
+    '083_resumable_classroom_archive_restore',
+    '["classroom-archive-v1-082-to-083"]'::jsonb,
+    v_counts,
+    jsonb_build_array(jsonb_build_object(
+      'storage_bucket', 'assignment-artifacts',
+      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_restore_id, repeat('a', 64), repeat('c', 64)),
+      'expected_sha256', repeat('c', 64),
+      'expected_byte_size', 10
+    )),
+    2147483648
+  );
+  if v_result->>'error_code' <> 'restore_cleanup_in_progress'
+    or coalesce((v_result->>'retryable')::boolean, false) is not true
+  then
+    raise exception 'Expired restore ignored an active cleanup lease: %', v_result;
+  end if;
+  if not exists (
+    select 1 from public.classroom_archive_operations
+    where id = v_restore_id
+      and status = 'failed'
+      and retryable is false
+      and error_code = 'archive_snapshot_expired'
+  ) or not exists (
+    select 1 from public.classroom_archive_object_upload_cleanup
+    where operation_id = v_restore_id and status = 'processing'
+  ) then
+    raise exception 'Cleanup lease rejection changed durable expiry state';
+  end if;
+
+  update public.classroom_archive_object_upload_cleanup
+  set status = 'pending', lease_token = null, lease_expires_at = null
+  where operation_id = v_restore_id;
+
+  v_result := public.begin_classroom_archive_restore(
+    v_restore_id,
+    v_teacher_id,
+    v_classroom_id,
+    v_archive_id,
+    repeat('e', 64),
+    '083_resumable_classroom_archive_restore',
+    '["classroom-archive-v1-082-to-083"]'::jsonb,
+    v_counts,
+    jsonb_build_array(jsonb_build_object(
+      'storage_bucket', 'assignment-artifacts',
+      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_restore_id, repeat('a', 64), repeat('c', 64)),
+      'expected_sha256', repeat('c', 64),
+      'expected_byte_size', 10
+    )),
+    1
+  );
+  if v_result->>'error_code' <> 'insufficient_database_headroom' then
+    raise exception 'Expired restore headroom rejection was not preserved: %', v_result;
+  end if;
+  if not exists (
+    select 1 from public.classroom_archive_operations
+    where id = v_restore_id
+      and status = 'failed'
+      and retryable is false
+      and error_code = 'archive_snapshot_expired'
+  ) or not exists (
+    select 1 from public.classroom_archive_object_upload_cleanup
+    where operation_id = v_restore_id and status = 'pending'
+  ) then
+    raise exception 'Rejected restore rearm committed transient state';
+  end if;
+
+  v_result := public.begin_classroom_archive_restore(
+    v_restore_id,
+    v_teacher_id,
+    v_classroom_id,
+    v_archive_id,
+    repeat('e', 64),
+    '083_resumable_classroom_archive_restore',
+    '["classroom-archive-v1-082-to-083"]'::jsonb,
+    v_counts,
+    jsonb_build_array(jsonb_build_object(
+      'storage_bucket', 'assignment-artifacts',
+      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_restore_id, repeat('a', 64), repeat('c', 64)),
+      'expected_sha256', repeat('c', 64),
+      'expected_byte_size', 10
+    )),
+    2147483648
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or v_result->>'operation_status' <> 'snapshot_ready'
+    or coalesce((v_result->>'replayed')::boolean, false) is not true
+  then
+    raise exception 'Expired same-id restore operation did not rearm: %', v_result;
+  end if;
+  if exists (
+    select 1 from public.classroom_archive_object_upload_cleanup
+    where operation_id = v_restore_id
+  ) then
+    raise exception 'Expired restore rearm retained stale upload cleanup state';
+  end if;
+
+  if not public.stage_classroom_archive_object_upload(
+    v_restore_id,
+    v_teacher_id,
+    'assignment-artifacts',
+    format(
+      'restores/%s/%s/%s-%s',
+      v_classroom_id,
+      v_restore_id,
+      repeat('a', 64),
+      repeat('c', 64)
+    ),
+    repeat('c', 64),
+    10
+  ) then
+    raise exception 'Natural expiry upload intent could not be staged';
+  end if;
+  update public.classroom_archive_operations
+  set snapshot_expires_at = now() - interval '1 second'
+  where id = v_restore_id;
+
+  v_result := public.begin_classroom_archive_restore(
+    v_restore_id,
+    v_teacher_id,
+    v_classroom_id,
+    v_archive_id,
+    repeat('e', 64),
+    '083_resumable_classroom_archive_restore',
+    '["classroom-archive-v1-082-to-083"]'::jsonb,
+    v_counts,
+    jsonb_build_array(jsonb_build_object(
+      'storage_bucket', 'assignment-artifacts',
+      'storage_path', format('restores/%s/%s/%s-%s', v_classroom_id, v_restore_id, repeat('a', 64), repeat('c', 64)),
+      'expected_sha256', repeat('c', 64),
+      'expected_byte_size', 10
+    )),
+    2147483648
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or v_result->>'operation_status' <> 'snapshot_ready'
+    or coalesce((v_result->>'replayed')::boolean, false) is not true
+  then
+    raise exception 'Natural restore expiry did not recover in one call: %', v_result;
+  end if;
+  if exists (
+    select 1 from public.classroom_archive_object_upload_cleanup
+    where operation_id = v_restore_id
+  ) then
+    raise exception 'Natural expiry recovery retained stale cleanup state';
+  end if;
 
   select jsonb_agg(row_data order by row_id) into v_rows
   from expected_restore_rows where table_name = 'classrooms';

--- a/scripts/run-classroom-archive-production-canary.ts
+++ b/scripts/run-classroom-archive-production-canary.ts
@@ -21,6 +21,8 @@ import {
   classroomArchiveProductionCanaryEvidenceDigest,
   classroomArchiveStorageIdentitySha256,
   createClassroomArchiveProductionCanaryPlan,
+  createClassroomArchiveProductionCanaryNormalizedEvidence,
+  createClassroomArchiveProductionCanaryVerifiedArchiveProjection,
   normalizeClassroomArchiveProductionCanaryCliArguments,
   runClassroomArchiveProductionCanary,
   verifyClassroomArchiveProductionCanaryPlan,
@@ -30,6 +32,7 @@ import {
   type ClassroomArchiveProductionCanaryFinalEvidence,
   type ClassroomArchiveProductionCanaryPlan,
   type ClassroomArchiveProductionCanaryState,
+  type ClassroomArchiveProductionCanaryStorageMapping,
 } from '@/lib/server/classroom-archive-production-canary'
 import { compactClassroomArchive } from '@/lib/server/classroom-archive-compaction'
 import {
@@ -414,9 +417,9 @@ async function mapWithConcurrency<T, R>(
 async function readCurrentEvidence(args: {
   supabase: SupabaseClient
   supabaseUrl: string
-  databaseSizeBytesBefore: number
   serviceRoleKey: string
   classroomId: string
+  storageMappings?: ClassroomArchiveProductionCanaryStorageMapping[]
 }): Promise<ClassroomArchiveProductionCanaryEvidence> {
   const reader = createSupabaseClassroomArchiveInventoryReader({
     supabase: args.supabase,
@@ -443,18 +446,29 @@ async function readCurrentEvidence(args: {
       }
     })
     const references = discoverClassroomStorageReferences(resources, args.supabaseUrl)
-    const storageDigests = await mapWithConcurrency(references, 4, async (reference) => {
+    const restoredIdentities = args.storageMappings
+      ? new Map(args.storageMappings.map((mapping) => [
+          `${mapping.bucket}\0${mapping.restorePath}`,
+          mapping.sourcePath,
+        ]))
+      : null
+    if (restoredIdentities && references.length !== args.storageMappings?.length) {
+      throw new Error('Production archive canary restored storage reference count differs')
+    }
+    const storageObjects = await mapWithConcurrency(references, 4, async (reference) => {
       const bytes = await downloadExactStorageBytes(
         args.supabase,
         reference.bucket,
         reference.path,
       )
+      const sourcePath = restoredIdentities?.get(`${reference.bucket}\0${reference.path}`)
+      if (restoredIdentities && !sourcePath) {
+        throw new Error('Production archive canary restored storage reference is unknown')
+      }
       return {
-        identity_sha256: classroomArchiveStorageIdentitySha256(
-          reference.bucket,
-          reference.path,
-        ),
-        byte_size: bytes.byteLength,
+        bucket: reference.bucket,
+        path: reference.path,
+        byteSize: bytes.byteLength,
         sha256: sha256Bytes(bytes),
       }
     })
@@ -462,10 +476,27 @@ async function readCurrentEvidence(args: {
       await reader.readRevision(args.classroomId),
     )
     if (revisionBefore !== revisionAfter) continue
+    if (args.storageMappings) {
+      return createClassroomArchiveProductionCanaryNormalizedEvidence({
+        sourceRevision: revisionAfter,
+        resources,
+        storageObjects,
+        storageMappings: args.storageMappings,
+        storagePathKind: 'restored',
+        supabaseUrl: args.supabaseUrl,
+      })
+    }
     return classroomArchiveProductionCanaryEvidenceDigest({
       sourceRevision: revisionAfter,
       resources: resourceDigests,
-      storageObjects: storageDigests,
+      storageObjects: storageObjects.map((object) => ({
+        identity_sha256: classroomArchiveStorageIdentitySha256(
+          object.bucket,
+          object.path,
+        ),
+        byte_size: object.byteSize,
+        sha256: object.sha256,
+      })),
     })
   }
   throw new Error('Production archive canary target changed during exact evidence capture')
@@ -615,27 +646,19 @@ async function readArchiveEvidence(args: {
       role: actor.role,
     })),
   })
-  const restoredEvidence = classroomArchiveProductionCanaryEvidenceDigest({
-    sourceRevision: metadata.source_revision,
-    resources: CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => {
-      const rows = restorePlan.resources[table] || []
-      const resource = resourceBytes(rows)
-      return {
-        table,
-        row_count: rows.length,
-        byte_size: resource.byteLength,
-        sha256: sha256Bytes(resource),
-      }
-    }),
-    storageObjects: restorePlan.storageObjects.map((object) => ({
-      identity_sha256: classroomArchiveStorageIdentitySha256(
-        object.bucket,
-        object.restorePath,
-      ),
-      byte_size: object.bytes.byteLength,
-      sha256: object.sha256,
-    })),
-  })
+  const plannedStoragePaths = restorePlan.storageObjects.map((object) => ({
+    bucket: object.bucket,
+    sourcePath: object.sourcePath,
+    restorePath: object.restorePath,
+  }))
+  const { restoredStorageMappings, restoredEvidence } =
+    createClassroomArchiveProductionCanaryVerifiedArchiveProjection({
+      verified,
+      sourceRevision: metadata.source_revision,
+      restoreOperationId: args.restoreOperationId,
+      supabaseUrl: args.supabaseUrl,
+      plannedStorageMappings: plannedStoragePaths,
+    })
   const restoredStorageDescriptors = restorePlan.storageObjects.map((object) => ({
     storage_bucket: object.bucket,
     storage_path: object.restorePath,
@@ -678,6 +701,7 @@ async function readArchiveEvidence(args: {
     },
     storageObjectCounts: metadata.storage_object_counts,
     restoreAdapterChain: restorePlan.adapterChain,
+    restoredStorageMappings,
     evidence,
     restoredEvidence,
   }
@@ -1030,6 +1054,13 @@ async function execute(planPath: string) {
         supabaseUrl,
         serviceRoleKey,
         classroomId: plan.classroom_id,
+      }),
+      readRestoredEvidence: (archive) => readCurrentEvidence({
+        supabase,
+        supabaseUrl,
+        serviceRoleKey,
+        classroomId: plan.classroom_id,
+        storageMappings: archive.restoredStorageMappings,
       }),
       readArchiveEvidence: archiveReader,
       readRestoreCompleted: () => readRestoreCompleted(supabase, plan),

--- a/src/lib/server/classroom-archive-production-canary.ts
+++ b/src/lib/server/classroom-archive-production-canary.ts
@@ -1,7 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
-import { canonicalJsonStringify } from '@/lib/server/classroom-archive-format'
+import {
+  canonicalJsonStringify,
+  decodeClassroomArchiveData,
+  type VerifiedClassroomArchiveBundle,
+} from '@/lib/server/classroom-archive-format'
 import type { ClassroomArchiveCompactionResult } from '@/lib/server/classroom-archive-compaction'
 import type { ClassroomArchiveExportResult } from '@/lib/server/classroom-archive-operations'
 import type { ClassroomArchiveRestoreResult } from '@/lib/server/classroom-archive-restore-operations'
@@ -136,6 +140,34 @@ export type ClassroomArchiveProductionCanaryState =
   | { phase: 'hot'; teacherId: string; archivedAt: string }
   | { phase: 'cold'; teacherId: string; archiveId: string }
 
+export type ClassroomArchiveProductionCanaryStorageMapping = {
+  bucket: string
+  sourcePath: string
+  restorePath: string
+}
+
+export function assertClassroomArchiveProductionCanaryStorageMappingsEqual(args: {
+  independent: ClassroomArchiveProductionCanaryStorageMapping[]
+  planned: ClassroomArchiveProductionCanaryStorageMapping[]
+}): void {
+  const normalize = (mappings: ClassroomArchiveProductionCanaryStorageMapping[]) =>
+    mappings.map((mapping) => ({
+      bucket: z.string().min(1).parse(mapping.bucket),
+      sourcePath: z.string().min(1).parse(mapping.sourcePath),
+      restorePath: z.string().min(1).parse(mapping.restorePath),
+    })).sort((left, right) => (
+      left.bucket.localeCompare(right.bucket) ||
+      left.sourcePath.localeCompare(right.sourcePath) ||
+      left.restorePath.localeCompare(right.restorePath)
+    ))
+  if (
+    canonicalJsonStringify(normalize(args.independent)) !==
+    canonicalJsonStringify(normalize(args.planned))
+  ) {
+    throw new Error('Production archive canary independent restored paths differ')
+  }
+}
+
 export type ClassroomArchiveProductionArchiveEvidence = {
   archiveId: string
   teacherId: string
@@ -148,6 +180,7 @@ export type ClassroomArchiveProductionArchiveEvidence = {
   operationRequestSha256: { export: string; compact: string; restore: string }
   storageObjectCounts: Record<string, unknown>
   restoreAdapterChain: string[]
+  restoredStorageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
   evidence: ClassroomArchiveProductionCanaryEvidence
   restoredEvidence: ClassroomArchiveProductionCanaryEvidence
 }
@@ -191,6 +224,9 @@ export type ClassroomArchiveProductionCanaryEvent = {
 export type ClassroomArchiveProductionCanaryDependencies = {
   readState(): Promise<ClassroomArchiveProductionCanaryState>
   readCurrentEvidence(): Promise<ClassroomArchiveProductionCanaryEvidence>
+  readRestoredEvidence(
+    archive: ClassroomArchiveProductionArchiveEvidence,
+  ): Promise<ClassroomArchiveProductionCanaryEvidence>
   readArchiveEvidence(): Promise<ClassroomArchiveProductionArchiveEvidence | null>
   readRestoreCompleted(): Promise<boolean>
   exportArchive(): Promise<ClassroomArchiveExportResult>
@@ -205,6 +241,269 @@ export type ClassroomArchiveProductionCanaryDependencies = {
 
 function sha256(value: string | Uint8Array): string {
   return createHash('sha256').update(value).digest('hex')
+}
+
+export function deriveClassroomArchiveProductionCanaryRestoredStoragePath(args: {
+  classroomId: string
+  operationId: string
+  sha256: string
+  sourcePath: string
+  contentType: string | null
+}): string {
+  const objectIdentity = sha256(
+    `${z.string().min(1).parse(args.sourcePath)}\0${args.contentType ?? '<null>'}`,
+  )
+  return [
+    'restores',
+    uuidSchema.parse(args.classroomId),
+    uuidSchema.parse(args.operationId),
+    `${objectIdentity}-${sha256Schema.parse(args.sha256)}`,
+  ].join('/')
+}
+
+function normalizeCanaryStorageMappings(
+  mappings: ClassroomArchiveProductionCanaryStorageMapping[],
+  storagePathKind: 'source' | 'restored',
+): Map<string, string> {
+  const paths = new Map<string, string>()
+  for (const mapping of mappings) {
+    const bucket = z.string().min(1).parse(mapping.bucket)
+    const sourcePath = z.string().min(1).parse(mapping.sourcePath)
+    const restorePath = z.string().min(1).parse(mapping.restorePath)
+    const identity = sha256(`${bucket}\0${sourcePath}`)
+    const path = storagePathKind === 'source' ? sourcePath : restorePath
+    const key = `${bucket}\0${path}`
+    const existing = paths.get(key)
+    if (existing && existing !== identity) {
+      throw new Error('Production canary storage normalization is ambiguous')
+    }
+    paths.set(key, identity)
+  }
+  return paths
+}
+
+function normalizeCanaryManagedUrls(
+  value: string,
+  supabaseOrigin: string,
+  paths: Map<string, string>,
+  storagePathKind: 'source' | 'restored',
+): string {
+  return value.replace(/https?:\/\/[^\s<>"'`]+/gi, (candidate) => {
+    const stripped = candidate.replace(/[),.;:!?]+$/, '')
+    const suffix = candidate.slice(stripped.length)
+    try {
+      const url = new URL(stripped)
+      if (url.origin !== supabaseOrigin) return candidate
+      const match = url.pathname.match(
+        /^\/storage\/v1\/object\/(public|sign|authenticated)\/([^/]+)\/(.+)$/,
+      )
+      if (!match) return candidate
+      const bucket = decodeURIComponent(match[2])
+      const path = decodeURIComponent(match[3])
+      if (storagePathKind === 'restored') {
+        const canonicalPath = [
+          '',
+          'storage',
+          'v1',
+          'object',
+          'public',
+          encodeURIComponent(bucket),
+          ...path.split('/').map((segment) => encodeURIComponent(segment)),
+        ].join('/')
+        if (stripped !== `${supabaseOrigin}${canonicalPath}`) return candidate
+      }
+      const identity = paths.get(`${bucket}\0${path}`)
+      return identity ? `pika-storage-object:${identity}${suffix}` : candidate
+    } catch {
+      return candidate
+    }
+  })
+}
+
+function normalizeCanaryResourceValue(args: {
+  value: unknown
+  table: string
+  key?: string
+  inTestDocuments?: boolean
+  supabaseOrigin: string
+  paths: Map<string, string>
+  storagePathKind: 'source' | 'restored'
+}): unknown {
+  if (typeof args.value === 'string') {
+    const directBucket = args.table === 'assignment_submission_artifacts' &&
+      args.key === 'storage_path'
+      ? 'assignment-artifacts'
+      : args.table === 'tests' && args.inTestDocuments && args.key === 'snapshot_path'
+        ? 'test-documents'
+        : null
+    if (directBucket) {
+      const identity = args.paths.get(`${directBucket}\0${args.value}`)
+      return identity ? `pika-storage-object:${identity}` : args.value
+    }
+    return normalizeCanaryManagedUrls(
+      args.value,
+      args.supabaseOrigin,
+      args.paths,
+      args.storagePathKind,
+    )
+  }
+  if (Array.isArray(args.value)) {
+    return args.value.map((value) => normalizeCanaryResourceValue({ ...args, value }))
+  }
+  if (!args.value || typeof args.value !== 'object') return args.value
+  return Object.fromEntries(Object.entries(args.value).map(([key, value]) => [
+    key,
+    normalizeCanaryResourceValue({
+      ...args,
+      value,
+      key,
+      inTestDocuments: args.inTestDocuments ||
+        (args.table === 'tests' && key === 'documents'),
+    }),
+  ]))
+}
+
+export function normalizeClassroomArchiveProductionCanaryResources(args: {
+  resources: Record<string, Array<Record<string, unknown>>>
+  storageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
+  storagePathKind: 'source' | 'restored'
+  supabaseUrl: string
+}): Record<string, Array<Record<string, unknown>>> {
+  const supabaseOrigin = new URL(args.supabaseUrl).origin
+  const paths = normalizeCanaryStorageMappings(args.storageMappings, args.storagePathKind)
+  return Object.fromEntries(Object.entries(args.resources).map(([table, rows]) => [
+    table,
+    rows.map((row) => normalizeCanaryResourceValue({
+      value: row,
+      table,
+      supabaseOrigin,
+      paths,
+      storagePathKind: args.storagePathKind,
+    }) as Record<string, unknown>),
+  ]))
+}
+
+export function createClassroomArchiveProductionCanaryNormalizedEvidence(args: {
+  sourceRevision: number
+  resources: Record<string, Array<Record<string, unknown>>>
+  storageObjects: Array<{
+    bucket: string
+    path: string
+    byteSize: number
+    sha256: string
+  }>
+  storageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
+  storagePathKind: 'source' | 'restored'
+  supabaseUrl: string
+}): ClassroomArchiveProductionCanaryEvidence {
+  if (args.storageObjects.length !== args.storageMappings.length) {
+    throw new Error('Production canary normalized storage object count differs')
+  }
+  const sourcePaths = new Map(args.storageMappings.map((mapping) => [
+    `${mapping.bucket}\0${
+      args.storagePathKind === 'source' ? mapping.sourcePath : mapping.restorePath
+    }`,
+    mapping.sourcePath,
+  ]))
+  const seenSourceIdentities = new Set<string>()
+  const storageObjects = args.storageObjects.map((object) => {
+    const sourcePath = sourcePaths.get(`${object.bucket}\0${object.path}`)
+    if (!sourcePath) {
+      throw new Error(
+        `Production canary ${args.storagePathKind} storage object path is unknown`,
+      )
+    }
+    const identitySha256 = sha256(`${object.bucket}\0${sourcePath}`)
+    if (seenSourceIdentities.has(identitySha256)) {
+      throw new Error('Production canary normalized storage object identity is duplicated')
+    }
+    seenSourceIdentities.add(identitySha256)
+    return {
+      identity_sha256: identitySha256,
+      byte_size: z.number().int().nonnegative().parse(object.byteSize),
+      sha256: sha256Schema.parse(object.sha256),
+    }
+  })
+  const resources = normalizeClassroomArchiveProductionCanaryResources({
+    resources: args.resources,
+    storageMappings: args.storageMappings,
+    storagePathKind: args.storagePathKind,
+    supabaseUrl: args.supabaseUrl,
+  })
+  return classroomArchiveProductionCanaryEvidenceDigest({
+    sourceRevision: args.sourceRevision,
+    resources: CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => {
+      const rows = resources[table] || []
+      const bytes = Buffer.from(
+        rows.map((row) => `${canonicalJsonStringify(row)}\n`).join(''),
+        'utf8',
+      )
+      return {
+        table,
+        row_count: rows.length,
+        byte_size: bytes.byteLength,
+        sha256: sha256(bytes),
+      }
+    }),
+    storageObjects,
+  })
+}
+
+export function createClassroomArchiveProductionCanaryArchiveProjection(args: {
+  verified: Extract<VerifiedClassroomArchiveBundle, { ok: true }>
+  sourceRevision: number
+  restoreOperationId: string
+  supabaseUrl: string
+}): {
+  restoredStorageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
+  restoredEvidence: ClassroomArchiveProductionCanaryEvidence
+} {
+  const decoded = decodeClassroomArchiveData(args.verified)
+  const restoredStorageMappings = args.verified.manifest.storage_objects.map((object) => ({
+    bucket: object.bucket,
+    sourcePath: object.source_path,
+    restorePath: deriveClassroomArchiveProductionCanaryRestoredStoragePath({
+      classroomId: args.verified.manifest.classroom_id,
+      operationId: args.restoreOperationId,
+      sha256: object.sha256,
+      sourcePath: object.source_path,
+      contentType: object.content_type,
+    }),
+  }))
+  return {
+    restoredStorageMappings,
+    restoredEvidence: createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: args.sourceRevision,
+      resources: decoded.resources,
+      storageObjects: args.verified.manifest.storage_objects.map((object) => ({
+        bucket: object.bucket,
+        path: object.source_path,
+        byteSize: object.byte_size,
+        sha256: object.sha256,
+      })),
+      storageMappings: restoredStorageMappings,
+      storagePathKind: 'source',
+      supabaseUrl: args.supabaseUrl,
+    }),
+  }
+}
+
+export function createClassroomArchiveProductionCanaryVerifiedArchiveProjection(args: {
+  verified: Extract<VerifiedClassroomArchiveBundle, { ok: true }>
+  sourceRevision: number
+  restoreOperationId: string
+  supabaseUrl: string
+  plannedStorageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
+}): {
+  restoredStorageMappings: ClassroomArchiveProductionCanaryStorageMapping[]
+  restoredEvidence: ClassroomArchiveProductionCanaryEvidence
+} {
+  const projection = createClassroomArchiveProductionCanaryArchiveProjection(args)
+  assertClassroomArchiveProductionCanaryStorageMappingsEqual({
+    independent: projection.restoredStorageMappings,
+    planned: args.plannedStorageMappings,
+  })
+  return projection
 }
 
 function decodeJwtClaims(value: string): unknown {
@@ -485,7 +784,9 @@ export async function runClassroomArchiveProductionCanary(args: {
     const completedArchive = archive !== null && await dependencies.readRestoreCompleted()
       ? archive
       : null
-    const currentEvidence = await dependencies.readCurrentEvidence()
+    const currentEvidence = completedArchive
+      ? await dependencies.readRestoredEvidence(completedArchive)
+      : await dependencies.readCurrentEvidence()
     assertClassroomArchiveProductionCanaryEvidenceEqual({
       expected: completedArchive?.restoredEvidence || plan.pre_evidence,
       actual: currentEvidence,
@@ -593,31 +894,60 @@ export async function runClassroomArchiveProductionCanary(args: {
   await recordEvent({ phase: 'restore', status: 'started' })
   let restored: ClassroomArchiveRestoreResult | null = null
   let restoreReconciled = false
+  let restoreCallError: unknown = null
   let restoreAttempts = 0
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     restoreAttempts = attempt
-    restored = await dependencies.restoreArchive()
+    try {
+      restored = await dependencies.restoreArchive()
+    } catch (error) {
+      restoreCallError = error
+      let stateAfterThrownRestore: ClassroomArchiveProductionCanaryState | null = null
+      try {
+        stateAfterThrownRestore = await readStateWithRetry()
+      } catch {
+        // Retry the fixed operation id; a later attempt can reconcile durable state.
+      }
+      if (stateAfterThrownRestore) assertStateIdentity(stateAfterThrownRestore, plan)
+      if (stateAfterThrownRestore?.phase === 'hot') {
+        const reconciledEvidence = await dependencies.readRestoredEvidence(archive)
+        assertClassroomArchiveProductionCanaryEvidenceEqual({
+          expected: archive.restoredEvidence,
+          actual: reconciledEvidence,
+          compareRevision: true,
+        })
+        restoreReconciled = true
+        break
+      }
+      continue
+    }
     if (restored.operation_id !== plan.operation_ids.restore) {
       throw new Error('Production archive restore operation identity does not match the plan')
     }
     if (restored.ok || !restored.retryable) break
   }
   if (!restored || !restored.ok) {
-    const errorCode = restored?.error_code || 'restore_result_missing'
-    const stateAfterRestore = await readStateWithRetry()
-    assertStateIdentity(stateAfterRestore, plan)
-    if (stateAfterRestore.phase !== 'hot') {
-      await recordEvent({ phase: 'restore', status: 'failed', errorCode })
-      if (!restored) throw new Error('Production archive restore did not return a result')
-      throw operationFailure('Production archive restore', restored)
+    const errorCode = restored?.error_code || (restoreCallError
+      ? 'restore_call_threw'
+      : 'restore_result_missing')
+    if (!restoreReconciled) {
+      const stateAfterRestore = await readStateWithRetry()
+      assertStateIdentity(stateAfterRestore, plan)
+      if (stateAfterRestore.phase !== 'hot') {
+        await recordEvent({ phase: 'restore', status: 'failed', errorCode })
+        if (!restored) {
+          throw restoreCallError || new Error('Production archive restore did not return a result')
+        }
+        throw operationFailure('Production archive restore', restored)
+      }
+      const reconciledEvidence = await dependencies.readRestoredEvidence(archive)
+      assertClassroomArchiveProductionCanaryEvidenceEqual({
+        expected: archive.restoredEvidence,
+        actual: reconciledEvidence,
+        compareRevision: true,
+      })
+      restoreReconciled = true
     }
-    const reconciledEvidence = await dependencies.readCurrentEvidence()
-    assertClassroomArchiveProductionCanaryEvidenceEqual({
-      expected: archive.restoredEvidence,
-      actual: reconciledEvidence,
-      compareRevision: true,
-    })
-    restoreReconciled = true
     await recordEvent({ phase: 'restore', status: 'reconciled', errorCode })
   } else {
     if (
@@ -631,7 +961,7 @@ export async function runClassroomArchiveProductionCanary(args: {
   }
 
   await recordEvent({ phase: 'verify', status: 'started' })
-  const postEvidence = await dependencies.readCurrentEvidence()
+  const postEvidence = await dependencies.readRestoredEvidence(archive)
   assertClassroomArchiveProductionCanaryEvidenceEqual({
     expected: archive.restoredEvidence,
     actual: postEvidence,

--- a/src/lib/server/classroom-archive-restore-operations.ts
+++ b/src/lib/server/classroom-archive-restore-operations.ts
@@ -250,7 +250,15 @@ async function loadArchiveMetadata(args: {
     .eq('classroom_id', args.classroomId)
     .eq('teacher_id', args.teacherId)
     .single()
-  if (response.error || !response.data) {
+  if (response.error && response.error.code !== 'PGRST116') {
+    throw new ClassroomArchiveRestoreError(
+      'classroom_archive_metadata_read_failed',
+      'Classroom archive metadata could not be read',
+      503,
+      true,
+    )
+  }
+  if (!response.data) {
     throw new ClassroomArchiveRestoreError(
       'classroom_archive_not_found',
       'Classroom archive not found',
@@ -323,7 +331,12 @@ async function uploadAndVerifyRestoreObject(args: {
   object: ClassroomArchiveRestorePlan['storageObjects'][number]
 }): Promise<boolean> {
   const bucket = args.supabase.storage.from(args.object.bucket)
-  let bytes = await readStorageBytes((await bucket.download(args.object.restorePath)).data)
+  let bytes: Uint8Array | null = null
+  try {
+    bytes = await readStorageBytes((await bucket.download(args.object.restorePath)).data)
+  } catch {
+    // An upload conflict plus read-back below can still reconcile an existing object.
+  }
   let uploaded = false
   if (!bytes) {
     const upload = await bucket.upload(args.object.restorePath, args.object.bytes, {
@@ -332,8 +345,11 @@ async function uploadAndVerifyRestoreObject(args: {
       upsert: false,
     })
     if (upload.error) {
-      bytes = await readStorageBytes((await bucket.download(args.object.restorePath)).data)
-      if (!bytes) {
+      try {
+        const readBack = await bucket.download(args.object.restorePath)
+        bytes = await readStorageBytes(readBack.data)
+        if (readBack.error || !bytes) throw new Error('read-back unavailable')
+      } catch {
         throw new ClassroomArchiveRestoreError(
           'restore_storage_upload_failed',
           'A classroom archive object could not be restored',
@@ -343,11 +359,28 @@ async function uploadAndVerifyRestoreObject(args: {
       }
     } else {
       uploaded = true
-      bytes = await readStorageBytes((await bucket.download(args.object.restorePath)).data)
+      try {
+        const readBack = await bucket.download(args.object.restorePath)
+        bytes = await readStorageBytes(readBack.data)
+        if (readBack.error || !bytes) throw new Error('read-back unavailable')
+      } catch {
+        throw new ClassroomArchiveRestoreError(
+          'restore_storage_readback_failed',
+          'A restored classroom object could not be read back for verification',
+          503,
+          true,
+        )
+      }
     }
   }
-  if (!bytes || sha256Bytes(bytes) !== args.object.sha256) {
-    if (uploaded) await bucket.remove([args.object.restorePath])
+  if (sha256Bytes(bytes) !== args.object.sha256) {
+    if (uploaded) {
+      try {
+        await bucket.remove([args.object.restorePath])
+      } catch {
+        // The staged upload intent leaves cleanup durable if best-effort removal fails.
+      }
+    }
     throw new ClassroomArchiveRestoreError(
       'restore_storage_checksum_mismatch',
       'A restored classroom object failed checksum verification',
@@ -364,13 +397,17 @@ async function recordRestoreFailure(args: {
   teacherId: string
   error: ClassroomArchiveRestoreError
 }): Promise<boolean> {
-  const response = await args.supabase.rpc('fail_classroom_archive_restore', {
-    p_operation_id: args.operationId,
-    p_teacher_id: args.teacherId,
-    p_error_code: args.error.code,
-    p_retryable: args.error.retryable,
-  })
-  return !response.error && response.data === true
+  try {
+    const response = await args.supabase.rpc('fail_classroom_archive_restore', {
+      p_operation_id: args.operationId,
+      p_teacher_id: args.teacherId,
+      p_error_code: args.error.code,
+      p_retryable: args.error.retryable,
+    })
+    return !response.error && response.data === true
+  } catch {
+    return false
+  }
 }
 
 function emitRestoreMetric(result: ClassroomArchiveRestoreResult, startedAt: number) {
@@ -399,6 +436,7 @@ export async function restoreClassroomArchive(args: {
   let operationStarted = false
   let finalizationAttempted = false
   let plan: ClassroomArchiveRestorePlan | null = null
+  const uploadedStorageObjects: Array<{ bucket: string; path: string }> = []
 
   try {
     const metadata = await loadArchiveMetadata(args)
@@ -556,7 +594,10 @@ export async function restoreClassroomArchive(args: {
           true,
         )
       }
-      await uploadAndVerifyRestoreObject({ supabase: args.supabase, object })
+      const uploaded = await uploadAndVerifyRestoreObject({ supabase: args.supabase, object })
+      if (uploaded) {
+        uploadedStorageObjects.push({ bucket: object.bucket, path: object.restorePath })
+      }
     }
     for (const table of getClassroomResourceOrder('restore')) {
       const rows = plan.resources[table] || []
@@ -654,10 +695,10 @@ export async function restoreClassroomArchive(args: {
     const error = cause instanceof ClassroomArchiveRestoreError
       ? cause
       : new ClassroomArchiveRestoreError(
-          'classroom_archive_restore_contract_invalid',
-          'Classroom archive restore failed contract validation',
-          500,
-          false,
+          'classroom_archive_restore_unexpected_failure',
+          'Classroom archive restore encountered a transient unexpected failure',
+          503,
+          true,
         )
     const cleanupAuthorized = operationStarted
       ? await recordRestoreFailure({
@@ -667,23 +708,35 @@ export async function restoreClassroomArchive(args: {
         error,
       })
       : false
-    if (!error.retryable && !finalizationAttempted && plan && cleanupAuthorized) {
+    const reportedError = operationStarted && !cleanupAuthorized
+      ? new ClassroomArchiveRestoreError(
+          'classroom_archive_restore_failure_recording_failed',
+          'Classroom archive restore failure state could not be confirmed',
+          503,
+          true,
+        )
+      : error
+    if (!reportedError.retryable && !finalizationAttempted && cleanupAuthorized) {
       const pathsByBucket = new Map<string, Set<string>>()
-      for (const object of plan.storageObjects) {
+      for (const object of uploadedStorageObjects) {
         const paths = pathsByBucket.get(object.bucket) || new Set<string>()
-        paths.add(object.restorePath)
+        paths.add(object.path)
         pathsByBucket.set(object.bucket, paths)
       }
       for (const [bucket, paths] of pathsByBucket) {
-        await args.supabase.storage.from(bucket).remove([...paths])
+        try {
+          await args.supabase.storage.from(bucket).remove([...paths])
+        } catch {
+          // Durable cleanup owns any object that cannot be removed best-effort here.
+        }
       }
     }
     const result = publicFailure({
       operationId: args.operationId,
-      code: error.code,
-      message: error.message,
-      status: error.status,
-      retryable: error.retryable,
+      code: reportedError.code,
+      message: reportedError.message,
+      status: reportedError.status,
+      retryable: reportedError.retryable,
     })
     emitRestoreMetric(result, startedAt)
     return result

--- a/supabase/migrations/097_classroom_archive_restore_recovery.sql
+++ b/supabase/migrations/097_classroom_archive_restore_recovery.sql
@@ -1,0 +1,213 @@
+-- Preserve fixed restore operation IDs across concurrent failure recording and expiry.
+
+alter function private.complete_classroom_archive_restore(uuid, uuid, jsonb)
+  rename to complete_classroom_archive_restore_v095;
+
+create or replace function private.complete_classroom_archive_restore(
+  p_operation_id uuid,
+  p_teacher_id uuid,
+  p_verification jsonb
+)
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_operation public.classroom_archive_operations;
+begin
+  select * into v_operation
+  from public.classroom_archive_operations
+  where id = p_operation_id
+    and teacher_id = p_teacher_id
+    and operation_type = 'restore'
+  for update;
+
+  if v_operation.status = 'failed'
+    and v_operation.retryable is true
+    and v_operation.snapshot_expires_at > clock_timestamp()
+  then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'error_code', v_operation.error_code,
+      'error', 'Restore operation failed and can be retried',
+      'retryable', true
+    );
+  end if;
+
+  return private.complete_classroom_archive_restore_v095(
+    p_operation_id,
+    p_teacher_id,
+    p_verification
+  );
+end;
+$$;
+
+revoke all on function private.complete_classroom_archive_restore_v095(uuid, uuid, jsonb)
+  from public, anon, authenticated, service_role;
+revoke all on function private.complete_classroom_archive_restore(uuid, uuid, jsonb)
+  from public, anon, authenticated, service_role;
+
+alter function public.begin_classroom_archive_restore(
+  uuid, uuid, uuid, uuid, text, text, jsonb, jsonb, jsonb, bigint
+) set schema private;
+alter function private.begin_classroom_archive_restore(
+  uuid, uuid, uuid, uuid, text, text, jsonb, jsonb, jsonb, bigint
+) rename to begin_classroom_archive_restore_v083;
+
+revoke all on function private.begin_classroom_archive_restore_v083(
+  uuid, uuid, uuid, uuid, text, text, jsonb, jsonb, jsonb, bigint
+) from public, anon, authenticated, service_role;
+
+create or replace function public.begin_classroom_archive_restore(
+  p_operation_id uuid,
+  p_teacher_id uuid,
+  p_classroom_id uuid,
+  p_archive_id uuid,
+  p_request_sha256 text,
+  p_target_schema_migration text,
+  p_adapter_chain jsonb,
+  p_resource_counts jsonb,
+  p_storage_objects jsonb,
+  p_database_budget_bytes bigint
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_operation public.classroom_archive_operations;
+  v_expected_objects_match boolean := false;
+  v_now timestamptz := clock_timestamp();
+  v_result jsonb;
+begin
+  perform public.cleanup_expired_classroom_archive_snapshots();
+  perform pg_advisory_xact_lock(hashtextextended(p_operation_id::text, 0));
+
+  select * into v_operation
+  from public.classroom_archive_operations
+  where id = p_operation_id
+  for update;
+
+  -- Fence the cleanup worker before deciding whether restored paths can be reused.
+  perform 1
+  from public.classroom_archive_object_upload_cleanup
+  where operation_id = p_operation_id
+  for update;
+
+  if v_operation.id is not null
+    and jsonb_typeof(p_storage_objects) = 'array'
+    and jsonb_array_length(p_storage_objects) <= 10000
+    and not exists (
+      select 1
+      from jsonb_array_elements(p_storage_objects) item
+      where jsonb_typeof(item) <> 'object'
+        or coalesce(item->>'expected_byte_size', '') !~ '^\d+$'
+    )
+  then
+    select not exists (
+      (select storage_bucket, storage_path, expected_sha256, expected_byte_size
+       from public.classroom_archive_restore_expected_objects
+       where operation_id = p_operation_id
+       except
+       select value->>'storage_bucket', value->>'storage_path',
+         value->>'expected_sha256', (value->>'expected_byte_size')::bigint
+       from jsonb_array_elements(p_storage_objects))
+      union all
+      (select value->>'storage_bucket', value->>'storage_path',
+         value->>'expected_sha256', (value->>'expected_byte_size')::bigint
+       from jsonb_array_elements(p_storage_objects)
+       except
+       select storage_bucket, storage_path, expected_sha256, expected_byte_size
+       from public.classroom_archive_restore_expected_objects
+       where operation_id = p_operation_id)
+    ) into v_expected_objects_match;
+  end if;
+
+  if v_operation.teacher_id = p_teacher_id
+    and v_operation.classroom_id = p_classroom_id
+    and v_operation.archive_id = p_archive_id
+    and v_operation.operation_type = 'restore'
+    and v_operation.request_sha256 = p_request_sha256
+    and v_operation.target_schema_migration = p_target_schema_migration
+    and v_operation.adapter_chain = p_adapter_chain
+    and v_operation.resource_counts = p_resource_counts
+    and v_expected_objects_match
+    and v_operation.status = 'failed'
+    and v_operation.retryable is false
+    and v_operation.error_code = 'archive_snapshot_expired'
+  then
+    if exists (
+      select 1
+      from public.classroom_archive_object_upload_cleanup
+      where operation_id = p_operation_id and status = 'processing'
+    ) then
+      return jsonb_build_object(
+        'ok', false,
+        'status', 409,
+        'operation_id', p_operation_id,
+        'error_code', 'restore_cleanup_in_progress',
+        'error', 'Expired restore object cleanup is still in progress',
+        'retryable', true
+      );
+    end if;
+
+    begin
+      delete from public.classroom_archive_restore_staging
+      where operation_id = p_operation_id;
+
+      delete from public.classroom_archive_object_upload_cleanup
+      where operation_id = p_operation_id;
+
+      update public.classroom_archive_operations
+      set
+        retryable = true,
+        snapshot_expires_at = v_now + interval '24 hours',
+        updated_at = v_now
+      where id = p_operation_id;
+
+      v_result := private.begin_classroom_archive_restore_v083(
+        p_operation_id,
+        p_teacher_id,
+        p_classroom_id,
+        p_archive_id,
+        p_request_sha256,
+        p_target_schema_migration,
+        p_adapter_chain,
+        p_resource_counts,
+        p_storage_objects,
+        p_database_budget_bytes
+      );
+      if coalesce((v_result->>'ok')::boolean, false) is not true then
+        raise exception 'Restore rearm was rejected' using errcode = 'PRA01';
+      end if;
+    exception when sqlstate 'PRA01' then
+      return v_result;
+    end;
+
+    return v_result;
+  end if;
+
+  return private.begin_classroom_archive_restore_v083(
+    p_operation_id,
+    p_teacher_id,
+    p_classroom_id,
+    p_archive_id,
+    p_request_sha256,
+    p_target_schema_migration,
+    p_adapter_chain,
+    p_resource_counts,
+    p_storage_objects,
+    p_database_budget_bytes
+  );
+end;
+$$;
+
+revoke all on function public.begin_classroom_archive_restore(
+  uuid, uuid, uuid, uuid, text, text, jsonb, jsonb, jsonb, bigint
+) from public, anon, authenticated;
+grant execute on function public.begin_classroom_archive_restore(
+  uuid, uuid, uuid, uuid, text, text, jsonb, jsonb, jsonb, bigint
+) to service_role;

--- a/tests/lib/server/classroom-archive-production-canary.test.ts
+++ b/tests/lib/server/classroom-archive-production-canary.test.ts
@@ -1,12 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
 import {
+  buildClassroomArchiveBundle,
+  verifyClassroomArchiveBundle,
+} from '@/lib/server/classroom-archive-format'
+import {
+  assertClassroomArchiveProductionCanaryStorageMappingsEqual,
   assertClassroomArchiveProductionCanaryExecution,
   classroomArchiveProductionCanaryAcknowledgement,
   classroomArchiveProductionCanaryEvidenceDigest,
+  createClassroomArchiveProductionCanaryArchiveProjection,
+  createClassroomArchiveProductionCanaryNormalizedEvidence,
   createClassroomArchiveProductionCanaryPlan,
+  createClassroomArchiveProductionCanaryVerifiedArchiveProjection,
   deriveClassroomArchiveProductionCanaryOperationId,
+  deriveClassroomArchiveProductionCanaryRestoredStoragePath,
   normalizeClassroomArchiveProductionCanaryCliArguments,
+  normalizeClassroomArchiveProductionCanaryResources,
   runClassroomArchiveProductionCanary,
   verifyClassroomArchiveProductionCanaryPlan,
   type ClassroomArchiveProductionCanaryDependencies,
@@ -95,6 +107,7 @@ function dependencies(options: {
   stateFailuresAtCalls?: number[]
   restoreCompleted?: boolean
   archiveFailures?: number
+  restoreThrows?: number
 } = {}): ClassroomArchiveProductionCanaryDependencies & {
   calls: string[]
   events: Array<{ phase: string; status: string }>
@@ -123,6 +136,7 @@ function dependencies(options: {
     operationRequestSha256: { export: SHA, compact: SHA, restore: SHA },
     storageObjectCounts: {},
     restoreAdapterChain: ['classroom-archive-v1-082-to-083'],
+    restoredStorageMappings: [],
     evidence: approvedPlan.pre_evidence,
     restoredEvidence: options.restoredEvidence || approvedPlan.pre_evidence,
   }
@@ -147,6 +161,13 @@ function dependencies(options: {
       return evidenceReads > 1 && options.postEvidence
         ? options.postEvidence
         : options.initialEvidence || approvedPlan.pre_evidence
+    }),
+    readRestoredEvidence: vi.fn(async () => {
+      calls.push('restored-evidence')
+      evidenceReads += 1
+      return evidenceReads > 1 && options.postEvidence
+        ? options.postEvidence
+        : options.initialEvidence || options.restoredEvidence || approvedPlan.pre_evidence
     }),
     readArchiveEvidence: vi.fn(async () => {
       calls.push('archive')
@@ -213,6 +234,9 @@ function dependencies(options: {
     restoreArchive: vi.fn(async () => {
       calls.push('restore')
       restoreCalls += 1
+      if (restoreCalls <= (options.restoreThrows || 0)) {
+        throw new Error('transient restore transport failure')
+      }
       if (options.restoreFailure || (options.retryRestore && restoreCalls === 1)) {
         return {
           ok: false as const,
@@ -298,6 +322,445 @@ describe('production classroom archive canary contract', () => {
       environment: { CLASSROOM_ARCHIVE_SOURCE_CLEANUP_ENABLED: 'true' },
     })).toThrow('cleanup gate')
   })
+
+  it('normalizes only deterministic restored storage references to source identities', () => {
+    const sourcePath = 'student/evidence.png'
+    const restorePath = deriveClassroomArchiveProductionCanaryRestoredStoragePath({
+      classroomId: CLASSROOM_ID,
+      operationId: plan().operation_ids.restore,
+      sha256: SHA,
+      sourcePath,
+      contentType: 'image/png',
+    })
+    const mappings = [{
+      bucket: 'assignment-artifacts',
+      sourcePath,
+      restorePath,
+    }]
+    const source = {
+      assignment_submission_artifacts: [{
+        id: 'artifact-1',
+        storage_path: sourcePath,
+        caption: 'Original caption',
+      }],
+      assignments: [{
+        id: 'assignment-1',
+        instructions: `See https://${PROJECT_REF}.supabase.co/storage/v1/object/sign/assignment-artifacts/${sourcePath}.`,
+      }],
+    }
+    const restored = {
+      assignment_submission_artifacts: [{
+        id: 'artifact-1',
+        storage_path: restorePath,
+        caption: 'Original caption',
+      }],
+      assignments: [{
+        id: 'assignment-1',
+        instructions: `See https://${PROJECT_REF}.supabase.co/storage/v1/object/public/assignment-artifacts/${restorePath}.`,
+      }],
+    }
+
+    expect(normalizeClassroomArchiveProductionCanaryResources({
+      resources: restored,
+      storageMappings: mappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).toEqual(normalizeClassroomArchiveProductionCanaryResources({
+      resources: source,
+      storageMappings: mappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    }))
+    restored.assignment_submission_artifacts[0].caption = 'Changed caption'
+    expect(normalizeClassroomArchiveProductionCanaryResources({
+      resources: restored,
+      storageMappings: mappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).not.toEqual(normalizeClassroomArchiveProductionCanaryResources({
+      resources: source,
+      storageMappings: mappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    }))
+
+    const staleNestedUrlOnly = {
+      assignment_submission_artifacts: [{
+        id: 'artifact-1',
+        storage_path: restorePath,
+        caption: 'Original caption',
+      }],
+      assignments: source.assignments,
+    }
+    expect(normalizeClassroomArchiveProductionCanaryResources({
+      resources: staleNestedUrlOnly,
+      storageMappings: mappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).not.toEqual(normalizeClassroomArchiveProductionCanaryResources({
+      resources: source,
+      storageMappings: mappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    }))
+
+    const authenticatedRestoredUrl = {
+      ...restored,
+      assignment_submission_artifacts: [{
+        id: 'artifact-1',
+        storage_path: restorePath,
+        caption: 'Original caption',
+      }],
+      assignments: [{
+        id: 'assignment-1',
+        instructions: `See https://${PROJECT_REF}.supabase.co/storage/v1/object/authenticated/assignment-artifacts/${restorePath}.`,
+      }],
+    }
+    expect(normalizeClassroomArchiveProductionCanaryResources({
+      resources: authenticatedRestoredUrl,
+      storageMappings: mappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).not.toEqual(normalizeClassroomArchiveProductionCanaryResources({
+      resources: source,
+      storageMappings: mappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    }))
+
+    const canonicalRestoredUrl = `https://${PROJECT_REF}.supabase.co/storage/v1/object/public/assignment-artifacts/${restorePath}`
+    const expectedNormalized = normalizeClassroomArchiveProductionCanaryResources({
+      resources: source,
+      storageMappings: mappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    for (const aliasedUrl of [
+      `${canonicalRestoredUrl}?token=unexpected`,
+      `${canonicalRestoredUrl}#unexpected`,
+      canonicalRestoredUrl.replace('https://', 'https://user@'),
+      canonicalRestoredUrl.replace('.supabase.co', '.supabase.co:443'),
+    ]) {
+      const aliased = {
+        assignment_submission_artifacts: [{
+          id: 'artifact-1',
+          storage_path: restorePath,
+          caption: 'Original caption',
+        }],
+        assignments: [{ id: 'assignment-1', instructions: `See ${aliasedUrl}.` }],
+      }
+      expect(normalizeClassroomArchiveProductionCanaryResources({
+        resources: aliased,
+        storageMappings: mappings,
+        storagePathKind: 'restored',
+        supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+      })).not.toEqual(expectedNormalized)
+    }
+
+    const wrongDirectRepresentation = {
+      assignment_submission_artifacts: [{
+        id: 'artifact-1',
+        storage_path: canonicalRestoredUrl,
+        caption: 'Original caption',
+      }],
+      assignments: restored.assignments,
+    }
+    expect(normalizeClassroomArchiveProductionCanaryResources({
+      resources: wrongDirectRepresentation,
+      storageMappings: mappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).not.toEqual(expectedNormalized)
+  })
+
+  it('builds the runner archive projection from verified source rows', () => {
+    const sourcePath = 'student/evidence.png'
+    const resources = Object.fromEntries(
+      CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => [table, []]),
+    ) as Record<string, Array<Record<string, unknown>>>
+    resources.classrooms = [{
+      id: CLASSROOM_ID,
+      teacher_id: TEACHER_ID,
+      title: 'Projection fixture',
+      archived_at: '2026-07-15T12:00:00.000Z',
+    }]
+    resources.assignments = [{
+      id: '10000000-0000-4000-8000-000000000001',
+      classroom_id: CLASSROOM_ID,
+      created_by: TEACHER_ID,
+    }]
+    resources.assignment_docs = [{
+      id: '10000000-0000-4000-8000-000000000002',
+      assignment_id: '10000000-0000-4000-8000-000000000001',
+      student_id: '10000000-0000-4000-8000-000000000004',
+    }]
+    resources.assignment_submission_artifacts = [{
+      id: '10000000-0000-4000-8000-000000000003',
+      assignment_doc_id: '10000000-0000-4000-8000-000000000002',
+      student_id: '10000000-0000-4000-8000-000000000004',
+      storage_path: sourcePath,
+      metadata: { preserved: true },
+    }]
+    const bundle = buildClassroomArchiveBundle({
+      archiveId: plan().operation_ids.export,
+      classroomId: CLASSROOM_ID,
+      teacherId: TEACHER_ID,
+      createdAt: '2026-07-15T12:00:00.000Z',
+      source: { schemaMigration: '082_verified_classroom_archive_exports', appCommit: COMMIT },
+      retention: { mode: 'teacher_managed', delete_after: null },
+      resources,
+      actors: [
+        { id: TEACHER_ID, email: 'teacher@example.test', role: 'teacher', profile: null },
+        {
+          id: '10000000-0000-4000-8000-000000000004',
+          email: 'student@example.test',
+          role: 'student',
+          profile: null,
+        },
+      ],
+      storageObjects: [{
+        bucket: 'assignment-artifacts',
+        sourcePath,
+        contentType: 'image/png',
+        bytes: Buffer.from('projection bytes'),
+      }],
+    })
+    const verified = verifyClassroomArchiveBundle(bundle.archive)
+    if (!verified.ok) throw new Error(verified.error)
+    const projection = createClassroomArchiveProductionCanaryArchiveProjection({
+      verified,
+      sourceRevision: 7,
+      restoreOperationId: plan().operation_ids.restore,
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    expect(projection.restoredStorageMappings).toEqual([expect.objectContaining({
+      bucket: 'assignment-artifacts',
+      sourcePath,
+    })])
+    expect(() => assertClassroomArchiveProductionCanaryStorageMappingsEqual({
+      independent: projection.restoredStorageMappings,
+      planned: projection.restoredStorageMappings.map((mapping) => ({
+        ...mapping,
+        restorePath: `${mapping.restorePath}-wrong`,
+      })),
+    })).toThrow('independent restored paths differ')
+    expect(createClassroomArchiveProductionCanaryVerifiedArchiveProjection({
+      verified,
+      sourceRevision: 7,
+      restoreOperationId: plan().operation_ids.restore,
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+      plannedStorageMappings: projection.restoredStorageMappings,
+    })).toEqual(projection)
+    expect(() => createClassroomArchiveProductionCanaryVerifiedArchiveProjection({
+      verified,
+      sourceRevision: 7,
+      restoreOperationId: plan().operation_ids.restore,
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+      plannedStorageMappings: projection.restoredStorageMappings.map((mapping) => ({
+        ...mapping,
+        restorePath: `${mapping.restorePath}-wrong`,
+      })),
+    })).toThrow('independent restored paths differ')
+    expect(projection.restoredEvidence).toEqual(
+      createClassroomArchiveProductionCanaryNormalizedEvidence({
+        sourceRevision: 7,
+        resources,
+        storageObjects: bundle.manifest.storage_objects.map((object) => ({
+          bucket: object.bucket,
+          path: object.source_path,
+          byteSize: object.byte_size,
+          sha256: object.sha256,
+        })),
+        storageMappings: projection.restoredStorageMappings,
+        storagePathKind: 'source',
+        supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+      }),
+    )
+    const runner = readFileSync(resolve(
+      process.cwd(),
+      'scripts/run-classroom-archive-production-canary.ts',
+    ), 'utf8')
+    expect(runner).toContain('createClassroomArchiveProductionCanaryVerifiedArchiveProjection({')
+    expect(runner).not.toContain('restorePlan.resources')
+  })
+
+  it('builds strict normalized evidence for the runner without sharing restore rows', () => {
+    const sourcePath = 'student/evidence.png'
+    const restorePath = deriveClassroomArchiveProductionCanaryRestoredStoragePath({
+      classroomId: CLASSROOM_ID,
+      operationId: plan().operation_ids.restore,
+      sha256: SHA,
+      sourcePath,
+      contentType: 'image/png',
+    })
+    const storageMappings = [{ bucket: 'assignment-artifacts', sourcePath, restorePath }]
+    const baseResources = Object.fromEntries(
+      CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => [table, []]),
+    ) as Record<string, Array<Record<string, unknown>>>
+    const sourceResources = {
+      ...baseResources,
+      classrooms: [{ id: CLASSROOM_ID, teacher_id: TEACHER_ID, title: 'Original' }],
+      assignment_submission_artifacts: [{ storage_path: sourcePath, metadata: { kept: true } }],
+    }
+    const restoredResources = {
+      ...baseResources,
+      classrooms: [{ id: CLASSROOM_ID, teacher_id: TEACHER_ID, title: 'Original' }],
+      assignment_submission_artifacts: [{ storage_path: restorePath, metadata: { kept: true } }],
+    }
+    const expected = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: sourceResources,
+      storageObjects: [{ bucket: 'assignment-artifacts', path: sourcePath, byteSize: 5, sha256: SHA }],
+      storageMappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    const actual = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: restoredResources,
+      storageObjects: [{ bucket: 'assignment-artifacts', path: restorePath, byteSize: 5, sha256: SHA }],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    expect(actual).toEqual(expected)
+
+    const drifted = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: {
+        ...restoredResources,
+        assignment_submission_artifacts: [{
+          storage_path: restorePath,
+          metadata: { kept: false },
+        }],
+      },
+      storageObjects: [{ bucket: 'assignment-artifacts', path: restorePath, byteSize: 5, sha256: SHA }],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    expect(drifted.evidence_sha256).not.toBe(expected.evidence_sha256)
+    const wrongBytes = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: restoredResources,
+      storageObjects: [{
+        bucket: 'assignment-artifacts',
+        path: restorePath,
+        byteSize: 5,
+        sha256: 'd'.repeat(64),
+      }],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    expect(wrongBytes.evidence_sha256).not.toBe(expected.evidence_sha256)
+    expect(() => createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: sourceResources,
+      storageObjects: [{ bucket: 'assignment-artifacts', path: sourcePath, byteSize: 5, sha256: SHA }],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).toThrow('restored storage object path is unknown')
+    expect(() => createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: restoredResources,
+      storageObjects: [],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).toThrow('storage object count differs')
+    expect(() => createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: restoredResources,
+      storageObjects: [
+        { bucket: 'assignment-artifacts', path: restorePath, byteSize: 5, sha256: SHA },
+        { bucket: 'assignment-artifacts', path: 'extra', byteSize: 1, sha256: SHA },
+      ],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).toThrow('storage object count differs')
+  })
+
+  it('binds each restored object checksum to its source identity', () => {
+    const sourcePaths = ['student/first.png', 'student/second.png']
+    const shas = ['1'.repeat(64), '2'.repeat(64)]
+    const storageMappings = sourcePaths.map((sourcePath, index) => ({
+      bucket: 'assignment-artifacts',
+      sourcePath,
+      restorePath: deriveClassroomArchiveProductionCanaryRestoredStoragePath({
+        classroomId: CLASSROOM_ID,
+        operationId: plan().operation_ids.restore,
+        sha256: shas[index],
+        sourcePath,
+        contentType: 'image/png',
+      }),
+    }))
+    const resources = Object.fromEntries(
+      CLASSROOM_RELATIONAL_RESOURCES.map(({ table }) => [table, []]),
+    ) as Record<string, Array<Record<string, unknown>>>
+    resources.classrooms = [{ id: CLASSROOM_ID, teacher_id: TEACHER_ID }]
+    resources.assignment_submission_artifacts = storageMappings.map((mapping, index) => ({
+      id: `artifact-${index}`,
+      storage_path: mapping.restorePath,
+    }))
+    const sourceResources = {
+      ...resources,
+      assignment_submission_artifacts: storageMappings.map((mapping, index) => ({
+        id: `artifact-${index}`,
+        storage_path: mapping.sourcePath,
+      })),
+    }
+    const expected = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources: sourceResources,
+      storageObjects: storageMappings.map((mapping, index) => ({
+        bucket: mapping.bucket,
+        path: mapping.sourcePath,
+        byteSize: index === 0 ? 5 : 7,
+        sha256: shas[index],
+      })),
+      storageMappings,
+      storagePathKind: 'source',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    const swapped = createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources,
+      storageObjects: storageMappings.map((mapping, index) => ({
+        bucket: mapping.bucket,
+        path: mapping.restorePath,
+        byteSize: index === 0 ? 7 : 5,
+        sha256: shas[index === 0 ? 1 : 0],
+      })),
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })
+    expect(swapped.evidence_sha256).not.toBe(expected.evidence_sha256)
+    expect(() => createClassroomArchiveProductionCanaryNormalizedEvidence({
+      sourceRevision: 7,
+      resources,
+      storageObjects: [
+        {
+          bucket: storageMappings[0].bucket,
+          path: storageMappings[0].restorePath,
+          byteSize: 5,
+          sha256: shas[0],
+        },
+        {
+          bucket: storageMappings[1].bucket,
+          path: 'restores/unknown-object',
+          byteSize: 7,
+          sha256: shas[1],
+        },
+      ],
+      storageMappings,
+      storagePathKind: 'restored',
+      supabaseUrl: `https://${PROJECT_REF}.supabase.co`,
+    })).toThrow('restored storage object path is unknown')
+  })
 })
 
 describe('production classroom archive canary orchestration', () => {
@@ -313,7 +776,7 @@ describe('production classroom archive canary orchestration', () => {
     })
     expect(deps.calls).toEqual([
       'state', 'archive', 'evidence', 'export', 'archive', 'compact', 'state',
-      'restore', 'evidence', 'verify',
+      'restore', 'restored-evidence', 'verify',
     ])
   })
 
@@ -399,6 +862,33 @@ describe('production classroom archive canary orchestration', () => {
     const drifting = dependencies({ postEvidence: changed })
     await expect(runClassroomArchiveProductionCanary({ plan: plan(), dependencies: drifting }))
       .rejects.toThrow('exact resource or storage evidence differs')
+  })
+
+  it('reconciles thrown restore calls from durable state before retrying', async () => {
+    const approvedPlan = plan()
+    const deps = dependencies({
+      restoreThrows: 1,
+      states: [
+        { phase: 'hot', teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+        { phase: 'cold', teacherId: TEACHER_ID, archiveId: approvedPlan.operation_ids.export },
+        { phase: 'hot', teacherId: TEACHER_ID, archivedAt: '2026-07-01T00:00:00.000Z' },
+      ],
+    })
+    const result = await runClassroomArchiveProductionCanary({
+      plan: approvedPlan,
+      dependencies: deps,
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      restoreReplayed: true,
+      restoreAttempts: 1,
+    })
+    expect(deps.calls.filter((call) => call === 'restore')).toHaveLength(1)
+    expect(deps.events).toContainEqual({
+      phase: 'restore',
+      status: 'reconciled',
+      errorCode: 'restore_call_threw',
+    })
   })
 
   it('reconciles an ambiguous restore response only from exact durable hot state', async () => {

--- a/tests/lib/server/classroom-archive-restore-operations.test.ts
+++ b/tests/lib/server/classroom-archive-restore-operations.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CLASSROOM_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
 import { buildClassroomArchiveBundle } from '@/lib/server/classroom-archive-format'
 import {
+  classroomArchiveRestoreObjectPath,
+} from '@/lib/server/classroom-archive-restore'
+import {
   isClassroomArchiveRestoreAllowed,
   resolveClassroomArchiveRestoreDatabaseBudget,
   restoreClassroomArchive,
@@ -71,6 +74,11 @@ function createSupabaseMock(options: {
   completeMalformed?: boolean
   stageFailure?: boolean
   failureRecorded?: boolean
+  failureRecordThrows?: boolean
+  postUploadReadFailureOnce?: boolean
+  stageRpcThrows?: boolean
+  preexistingRestoreObject?: boolean
+  metadataErrorOnce?: boolean
 } = {}) {
   const bundle = fixture()
   const counts = Object.fromEntries(
@@ -85,6 +93,19 @@ function createSupabaseMock(options: {
     : bundle.archive
   const stored = new Map<string, Uint8Array>()
   const removed: string[] = []
+  if (options.preexistingRestoreObject) {
+    const object = bundle.manifest.storage_objects[0]
+    const restorePath = classroomArchiveRestoreObjectPath({
+      classroomId: CLASSROOM_ID,
+      operationId: OPERATION_ID,
+      sha256: object.sha256,
+      sourcePath: object.source_path,
+      contentType: object.content_type,
+    })
+    stored.set(`assignment-artifacts/${restorePath}`, Buffer.from('restore evidence'))
+  }
+  let postUploadReadFailed = false
+  let metadataReads = 0
   const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
     if (name === 'begin_classroom_archive_restore') {
       if (options.beginError) return { data: null, error: options.beginError }
@@ -105,6 +126,7 @@ function createSupabaseMock(options: {
       }
     }
     if (name === 'stage_classroom_archive_restore_rows') {
+      if (options.stageRpcThrows) throw new Error('staging transport unavailable')
       if (options.stageFailure) {
         return {
           data: {
@@ -155,6 +177,7 @@ function createSupabaseMock(options: {
       }
     }
     if (name === 'fail_classroom_archive_restore') {
+      if (options.failureRecordThrows) throw new Error('failure record unavailable')
       return { data: options.failureRecorded !== false, error: null }
     }
     return { data: true, error: null }
@@ -165,8 +188,13 @@ function createSupabaseMock(options: {
       const query = {
         select: vi.fn(() => query),
         eq: vi.fn(() => query),
-        single: vi.fn(async () => ({
-          data: {
+        single: vi.fn(async () => {
+          metadataReads += 1
+          if (options.metadataErrorOnce && metadataReads === 1) {
+            return { data: null, error: { code: 'PGRST503', message: 'temporarily unavailable' } }
+          }
+          return {
+            data: {
             id: ARCHIVE_ID,
             classroom_id: CLASSROOM_ID,
             teacher_id: TEACHER_ID,
@@ -177,9 +205,10 @@ function createSupabaseMock(options: {
             compressed_byte_size: bundle.archive.byteLength,
             uncompressed_byte_size: bundle.uncompressedByteSize,
             resource_counts: counts,
-          },
-          error: null,
-        })),
+            },
+            error: null,
+          }
+        }),
       }
       return query
     }
@@ -202,6 +231,15 @@ function createSupabaseMock(options: {
         const bytes = bucket === 'classroom-archives'
           ? archive
           : stored.get(`${bucket}/${path}`)
+        if (
+          bucket !== 'classroom-archives' &&
+          bytes &&
+          options.postUploadReadFailureOnce &&
+          !postUploadReadFailed
+        ) {
+          postUploadReadFailed = true
+          throw new Error('transient read failure')
+        }
         return bytes
           ? {
               data: {
@@ -381,9 +419,113 @@ describe('classroom archive restore coordinator', () => {
 
     expect(result).toEqual(expect.objectContaining({
       ok: false,
+      error_code: 'classroom_archive_restore_failure_recording_failed',
+      retryable: true,
+    }))
+    expect(mock.stored.size).toBe(1)
+    expect(mock.removed).toEqual([])
+  })
+
+  it('retries the same operation after a transient post-upload read failure', async () => {
+    const mock = createSupabaseMock({ postUploadReadFailureOnce: true })
+    const args = {
+      supabase: mock.client,
+      operationId: OPERATION_ID,
+      archiveId: ARCHIVE_ID,
+      teacherId: TEACHER_ID,
+      classroomId: CLASSROOM_ID,
+      databaseBudgetBytes: 524288000,
+      supabaseUrl: 'https://project.supabase.co',
+    }
+
+    await expect(restoreClassroomArchive(args)).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      operation_id: OPERATION_ID,
+      error_code: 'restore_storage_readback_failed',
+      retryable: true,
+    }))
+    expect(mock.stored.size).toBe(1)
+    expect(mock.removed).toEqual([])
+
+    await expect(restoreClassroomArchive(args)).resolves.toEqual(expect.objectContaining({
+      ok: true,
+      operation_id: OPERATION_ID,
+    }))
+  })
+
+  it('returns a structured failure when durable failure recording throws', async () => {
+    const mock = createSupabaseMock({ stageFailure: true, failureRecordThrows: true })
+    await expect(restoreClassroomArchive({
+      supabase: mock.client,
+      operationId: OPERATION_ID,
+      archiveId: ARCHIVE_ID,
+      teacherId: TEACHER_ID,
+      classroomId: CLASSROOM_ID,
+      databaseBudgetBytes: 524288000,
+      supabaseUrl: 'https://project.supabase.co',
+    })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      error_code: 'classroom_archive_restore_failure_recording_failed',
+      retryable: true,
+    }))
+    expect(mock.stored.size).toBe(1)
+    expect(mock.removed).toEqual([])
+  })
+
+  it('keeps unexpected SDK failures retryable for the fixed operation id', async () => {
+    const mock = createSupabaseMock({ stageRpcThrows: true })
+    await expect(restoreClassroomArchive({
+      supabase: mock.client,
+      operationId: OPERATION_ID,
+      archiveId: ARCHIVE_ID,
+      teacherId: TEACHER_ID,
+      classroomId: CLASSROOM_ID,
+      databaseBudgetBytes: 524288000,
+      supabaseUrl: 'https://project.supabase.co',
+    })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      error_code: 'classroom_archive_restore_unexpected_failure',
+      retryable: true,
+    }))
+  })
+
+  it('does not remove a matching object that this invocation reused', async () => {
+    const mock = createSupabaseMock({ stageFailure: true, preexistingRestoreObject: true })
+    await expect(restoreClassroomArchive({
+      supabase: mock.client,
+      operationId: OPERATION_ID,
+      archiveId: ARCHIVE_ID,
+      teacherId: TEACHER_ID,
+      classroomId: CLASSROOM_ID,
+      databaseBudgetBytes: 524288000,
+      supabaseUrl: 'https://project.supabase.co',
+    })).resolves.toEqual(expect.objectContaining({
+      ok: false,
       error_code: 'restore_staging_rejected',
     }))
     expect(mock.stored.size).toBe(1)
     expect(mock.removed).toEqual([])
+  })
+
+  it('retries the same operation after a transient archive metadata read error', async () => {
+    const mock = createSupabaseMock({ metadataErrorOnce: true })
+    const args = {
+      supabase: mock.client,
+      operationId: OPERATION_ID,
+      archiveId: ARCHIVE_ID,
+      teacherId: TEACHER_ID,
+      classroomId: CLASSROOM_ID,
+      databaseBudgetBytes: 524288000,
+      supabaseUrl: 'https://project.supabase.co',
+    }
+    await expect(restoreClassroomArchive(args)).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      error_code: 'classroom_archive_metadata_read_failed',
+      retryable: true,
+    }))
+    await expect(restoreClassroomArchive(args)).resolves.toEqual(expect.objectContaining({
+      ok: true,
+      operation_id: OPERATION_ID,
+    }))
   })
 })

--- a/tests/unit/classroom-archive-restore-recovery-migration.test.ts
+++ b/tests/unit/classroom-archive-restore-recovery-migration.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/097_classroom_archive_restore_recovery.sql',
+  ),
+  'utf8',
+)
+
+describe('classroom archive restore recovery migration', () => {
+  it('keeps concurrent retryable finalization replayable', () => {
+    expect(migration).toContain("v_operation.status = 'failed'")
+    expect(migration).toContain('v_operation.retryable is true')
+    expect(migration).toContain(
+      'v_operation.snapshot_expires_at > clock_timestamp()',
+    )
+    expect(migration).toContain("'retryable', true")
+    expect(migration).toContain('private.complete_classroom_archive_restore_v095')
+  })
+
+  it('rearms only the exact expired restore request with the same operation id', () => {
+    expect(migration).toContain("v_operation.error_code = 'archive_snapshot_expired'")
+    expect(migration).toContain('v_operation.request_sha256 = p_request_sha256')
+    expect(migration).toContain('v_operation.adapter_chain = p_adapter_chain')
+    expect(migration).toContain('v_operation.resource_counts = p_resource_counts')
+    expect(migration).toContain('public.classroom_archive_restore_expected_objects')
+    expect(migration).toContain(
+      'delete from public.classroom_archive_object_upload_cleanup',
+    )
+    expect(migration).toContain("status = 'processing'")
+    expect(migration).toContain("'restore_cleanup_in_progress'")
+    expect(migration).toContain("snapshot_expires_at = v_now + interval '24 hours'")
+    expect(migration).toContain("exception when sqlstate 'PRA01'")
+    expect(migration).toContain('private.begin_classroom_archive_restore_v083')
+    expect(migration.indexOf('cleanup_expired_classroom_archive_snapshots')).toBeLessThan(
+      migration.indexOf('select * into v_operation', migration.indexOf('security definer')),
+    )
+  })
+
+  it('preserves service-role-only execution through public wrappers', () => {
+    expect(migration).toContain(
+      'revoke all on function public.begin_classroom_archive_restore',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.begin_classroom_archive_restore',
+    )
+    expect(migration).toContain(
+      'revoke all on function private.complete_classroom_archive_restore',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- harden restore retry, storage read-back, failure persistence, and cleanup ownership
- verify restored classrooms with an independent archive-derived equality oracle
- add migration 097 for concurrent finalization and safe same-ID expiry recovery
- expand canary, restore, migration, and database contract regressions

## Why
The approved production archive canary must remain recoverable under transport failures, concurrent finalization, snapshot expiry, and cleanup-worker races. The prior implementation could terminally poison a fixed restore operation ID or invalidate cleanup authority during recovery.

## Deployment obligation
- A human must apply migration 097 before this app version is deployed or the production canary is run.
- Keep classroom source cleanup and Gradex cleanup disabled.
- Prepare a fresh named canary plan after production reaches this commit; do not reuse the obsolete local plan.

## Validation
- 364 test files / 3,345 tests
- production build
- TypeScript
- architecture boundaries: 600 modules, 0 allowances
- focused ESLint and Pika pre-commit audit
- Bash syntax and git diff checks
- repeated independent review/fix loops; final SQL and application reviews found no actionable issues

`pnpm db:types:check` is intentionally blocked locally because the database remains at migration 096; migration 097 was not applied by the agent.