### PR TITLE
Scope archive compaction timeout

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,9 +7,9 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Product status: core classroom, assignment, quiz/test, and auth flows are live.
 - Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
 - Feature inventory: `.ai/features.json` is the status authority for big epics; check it directly for current pass/fail state.
-- Classroom archives: production migrations 001-096, the read-only inventory, and the hosted catalog
-  audit are verified. Source and Gradex cleanup remain disabled. The named export/compact/immediate-
-  restore production canary and its post-run verification remain before rollout completion.
+- Classroom archives: production migrations 001-097 and hosted audits are verified. The named export
+  completed, but compaction rolled back on timeout. Apply migration 098, then resume the same fixed
+  operation. Cleanup remains disabled; immediate restore verification remains.
 
 ## Environment And Workflow Facts
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13687,3 +13687,13 @@
 - `bash scripts/repo-tidy.sh` (clean run against the tidied repo)
 - `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
 - `pnpm lint`
+
+## 2026-07-10 — Issue backlog triage + CONTRIBUTING "Finding work" section
+
+**Completed:**
+- Triaged 61 open issues → 46. Closed 10 delivered-by-merged-PR (#86/#87/#88/#99/#144/#418/#431/#460/#523/#417), 2 duplicates (#451→#152, #366→#362), 1 abandoned (#252), 2 out-of-direction Clerk auth (#434/#449).
+- Labeled all 46 survivors (0 unlabeled): 14 bug, 29 enhancement, 4 good-first-issue, 2 needs-triage (new label).
+- Added a "Finding something to work on" section to CONTRIBUTING.md pointing collaborators at label filters and noting big ideas (e.g. gamification #205) vs ad-hoc feature work.
+
+**Validation:**
+- `gh issue list` label coverage check (0 unlabeled)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,16 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-10 — Issue backlog triage + CONTRIBUTING "Finding work" section
-
-**Completed:**
-- Triaged 61 open issues → 46. Closed 10 delivered-by-merged-PR (#86/#87/#88/#99/#144/#418/#431/#460/#523/#417), 2 duplicates (#451→#152, #366→#362), 1 abandoned (#252), 2 out-of-direction Clerk auth (#434/#449).
-- Labeled all 46 survivors (0 unlabeled): 14 bug, 29 enhancement, 4 good-first-issue, 2 needs-triage (new label).
-- Added a "Finding something to work on" section to CONTRIBUTING.md pointing collaborators at label filters and noting big ideas (e.g. gamification #205) vs ad-hoc feature work.
-
-**Validation:**
-- `gh issue list` label coverage check (0 unlabeled)
-
 ## 2026-07-10 — Auto-label new issues with needs-triage
 
 **Completed:**
@@ -800,3 +790,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Pika pre-commit audit
 - `git diff --check`
 - `pnpm db:types:check` intentionally blocked because local database history remains at 096 and AI did not apply migration 097
+
+## 2026-07-15 — Production archive canary timeout hardening
+
+**Completed:**
+- Verified production migrations 001-097, released the reviewed archive recovery changes, and prepared a fresh named canary against the exact production deployment.
+- Completed the approved production export for one archived-hot classroom: 42 relational resources and 20 source objects were captured in a 2,489,962-byte compressed archive with independent evidence.
+- Kept the classroom hot after two same-operation compaction attempts rolled back atomically. No source or Gradex cleanup ran; all 20 source cleanup rows remain staged and no ownership verification or deletion attempt was recorded.
+- Correlated both failures with PostgreSQL SQLSTATE `57014` in hosted logs: `complete_classroom_archive_compaction` exceeded the default statement timeout while finalizing the transition.
+- Added migration 098 to set `statement_timeout = '60s'` only on the service-only compaction finalizer. Added source and replayed-database assertions that reject role- or database-wide timeout changes.
+- Left migration application and the existing canary resume to a human. Independent subagent review was unavailable due to the account usage limit; local SQL review found no additional issue.
+
+**Deployment obligation:**
+- Apply migration 098 before resuming the existing fixed canary operation from its approved runner commit.
+- Keep source cleanup and Gradex cleanup disabled. Resume the same plan; do not prepare a replacement operation or release a different runner before the round trip completes.
+
+**Validation:**
+- Focused archive timeout/compaction/migration suites (3 files / 11 tests)
+- `pnpm vitest run` (365 files / 3,346 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- Bash syntax validation for the compaction database contract harness
+- Pika pre-commit audit (no TypeScript files changed)
+- `git diff --check`
+- Database replay deferred to PR CI because local database history remains at 097 and AI did not apply migration 098

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -223,11 +223,16 @@ On failure, roll back relational writes, remove operation-scoped temporary objec
 tombstone and original archive, and store a retryable error code. Never mark the classroom hot or
 active after a partial restore.
 
+The atomic cold-compaction finalizer has a function-scoped 60-second statement timeout. This is the
+maximum configurable timeout for Supabase client/API queries and does not widen role, database, or
+ordinary user-query timeouts. A timeout rolls back the transition and remains retryable under the
+same operation id.
+
 ### Named Production Round-Trip Canary
 
 `pnpm canary:classroom-archive-production` is the only supported operator runner for the first named
 production export, cold-compaction, and immediate restore. It is not a route, schedule, or general
-classroom command. Before use, migrations 082 through 096, the direct catalog audit, the read-only
+classroom command. Before use, migrations 082 through 098, the direct catalog audit, the read-only
 inventory, database headroom, and deployment of the exact runner commit must be independently
 verified.
 

--- a/scripts/check-classroom-archive-compaction-database.sh
+++ b/scripts/check-classroom-archive-compaction-database.sh
@@ -122,6 +122,23 @@ create trigger reject_rollback_compaction
   before delete on public.classrooms
   for each row execute function public.reject_test_classroom_archive_compaction();
 
+do $timeout_contract$
+begin
+  if not exists (
+    select 1
+    from pg_proc procedure
+    join pg_namespace namespace on namespace.oid = procedure.pronamespace
+    where namespace.nspname = 'public'
+      and procedure.proname = 'complete_classroom_archive_compaction'
+      and pg_get_function_identity_arguments(procedure.oid) =
+        'p_operation_id uuid, p_teacher_id uuid, p_actors jsonb, p_verification jsonb'
+      and procedure.proconfig @> array['statement_timeout=60s']::text[]
+  ) then
+    raise exception 'Compaction finalizer does not have the function-scoped 60-second timeout';
+  end if;
+end;
+$timeout_contract$;
+
 set local role service_role;
 
 do $contract$

--- a/supabase/migrations/098_classroom_archive_compaction_timeout.sql
+++ b/supabase/migrations/098_classroom_archive_compaction_timeout.sql
@@ -1,0 +1,9 @@
+-- Give the service-only atomic compaction finalizer enough time for large classrooms.
+
+alter function public.complete_classroom_archive_compaction(
+  uuid, uuid, jsonb, jsonb
+) set statement_timeout = '60s';
+
+comment on function public.complete_classroom_archive_compaction(
+  uuid, uuid, jsonb, jsonb
+) is 'Atomically verifies and cold-compacts one archived classroom; service role only, with a function-scoped 60-second statement timeout.';

--- a/tests/unit/classroom-archive-compaction-timeout-migration.test.ts
+++ b/tests/unit/classroom-archive-compaction-timeout-migration.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/098_classroom_archive_compaction_timeout.sql',
+  ),
+  'utf8',
+)
+
+describe('classroom archive compaction timeout migration', () => {
+  it('extends only the atomic compaction finalizer to the REST API maximum', () => {
+    expect(migration).toContain(
+      'alter function public.complete_classroom_archive_compaction(',
+    )
+    expect(migration).toContain("set statement_timeout = '60s'")
+    expect(migration).not.toMatch(/alter\s+(?:database|role)/i)
+    expect(migration.match(/set statement_timeout/g)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- set a 60-second statement timeout only on `complete_classroom_archive_compaction`
- verify the setting in source tests and the ephemeral PostgreSQL contract replay
- record the production canary timeout evidence and required same-operation resume

## Production evidence
- the approved named export completed with 42 relational resources and 20 source objects
- both same-operation compaction attempts rolled back with PostgreSQL SQLSTATE `57014`
- the classroom remains hot; source and Gradex cleanup remain disabled
- no ownership verification or deletion attempt was recorded

## Rollout
1. Merge this PR.
2. A human applies migration `098`; AI must not apply migrations.
3. Resume the existing canary plan from approved runner commit `26e2ecabf7dae4e42e27fda8eead9db7155375a6`.
4. Verify immediate restore and durable evidence before enabling any cleanup or completing the archive epic.

## Validation
- `pnpm test --run` (365 files / 3,346 tests)
- `pnpm exec tsc --noEmit`
- `pnpm run check:architecture` (600 modules / 0 allowances)
- `pnpm build`
- `bash -n scripts/check-classroom-archive-compaction-database.sh`
- Pika pre-commit audit
- `git diff --check`

The database replay is intentionally delegated to PR CI because the local database remains at migration `097` and repository policy prohibits AI migration application.