### PR TITLE
Allow explicitly authorized AI migrations

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -29,12 +29,12 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 - Repeated client-side reads use `fetchJSONWithCache` from `@/lib/request-cache`
 - Tiptap content parsing uses `parseContentField` from `@/lib/tiptap-content`
 - App code uses semantic tokens and `@/ui` primitives, not raw `dark:` classes or `@/components` UI imports
-- AI may create or edit migration files, but humans apply migrations manually
+- AI applies migrations only with one-time permission naming the target and migration
 
 ## Known Hazards
 
 - Do not work in the hub checkout for non-trivial changes; create or open a dedicated worktree first
 - Do not tail `.ai/JOURNAL-ARCHIVE.md` by default; it is intentionally large
 - Keep `.ai/SESSION-LOG.md` rolling; immediately run `node scripts/trim-session-log.mjs` after each append
-- Do not run `supabase db push`, `supabase db reset`, or other migration-application commands as an AI agent
+- Migration approval never covers reset, repair, rollback, seeding, or cleanup
 - `main` accepts linear history only; `production` merges go through the protected PR flow

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13697,3 +13697,12 @@
 
 **Validation:**
 - `gh issue list` label coverage check (0 unlabeled)
+
+## 2026-07-10 — Auto-label new issues with needs-triage
+
+**Completed:**
+- Added .github/workflows/triage-label.yml: on issue `opened`, adds `needs-triage` if the issue has zero labels (leaves template/pre-labeled issues alone).
+- Dependency-free (uses pre-installed gh CLI, no pinned actions) and least-privilege (`permissions: issues: write` only, over the repo's read-only default).
+
+**Validation:**
+- YAML parse check; workflow runs only on issue events (no CI impact to validate here)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,15 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-10 — Auto-label new issues with needs-triage
-
-**Completed:**
-- Added .github/workflows/triage-label.yml: on issue `opened`, adds `needs-triage` if the issue has zero labels (leaves template/pre-labeled issues alone).
-- Dependency-free (uses pre-installed gh CLI, no pinned actions) and least-privilege (`permissions: issues: write` only, over the repo's read-only default).
-
-**Validation:**
-- YAML parse check; workflow runs only on issue events (no CI impact to validate here)
-
 ## 2026-07-11 — Teacher-ready blueprint classroom rollover
 
 **Completed:**
@@ -815,3 +806,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Pika pre-commit audit (no TypeScript files changed)
 - `git diff --check`
 - Database replay deferred to PR CI because local database history remains at 097 and AI did not apply migration 098
+
+## 2026-07-15 — Explicit AI migration authorization policy
+
+**Completed:**
+- Replaced the blanket AI migration-application prohibition with a human-controlled-by-default contract that permits one exact application only after a current-task instruction names the target environment and exact migration.
+- Required target verification, migration-list inspection, an explicit local/linked dry run, approved-set equality, applicable tests, and read-only post-application verification.
+- Kept reset, migration-history repair, rollback/down, seeding, data cleanup, Storage deletion, alternate database URLs, project relinking, and extra push flags outside ordinary migration approval.
+- Made failed or partial application attempts consume the permission and require renewed authorization before retry.
+- Updated active agent, architecture, project, schema, archive, and legacy-contract guidance and added a regression that prevents blanket prohibition or overbroad authorization from returning.
+- No migration or Supabase project state changed. During validation, a shell search expanded an inline command, but the unlinked worktree failed target resolution before preview or application; it was not retried.
+
+**Validation:**
+- Migration authorization and startup guidance suites (2 files / 29 tests)
+- `pnpm vitest run` (366 files / 3,349 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- `git diff --check`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ Use `docs/guides/ai-ui-testing.md` and `.codex/prompts/ui-verify.md` for the act
 - All deadline calculations use `America/Toronto` timezone.
 - Do not introduce new dependencies unless explicitly approved.
 - Do not commit secrets (`.env.local`, Supabase keys, session secrets).
+- Migration application is human-controlled by default. AI may apply only with one-time permission
+  naming the target and exact migration; follow `docs/guidance/schema-rollout-checklist.md`.
 
 ## When Docs Conflict
 1. `.ai/features.json` (status authority)

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -47,7 +47,7 @@ Inspect or edit source only after startup and routed docs.
 - Repeated client-side reads: use `fetchJSONWithCache` from `@/lib/request-cache`
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
-- Migrations: AI may create or edit migration files, but humans apply them manually
+- Migrations: require one-time permission naming target and migration; follow the schema rollout checklist
 - Workflow: use a worktree; include `Model recommendation: <model> - <reason>`; append `.ai/SESSION-LOG.md`; run `node scripts/trim-session-log.mjs`
 - Risk profile: declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform`
 

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -65,7 +65,9 @@ Adopt a specialized agent role based on your task type. All agents must first re
 
 **Responsibilities**: Design tables and relationships. Write Supabase migrations (SQL). Implement RLS policies. Ensure proper indexing. Document schema changes.
 
-**Must NOT**: Run or apply migrations (human does this). Skip RLS policies. Create tables without constraints. Use raw SQL in app code.
+**Must NOT**: Apply migrations without the one-time target-and-migration authorization in the
+schema rollout checklist. Skip RLS policies. Create tables without constraints. Use raw SQL in app
+code.
 
 ---
 

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -87,7 +87,7 @@ tests/                             # Vitest unit + API suites
 - `src/types/database.ts` composes the generated schema with application-owned JSON, status, and RPC result contracts that PostgreSQL metadata cannot express precisely.
 - Both central clients in `src/lib/supabase.ts` use the composed `Database` type. New server data access should flow through those factories.
 - Use `TableRow`, `TableInsert`, and `TableUpdate` from `@/types/database` for persisted payloads instead of generic records or local copies of table shapes.
-- After changing a migration, start the local Supabase stack through the documented human workflow and run `pnpm run db:types:generate`. CI replays migrations in an ephemeral database and runs `pnpm run db:types:check` to reject drift.
+- After changing a migration, start the local Supabase stack through the authorized migration workflow and run `pnpm run db:types:generate`. CI replays migrations in an ephemeral database and runs `pnpm run db:types:check` to reject drift.
 
 ### Enforced Module Boundaries
 - Run `pnpm check:architecture` before committing changes that move code across layers.

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -54,8 +54,11 @@ Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
    - Maintainer default: symlink the worktree’s `.env.local` to `$HOME/Repos/.env/pika/.env.local`
    - Collaborator default: `cp .env.example .env.local`, then fill in the required values
    - Exception-only: use a branch-specific env file when intentionally isolating backend state
-3. Ensure pending migrations have been applied by a human before runtime work that depends on them.
-   - AI agents may create or edit migration files, but must not run `supabase db push`, `supabase db reset`, or similar migration commands
+3. Ensure pending migrations have been applied before runtime work that depends on them.
+   - Migration application is human-controlled by default. AI requires the one-time, exact target
+     and migration authorization defined in
+     [`docs/guidance/schema-rollout-checklist.md`](../guidance/schema-rollout-checklist.md); reset,
+     repair, rollback, seeding, and cleanup require separate approval.
 4. `pnpm dev` and open http://localhost:3000
 5. Optional: `pnpm seed`
    - To wipe + reseed against a specific env file: `ENV_FILE=.env.custom.local ALLOW_DB_WIPE=true pnpm seed:fresh`
@@ -166,7 +169,7 @@ Legacy anon/service keys are supported but publishable/secret are preferred.
 ## Deployment
 
 - Host on Vercel; configure env vars in dashboard; set `ENABLE_MOCK_EMAIL=false` and add real email provider before production.
-- Supabase Cloud for DB; enable connection pooling; treat migrations as a separate human-controlled deploy step.
+- Supabase Cloud for DB; enable connection pooling; treat migrations as a separately authorized deploy step.
 - If using cron, configure schedules in `vercel.json` or the Vercel dashboard for production. On the Hobby plan, Vercel cron jobs must run at most once per day, so do not add sub-daily schedules. Current repo-managed schedules: nightly log summaries at `0 6 * * *` (06:00 UTC) and history cleanup at `0 7 * * *` (07:00 UTC).
 
 ---

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -457,7 +457,7 @@ restore rollback, and archives without a successful read-back check.
    relationships with the contract. No writes.
 3. **Export only:** create private archives for selected archived classrooms but retain all hot data.
    Compare counts/checksums and measure compression. Migration 082 and the teacher-only API implement
-   this stage; rollout still requires human migration application and selected production canaries.
+   this stage; rollout still requires authorized migration application and selected production canaries.
 4. **Restore canary:** use migration 083's rollback-only database contract first. A teacher-approved
    cold canary may then use the gated restore endpoint; compare all rows/objects and preserve the
    immutable source archive. Production compaction remains disabled.
@@ -471,7 +471,8 @@ restore rollback, and archives without a successful read-back check.
    remaining readers/writers and every retained archive has a tested adapter.
 
 Production database access for inventory and verification is read-only unless a human explicitly
-approves a named canary operation. Migrations are applied by humans.
+approves a named canary operation. Migration application follows the schema rollout authorization
+contract.
 
 Run the production inventory only after verifying the linked project. The command validates the
 expected project ref against `NEXT_PUBLIC_SUPABASE_URL`, compares the deployed 42-resource archive

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -9,8 +9,8 @@ The current product contract is:
 - Legacy quiz routes/tabs are removed from the product surface.
 - Some database tables, payload aliases, TypeScript aliases, package fields, and
   tests intentionally still use `quiz` names while compatibility is maintained.
-- AI agents may create migration files after approval, but humans apply
-  migrations manually.
+- AI agents may create migration files after approval. Application follows the
+  one-time authorization contract in the schema rollout checklist.
 
 ## Current Inventory
 
@@ -199,7 +199,7 @@ Requires a follow-up design and approval:
    - Follow `docs/guidance/schema-rollout-checklist.md`.
    - Include deterministic backfill, compatibility views or aliases if needed,
      regression tests for pre/post shapes, and rollback notes.
-   - Do not apply migrations as an AI agent.
+   - Apply only under the one-time target-and-migration authorization contract.
 
 ### Archive v1 gate
 

--- a/docs/guidance/schema-rollout-checklist.md
+++ b/docs/guidance/schema-rollout-checklist.md
@@ -26,7 +26,39 @@ Use this checklist for migrations, Supabase query-shape changes, compatibility s
 - Constraints/defaults match the intended application behavior
 - Migration numbering does not collide with `origin/main`
 - Any compatibility window is documented in the PR notes
-- AI does not apply migrations locally; humans do
+- Migration application remains human-controlled unless the authorization contract below is satisfied
+
+## AI Migration Application Authorization
+
+Migration application is human-controlled by default. An AI agent may execute it only when the user
+gives a direct, one-time instruction in the current task that names both the target environment
+(`local`, `staging`, or `production`) and the exact migration number(s) or filename(s). Broad requests
+such as "apply migrations", "continue", or approval from an earlier task are not authorization.
+Permission expires after one attempted non-dry-run application command and cannot be reused for a
+retry or a different target.
+
+Before applying an authorized migration:
+
+1. Resolve the repository root and verify the checkout containing the approved migration.
+2. Verify the Supabase target binding without printing credentials or secrets.
+3. Run `supabase migration list` and then `supabase db push --dry-run` with the explicit `--local` or
+   `--linked` target. Stop if the preview includes any unapproved migration or history drift.
+4. Confirm applicable tests and migration replay checks passed. If the migration contains destructive
+   or irreversible SQL, the permission must explicitly acknowledge that impact.
+
+During and after application:
+
+- Apply reviewed migration files through `supabase db push` with the verified target flag. Do not
+  paste migration SQL into the Dashboard SQL editor or `psql` unless separately authorized.
+- Apply only the approved migration set to the approved target. Do not add `--include-all`,
+  `--include-roles`, `--include-seed`, change the linked project, or use an alternate `--db-url`
+  without separate permission.
+- Migration approval never authorizes `supabase db reset`, migration history repair, rollback/down
+  operations, seeding, data cleanup, or Storage deletion. Each requires separate explicit approval.
+- Stop on unexpected prompts, target mismatches, extra migrations, or partial failure. Report the
+  durable state and obtain new permission before retrying.
+- Re-run `supabase migration list`, verify the relevant database contract with read-only checks, and
+  report the target, applied migration numbers, and verification result without exposing secrets.
 
 ## Generated Database Contract
 

--- a/docs/semester-plan.md
+++ b/docs/semester-plan.md
@@ -106,7 +106,7 @@ esac
                       │
 ┌─────────────────────▼───────────────────────────────────┐
 │ 4. APPLY                                                │
-│    - Human applies migration via Supabase Dashboard     │
+│    - Authorized operator applies the migration          │
 │    - Verify via quick smoke test                        │
 └─────────────────────┬───────────────────────────────────┘
                       │

--- a/tests/unit/ai-migration-authorization-policy.test.ts
+++ b/tests/unit/ai-migration-authorization-policy.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readRepoFile = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8')
+
+const policy = readRepoFile('docs/guidance/schema-rollout-checklist.md')
+
+describe('AI migration application authorization policy', () => {
+  it('requires current, one-time authorization for an exact target and migration', () => {
+    expect(policy).toContain('human-controlled by default')
+    expect(policy).toContain('direct, one-time instruction in the current task')
+    expect(policy).toContain('target environment')
+    expect(policy).toContain('exact migration number(s) or filename(s)')
+    expect(policy).toContain(
+      'Permission expires after one attempted non-dry-run application command',
+    )
+    expect(policy).toContain('"apply migrations", "continue"')
+    expect(policy).toContain('approval from an earlier task')
+    expect(policy).toContain('supabase migration list')
+    expect(policy).toContain('supabase db push --dry-run')
+  })
+
+  it('does not let migration approval authorize destructive maintenance', () => {
+    expect(policy).toContain('supabase db reset')
+    expect(policy).toContain('migration history repair')
+    expect(policy).toContain('rollback/down')
+    expect(policy).toContain('seeding')
+    expect(policy).toContain('data cleanup')
+    expect(policy).toContain('Storage deletion')
+    expect(policy).toContain('requires separate explicit approval')
+    expect(policy).toContain('Do not add `--include-all`')
+    expect(policy).toContain('`--include-seed`')
+    expect(policy).toContain('alternate `--db-url`')
+    expect(policy).toMatch(/Do not\s+paste migration SQL into the Dashboard SQL editor/)
+  })
+
+  it('removes the blanket prohibition from active agent guidance', () => {
+    const activeGuidance = [
+      'AGENTS.md',
+      '.ai/CURRENT.md',
+      'docs/ai-instructions.md',
+      'docs/core/agents.md',
+      'docs/core/project-context.md',
+      'docs/guidance/legacy-quiz-contract-cleanup.md',
+      'docs/guidance/schema-rollout-checklist.md',
+    ]
+      .map(readRepoFile)
+      .join('\n')
+
+    expect(activeGuidance).not.toMatch(/humans apply migrations manually/i)
+    expect(activeGuidance).not.toMatch(/AI does not apply migrations/i)
+    expect(activeGuidance).not.toMatch(/Do not apply migrations as an AI agent/i)
+    expect(activeGuidance).not.toMatch(/Run or apply migrations \(human does this\)/i)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the blanket AI migration prohibition with a human-controlled-by-default authorization contract
- require a current, one-time instruction naming the target environment and exact migration
- require target verification, migration-list inspection, dry-run equality, tests, and read-only post-apply verification
- keep reset, repair, rollback, seeding, cleanup, Storage deletion, relinking, alternate URLs, and extra push flags outside ordinary approval
- add regression coverage across active agent guidance

## Authorization examples
Valid: `Apply migration 098 to production.`

Not valid: `Apply migrations`, `continue`, contextual approval that does not name the migration, or approval from an earlier task.

A failed or partial non-dry-run attempt consumes the permission and requires renewed authorization. Destructive or irreversible SQL must be explicitly acknowledged.

## Scope
Documentation and policy tests only. This PR does not apply migration 098 and does not change any Supabase project state.

## Validation
- focused migration-policy/startup suites (2 files / 29 tests)
- `pnpm test --run` (366 files / 3,349 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm run check:architecture` (600 modules / 0 allowances)
- Pika pre-commit audit
- `git diff --check`