### PR TITLE
Harden assignment submission integrity

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,8 +7,8 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-098 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Phase 2 assignment integrity is active in PR #891 on `codex/assignment-submit-save-integrity`: atomic writes, recovery-safe retries, mount-local writer fences, artifact cleanup evidence, concurrency gates, and local teacher/student visual verification are green. Production remains at migration 098.
-- Before merge: wait for PR CI and rereview after the cloned-tab writer-fence fix. Apply and verify migration 099 before deploying the app version.
+- PR #891 assignment integrity is active: atomic writes, recovery-safe retries, mount-local writer fences, cleanup, concurrency checks, and final client race reviews are green. Production remains at migration 098.
+- Before merge/deploy: wait for CI on the final review fixes, then apply and verify migration 099 before deploying the app version.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,12 +1,14 @@
 # Pika Current Context
 
-Read this at session start. `.ai/features.json` is the big-epic status authority; `.ai/SESSION-LOG.md` is recent handoff context. Read `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+Read this at session start. `.ai/features.json` is the epic status authority; `.ai/SESSION-LOG.md` holds recent handoff context.
 
 ## Current Focus
 
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-098 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
-- The active product-experience program is tracked in `.ai/features.json`. Phase 1 evidence lives in `docs/guidance/ui/product-experience-audit-2026-07.md`; the next slice disables legacy permanent hot-archive deletion.
+- The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
+- Phase 2 assignment integrity is active in PR #891 on `codex/assignment-submit-save-integrity`: atomic writes, recovery-safe retries, artifact cleanup evidence, concurrency gates, and local teacher/student visual verification are green. Production remains at migration 098.
+- Before merge: finish PR CI and review. Apply and verify migration 099 before deploying the app version.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,10 +5,9 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 ## Current Focus
 
 - Core classroom, assignment, test, and auth flows are live.
-- Production migrations 001-098 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
+- Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- PR #891 assignment integrity is active: atomic writes, recovery-safe retries, mount-local writer fences, cleanup, concurrency checks, and final client race reviews are green. Production remains at migration 098.
-- Before merge/deploy: wait for CI on the final review fixes, then apply and verify migration 099 before deploying the app version.
+- PR #891 assignment integrity is reviewed and green: atomic writes, recovery-safe retries, mount-local writer fences, cleanup, and concurrency checks. Migration 099 is verified in production; merge and deploy the application version next.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,8 +7,8 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-098 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Phase 2 assignment integrity is active in PR #891 on `codex/assignment-submit-save-integrity`: atomic writes, recovery-safe retries, artifact cleanup evidence, concurrency gates, and local teacher/student visual verification are green. Production remains at migration 098.
-- Before merge: finish PR CI and review. Apply and verify migration 099 before deploying the app version.
+- Phase 2 assignment integrity is active in PR #891 on `codex/assignment-submit-save-integrity`: atomic writes, recovery-safe retries, mount-local writer fences, artifact cleanup evidence, concurrency gates, and local teacher/student visual verification are green. Production remains at migration 098.
+- Before merge: wait for PR CI and rereview after the cloned-tab writer-fence fix. Apply and verify migration 099 before deploying the app version.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13771,3 +13771,21 @@
 - No application runtime path, database migration, database row, storage object, dependency, or production environment changed.
 
 **Validation:**
+
+## 2026-07-13 — Enforce architecture dependency boundaries
+
+**Completed:**
+- Added a TypeScript import-graph analyzer for runtime-aware imports, re-exports, dynamic imports, and CommonJS `require`, with independent traversal from every `'use client'` entry.
+- Enforced dependency direction between domain, UI, presentation, API, server-only, and shared type layers; blocked browser reachability to server modules, Supabase runtime clients, Next.js server APIs, and Node built-ins.
+- Added a deletion-only baseline for four existing client paths that reach `src/lib/server/assessment-drafts.ts` through assessment markdown helpers. New violations and obsolete baseline entries fail the check.
+- Replaced the duplicated browser Supabase parser with the shared analyzer, documented the boundaries, and added `pnpm check:architecture` to CI.
+- No runtime product behavior, database migrations, dependencies, or production data changed.
+
+**Validation:**
+- `pnpm run check:architecture` (556 modules; 4 deletion-only allowances)
+- `pnpm test`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm exec vitest run tests/lib/contracts/classroom-lifecycle.test.ts tests/lib/contracts/classroom-artifacts.test.ts` (15 tests)
+- Read-only local catalog audit: `CLASSROOM_SCHEMA_AUDIT_DATABASE_URL=... pnpm exec tsx scripts/check-classroom-resource-schema.ts` (97 public foreign-key relationships)

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13813,3 +13813,27 @@
 - Classroom schema audit (102 public foreign-key relationships)
 - `bash -n scripts/check-classroom-archive-database.sh`
 - `git diff --check`
+
+## 2026-07-13 — Resumable and version-aware classroom archive restore
+
+**Completed:**
+- Added migration 083 with cold tombstones outside the classroom ownership graph, bounded idempotent JSONB staging, conservative database-capacity preflight, concurrent-operation rejection, service-role-only RPCs, and one atomic 42-resource finalization transaction.
+- Added strict archive decoding, source-to-target adapter selection, actor reconciliation, exact storage-reference matching, deterministic operation-scoped object paths, managed-reference rewriting, and outer/read-back checksum verification.
+- Added a separately gated teacher restore endpoint requiring an enable flag, teacher UUID allowlist, idempotency key, and explicit database-budget setting; applying the migration alone does not expose restore or enable compaction.
+- Preserved exact archived values by suppressing blueprint/archive touch triggers only inside the transaction-local restore context and restoring the archived revision explicitly; PostgreSQL records final referential-integrity evidence after inserts pass.
+- Added rollback-only database coverage for capacity refusal, schema drift, unresolved actors, concurrent restores, expired-operation replacement, idempotent staging/completion, exact JSONB row equality, revision preservation, tombstone cleanup, and browser-role denial.
+- Corrected restore concurrency so only unexpired snapshots block a replacement operation; expired operations can no longer strand a cold classroom while awaiting cleanup automation.
+- Kept the archive epic unfinished: cold compaction, separate deidentified Gradex extract generation, cleanup automation, teacher UI, and production canaries remain pending. No production database, migration, row, or storage object was modified.
+
+**Validation:**
+- `pnpm test` (324 files, 2,866 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- Pika audit
+- Fresh isolated Supabase replay through migrations 080/081/082/083 with matching source/copy migration hashes
+- Verified export and restore database contracts executed as `service_role`
+- Post-review focused restore suite (4 files, 21 tests) and fresh rollback-only restore canary, including expired-operation replacement
+- Classroom schema audit (105 public foreign-key relationships)
+- Supabase lint: one existing migration-082 false positive for the function-local `classroom_archive_actor_ids` temporary table; both executable database contracts pass
+- `git diff --check`

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13789,3 +13789,27 @@
 - `pnpm build`
 - `pnpm exec vitest run tests/lib/contracts/classroom-lifecycle.test.ts tests/lib/contracts/classroom-artifacts.test.ts` (15 tests)
 - Read-only local catalog audit: `CLASSROOM_SCHEMA_AUDIT_DATABASE_URL=... pnpm exec tsx scripts/check-classroom-resource-schema.ts` (97 public foreign-key relationships)
+
+## 2026-07-13 — Verified export-only classroom archives
+
+**Completed:**
+- Added migration 082 and a fail-closed teacher API for private, immutable, deterministic classroom archive exports without deleting any hot row or source object.
+- Added idempotent snapshot/finalization RPCs, revision triggers for all 41 descendants, durable operation evidence, strict actor snapshots, 50 MB private archive/Gradex buckets, full upload read-back verification, and terminal/retry recovery behavior.
+- Added canonical tar+gzip and NDJSON serialization with strict manifest, row/byte/checksum, actor, storage-object, content, and outer-artifact verification.
+- Extended the 42-resource schema contract to audit actual primary keys and every direct actor foreign key; actor capture now uses only those explicit columns and rejects arbitrary user UUIDs in free text.
+- Restricted storage discovery by source context: assignment artifacts from relational paths, submission images from embedded content, and test documents only from `tests.documents`.
+- Added a server-only export enable flag plus teacher UUID allowlist, future-retention validation, structured privacy-safe metrics, database CI, recovery guidance, and adversarial regressions.
+- Kept the archive epic unfinished: restore, Gradex extract generation, cold compaction, cleanup automation, teacher UI, and production canaries remain pending.
+
+**Validation:**
+- `pnpm test` (320 files, 2,844 tests)
+- `pnpm lint`
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- Pika audit
+- Fresh isolated Supabase replay through migrations 080/081/082
+- Atomic blueprint database contract
+- Verified archive database contract, including stale-source, terminal replay, unrelated-UUID privacy, retention, grants, and immutable metadata checks
+- Classroom schema audit (102 public foreign-key relationships)
+- `bash -n scripts/check-classroom-archive-database.sh`
+- `git diff --check`

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13757,3 +13757,17 @@
 - `bash -n scripts/check-atomic-blueprint-operations.sh`
 - `git diff --check`
 - Ephemeral Supabase migration/behavior check pending PR CI
+
+## 2026-07-13 — Canonical classroom lifecycle and archive contracts
+
+**Completed:**
+- Added strict Zod-derived contracts for active, hot-archived, and cold-archived lifecycle states, with separate verified evidence for compaction and completed restore.
+- Encoded the current 42-table classroom ownership graph, all restore dependencies, privacy classes, parent-first restore order, child-first cleanup order, and a deidentified Gradex allowlist.
+- Added strict version 1 classroom archive and Gradex extract manifests with canonical file paths, row/byte counts, SHA-256 checksums, retention metadata, actor snapshots, managed storage descriptors, and restore preflight gates.
+- Defined the existing course package as a reusable, student-free, non-recoverable artifact; defined private archive/Gradex destinations and referenced-only discovery for the three current source buckets.
+- Added a read-only PostgreSQL catalog audit that fails on untracked/stale classroom resources, missing restore dependencies, or invalid selection keys, plus recovery, observability, compatibility, and production-canary guidance.
+- Added the unfinished `epic-classroom-lifecycle-archives` entry to the append-only feature inventory so repository status reflects the remaining implementation and production verification work.
+- Removed a duplicated architectural-direction section from `.ai/CURRENT.md` to keep the required startup context below its 16,000-character budget after adding the epic.
+- No application runtime path, database migration, database row, storage object, dependency, or production environment changed.
+
+**Validation:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,30 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Resumable and version-aware classroom archive restore
-
-**Completed:**
-- Added migration 083 with cold tombstones outside the classroom ownership graph, bounded idempotent JSONB staging, conservative database-capacity preflight, concurrent-operation rejection, service-role-only RPCs, and one atomic 42-resource finalization transaction.
-- Added strict archive decoding, source-to-target adapter selection, actor reconciliation, exact storage-reference matching, deterministic operation-scoped object paths, managed-reference rewriting, and outer/read-back checksum verification.
-- Added a separately gated teacher restore endpoint requiring an enable flag, teacher UUID allowlist, idempotency key, and explicit database-budget setting; applying the migration alone does not expose restore or enable compaction.
-- Preserved exact archived values by suppressing blueprint/archive touch triggers only inside the transaction-local restore context and restoring the archived revision explicitly; PostgreSQL records final referential-integrity evidence after inserts pass.
-- Added rollback-only database coverage for capacity refusal, schema drift, unresolved actors, concurrent restores, expired-operation replacement, idempotent staging/completion, exact JSONB row equality, revision preservation, tombstone cleanup, and browser-role denial.
-- Corrected restore concurrency so only unexpired snapshots block a replacement operation; expired operations can no longer strand a cold classroom while awaiting cleanup automation.
-- Kept the archive epic unfinished: cold compaction, separate deidentified Gradex extract generation, cleanup automation, teacher UI, and production canaries remain pending. No production database, migration, row, or storage object was modified.
-
-**Validation:**
-- `pnpm test` (324 files, 2,866 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- Pika audit
-- Fresh isolated Supabase replay through migrations 080/081/082/083 with matching source/copy migration hashes
-- Verified export and restore database contracts executed as `service_role`
-- Post-review focused restore suite (4 files, 21 tests) and fresh rollback-only restore canary, including expired-operation replacement
-- Classroom schema audit (105 public foreign-key relationships)
-- Supabase lint: one existing migration-082 false positive for the function-local `classroom_archive_actor_ids` temporary table; both executable database contracts pass
-- `git diff --check`
-
 ## 2026-07-13 — Deidentified Gradex artifact transformer
 
 **Completed:**
@@ -863,3 +839,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining before merge:**
 - Push the final review fixes and wait for PR checks. Migration 099 still requires exact one-time target authorization and must be applied and verified before this application version is deployed.
+
+## 2026-07-18 — Production assignment integrity migration
+
+**Completed:**
+- Applied only migration `099_assignment_submission_integrity_guards.sql` to the linked production Pika project after exact one-time authorization and a clean dry run.
+- Verified production migration history is aligned through 099, both new ledger tables have RLS enabled, the writer-fence columns are present, and the four application RPCs exist with execution granted to `service_role` but denied to `anon` and `authenticated`.
+- No reset, repair, rollback, seed, cleanup, Storage deletion, or application deployment was performed.
+
+**Validation:**
+- `supabase migration list --linked` records migrations 001-099
+- Read-only production catalog checks for RPC signatures, role grants, RLS, save RPC overload count, and assignment document columns
+- PR #891 CI: architecture/database contracts, full test/build, and UI policy checks passed before application
+
+**Remaining:**
+- Merge PR #891 to deploy the application version that uses migration 099, then continue the product-experience program.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,30 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Verified export-only classroom archives
-
-**Completed:**
-- Added migration 082 and a fail-closed teacher API for private, immutable, deterministic classroom archive exports without deleting any hot row or source object.
-- Added idempotent snapshot/finalization RPCs, revision triggers for all 41 descendants, durable operation evidence, strict actor snapshots, 50 MB private archive/Gradex buckets, full upload read-back verification, and terminal/retry recovery behavior.
-- Added canonical tar+gzip and NDJSON serialization with strict manifest, row/byte/checksum, actor, storage-object, content, and outer-artifact verification.
-- Extended the 42-resource schema contract to audit actual primary keys and every direct actor foreign key; actor capture now uses only those explicit columns and rejects arbitrary user UUIDs in free text.
-- Restricted storage discovery by source context: assignment artifacts from relational paths, submission images from embedded content, and test documents only from `tests.documents`.
-- Added a server-only export enable flag plus teacher UUID allowlist, future-retention validation, structured privacy-safe metrics, database CI, recovery guidance, and adversarial regressions.
-- Kept the archive epic unfinished: restore, Gradex extract generation, cold compaction, cleanup automation, teacher UI, and production canaries remain pending.
-
-**Validation:**
-- `pnpm test` (320 files, 2,844 tests)
-- `pnpm lint`
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- Pika audit
-- Fresh isolated Supabase replay through migrations 080/081/082
-- Atomic blueprint database contract
-- Verified archive database contract, including stale-source, terminal replay, unrelated-UUID privacy, retention, grants, and immutable metadata checks
-- Classroom schema audit (102 public foreign-key relationships)
-- `bash -n scripts/check-classroom-archive-database.sh`
-- `git diff --check`
-
 ## 2026-07-13 — Resumable and version-aware classroom archive restore
 
 **Completed:**
@@ -866,3 +842,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining before merge:**
 - Push the review fix, wait for PR checks, and rereview PR #891. Migration 099 must still be applied and verified before the application version is deployed.
+
+## 2026-07-18 — Assignment submit/recovery race review fixes
+
+**Completed:**
+- Ran independent Sol/high database, client-state, and integration reviews of PR #891 after CI passed. The client review found and fixed four ordering/recovery defects: a conflict catch overwriting a newer durable draft, edits arriving during a successful submit being shown or cleared incorrectly, queued save reconciliation being cleared by a later submit response, and a definitively rejected equal-content recovered operation retaining a stale writer fence.
+- Added a synchronous preserved-draft reference so the submitted server snapshot remains authoritative while newer local content survives save/submit response reordering and can be restored after unsubmit.
+- Replaced stale recovered operations with a fresh mount-local writer identity and refreshed revision while retaining the original metric-session identity and cumulative counters for database deduplication.
+- Added behavior regressions for all four races. Final independent rereviews reported no findings and confirmed the tests fail against the prior implementation.
+- No production data, Storage, migration history, deployment, or visible layout was modified.
+
+**Validation:**
+- `pnpm test` (375 files / 3,487 tests)
+- Focused assignment integrity suites (3 files / 71 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm run check:architecture` (604 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`
+
+**Remaining before merge:**
+- Push the final review fixes and wait for PR checks. Migration 099 still requires exact one-time target authorization and must be applied and verified before this application version is deployed.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,24 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Enforce architecture dependency boundaries
-
-**Completed:**
-- Added a TypeScript import-graph analyzer for runtime-aware imports, re-exports, dynamic imports, and CommonJS `require`, with independent traversal from every `'use client'` entry.
-- Enforced dependency direction between domain, UI, presentation, API, server-only, and shared type layers; blocked browser reachability to server modules, Supabase runtime clients, Next.js server APIs, and Node built-ins.
-- Added a deletion-only baseline for four existing client paths that reach `src/lib/server/assessment-drafts.ts` through assessment markdown helpers. New violations and obsolete baseline entries fail the check.
-- Replaced the duplicated browser Supabase parser with the shared analyzer, documented the boundaries, and added `pnpm check:architecture` to CI.
-- No runtime product behavior, database migrations, dependencies, or production data changed.
-
-**Validation:**
-- `pnpm run check:architecture` (556 modules; 4 deletion-only allowances)
-- `pnpm test`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm exec vitest run tests/lib/contracts/classroom-lifecycle.test.ts tests/lib/contracts/classroom-artifacts.test.ts` (15 tests)
-- Read-only local catalog audit: `CLASSROOM_SCHEMA_AUDIT_DATABASE_URL=... pnpm exec tsx scripts/check-classroom-resource-schema.ts` (97 public foreign-key relationships)
-
 ## 2026-07-13 — Verified export-only classroom archives
 
 **Completed:**
@@ -864,3 +846,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining before merge:**
 - Push the CI compatibility and integration-fixture fixes, wait for PR checks and review, then merge only after the required migration-first deployment obligation is clear.
+
+## 2026-07-17 — Assignment cloned-tab writer-fence review fix
+
+**Completed:**
+- Fixed the PR #891 review finding where a live assignment save-session identity persisted in cloneable `sessionStorage` could be inherited by a duplicated tab. A stale page-exit save from that tab could otherwise be mistaken for a same-editor superseding save and bypass the database revision conflict.
+- Made each mounted student assignment editor use a fresh writer identity and sequence. Exact uncertain operations still retain and replay their original immutable save identity from durable recovery evidence.
+- Replaced the cross-remount identity-reuse test with a regression proving copied writer state is ignored and a remounted editor starts a distinct fence at sequence one.
+- Did not read or modify production, apply migration 099, merge the PR, or advance the broader phased product-experience goal.
+
+**Validation:**
+- `pnpm test` (375 files / 3,484 tests)
+- Focused assignment integrity suites (3 files / 68 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm run check:architecture` (604 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`
+
+**Remaining before merge:**
+- Push the review fix, wait for PR checks, and rereview PR #891. Migration 099 must still be applied and verified before the application version is deployed.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,20 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Canonical classroom lifecycle and archive contracts
-
-**Completed:**
-- Added strict Zod-derived contracts for active, hot-archived, and cold-archived lifecycle states, with separate verified evidence for compaction and completed restore.
-- Encoded the current 42-table classroom ownership graph, all restore dependencies, privacy classes, parent-first restore order, child-first cleanup order, and a deidentified Gradex allowlist.
-- Added strict version 1 classroom archive and Gradex extract manifests with canonical file paths, row/byte counts, SHA-256 checksums, retention metadata, actor snapshots, managed storage descriptors, and restore preflight gates.
-- Defined the existing course package as a reusable, student-free, non-recoverable artifact; defined private archive/Gradex destinations and referenced-only discovery for the three current source buckets.
-- Added a read-only PostgreSQL catalog audit that fails on untracked/stale classroom resources, missing restore dependencies, or invalid selection keys, plus recovery, observability, compatibility, and production-canary guidance.
-- Added the unfinished `epic-classroom-lifecycle-archives` entry to the append-only feature inventory so repository status reflects the remaining implementation and production verification work.
-- Removed a duplicated architectural-direction section from `.ai/CURRENT.md` to keep the required startup context below its 16,000-character budget after adding the epic.
-- No application runtime path, database migration, database row, storage object, dependency, or production environment changed.
-
-**Validation:**
-
 ## 2026-07-13 — Enforce architecture dependency boundaries
 
 **Completed:**
@@ -835,3 +821,46 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Bash syntax validation for the Pika audit script
 - Pika pre-commit audit
 - `git diff --check`
+
+## 2026-07-16 — Phase 2 assignment save and submission integrity
+
+**In progress:**
+- Replaced split assignment draft, submit, unsubmit, and combined assignment/requirement writes with migration-first atomic RPC contracts, revision fences, advisory-lock ordering, durable save-operation replay evidence, and bounded authenticity metric checkpoints.
+- Hardened the student editor for immutable retry payloads, response and body timeouts, exact ambiguity reconciliation, persistent tab writer identity, monotonic recovery generations, 30-day recovery expiry, same-content metric replay, stale page-exit responses, and restore deferral.
+- Added authoritative submit-history enforcement, submitted-content and artifact immutability guards, legacy-writer compatibility, archive-restore normalization, and a 35-day save-ledger cleanup while preserving the 42-resource archive contract.
+- Added durable provisional evidence and a leased cleanup cron for assignment image Storage objects. Upload and row-commit ambiguity are reference-aware; shared paths are not deleted; failed cleanup remains retryable.
+- Added strict Zod request boundaries and validating, additive-compatible RPC response decoders that strip unknown future fields before returning older app shapes.
+- Added migration 099, atomic and live-concurrency SQL harnesses, CI database-contract gates, rollout guidance, generated type coverage, and a narrow Pika-audit exemption for the canonical `parseContentField` implementation.
+- Multiple review rounds found and fixed retry, metric, recovery, artifact cleanup, RPC compatibility, migration-upgrade, lock-order, privilege, timeout, and test-coverage issues. Final client, API, and database rereviews returned no actionable findings.
+- Opened PR #891. Its first architecture-database run exposed three stale-revision setups in the pre-existing feedback-return harness that directly edited submitted content. Replaced those setup writes with allowed feedback-draft revisions so the harness continues testing serialization without violating migration 099's submitted-content guard.
+- The next CI run exposed a synthetic archive ownership race row that referenced no assignment document. Rebuilt the fixture with a real active classroom, assignment, unsubmitted document, and requirement so migration 099's document guard runs normally and the existing archive path reservation still proves serialization.
+- Closed the remaining assignment utility coverage branches for default release clocks and returned documents missing a submission timestamp. The full coverage gate is back to 100% for `src/lib/assignments.ts`.
+- The subsequent real archive round-trip exposed an empty-`search_path` restore wrapper resolving its deferred constraint by an unqualified name. Schema-qualified the migration 099 constraint flush and tightened its migration contract test.
+- The full recovery drill then exposed a stale fixture sequence that inserted a submitted document before its required artifact. The drill now creates an unsubmitted document, attaches its requirement and artifact, and only then submits through the guarded update path. It also verifies submit-history source/restore equality and removes and checks its artifact-cleanup ledger during teardown; a source contract preserves those checks.
+- No production data, Storage, migration history, or deployment was read or modified.
+
+**Deployment obligation:**
+- Apply and verify migration 099 before deploying this application version. Leave migration 099 in place if the app rolls back; do not deploy the new writers before it.
+- Migration application remains human-controlled and requires exact one-time permission naming the target and migration 099.
+
+**Validation:**
+- Focused assignment client/API/server suites, including 46 editor save/submit tests and additive-schema/ambiguous-upload regressions
+- `pnpm test:coverage` (375 files / 3,483 tests; `src/lib/assignments.ts` at 100%)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm run check:architecture` (604 modules / 0 allowances)
+- Atomic assignment SQL transaction harness
+- Assignment concurrency harness against a disposable 001-099 database replay
+- Atomic feedback-return harness against a disposable 001-099 database replay after the CI compatibility fix
+- Classroom archive compaction database contract against a disposable 001-099 database replay after the relational race-fixture fix
+- Real classroom compaction and resumable restore round trip against a disposable 001-099 database replay after the schema-qualified constraint fix
+- Recovery-drill fixture ordering contract plus TypeScript validation after the migration 099 compatibility fix
+- Generated database types match the normalized disposable 001-099 schema
+- Pika pre-commit audit
+- `git diff --check`
+- Local Playwright verification on the assignment surfaces: student editor and restore dialog on desktop/mobile in light/dark; teacher assignment list on desktop/mobile in light/dark
+- The student autosave response was mocked in-browser because local migration 099 is intentionally unapplied; final captures had no console errors and no database write was sent
+
+**Remaining before merge:**
+- Push the CI compatibility and integration-fixture fixes, wait for PR checks and review, then merge only after the required migration-first deployment obligation is clear.

--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -239,9 +239,11 @@ while IFS= read -r file; do
   fi
 
   # c) Duplicated parseContentField function
-  while IFS=: read -r lineno _; do
-    report_violation "duplicate-parseContentField" "$file:$lineno" "import parseContentField from @/lib/tiptap-content instead"
-  done < <(grep -nE '(function|const) parseContentField' "$FULL" 2>/dev/null || true)
+  if [[ "$file" != "src/lib/tiptap-content.ts" ]]; then
+    while IFS=: read -r lineno _; do
+      report_violation "duplicate-parseContentField" "$file:$lineno" "import parseContentField from @/lib/tiptap-content instead"
+    done < <(grep -nE '(function|const) parseContentField' "$FULL" 2>/dev/null || true)
+  fi
 
   # d) console.log in production code (not tests)
   if [[ "$file" != *.test.ts && "$file" != *.spec.ts && "$file" != *.test.tsx && "$file" != *.spec.tsx ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Verify atomic assignment feedback returns
         run: bash scripts/check-atomic-assignment-feedback-returns.sh
 
+      - name: Verify atomic assignment draft and submission integrity
+        run: bash scripts/check-atomic-assignment-submissions.sh
+
+      - name: Verify assignment submission concurrency
+        run: bash scripts/check-assignment-submission-concurrency.sh
+
       - name: Verify atomic student test submission
         run: bash scripts/check-atomic-test-submit.sh
 

--- a/docs/guidance/atomic-assignment-submission-rollout.md
+++ b/docs/guidance/atomic-assignment-submission-rollout.md
@@ -1,0 +1,69 @@
+# Atomic Assignment Submission Rollout
+
+Migration `099_assignment_submission_integrity_guards.sql` is a migration-first compatibility release.
+The application in the same pull request requires the new save, submit, unsubmit, and combined teacher
+update RPCs, so migration 099 must be applied and verified before the application is deployed.
+
+## Deployment Order
+
+1. Keep the previous application version deployed and apply migration 099.
+2. Verify the migration is recorded and that the atomic assignment and concurrency database harnesses
+   pass against an ephemeral replay of migrations 001 through 099.
+3. Verify the service role can execute the four new RPCs while `anon` and `authenticated` cannot.
+4. Deploy the application version that routes assignment saves, submissions, unsubmit, and combined
+   assignment-and-requirement updates through those RPCs.
+5. Drain every previous-version application instance before treating the new RPC contracts as the only
+   supported assignment writers.
+6. Run a controlled non-production save, submit, unsubmit, requirement edit, and history restore canary.
+
+Do not deploy the application before migration 099. New application writes deliberately fail closed when
+the RPCs are unavailable. Leave migration 099 in place if the application is rolled back.
+
+## Previous-Version Compatibility
+
+During the migration-first overlap:
+
+- the new assignment document columns are nullable, so previous-version reads and direct draft saves remain valid;
+- the new server accepts the previous bundle's strict four-field PATCH shape and adapts it to a revision-guarded
+  atomic save until old browser tabs have drained; remove this adapter in a later compatibility PR;
+- previous-version direct submission does not acquire the assignment advisory lock after locking the document,
+  preventing lock-order inversion with the new combined teacher RPC;
+- requirement mutations serialize with assignment documents and reject changes after a submission wins;
+- previous-version archive restores are accepted because the database normalizer adds the missing nullable
+  `save_session_id` and `save_sequence` fields before exact-column validation;
+- the application keeps restore target `083` and adapter identity `classroom-archive-v1-082-to-083`, so operation
+  retries retain the same request hash across deployment while database normalization adapts current columns;
+- a durable save-operation ledger de-duplicates retries even after another browser tab becomes the latest writer;
+- save-operation evidence stores a SHA-256 content digest, the saved revision, and compact cumulative input
+  counters keyed by a metric session; a later attempt subtracts the greatest committed counter checkpoint, so a
+  missing intermediate response cannot duplicate authenticity metrics;
+- save-operation evidence has no classroom ownership foreign key and is removed after 35 days, five days after
+  browser recovery drafts expire; this keeps migration-first archive manifests at their existing 42-resource
+  contract while preserving short-lived retries across compaction;
+- a deferred database trigger creates a counted authoritative submit snapshot when a legacy direct submit does
+  not already contain one; verified archive restores preserve their archived history rows and counts exactly;
+- pre-099 history cleanup remains compatible because authoritative submit rows are silently skipped instead of
+  making the old bulk cleanup transaction fail;
+- image uploads create delayed cleanup evidence before Storage is written; committed artifact rows adopt that
+  evidence, while interrupted uploads and deleted or replaced paths remain in a leased queue until Storage
+  deletion and durable completion are both acknowledged.
+
+The previous teacher route commits assignment metadata separately from requirement replacement. If a student
+submission wins that narrow race, the requirement mutation is rejected while independently valid metadata may
+already be saved. This is the previous route's existing transaction boundary, not a loss of submission data;
+the new application removes it by using the combined atomic teacher RPC.
+
+## Production Boundaries
+
+Migration application remains human-controlled under `docs/guidance/schema-rollout-checklist.md`. This rollout
+does not authorize production data cleanup, archive compaction, Storage deletion, migration repair, or rollback.
+Those operations require separate explicit approval.
+
+## Local Visual Verification
+
+The assignment surfaces were verified with Playwright against local seeded data on desktop and mobile in light
+and dark themes. Coverage included the student editor save-status signal, history preview, restore confirmation
+dialog, and teacher assignment-list regression views. Because migration 099 was intentionally not applied to the
+shared local database, the editor's PATCH response was fulfilled by a browser-only route mock after the real
+read completed. No assignment database write was sent during the final captures, and the final browser sessions
+reported no console errors.

--- a/scripts/check-assignment-submission-concurrency.sh
+++ b/scripts/check-assignment-submission-concurrency.sh
@@ -1,0 +1,492 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+DB_CONTAINER="$(docker ps --filter 'name=^supabase_db_pika$' --format '{{.Names}}' | head -n 1)"
+if [[ -z "$DB_CONTAINER" ]]; then
+  DB_CONTAINER="$(docker ps --filter 'name=supabase_db_' --format '{{.Names}}' | head -n 1)"
+fi
+
+if [[ -z "$DB_CONTAINER" ]]; then
+  echo "Local Supabase database container is not running." >&2
+  exit 1
+fi
+
+TMP_DB="${ASSIGNMENT_CONCURRENCY_DATABASE_NAME:-pika_assignment_concurrency_${RANDOM}_$$}"
+cleanup() {
+  if [[ "${KEEP_ASSIGNMENT_CONCURRENCY_DATABASE:-false}" == "true" ]]; then
+    echo "Kept disposable assignment database: $TMP_DB"
+    return
+  fi
+  docker exec "$DB_CONTAINER" dropdb -U postgres --if-exists "$TMP_DB" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker exec "$DB_CONTAINER" createdb -U postgres "$TMP_DB"
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c '
+  drop schema public;
+  create schema extensions;
+  create extension "uuid-ossp" with schema extensions;
+  create extension pgcrypto with schema extensions;
+  create extension pg_stat_statements with schema extensions;
+  create schema vault;
+  create extension supabase_vault with schema vault;
+  create extension pg_net with schema extensions;
+' >/dev/null
+
+# Clone only the Supabase platform baseline, then rebuild application schemas at 098.
+docker exec "$DB_CONTAINER" pg_dump -U postgres -d postgres --schema-only --no-owner --no-privileges \
+  --schema=public --schema=private --schema=auth --schema=storage \
+  | sed '/^SET log_min_messages =/d; /^CREATE SCHEMA extensions;/d; /^CREATE SCHEMA vault;/d' \
+  | docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+set client_min_messages = warning;
+do $$
+declare
+  v_policy record;
+begin
+  for v_policy in
+    select schemaname, tablename, policyname
+    from pg_policies
+    where schemaname = 'storage'
+  loop
+    execute format(
+      'drop policy %I on %I.%I',
+      v_policy.policyname,
+      v_policy.schemaname,
+      v_policy.tablename
+    );
+  end loop;
+end;
+$$;
+drop schema public cascade;
+drop schema private cascade;
+create schema public;
+SQL
+
+for migration in "$ROOT"/supabase/migrations/*.sql; do
+  if [[ "$(basename "$migration")" == 099_* ]]; then
+    break
+  fi
+  docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+    psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+    < "$migration" >/dev/null
+done
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+begin;
+select set_config('pika.classroom_archive_restore', 'on', true);
+select set_config('pika.classroom_archive_source_revision', '1', true);
+insert into public.users (id, email, role, email_verified_at) values
+  ('20000000-0000-4000-8000-000000000001', 'backfill-teacher@example.invalid', 'teacher', clock_timestamp()),
+  ('20000000-0000-4000-8000-000000000002', 'backfill-student@example.invalid', 'student', clock_timestamp());
+insert into public.classrooms (id, teacher_id, title, class_code) values
+  ('20000000-0000-4000-8000-000000000003', '20000000-0000-4000-8000-000000000001', 'Backfill', 'BACKFILL');
+insert into public.assignments (id, classroom_id, title, description, due_at, created_by) values
+  ('20000000-0000-4000-8000-000000000004', '20000000-0000-4000-8000-000000000003',
+   'Backfill assignment', '', '2026-03-01T00:00:00.000Z', '20000000-0000-4000-8000-000000000001');
+insert into public.assignment_docs (
+  id, assignment_id, student_id, content, is_submitted, submitted_at
+) values (
+  '20000000-0000-4000-8000-000000000005', '20000000-0000-4000-8000-000000000004',
+  '20000000-0000-4000-8000-000000000002', '{"type":"doc","content":[]}'::jsonb,
+  true, '2026-02-01T00:00:00.000Z'
+);
+insert into public.assignment_doc_history (
+  id, assignment_doc_id, patch, snapshot, word_count, char_count, trigger, created_at
+) values (
+  '20000000-0000-4000-8000-000000000006', '20000000-0000-4000-8000-000000000005',
+  null, '{"type":"doc","content":[]}'::jsonb, 0, 0, 'submit', '2026-01-01T00:00:00.000Z'
+);
+commit;
+SQL
+docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+  < "$ROOT/supabase/migrations/099_assignment_submission_integrity_guards.sql" >/dev/null
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $$
+begin
+  if (select count(*) from public.classroom_archive_resource_contract) <> 42 then
+    raise exception 'Migration changed the 42-resource classroom archive contract';
+  end if;
+  if exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.assignment_doc_save_operations'::regclass
+      and contype = 'f'
+  ) then
+    raise exception 'Operational save ledger unexpectedly entered classroom FK ownership';
+  end if;
+  if not exists (
+    select 1
+    from public.assignment_doc_history h
+    join public.assignment_docs d on d.id = h.assignment_doc_id
+    where d.id = '20000000-0000-4000-8000-000000000005'
+      and h.trigger = 'submit'
+      and h.created_at >= d.submitted_at
+      and h.patch is null
+      and h.snapshot = d.content
+  ) then
+    raise exception 'Migration did not backfill the current authoritative submit snapshot';
+  end if;
+end;
+$$;
+SQL
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+insert into public.users (id, email, role, email_verified_at) values
+  ('10000000-0000-4000-8000-000000000001', 'concurrency-teacher@example.invalid', 'teacher', clock_timestamp()),
+  ('10000000-0000-4000-8000-000000000002', 'concurrency-student@example.invalid', 'student', clock_timestamp());
+
+insert into public.classrooms (id, teacher_id, title, class_code) values
+  ('10000000-0000-4000-8000-000000000003', '10000000-0000-4000-8000-000000000001', 'Concurrency', 'CONCUR01');
+
+insert into public.assignments (id, classroom_id, title, description, due_at, created_by) values
+  ('10000000-0000-4000-8000-000000000004', '10000000-0000-4000-8000-000000000003',
+   'Concurrency assignment', '', clock_timestamp() + interval '1 day', '10000000-0000-4000-8000-000000000001');
+
+insert into public.assignment_docs (
+  id, assignment_id, student_id, content, save_session_id, save_sequence
+) values (
+  '10000000-0000-4000-8000-000000000005', '10000000-0000-4000-8000-000000000004',
+  '10000000-0000-4000-8000-000000000002', '{"type":"doc","content":[]}'::jsonb,
+  '10000000-0000-4000-8000-000000000006', 1
+);
+
+insert into public.assignment_doc_history (
+  id, assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+) values (
+  '10000000-0000-4000-8000-000000000007', '10000000-0000-4000-8000-000000000005',
+  null, '{"type":"doc","content":[]}'::jsonb, 0, 0, 'baseline'
+);
+
+insert into public.assignment_submission_requirements (
+  id, assignment_id, type, label, required, position
+) values (
+  '10000000-0000-4000-8000-000000000008', '10000000-0000-4000-8000-000000000004',
+  'link', 'Link', false, 0
+);
+
+insert into public.assignment_submission_artifacts (
+  id, assignment_doc_id, requirement_id, student_id, type, url, validation_status
+) values (
+  '10000000-0000-4000-8000-000000000009', '10000000-0000-4000-8000-000000000005',
+  '10000000-0000-4000-8000-000000000008', '10000000-0000-4000-8000-000000000002',
+  'link', 'https://example.invalid/old', 'valid'
+);
+SQL
+
+run_history_cleanup_race() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+create or replace function public.pause_assignment_doc_update_for_concurrency_check()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if current_setting('pika.assignment_concurrency_pause', true) = 'on' then
+    perform pg_sleep(1);
+  end if;
+  return new;
+end;
+$$;
+create trigger zzz_pause_assignment_doc_update_for_concurrency_check
+after update on public.assignment_docs
+for each row execute function public.pause_assignment_doc_update_for_concurrency_check();
+SQL
+
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c "
+    set lock_timeout = '5s';
+    begin;
+    select set_config('pika.assignment_concurrency_pause', 'on', true);
+    select public.save_assignment_doc_atomic(
+      '10000000-0000-4000-8000-000000000004',
+      '10000000-0000-4000-8000-000000000002',
+      '{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\"}]}'::jsonb,
+      (select updated_at from public.assignment_docs where id = '10000000-0000-4000-8000-000000000005'),
+      'autosave', 0, 1, '[]'::jsonb, null, 0, 0,
+      '10000000-0000-4000-8000-000000000006', 2, gen_random_uuid()
+    );
+    commit;
+  " >/dev/null &
+  local save_pid=$!
+
+  sleep 0.2
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c "
+    set lock_timeout = '5s';
+    begin;
+    delete from public.assignment_doc_history
+      where id = '10000000-0000-4000-8000-000000000007';
+    select pg_sleep(1);
+    commit;
+  " >/dev/null &
+  local cleanup_pid=$!
+
+  wait "$save_pid"
+  wait "$cleanup_pid"
+
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+drop trigger zzz_pause_assignment_doc_update_for_concurrency_check on public.assignment_docs;
+drop function public.pause_assignment_doc_update_for_concurrency_check();
+SQL
+}
+
+run_old_submit_new_requirement_rpc_race() {
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c "
+    set lock_timeout = '5s';
+    begin;
+    update public.assignment_docs
+      set is_submitted = true, submitted_at = clock_timestamp()
+      where id = '10000000-0000-4000-8000-000000000005';
+    select pg_sleep(1);
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+    ) select id, null, content, 0, 0, 'submit'
+      from public.assignment_docs
+      where id = '10000000-0000-4000-8000-000000000005';
+    commit;
+  " >/dev/null &
+  local submit_pid=$!
+
+  sleep 0.2
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+set lock_timeout = '5s';
+do $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.update_assignment_with_submission_requirements_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '{"title":"Concurrent teacher update"}'::jsonb,
+    '[{"id":"10000000-0000-4000-8000-000000000008","type":"link","label":"Link","required":false,"position":0,"validation_policy_json":{}}]'::jsonb
+  );
+  if (v_result->>'status')::integer is distinct from 409 then
+    raise exception 'Concurrent requirement update was not rejected: %', v_result;
+  end if;
+exception
+  when check_violation then
+    if sqlerrm not like '%assignment_requirements_submitted_documents_immutable%' then
+      raise;
+    end if;
+end;
+$$;
+SQL
+  local requirement_rpc_pid=$!
+
+  wait "$submit_pid"
+  wait "$requirement_rpc_pid"
+
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.unsubmit_assignment_doc_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '10000000-0000-4000-8000-000000000002'
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Concurrency fixture could not be reset after direct submit: %', v_result;
+  end if;
+end;
+$$;
+SQL
+}
+
+run_legacy_stale_snapshot_repair() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $$
+declare
+  v_result jsonb;
+  v_revision timestamptz;
+begin
+  select updated_at into v_revision
+  from public.assignment_docs
+  where id = '10000000-0000-4000-8000-000000000005';
+
+  v_result := public.save_assignment_doc_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '10000000-0000-4000-8000-000000000002',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Concurrent newer draft"}]}]}'::jsonb,
+    v_revision, 'autosave', 0, 1, '[]'::jsonb, null, 3, 22,
+    '10000000-0000-4000-8000-000000000006', 3, gen_random_uuid()
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Newer overlap save failed: %', v_result;
+  end if;
+end;
+$$;
+
+update public.assignment_docs
+set is_submitted = true, submitted_at = clock_timestamp()
+where id = '10000000-0000-4000-8000-000000000005';
+
+do $$
+begin
+  begin
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+    ) values (
+      '10000000-0000-4000-8000-000000000005', null,
+      '{"type":"doc","content":[]}'::jsonb, 0, 0, 'submit'
+    );
+    raise exception 'Stale legacy submit snapshot unexpectedly succeeded';
+  exception
+    when check_violation then
+      if sqlerrm not like '%assignment_submit_history_snapshot_invalid%' then
+        raise;
+      end if;
+  end;
+
+  if not exists (
+    select 1
+    from public.assignment_doc_history h
+    join public.assignment_docs d on d.id = h.assignment_doc_id
+    where d.id = '10000000-0000-4000-8000-000000000005'
+      and h.trigger = 'submit'
+      and h.created_at >= d.submitted_at
+      and h.patch is null
+      and h.snapshot = d.content
+      and h.word_count = 3
+      and h.char_count = 22
+  ) then
+    raise exception 'Legacy direct submit was left without authoritative counted history';
+  end if;
+
+  if coalesce((public.unsubmit_assignment_doc_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '10000000-0000-4000-8000-000000000002'
+  )->>'ok')::boolean, false) is not true then
+    raise exception 'Legacy overlap fixture could not be reset';
+  end if;
+end;
+$$;
+SQL
+}
+
+run_teacher_artifact_race() {
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c "
+    set lock_timeout = '5s';
+    begin;
+    select 1 from public.assignment_submission_artifacts
+      where id = '10000000-0000-4000-8000-000000000009' for update;
+    select pg_sleep(1);
+    update public.assignment_submission_artifacts
+      set url = 'https://example.invalid/new'
+      where id = '10000000-0000-4000-8000-000000000009';
+    commit;
+  " >/dev/null &
+  local artifact_pid=$!
+
+  sleep 0.2
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+set lock_timeout = '5s';
+do $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.update_assignment_with_submission_requirements_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '{}'::jsonb,
+    '[{"id":"10000000-0000-4000-8000-000000000008","type":"link","label":"Link","required":false,"position":0,"validation_policy_json":{}}]'::jsonb
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Concurrent teacher requirement update failed: %', v_result;
+  end if;
+end;
+$$;
+SQL
+  local requirement_pid=$!
+
+  wait "$artifact_pid"
+  wait "$requirement_pid"
+}
+
+run_old_replace_new_combined_race() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+set lock_timeout = '5s';
+begin;
+select * from public.replace_assignment_submission_requirements_atomic(
+  '10000000-0000-4000-8000-000000000004',
+  '[{"id":"10000000-0000-4000-8000-000000000008","type":"link","label":"Legacy","required":false,"position":0,"validation_policy_json":{}}]'::jsonb
+);
+select pg_sleep(1);
+commit;
+SQL
+  local legacy_pid=$!
+
+  sleep 0.2
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+set lock_timeout = '5s';
+do $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.update_assignment_with_submission_requirements_atomic(
+    '10000000-0000-4000-8000-000000000004',
+    '{"title":"Combined after legacy"}'::jsonb,
+    '[{"id":"10000000-0000-4000-8000-000000000008","type":"link","label":"Combined","required":false,"position":0,"validation_policy_json":{}}]'::jsonb
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Combined update after legacy overlap failed: %', v_result;
+  end if;
+end;
+$$;
+SQL
+  local combined_pid=$!
+
+  wait "$legacy_pid"
+  wait "$combined_pid"
+}
+
+run_artifact_cleanup_lease_reenqueue_race() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $$
+declare
+  v_path text := 'concurrency/cleanup-lease.png';
+  v_first_lease constant uuid := '10000000-0000-4000-8000-000000000020';
+  v_second_lease constant uuid := '10000000-0000-4000-8000-000000000021';
+  v_claim public.assignment_artifact_storage_cleanup%rowtype;
+begin
+  perform public.enqueue_assignment_artifact_storage_cleanup_path(v_path, 0);
+  select * into v_claim
+  from public.claim_assignment_artifact_storage_cleanup_path(v_path, v_first_lease, 120);
+  if v_claim.id is null then
+    raise exception 'Cleanup lease race fixture was not claimed';
+  end if;
+
+  -- This models a second request arriving while the first worker is outside
+  -- PostgreSQL deleting from Storage under its committed lease.
+  perform public.enqueue_assignment_artifact_storage_cleanup_path(v_path, 0);
+  if not exists (
+    select 1 from public.assignment_artifact_storage_cleanup
+    where id = v_claim.id and status = 'processing' and lease_token = v_first_lease
+  ) then
+    raise exception 'Concurrent re-enqueue revoked the active cleanup lease';
+  end if;
+  if exists (
+    select 1 from public.claim_assignment_artifact_storage_cleanup_path(v_path, v_second_lease, 120)
+  ) then
+    raise exception 'Concurrent exact-path claim stole an active cleanup lease';
+  end if;
+  if public.complete_assignment_artifact_storage_cleanup(v_claim.id, v_second_lease) then
+    raise exception 'Stale cleanup worker completed another lease';
+  end if;
+  if not public.complete_assignment_artifact_storage_cleanup(v_claim.id, v_first_lease) then
+    raise exception 'Owning cleanup worker could not complete its lease';
+  end if;
+end;
+$$;
+SQL
+}
+
+run_history_cleanup_race
+run_legacy_stale_snapshot_repair
+run_old_submit_new_requirement_rpc_race
+run_teacher_artifact_race
+run_old_replace_new_combined_race
+run_artifact_cleanup_lease_reenqueue_race
+
+echo "Assignment submission concurrency checks passed in a disposable database."

--- a/scripts/check-atomic-assignment-feedback-returns.sh
+++ b/scripts/check-atomic-assignment-feedback-returns.sh
@@ -521,18 +521,18 @@ AI_RUN_DOC_ID="$(docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X 
 AI_RUN_EXPECTED="$(docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 -Atc \
   "select updated_at from public.assignment_docs where id = '$AI_RUN_DOC_ID';")"
 
-docker exec -e PGAPPNAME=atomic-student-autosave-holder -i "$DB_CONTAINER" \
+docker exec -e PGAPPNAME=atomic-doc-revision-holder -i "$DB_CONTAINER" \
   psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 begin;
 update public.assignment_docs
-set content = '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"New student work"}]}]}'::jsonb
+set teacher_feedback_draft = 'Concurrent revision'
 where assignment_id = 'd0000000-0000-4000-8000-000000000016'
   and student_id = 'd0000000-0000-4000-8000-000000000005';
 select pg_sleep(3);
 commit;
 SQL
 STUDENT_UPDATE_PID=$!
-wait_for_application_event atomic-student-autosave-holder PgSleep
+wait_for_application_event atomic-doc-revision-holder PgSleep
 
 set +e
 docker exec -e PGAPPNAME=atomic-ai-run-create-worker -i "$DB_CONTAINER" \
@@ -564,7 +564,7 @@ wait "$AI_RUN_CREATE_PID"
 AI_RUN_CREATE_STATUS=$?
 set -e
 if [[ "$AI_RUN_CREATE_STATUS" -eq 0 ]]; then
-  echo "Expected AI-run creation to reject a concurrent student document update." >&2
+  echo "Expected AI-run creation to reject a concurrent assignment document update." >&2
   exit 1
 fi
 
@@ -617,7 +617,7 @@ begin
     and student_id = 'd0000000-0000-4000-8000-000000000003';
 
   update public.assignment_docs
-  set content = '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb
+  set teacher_feedback_draft = 'Concurrent grade revision'
   where assignment_id = 'd0000000-0000-4000-8000-000000000017'
     and student_id = 'd0000000-0000-4000-8000-000000000003';
 
@@ -900,7 +900,7 @@ begin
   where assignment_id = 'd0000000-0000-4000-8000-000000000021'
     and student_id = 'd0000000-0000-4000-8000-000000000005';
 
-  update public.assignment_docs set content = '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb
+  update public.assignment_docs set teacher_feedback_draft = 'Concurrent repo review revision'
   where assignment_id = 'd0000000-0000-4000-8000-000000000021'
     and student_id = 'd0000000-0000-4000-8000-000000000005';
 

--- a/scripts/check-atomic-assignment-submissions.sh
+++ b/scripts/check-atomic-assignment-submissions.sh
@@ -1,0 +1,832 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+DB_CONTAINER="$(docker ps --filter 'name=^supabase_db_pika$' --format '{{.Names}}' | head -n 1)"
+if [[ -z "$DB_CONTAINER" ]]; then
+  DB_CONTAINER="$(docker ps --filter 'name=supabase_db_' --format '{{.Names}}' | head -n 1)"
+fi
+
+if [[ -z "$DB_CONTAINER" ]]; then
+  echo "Local Supabase database container is not running." >&2
+  exit 1
+fi
+
+{
+  printf 'begin;\n'
+  sed 's/^/ /' "$ROOT/supabase/migrations/099_assignment_submission_integrity_guards.sql"
+  cat <<'SQL'
+
+create temporary table assignment_integrity_ids (
+  teacher_id uuid,
+  student_id uuid,
+  classroom_id uuid,
+  assignment_id uuid,
+  requirement_id uuid,
+  doc_id uuid
+) on commit drop;
+
+do $$
+declare
+  v_table text;
+  v_guard text;
+  v_archive text;
+  v_function text;
+begin
+  if (
+    select count(*)
+    from pg_proc
+    where pronamespace = 'public'::regnamespace
+      and proname = 'save_assignment_doc_atomic'
+  ) <> 1 then
+    raise exception 'Obsolete assignment save RPC overload survived migration replay';
+  end if;
+
+  foreach v_table in array array[
+    'assignment_docs',
+    'assignment_doc_history',
+    'assignment_submission_requirements',
+    'assignment_submission_artifacts'
+  ] loop
+    select min(tgname) filter (where tgname like 'aaa_%'),
+           min(tgname) filter (where tgname = 'car_' || v_table)
+    into v_guard, v_archive
+    from pg_trigger
+    where tgrelid = ('public.' || v_table)::regclass and not tgisinternal;
+    if v_guard is null or v_archive is null or v_guard >= v_archive then
+      raise exception 'Assignment guard trigger does not precede archive trigger on %', v_table;
+    end if;
+  end loop;
+
+  foreach v_function in array array[
+    'public.save_assignment_doc_atomic(uuid,uuid,jsonb,timestamp with time zone,text,integer,integer,jsonb,jsonb,integer,integer,uuid,bigint,uuid)',
+    'public.submit_assignment_doc_atomic(uuid,uuid,jsonb,timestamp with time zone,integer,integer)',
+    'public.unsubmit_assignment_doc_atomic(uuid,uuid)',
+    'public.delete_assignment_submission_artifact_atomic(uuid,uuid,uuid)',
+    'public.claim_assignment_artifact_storage_cleanup(uuid,integer,integer)',
+    'public.claim_assignment_artifact_storage_cleanup_path(text,uuid,integer)',
+    'public.complete_assignment_artifact_storage_cleanup(uuid,uuid)',
+    'public.fail_assignment_artifact_storage_cleanup(uuid,uuid,text)',
+    'public.enqueue_assignment_artifact_storage_cleanup_path(text,integer)',
+    'public.cleanup_assignment_doc_save_operations(timestamp with time zone)',
+    'public.update_assignment_with_submission_requirements_atomic(uuid,jsonb,jsonb)'
+  ] loop
+    if has_function_privilege('anon', v_function, 'execute')
+      or has_function_privilege('authenticated', v_function, 'execute')
+      or not has_function_privilege('service_role', v_function, 'execute') then
+      raise exception 'Assignment RPC privilege contract is invalid for %', v_function;
+    end if;
+  end loop;
+
+  if to_regprocedure('public.complete_assignment_artifact_storage_cleanup_path(text)') is not null then
+    raise exception 'Unfenced assignment artifact cleanup path completion RPC survived migration replay';
+  end if;
+
+  if has_table_privilege('anon', 'public.assignment_artifact_storage_cleanup', 'select')
+    or has_table_privilege('authenticated', 'public.assignment_artifact_storage_cleanup', 'insert')
+    or not has_table_privilege('service_role', 'public.assignment_artifact_storage_cleanup', 'select')
+    or not has_table_privilege('service_role', 'public.assignment_artifact_storage_cleanup', 'insert')
+    or not has_table_privilege('service_role', 'public.assignment_artifact_storage_cleanup', 'delete') then
+    raise exception 'Assignment artifact cleanup table privilege contract is invalid';
+  end if;
+
+  foreach v_function in array array[
+    'public.guard_assignment_submission_requirement_mutation()',
+    'public.guard_assignment_submission_artifact_mutation()',
+    'public.validate_assignment_submission_transition()',
+    'public.guard_assignment_doc_history_after_submit()',
+    'public.guard_submitted_assignment_doc_content()',
+    'public.enqueue_deleted_assignment_artifact_storage_cleanup()',
+    'public.ensure_current_assignment_submit_history()'
+  ] loop
+    if has_function_privilege('anon', v_function, 'execute')
+      or has_function_privilege('authenticated', v_function, 'execute')
+      or has_function_privilege('service_role', v_function, 'execute') then
+      raise exception 'Assignment trigger function is externally executable: %', v_function;
+    end if;
+  end loop;
+end;
+$$;
+
+do $$
+declare
+  v_path text := 'atomic/cleanup-lease.png';
+  v_first_lease uuid := gen_random_uuid();
+  v_second_lease uuid := gen_random_uuid();
+  v_claim public.assignment_artifact_storage_cleanup%rowtype;
+begin
+  perform public.enqueue_assignment_artifact_storage_cleanup_path(v_path, 0);
+  select * into v_claim
+  from public.claim_assignment_artifact_storage_cleanup_path(v_path, v_first_lease, 120);
+  if v_claim.id is null or v_claim.lease_token is distinct from v_first_lease then
+    raise exception 'Exact-path cleanup claim did not acquire its lease';
+  end if;
+
+  perform public.enqueue_assignment_artifact_storage_cleanup_path(v_path, 0);
+  if not exists (
+    select 1 from public.assignment_artifact_storage_cleanup
+    where id = v_claim.id and status = 'processing' and lease_token = v_first_lease
+  ) then
+    raise exception 'Re-enqueue revoked an active cleanup lease';
+  end if;
+  if exists (
+    select 1 from public.claim_assignment_artifact_storage_cleanup_path(v_path, v_second_lease, 120)
+  ) then
+    raise exception 'A second worker stole an active exact-path cleanup lease';
+  end if;
+  if public.complete_assignment_artifact_storage_cleanup(v_claim.id, v_second_lease) then
+    raise exception 'A stale cleanup lease completed another worker claim';
+  end if;
+  if not public.complete_assignment_artifact_storage_cleanup(v_claim.id, v_first_lease) then
+    raise exception 'The owning cleanup lease could not complete its claim';
+  end if;
+end;
+$$;
+
+do $$
+declare
+  v_row jsonb;
+begin
+  v_row := public.normalize_classroom_archive_restore_row(
+    gen_random_uuid(),
+    'assignment_docs',
+    '{"id":"10000000-0000-4000-8000-000000000001"}'::jsonb
+  );
+  if not (v_row ? 'save_session_id')
+    or not (v_row ? 'save_sequence')
+    or jsonb_typeof(v_row->'save_session_id') <> 'null'
+    or jsonb_typeof(v_row->'save_sequence') <> 'null' then
+    raise exception 'Pre-099 assignment archive row was not normalized: %', v_row;
+  end if;
+end;
+$$;
+
+insert into assignment_integrity_ids
+select gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid();
+
+insert into public.users (id, email, role, email_verified_at)
+select teacher_id, 'assignment-integrity-teacher@example.invalid', 'teacher', clock_timestamp()
+from assignment_integrity_ids
+union all
+select student_id, 'assignment-integrity-student@example.invalid', 'student', clock_timestamp()
+from assignment_integrity_ids;
+
+insert into public.classrooms (id, teacher_id, title, class_code)
+select classroom_id, teacher_id, 'Assignment integrity check', upper(substr(replace(classroom_id::text, '-', ''), 1, 8))
+from assignment_integrity_ids;
+
+insert into public.assignments (id, classroom_id, title, description, due_at, created_by)
+select assignment_id, classroom_id, 'Atomic assignment', '', clock_timestamp() + interval '1 day', teacher_id
+from assignment_integrity_ids;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_result jsonb;
+  v_revision timestamptz;
+  v_base_revision timestamptz;
+  v_doc_id uuid;
+  v_content jsonb;
+  v_session_id uuid := gen_random_uuid();
+  v_other_session_id uuid := gen_random_uuid();
+  v_metric_session_id uuid := gen_random_uuid();
+  v_initial_metric_session_id uuid := gen_random_uuid();
+  v_chain_session_id uuid := gen_random_uuid();
+  v_chain_metric_session_id uuid := gen_random_uuid();
+  v_before_retry_keys bigint;
+  v_before_cross_keys bigint;
+begin
+  select * into v_ids from assignment_integrity_ids;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Initial"}]}]}'::jsonb,
+    null, 'autosave', 0, 7, '[]'::jsonb, null, 1, 7,
+    v_session_id, 1, v_initial_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Initial atomic save failed: %', v_result;
+  end if;
+
+  v_doc_id := (v_result->'doc'->>'id')::uuid;
+  update assignment_integrity_ids set doc_id = v_doc_id;
+  select updated_at into v_revision from public.assignment_docs where id = v_doc_id;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Initial"}]}]}'::jsonb,
+    null, 'autosave', 0, 7, '[]'::jsonb, null, 1, 7,
+    v_session_id, 1, v_initial_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Lost create response was not exactly replayable: %', v_result;
+  end if;
+  if (select sum(keystroke_count) from public.assignment_doc_history where assignment_doc_id = v_doc_id)
+    is distinct from 7::bigint then
+    raise exception 'Create replay duplicated input metrics';
+  end if;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Older in flight"}]}]}'::jsonb,
+    v_revision, 'blur', 1, 4,
+    '[{"op":"replace","path":"/content/0/content/0/text","value":"Older in flight"}]'::jsonb,
+    null, 3, 15, v_session_id, 2, v_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Older atomic save failed: %', v_result;
+  end if;
+  v_base_revision := v_revision;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Latest"}]}]}'::jsonb,
+    v_base_revision, 'blur', 2, 6, '[]'::jsonb, null, 1, 6,
+    v_session_id, 3, v_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Superseding pagehide save failed: %', v_result;
+  end if;
+
+  select content, updated_at into v_content, v_revision
+  from public.assignment_docs where id = v_doc_id;
+  if v_content #>> '{content,0,content,0,text}' <> 'Latest' then
+    raise exception 'Superseding save did not preserve the latest content';
+  end if;
+  if (select sum(keystroke_count) from public.assignment_doc_history where assignment_doc_id = v_doc_id)
+    is distinct from 13::bigint then
+    raise exception 'Superseding save did not de-duplicate in-flight input metrics';
+  end if;
+
+  v_base_revision := v_revision;
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_base_revision, 'blur', 0, 0, '[]'::jsonb, null, 1, 6,
+    v_session_id, 4, gen_random_uuid()
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Pagehide fence save failed: %', v_result;
+  end if;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Late older write"}]}]}'::jsonb,
+    v_base_revision, 'autosave', 0, 1, '[]'::jsonb, null, 3, 16,
+    v_session_id, 3, v_metric_session_id
+  );
+  if (v_result->>'status')::integer is distinct from 409 then
+    raise exception 'Fenced older save was not rejected: %', v_result;
+  end if;
+
+  select updated_at into v_revision from public.assignment_docs where id = v_doc_id;
+  select coalesce(sum(keystroke_count), 0) into v_before_cross_keys
+  from public.assignment_doc_history where assignment_doc_id = v_doc_id;
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_revision, 'autosave', 0, 7, '[]'::jsonb, null, 1, 6,
+    v_other_session_id, 1, v_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Intervening editor save failed: %', v_result;
+  end if;
+  if (select coalesce(sum(keystroke_count), 0) from public.assignment_doc_history
+      where assignment_doc_id = v_doc_id) <> v_before_cross_keys + 1 then
+    raise exception 'Cross-session supersession did not de-duplicate input metrics';
+  end if;
+  select coalesce(sum(keystroke_count), 0) into v_before_retry_keys
+  from public.assignment_doc_history where assignment_doc_id = v_doc_id;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Latest"}]}]}'::jsonb,
+    v_base_revision, 'blur', 2, 6, '[]'::jsonb, null, 1, 6,
+    v_session_id, 3, v_metric_session_id
+  );
+  if v_result->>'error_code' <> 'assignment_doc_save_replayed' then
+    raise exception 'Committed save retry was not recognized after an intervening editor save: %', v_result;
+  end if;
+  if (select coalesce(sum(keystroke_count), 0) from public.assignment_doc_history
+      where assignment_doc_id = v_doc_id) <> v_before_retry_keys then
+    raise exception 'Committed save retry duplicated input metrics';
+  end if;
+
+  select updated_at into v_base_revision from public.assignment_docs where id = v_doc_id;
+  select coalesce(sum(keystroke_count), 0) into v_before_retry_keys
+  from public.assignment_doc_history where assignment_doc_id = v_doc_id;
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_base_revision, 'autosave', 0, 2, '[]'::jsonb, null, 1, 6,
+    v_chain_session_id, 1, v_chain_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Metric ancestry base save failed: %', v_result;
+  end if;
+  -- Sequence 2 (four cumulative keystrokes) is intentionally absent.
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_base_revision, 'autosave', 0, 6, '[]'::jsonb, null, 1, 6,
+    v_chain_session_id, 3, v_chain_metric_session_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Metric ancestry save after a missing attempt failed: %', v_result;
+  end if;
+  if (select coalesce(sum(keystroke_count), 0) from public.assignment_doc_history
+      where assignment_doc_id = v_doc_id) <> v_before_retry_keys + 6 then
+    raise exception 'Missing intermediate save duplicated committed metric ancestry';
+  end if;
+
+  select updated_at into v_base_revision from public.assignment_docs where id = v_doc_id;
+  update public.assignment_docs
+  set content = '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Legacy direct write"}]}]}'::jsonb
+  where id = v_doc_id;
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Atomic overwrite"}]}]}'::jsonb,
+    v_base_revision, 'autosave', 0, 0, '[]'::jsonb, null, 2, 16,
+    v_chain_session_id, 4, gen_random_uuid()
+  );
+  if (v_result->>'error_code') is distinct from 'assignment_doc_revision_conflict' then
+    raise exception 'Legacy direct write bypassed the atomic revision fence: %', v_result;
+  end if;
+
+  if not exists (
+    select 1 from public.assignment_doc_history
+    where assignment_doc_id = v_doc_id
+  ) then
+    raise exception 'Atomic saves did not create history evidence';
+  end if;
+end;
+$$;
+
+do $$
+declare
+  v_doc_id uuid;
+  v_deleted integer;
+begin
+  select doc_id into v_doc_id from assignment_integrity_ids;
+  update public.assignment_doc_save_operations
+  set completed_at = clock_timestamp() - interval '40 days'
+  where id = (
+    select id from public.assignment_doc_save_operations
+    where assignment_doc_id = v_doc_id and save_sequence = 1
+    order by completed_at, id
+    limit 1
+  );
+
+  v_deleted := public.cleanup_assignment_doc_save_operations(
+    clock_timestamp() - interval '35 days'
+  );
+  if v_deleted <> 1 then
+    raise exception 'Assignment save operation retention cleanup deleted % rows', v_deleted;
+  end if;
+  if not exists (
+    select 1 from public.assignment_doc_save_operations
+    where assignment_doc_id = v_doc_id and save_sequence = 3
+  ) then
+    raise exception 'Assignment save operation cleanup removed recent replay evidence';
+  end if;
+end;
+$$;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_result jsonb;
+  v_revision timestamptz;
+  v_before_count bigint;
+  v_after_count bigint;
+  v_before_keys bigint;
+  v_content jsonb;
+  v_session_id uuid;
+begin
+  select * into v_ids from assignment_integrity_ids;
+  select content, updated_at, save_session_id
+  into v_content, v_revision, v_session_id
+  from public.assignment_docs where id = v_ids.doc_id;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Before restore"}]}]}'::jsonb,
+    v_revision, 'autosave', 0, 1, '[]'::jsonb, null, 2, 14,
+    v_session_id, 5, gen_random_uuid()
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Pre-restore save failed: %', v_result;
+  end if;
+
+  select updated_at into v_revision from public.assignment_docs where id = v_ids.doc_id;
+  select count(*) into v_before_count
+  from public.assignment_doc_history where assignment_doc_id = v_ids.doc_id;
+
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_revision, 'restore', 0, 0, '[]'::jsonb, v_content, 1, 6,
+    v_session_id, 6, gen_random_uuid()
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or v_result->'history_entry'->>'trigger' <> 'restore' then
+    raise exception 'Restore save did not append restore history: %', v_result;
+  end if;
+
+  select count(*) into v_after_count
+  from public.assignment_doc_history where assignment_doc_id = v_ids.doc_id;
+  if v_after_count <> v_before_count + 1 then
+    raise exception 'Restore save coalesced the preceding history entry';
+  end if;
+
+  select updated_at into v_revision from public.assignment_docs where id = v_ids.doc_id;
+  select coalesce(sum(keystroke_count), 0) into v_before_keys
+  from public.assignment_doc_history where assignment_doc_id = v_ids.doc_id;
+  v_result := public.save_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_content,
+    v_revision, 'autosave', 0, 3, '[]'::jsonb, null, 1, 6,
+    v_session_id, 7, gen_random_uuid()
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or v_result->'history_entry' is null then
+    raise exception 'Edit-and-revert metrics were not persisted: %', v_result;
+  end if;
+  if (select coalesce(sum(keystroke_count), 0) from public.assignment_doc_history
+      where assignment_doc_id = v_ids.doc_id) <> v_before_keys + 3 then
+    raise exception 'Edit-and-revert metrics were not counted exactly once';
+  end if;
+  if (select count(*) from public.assignment_doc_history
+      where assignment_doc_id = v_ids.doc_id) <> v_after_count + 1 then
+    raise exception 'Autosave after restore overwrote the restore checkpoint (before %, after %)',
+      v_after_count,
+      (select count(*) from public.assignment_doc_history where assignment_doc_id = v_ids.doc_id);
+  end if;
+  if not exists (
+    select 1 from public.assignment_doc_history
+    where assignment_doc_id = v_ids.doc_id and trigger = 'restore'
+  ) then
+    raise exception 'Autosave after restore removed the restore checkpoint';
+  end if;
+end;
+$$;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_result jsonb;
+begin
+  select * into v_ids from assignment_integrity_ids;
+  v_result := public.update_assignment_with_submission_requirements_atomic(
+    v_ids.assignment_id,
+    '{"instructions_markdown":"Updated instructions","description":"Updated instructions"}'::jsonb,
+    '[]'::jsonb
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or (select description from public.assignments where id = v_ids.assignment_id)
+      <> 'Updated instructions' then
+    raise exception 'Combined assignment update left description stale: %', v_result;
+  end if;
+end;
+$$;
+
+insert into public.assignment_submission_requirements (
+  id, assignment_id, type, label, required, position
+)
+select requirement_id, assignment_id, 'link', 'Required link', true, 0
+from assignment_integrity_ids;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_revision timestamptz;
+begin
+  select * into v_ids from assignment_integrity_ids;
+  select updated_at into v_revision from public.assignment_docs where id = v_ids.doc_id;
+  begin
+    perform public.submit_assignment_doc_atomic(
+      v_ids.assignment_id, v_ids.student_id,
+      (select content from public.assignment_docs where id = v_ids.doc_id),
+      v_revision, 1, 6
+    );
+    raise exception 'Submission without its required artifact unexpectedly succeeded';
+  exception
+    when check_violation then
+      if sqlerrm not like '%assignment_submission_requirements_incomplete%' then
+        raise;
+      end if;
+  end;
+end;
+$$;
+
+insert into public.assignment_submission_artifacts (
+  assignment_doc_id, requirement_id, student_id, type, url, validation_status
+)
+select doc_id, requirement_id, student_id, 'link', 'https://example.invalid/work', 'valid'
+from assignment_integrity_ids;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_revision timestamptz;
+  v_result jsonb;
+  v_submit_history_id uuid;
+begin
+  select * into v_ids from assignment_integrity_ids;
+  select updated_at into v_revision from public.assignment_docs where id = v_ids.doc_id;
+  v_result := public.submit_assignment_doc_atomic(
+    v_ids.assignment_id, v_ids.student_id,
+    (select content from public.assignment_docs where id = v_ids.doc_id),
+    v_revision, 1, 6
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Atomic submission failed: %', v_result;
+  end if;
+
+  select id into v_submit_history_id
+  from public.assignment_doc_history
+  where assignment_doc_id = v_ids.doc_id and trigger = 'submit';
+  if v_submit_history_id is null then
+    raise exception 'Atomic submission did not create authoritative history';
+  end if;
+
+  v_result := public.update_assignment_with_submission_requirements_atomic(
+    v_ids.assignment_id,
+    '{"title":"Must not persist"}'::jsonb,
+    '[]'::jsonb
+  );
+  if (v_result->>'status')::integer is distinct from 409 then
+    raise exception 'Submitted requirement update was not rejected atomically: %', v_result;
+  end if;
+  if (select title from public.assignments where id = v_ids.assignment_id) = 'Must not persist' then
+    raise exception 'Assignment fields changed despite rejected requirement update';
+  end if;
+
+  begin
+    update public.assignment_submission_artifacts
+    set url = 'https://example.invalid/changed'
+    where assignment_doc_id = v_ids.doc_id;
+    raise exception 'Submitted artifact mutation unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    update public.assignment_submission_requirements
+    set label = 'Changed requirement'
+    where id = v_ids.requirement_id;
+    raise exception 'Submitted requirement mutation unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    update public.assignment_doc_history
+    set snapshot = '{}'::jsonb
+    where id = v_submit_history_id;
+    raise exception 'Submit history rewrite unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  delete from public.assignment_doc_history where id = v_submit_history_id;
+  if not exists (
+    select 1 from public.assignment_doc_history where id = v_submit_history_id
+  ) then
+    raise exception 'Compatibility cleanup deleted authoritative submit history';
+  end if;
+
+  begin
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+    ) values (v_ids.doc_id, null, '{"type":"doc","content":[]}'::jsonb, 0, 0, 'submit');
+    raise exception 'Malformed submit history unexpectedly succeeded';
+  exception
+    when check_violation then
+      if sqlerrm not like '%assignment_submit_history_snapshot_invalid%' then
+        raise;
+      end if;
+  end;
+
+  begin
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+    ) values (v_ids.doc_id, null, '{}'::jsonb, 0, 0, 'submit');
+    raise exception 'Duplicate submit history unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    update public.assignment_docs
+    set content = '{"type":"doc","content":[]}'::jsonb
+    where id = v_ids.doc_id;
+    raise exception 'Submitted document content mutation unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    update public.assignment_docs
+    set student_id = v_ids.teacher_id
+    where id = v_ids.doc_id;
+    raise exception 'Submitted document identity mutation unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    update public.assignment_docs
+    set submitted_at = submitted_at + interval '1 minute'
+    where id = v_ids.doc_id;
+    raise exception 'Submitted timestamp mutation unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  begin
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+    ) values (v_ids.doc_id, null, '{}'::jsonb, 0, 0, 'autosave');
+    raise exception 'Post-submit autosave history unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+
+  update public.assignment_docs
+  set returned_at = clock_timestamp()
+  where id = v_ids.doc_id;
+  v_result := public.unsubmit_assignment_doc_atomic(v_ids.assignment_id, v_ids.student_id);
+  if (v_result->>'status')::integer is distinct from 409 then
+    raise exception 'Unsubmit did not lose atomically to teacher return: %', v_result;
+  end if;
+
+  update public.assignment_docs
+  set returned_at = null
+  where id = v_ids.doc_id;
+  v_result := public.unsubmit_assignment_doc_atomic(v_ids.assignment_id, v_ids.student_id);
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or coalesce((v_result->'doc'->>'is_submitted')::boolean, true) is not false then
+    raise exception 'Atomic unsubmit failed: %', v_result;
+  end if;
+
+  update public.assignment_docs
+  set returned_at = clock_timestamp() - interval '1 minute',
+      is_submitted = true,
+      submitted_at = clock_timestamp()
+  where id = v_ids.doc_id;
+  v_result := public.unsubmit_assignment_doc_atomic(v_ids.assignment_id, v_ids.student_id);
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or coalesce((v_result->'doc'->>'is_submitted')::boolean, true) is not false then
+    raise exception 'A newer resubmission could not be unsubmitted: %', v_result;
+  end if;
+
+  update public.assignment_docs
+  set is_submitted = true, submitted_at = clock_timestamp()
+  where id = v_ids.doc_id;
+  set constraints ensure_current_assignment_submit_history immediate;
+  if not exists (
+    select 1 from public.assignment_doc_history h
+    join public.assignment_docs d on d.id = h.assignment_doc_id
+    where d.id = v_ids.doc_id
+      and h.trigger = 'submit'
+      and h.created_at >= d.submitted_at
+      and h.patch is null
+      and h.snapshot = d.content
+  ) then
+    raise exception 'Legacy direct submit did not synthesize authoritative history';
+  end if;
+  set constraints ensure_current_assignment_submit_history deferred;
+  v_result := public.unsubmit_assignment_doc_atomic(v_ids.assignment_id, v_ids.student_id);
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    raise exception 'Legacy direct-submit repair fixture could not be reset: %', v_result;
+  end if;
+end;
+$$;
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_requirement_id uuid := gen_random_uuid();
+  v_cleanup_id uuid;
+  v_lease_token uuid := gen_random_uuid();
+  v_second_lease_token uuid := gen_random_uuid();
+  v_third_lease_token uuid := gen_random_uuid();
+  v_result jsonb;
+begin
+  select * into v_ids from assignment_integrity_ids;
+  insert into public.assignment_submission_requirements (
+    id, assignment_id, type, label, required, position
+  ) values (v_requirement_id, v_ids.assignment_id, 'image', 'Cleanup image', false, 1);
+  insert into public.assignment_submission_artifacts (
+    assignment_doc_id, requirement_id, student_id, type, storage_path, validation_status
+  ) values (
+    v_ids.doc_id, v_requirement_id, v_ids.student_id, 'image',
+    'assignment-integrity/cleanup.png', 'valid'
+  );
+
+  v_result := public.delete_assignment_submission_artifact_atomic(
+    v_ids.assignment_id, v_ids.student_id, v_requirement_id
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true
+    or v_result->>'storage_path' <> 'assignment-integrity/cleanup.png' then
+    raise exception 'Atomic artifact deletion did not return queued Storage path: %', v_result;
+  end if;
+  if not exists (
+    select 1 from public.assignment_artifact_storage_cleanup
+    where storage_path = 'assignment-integrity/cleanup.png' and status = 'pending'
+  ) then
+    raise exception 'Artifact deletion did not durably enqueue Storage cleanup';
+  end if;
+
+  select id into v_cleanup_id
+  from public.claim_assignment_artifact_storage_cleanup(v_lease_token, 1, 60);
+  if v_cleanup_id is null then
+    raise exception 'Artifact cleanup row was not claimable';
+  end if;
+  update public.assignment_artifact_storage_cleanup
+  set attempt_count = 26,
+      lease_expires_at = clock_timestamp() - interval '1 second'
+  where id = v_cleanup_id;
+  if public.complete_assignment_artifact_storage_cleanup(v_cleanup_id, v_lease_token) then
+    raise exception 'Expired artifact cleanup lease completed work';
+  end if;
+  perform public.claim_assignment_artifact_storage_cleanup(v_second_lease_token, 1, 60);
+  if not public.fail_assignment_artifact_storage_cleanup(
+    v_cleanup_id, v_second_lease_token, 'retry check'
+  ) then
+    raise exception 'Artifact cleanup failure was not durably recorded';
+  end if;
+
+  update public.assignment_artifact_storage_cleanup
+  set next_attempt_at = clock_timestamp()
+  where id = v_cleanup_id;
+  perform public.claim_assignment_artifact_storage_cleanup(v_third_lease_token, 1, 60);
+  if not public.complete_assignment_artifact_storage_cleanup(v_cleanup_id, v_third_lease_token) then
+    raise exception 'Artifact cleanup completion was not lease-fenced';
+  end if;
+  if exists (select 1 from public.assignment_artifact_storage_cleanup where id = v_cleanup_id) then
+    raise exception 'Completed artifact cleanup evidence was not removed';
+  end if;
+end;
+$$;
+
+-- Document and assignment parent cascades must remain valid.
+delete from public.assignment_docs
+where id = (select doc_id from assignment_integrity_ids);
+
+do $$
+declare
+  v_ids assignment_integrity_ids%rowtype;
+  v_assignment_id uuid := gen_random_uuid();
+  v_requirement_id uuid := gen_random_uuid();
+  v_doc_id uuid := gen_random_uuid();
+begin
+  select * into v_ids from assignment_integrity_ids;
+  insert into public.assignments (id, classroom_id, title, description, due_at, created_by)
+  values (v_assignment_id, v_ids.classroom_id, 'Restore assignment', '', clock_timestamp() + interval '1 day', v_ids.teacher_id);
+  insert into public.assignment_submission_requirements (id, assignment_id, type, label)
+  values (v_requirement_id, v_assignment_id, 'link', 'Restore link');
+  insert into public.assignment_docs (
+    id, assignment_id, student_id, content_legacy, content, is_submitted, submitted_at
+  ) values (
+    v_doc_id, v_assignment_id, v_ids.student_id, '',
+    '{"type":"doc","content":[]}'::jsonb, true, clock_timestamp()
+  );
+
+  perform set_config('pika.classroom_archive_restore', 'on', true);
+  insert into public.assignment_submission_artifacts (
+    assignment_doc_id, requirement_id, student_id, type, url, validation_status
+  ) values (v_doc_id, v_requirement_id, v_ids.student_id, 'link', 'https://example.invalid/restored', 'valid');
+  insert into public.assignment_doc_history (
+    assignment_doc_id, patch, snapshot, word_count, char_count, trigger
+  ) values (v_doc_id, null, '{"type":"doc","content":[]}'::jsonb, 0, 0, 'baseline');
+  set constraints ensure_current_assignment_submit_history immediate;
+  if exists (
+    select 1 from public.assignment_doc_history h
+    join public.assignment_docs d on d.id = h.assignment_doc_id
+    where d.id = v_doc_id
+      and h.trigger = 'submit'
+      and h.created_at >= d.submitted_at
+      and h.snapshot = d.content
+  ) then
+    raise exception 'Archive restore added history that was not present in the verified archive';
+  end if;
+  if (select count(*) from public.assignment_doc_history where assignment_doc_id = v_doc_id) <> 1 then
+    raise exception 'Archive restore changed the verified assignment history count';
+  end if;
+  set constraints ensure_current_assignment_submit_history deferred;
+  perform set_config('pika.classroom_archive_restore', 'off', true);
+  set constraints ensure_current_assignment_submit_history immediate;
+  if (select count(*) from public.assignment_doc_history where assignment_doc_id = v_doc_id) <> 1 then
+    raise exception 'Deferred submit repair escaped restore maintenance mode';
+  end if;
+  set constraints ensure_current_assignment_submit_history deferred;
+
+  perform set_config('pika.classroom_archive_compaction', 'on', true);
+  delete from public.assignment_submission_artifacts where assignment_doc_id = v_doc_id;
+  insert into public.assignment_submission_artifacts (
+    assignment_doc_id, requirement_id, student_id, type, url, validation_status
+  ) values (v_doc_id, v_requirement_id, v_ids.student_id, 'link', 'https://example.invalid/restored', 'valid');
+  perform set_config('pika.classroom_archive_compaction', 'off', true);
+
+  delete from public.assignments where id = v_assignment_id;
+end;
+$$;
+
+-- Classroom cascades traverse submitted requirements, artifacts, docs, and history.
+delete from public.classrooms
+where id = (select classroom_id from assignment_integrity_ids);
+
+rollback;
+SQL
+} | docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1
+
+echo "Atomic assignment save/submission checks passed (transaction rolled back)."

--- a/scripts/check-classroom-archive-compaction-database.sh
+++ b/scripts/check-classroom-archive-compaction-database.sh
@@ -1039,6 +1039,13 @@ where storage_bucket = 'assignment-artifacts'
       'assignment-artifacts', :'staging_race_path'
     )
   );
+delete from public.classrooms
+where id = '21000000-0000-4000-8000-000000000030'::uuid;
+delete from public.users
+where id in (
+  '11000000-0000-4000-8000-000000000029'::uuid,
+  '11000000-0000-4000-8000-000000000030'::uuid
+);
 SQL
   rm -f "$RACE_OUTPUT"
 }
@@ -1053,6 +1060,45 @@ docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=
   -v storage_path="$RACE_PATH" \
   -v storage_race_path="$RACE_STORAGE_PATH" \
   -v staging_race_path="$RACE_STAGING_PATH" <<'SQL' >/dev/null
+insert into public.users (id, email, role)
+values
+  ('11000000-0000-4000-8000-000000000029', 'archive-race-teacher@example.test', 'teacher'),
+  ('11000000-0000-4000-8000-000000000030', 'archive-race-student@example.test', 'student');
+
+insert into public.classrooms (id, teacher_id, title, class_code)
+values (
+  '21000000-0000-4000-8000-000000000030',
+  '11000000-0000-4000-8000-000000000029',
+  'Archive ownership race hot classroom',
+  'CMP029'
+);
+
+insert into public.assignments (id, classroom_id, title, description, due_at, created_by)
+values (
+  '22000000-0000-4000-8000-000000000029',
+  '21000000-0000-4000-8000-000000000030',
+  'Archive ownership race assignment',
+  'Keeps the concurrent artifact write relationally valid',
+  clock_timestamp() + interval '1 day',
+  '11000000-0000-4000-8000-000000000029'
+);
+
+insert into public.assignment_docs (id, assignment_id, student_id, content)
+values (
+  '23000000-0000-4000-8000-000000000029',
+  '22000000-0000-4000-8000-000000000029',
+  '11000000-0000-4000-8000-000000000030',
+  '{"type":"doc","content":[]}'::jsonb
+);
+
+insert into public.assignment_submission_requirements (id, assignment_id, type, label)
+values (
+  '27000000-0000-4000-8000-000000000029',
+  '22000000-0000-4000-8000-000000000029',
+  'image',
+  'Archive ownership race evidence'
+);
+
 insert into public.classroom_archive_operations (
   id, teacher_id, classroom_id, operation_type, request_sha256, status,
   source_revision, source_schema_migration, source_app_commit, retention,
@@ -1145,7 +1191,7 @@ if [[ "${LOCK_COUNT:-0}" -eq 0 ]]; then
 fi
 
 RACE_WRITE_OUTPUT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
-  -c "set statement_timeout = '10s'; insert into public.assignment_submission_artifacts (assignment_doc_id, requirement_id, student_id, type, storage_path) values ('23000000-0000-4000-8000-000000000029', '27000000-0000-4000-8000-000000000029', '11000000-0000-4000-8000-000000000029', 'image', '$RACE_PATH');" 2>&1)" && RACE_WRITE_STATUS=0 || RACE_WRITE_STATUS=$?
+  -c "set statement_timeout = '10s'; insert into public.assignment_submission_artifacts (assignment_doc_id, requirement_id, student_id, type, storage_path) values ('23000000-0000-4000-8000-000000000029', '27000000-0000-4000-8000-000000000029', '11000000-0000-4000-8000-000000000030', 'image', '$RACE_PATH');" 2>&1)" && RACE_WRITE_STATUS=0 || RACE_WRITE_STATUS=$?
 wait "$RACE_VERIFIER_PID"
 
 RACE_BOUND_COUNTS="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \

--- a/scripts/run-classroom-archive-recovery-drill.ts
+++ b/scripts/run-classroom-archive-recovery-drill.ts
@@ -35,6 +35,9 @@ const fixtureTables = [
 
 type SupabaseClient = ReturnType<typeof getServiceRoleClient>
 type FixtureTable = typeof fixtureTables[number]
+type FixtureSnapshot = Record<FixtureTable, Record<string, unknown>> & {
+  assignment_doc_history: Record<string, unknown>
+}
 type FixtureIds = Record<FixtureTable, string> & {
   teacher: string
   student: string
@@ -91,13 +94,29 @@ async function loadFixtureRow(
 async function loadFixtureSnapshot(
   supabase: SupabaseClient,
   ids: FixtureIds,
-): Promise<Record<FixtureTable, Record<string, unknown>>> {
-  return Object.fromEntries(await Promise.all(
+): Promise<FixtureSnapshot> {
+  const rows = Object.fromEntries(await Promise.all(
     fixtureTables.map(async (table) => [
       table,
       await loadFixtureRow(supabase, table, ids[table]),
     ]),
   )) as Record<FixtureTable, Record<string, unknown>>
+  const historyResponse = await supabase
+    .from('assignment_doc_history')
+    .select('*')
+    .eq('assignment_doc_id', ids.assignment_docs)
+    .eq('trigger', 'submit')
+    .single()
+  if (historyResponse.error || !historyResponse.data) {
+    throw new Error(
+      `Fixture submit history is unavailable: ${historyResponse.error?.code || 'missing'}`,
+    )
+  }
+
+  return {
+    ...rows,
+    assignment_doc_history: z.record(z.string(), z.unknown()).parse(historyResponse.data),
+  }
 }
 
 async function readStorageBytes(
@@ -202,8 +221,8 @@ async function createFixture(args: {
         content: [{ type: 'text', text: 'Synthetic recovery answer' }],
       }],
     },
-    is_submitted: true,
-    submitted_at: '2026-07-13T13:00:00.000Z',
+    is_submitted: false,
+    submitted_at: null,
   })
   await insertFixtureRow(args.supabase, 'assignment_submission_requirements', {
     id: args.ids.assignment_submission_requirements,
@@ -232,6 +251,19 @@ async function createFixture(args: {
     validation_status: 'valid',
     validated_at: '2026-07-13T13:01:00.000Z',
   })
+
+  const submitResponse = await args.supabase
+    .from('assignment_docs')
+    .update({
+      is_submitted: true,
+      submitted_at: '2026-07-13T13:00:00.000Z',
+    })
+    .eq('id', args.ids.assignment_docs)
+    .select('id')
+    .single()
+  if (submitResponse.error) {
+    throw new Error(`Fixture submit failed for assignment_docs: ${submitResponse.error.code}`)
+  }
 }
 
 async function removeFixture(args: {
@@ -276,7 +308,22 @@ async function removeFixture(args: {
   await deleteRows('classroom_archives', 'id', [args.ids.exportOperation])
   await deleteRows('classroom_archive_operations', 'id', [args.ids.exportOperation])
   await deleteRows('classrooms', 'id', [args.ids.classrooms])
+  const cleanupPaths = [...new Set([args.sourceObjectPath, args.restoredObjectPath])]
+  await deleteRows('assignment_artifact_storage_cleanup', 'storage_path', cleanupPaths)
   await deleteRows('users', 'id', [args.ids.student, args.ids.teacher])
+
+  for (const cleanupPath of cleanupPaths) {
+    try {
+      await assertRowAbsent(
+        args.supabase,
+        'assignment_artifact_storage_cleanup',
+        'storage_path',
+        cleanupPath,
+      )
+    } catch {
+      failures.push('leftover:assignment_artifact_storage_cleanup')
+    }
+  }
 
   if (sourcePathHash) {
     const reservation = await args.supabase
@@ -493,7 +540,7 @@ async function runRecoveryDrill() {
       target: 'loopback-supabase',
       fixture_classroom_id: ids.classrooms,
       resource_table_count: Object.keys(exported.resource_counts).length,
-      representative_rows_verified: fixtureTables.length,
+      representative_rows_verified: fixtureTables.length + 1,
       storage_objects_verified: 1,
       source_cleanup_deletion_verified: true,
       deidentified_source_fence_retained: true,

--- a/src/app/api/assignment-docs/[id]/artifacts/[requirementId]/route.ts
+++ b/src/app/api/assignment-docs/[id]/artifacts/[requirementId]/route.ts
@@ -5,15 +5,25 @@ import { getImageValidationError } from '@/lib/image-upload'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import {
+  deleteAssignmentSubmissionArtifactAtomic,
   isMissingAssignmentSubmissionSchemaError,
   loadUserGitHubIdentity,
 } from '@/lib/server/assignment-submission-artifacts'
+import {
+  adoptProvisionalAssignmentArtifactStorageCleanup,
+  assignmentArtifactStoragePathIsReferenced,
+  createProvisionalAssignmentArtifactStorageCleanup,
+  enqueueAssignmentArtifactStorageCleanupPath,
+  removeQueuedAssignmentArtifactStoragePath,
+  type ProvisionalAssignmentArtifactStorageCleanup,
+} from '@/lib/server/assignment-artifact-storage-cleanup'
 import {
   getGitHubIdentityValidationFromArtifact,
   normalizeGitHubLogin,
   validateAssignmentSubmissionArtifactValue,
 } from '@/lib/server/assignment-submission-validation'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { assignmentArtifactPutRequestSchema } from '@/lib/validations/assignment-doc-submissions'
 import type { AssignmentSubmissionArtifact, AssignmentSubmissionRequirement } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -21,6 +31,73 @@ export const revalidate = 0
 
 const ASSIGNMENT_ARTIFACTS_BUCKET = 'assignment-artifacts'
 const SIGNED_IMAGE_URL_EXPIRES_SECONDS = 60 * 60
+
+function isSubmittedArtifactMutationError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const record = error as { code?: string; message?: string }
+  return (
+    record.code === '23514'
+    && record.message?.includes('assignment_artifact_submitted_document_immutable') === true
+  )
+}
+
+function submittedArtifactMutationResponse() {
+  return NextResponse.json(
+    { error: 'Cannot edit a submitted document' },
+    { status: 409 }
+  )
+}
+
+async function compensateUploadedArtifact(input: {
+  supabase: ReturnType<typeof getServiceRoleClient>
+  storagePath: string
+  provisionalCleanup: ProvisionalAssignmentArtifactStorageCleanup | null
+}): Promise<void> {
+  const isReferenced = await assignmentArtifactStoragePathIsReferenced(input)
+  if (isReferenced === true) {
+    if (input.provisionalCleanup) {
+      await adoptProvisionalAssignmentArtifactStorageCleanup({
+        supabase: input.supabase,
+        cleanup: input.provisionalCleanup,
+      })
+    }
+    return
+  }
+  if (isReferenced === null) {
+    if (!input.provisionalCleanup) {
+      await enqueueAssignmentArtifactStorageCleanupPath({
+        supabase: input.supabase,
+        storagePath: input.storagePath,
+      })
+    }
+    return
+  }
+
+  let removed = false
+  try {
+    const removal = await input.supabase.storage
+      .from(ASSIGNMENT_ARTIFACTS_BUCKET)
+      .remove([input.storagePath])
+    removed = !removal.error
+  } catch {
+    removed = false
+  }
+
+  if (removed && input.provisionalCleanup) {
+    await adoptProvisionalAssignmentArtifactStorageCleanup({
+      supabase: input.supabase,
+      cleanup: input.provisionalCleanup,
+    })
+    return
+  }
+
+  if (!removed && !input.provisionalCleanup) {
+    await enqueueAssignmentArtifactStorageCleanupPath({
+      supabase: input.supabase,
+      storagePath: input.storagePath,
+    })
+  }
+}
 
 async function loadStudentAssignmentContext(opts: {
   assignmentId: string
@@ -120,6 +197,7 @@ async function withSignedImageUrl(supabase: ReturnType<typeof getServiceRoleClie
 export const PUT = withErrorHandler('PutAssignmentSubmissionArtifact', async (request: NextRequest, context) => {
   const user = await requireRole('student')
   const { id: assignmentId, requirementId } = await context.params
+  const body = assignmentArtifactPutRequestSchema.parse(await request.json())
   const result = await loadStudentAssignmentContext({ assignmentId, requirementId, studentId: user.id })
   if (result.kind === 'response') return result.response
 
@@ -128,13 +206,12 @@ export const PUT = withErrorHandler('PutAssignmentSubmissionArtifact', async (re
     return NextResponse.json({ error: 'Use image upload for screenshot requirements.' }, { status: 400 })
   }
 
-  const body = await request.json()
-  const url = typeof body.url === 'string' ? body.url : ''
+  const url = body.url
   const identity = requirement.type === 'repo_link'
     ? await loadUserGitHubIdentity(supabase, user.id)
     : null
   const githubLogin = requirement.type === 'repo_link'
-    ? normalizeGitHubLogin(typeof body.github_login === 'string' ? body.github_login : identity?.github_login)
+    ? normalizeGitHubLogin(body.github_login ?? identity?.github_login)
     : null
 
   const validation = await validateAssignmentSubmissionArtifactValue({
@@ -167,6 +244,9 @@ export const PUT = withErrorHandler('PutAssignmentSubmissionArtifact', async (re
     .single()
 
   if (error || !artifact) {
+    if (isSubmittedArtifactMutationError(error)) {
+      return submittedArtifactMutationResponse()
+    }
     if (isMissingAssignmentSubmissionSchemaError(error)) {
       return NextResponse.json({ error: 'Submission artifacts are not available yet.' }, { status: 503 })
     }
@@ -211,15 +291,26 @@ export const POST = withErrorHandler('PostAssignmentSubmissionArtifactImage', as
     return NextResponse.json({ error: validationError }, { status: 400 })
   }
 
-  const { data: previousArtifact } = await supabase
+  const { data: previousArtifact, error: previousArtifactError } = await supabase
     .from('assignment_submission_artifacts')
     .select('id, storage_path')
     .eq('assignment_doc_id', doc.id)
     .eq('requirement_id', requirement.id)
     .maybeSingle()
+  if (previousArtifactError) {
+    throw new Error('Failed to load the previous image artifact')
+  }
 
   const ext = file.name.split('.').pop() || 'png'
   const storagePath = `${user.id}/${assignmentId}/${requirement.id}-${Date.now()}-${crypto.randomUUID()}.${ext}`
+  const provisionalCleanup = await createProvisionalAssignmentArtifactStorageCleanup({
+    supabase,
+    storagePath,
+  })
+  if (!provisionalCleanup) {
+    throw new Error('Failed to protect image upload with durable cleanup evidence')
+  }
+
   const buffer = Buffer.from(await file.arrayBuffer())
   const { error: uploadError } = await supabase.storage
     .from(ASSIGNMENT_ARTIFACTS_BUCKET)
@@ -232,53 +323,69 @@ export const POST = withErrorHandler('PostAssignmentSubmissionArtifactImage', as
     throw new Error('Failed to upload image')
   }
 
-  const signed = await supabase.storage
-    .from(ASSIGNMENT_ARTIFACTS_BUCKET)
-    .createSignedUrl(storagePath, SIGNED_IMAGE_URL_EXPIRES_SECONDS)
-  const signedUrl = signed.data?.signedUrl ?? null
+  let artifact: unknown = null
+  let error: unknown = null
+  try {
+    const signed = await supabase.storage
+      .from(ASSIGNMENT_ARTIFACTS_BUCKET)
+      .createSignedUrl(storagePath, SIGNED_IMAGE_URL_EXPIRES_SECONDS)
+    const signedUrl = signed.data?.signedUrl ?? null
 
-  const validation = await validateAssignmentSubmissionArtifactValue({
-    type: 'image',
-    storagePath,
-    url: signedUrl,
-  })
+    const validation = await validateAssignmentSubmissionArtifactValue({
+      type: 'image',
+      storagePath,
+      url: signedUrl,
+    })
 
-  const { data: artifact, error } = await supabase
-    .from('assignment_submission_artifacts')
-    .upsert({
-      assignment_doc_id: doc.id,
-      requirement_id: requirement.id,
-      student_id: user.id,
-      type: requirement.type,
-      url: null,
-      storage_path: storagePath,
-      metadata_json: {
-        file_name: file.name,
-        file_size: file.size,
-        content_type: file.type,
-      },
-      validation_status: validation.validation_status,
-      validation_message: validation.validation_message,
-      validated_at: new Date().toISOString(),
-    }, { onConflict: 'assignment_doc_id,requirement_id' })
-    .select('*')
-    .single()
+    const save = await supabase
+      .from('assignment_submission_artifacts')
+      .upsert({
+        assignment_doc_id: doc.id,
+        requirement_id: requirement.id,
+        student_id: user.id,
+        type: requirement.type,
+        url: null,
+        storage_path: storagePath,
+        metadata_json: {
+          file_name: file.name,
+          file_size: file.size,
+          content_type: file.type,
+        },
+        validation_status: validation.validation_status,
+        validation_message: validation.validation_message,
+        validated_at: new Date().toISOString(),
+      }, { onConflict: 'assignment_doc_id,requirement_id' })
+      .select('*')
+      .single()
+    artifact = save.data
+    error = save.error
+  } catch (saveError) {
+    await compensateUploadedArtifact({ supabase, storagePath, provisionalCleanup })
+    throw saveError
+  }
 
   if (error || !artifact) {
-    await supabase.storage
-      .from(ASSIGNMENT_ARTIFACTS_BUCKET)
-      .remove([storagePath])
+    await compensateUploadedArtifact({ supabase, storagePath, provisionalCleanup })
 
+    if (isSubmittedArtifactMutationError(error)) {
+      return submittedArtifactMutationResponse()
+    }
     if (isMissingAssignmentSubmissionSchemaError(error)) {
       return NextResponse.json({ error: 'Submission artifacts are not available yet.' }, { status: 503 })
     }
     throw new Error('Failed to save image artifact')
   }
 
+  await adoptProvisionalAssignmentArtifactStorageCleanup({
+    supabase,
+    cleanup: provisionalCleanup,
+  })
+
   if (previousArtifact?.storage_path && previousArtifact.storage_path !== storagePath) {
-    await supabase.storage
-      .from(ASSIGNMENT_ARTIFACTS_BUCKET)
-      .remove([previousArtifact.storage_path])
+    await removeQueuedAssignmentArtifactStoragePath({
+      supabase,
+      storagePath: previousArtifact.storage_path,
+    })
   }
 
   return NextResponse.json({ artifact: await withSignedImageUrl(supabase, artifact as AssignmentSubmissionArtifact) })
@@ -290,29 +397,26 @@ export const DELETE = withErrorHandler('DeleteAssignmentSubmissionArtifact', asy
   const result = await loadStudentAssignmentContext({ assignmentId, requirementId, studentId: user.id })
   if (result.kind === 'response') return result.response
 
-  const { supabase, doc } = result
-  const { data: existing } = await supabase
-    .from('assignment_submission_artifacts')
-    .select('id, storage_path')
-    .eq('assignment_doc_id', doc.id)
-    .eq('requirement_id', requirementId)
-    .maybeSingle()
-
-  if (existing?.storage_path) {
-    await supabase.storage
-      .from(ASSIGNMENT_ARTIFACTS_BUCKET)
-      .remove([existing.storage_path])
+  const { supabase } = result
+  const deletion = await deleteAssignmentSubmissionArtifactAtomic({
+    supabase,
+    assignmentId,
+    studentId: user.id,
+    requirementId,
+  })
+  if (!deletion.ok) {
+    return NextResponse.json({ error: deletion.error }, { status: deletion.status })
   }
 
-  const { error } = await supabase
-    .from('assignment_submission_artifacts')
-    .delete()
-    .eq('assignment_doc_id', doc.id)
-    .eq('requirement_id', requirementId)
+  const cleanup = deletion.storagePath
+    ? await removeQueuedAssignmentArtifactStoragePath({
+        supabase,
+        storagePath: deletion.storagePath,
+      })
+    : { completed: true }
 
-  if (error && !isMissingAssignmentSubmissionSchemaError(error)) {
-    throw new Error('Failed to delete submission artifact')
-  }
-
-  return NextResponse.json({ ok: true })
+  return NextResponse.json(
+    { ok: true, cleanup_pending: !cleanup.completed },
+    { status: cleanup.completed ? 200 : 202 }
+  )
 })

--- a/src/app/api/assignment-docs/[id]/restore/route.ts
+++ b/src/app/api/assignment-docs/[id]/restore/route.ts
@@ -1,12 +1,16 @@
 import { NextResponse } from 'next/server'
+import { randomUUID } from 'node:crypto'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
-import { countCharacters, countWords } from '@/lib/tiptap-content'
+import { parseContentField } from '@/lib/tiptap-content'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import type { AssignmentDocHistoryEntry } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
+import { sanitizeDocForStudent } from '@/lib/assignments'
+import { saveAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
+import { assignmentDocRestoreRequestSchema } from '@/lib/validations/assignment-doc-submissions'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -14,15 +18,7 @@ export const revalidate = 0
 export const POST = withErrorHandler('PostRestoreAssignmentDoc', async (request, context) => {
   const user = await requireRole('student')
   const { id: assignmentId } = await context.params
-  const body = await request.json()
-  const { history_id: historyId } = body as { history_id?: string }
-
-  if (!historyId) {
-    return NextResponse.json(
-      { error: 'history_id is required' },
-      { status: 400 }
-    )
-  }
+  const { history_id: historyId } = assignmentDocRestoreRequestSchema.parse(await request.json())
 
   const supabase = getServiceRoleClient()
 
@@ -56,7 +52,7 @@ export const POST = withErrorHandler('PostRestoreAssignmentDoc', async (request,
 
   const { data: doc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, is_submitted')
+    .select('id, is_submitted, content, updated_at')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -115,33 +111,28 @@ export const POST = withErrorHandler('PostRestoreAssignmentDoc', async (request,
     )
   }
 
-  const { data: updatedDoc, error: updateError } = await supabase
-    .from('assignment_docs')
-    .update({ content: restoredContent })
-    .eq('id', doc.id)
-    .select()
-    .single()
+  const saveSessionId = randomUUID()
+  const restoreResult = await saveAssignmentDocAtomic({
+    supabase,
+    assignmentId,
+    studentId: user.id,
+    previousContent: parseContentField(doc.content),
+    content: restoredContent,
+    expectedUpdatedAt: doc.updated_at,
+    trigger: 'restore',
+    pasteWordCount: 0,
+    keystrokeCount: 0,
+    saveSessionId,
+    saveSequence: 1,
+    metricSessionId: saveSessionId,
+  })
 
-  if (updateError) {
-    console.error('Error restoring assignment doc:', updateError)
+  if (!restoreResult.ok) {
     return NextResponse.json(
-      { error: 'Failed to restore document' },
-      { status: 500 }
+      { error: restoreResult.error },
+      { status: restoreResult.status }
     )
   }
 
-  try {
-    await supabase.from('assignment_doc_history').insert({
-      assignment_doc_id: doc.id,
-      patch: null,
-      snapshot: restoredContent,
-      word_count: countWords(restoredContent),
-      char_count: countCharacters(restoredContent),
-      trigger: 'restore',
-    })
-  } catch (historyError) {
-    console.error('Error saving assignment doc history:', historyError)
-  }
-
-  return NextResponse.json({ doc: updatedDoc })
+  return NextResponse.json({ doc: sanitizeDocForStudent(restoreResult.doc) })
 })

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireAuth, requireRole } from '@/lib/auth'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
-import { countCharacters, countWords, isValidTiptapContent, parseContentField } from '@/lib/tiptap-content'
+import { parseContentField } from '@/lib/tiptap-content'
 import { sanitizeDocForStudent } from '@/lib/assignments'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
-import {
-  insertVersionedBaselineHistory,
-  persistVersionedHistory,
-} from '@/lib/server/versioned-history'
+import { saveAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { withErrorHandler } from '@/lib/api-handler'
 import { loadAssignmentFeedbackEntries } from '@/lib/server/assignment-feedback'
@@ -17,27 +14,10 @@ import {
   loadAssignmentSubmissionRequirements,
   loadUserGitHubIdentity,
 } from '@/lib/server/assignment-submission-artifacts'
-import type { AssignmentDocHistoryEntry, AssignmentDocHistoryTrigger, TiptapContent } from '@/types'
+import { assignmentDocSaveRequestSchema } from '@/lib/validations/assignment-doc-submissions'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-const HISTORY_MIN_INTERVAL_MS = 10_000
-const HISTORY_SELECT_FIELDS =
-  'id, assignment_doc_id, patch, snapshot, word_count, char_count, paste_word_count, keystroke_count, trigger, created_at'
-
-function buildHistoryMetrics(
-  content: TiptapContent,
-  pasteWordCount: number,
-  keystrokeCount: number
-) {
-  return {
-    word_count: countWords(content),
-    char_count: countCharacters(content),
-    paste_word_count: pasteWordCount,
-    keystroke_count: keystrokeCount,
-  }
-}
-
 function parseTimestamp(value: unknown) {
   if (typeof value !== 'string' || value.length === 0) return null
   const time = new Date(value).getTime()
@@ -248,7 +228,7 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
           ...assignment,
           instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
         },
-        doc: created,
+        doc: sanitizeDocForStudent(created),
         feedback_entries: [],
         ...submissionContext,
         wasFirstView: true,
@@ -284,16 +264,19 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
   // Mark as viewed if this request clears a first-view or returned-feedback notification.
   if (existingDoc && shouldRefreshViewedAt(existingDoc)) {
     const viewedAt = new Date().toISOString()
-    const { error: viewedError } = await supabase
+    const { data: viewedDoc, error: viewedError } = await supabase
       .from('assignment_docs')
       .update({ viewed_at: viewedAt })
       .eq('id', existingDoc.id)
+      .select('updated_at')
+      .single()
 
     if (viewedError) {
       console.error('Error updating assignment viewed_at:', viewedError)
       // Non-fatal: continue with response, but don't clear local notification count.
     } else {
       existingDoc.viewed_at = viewedAt
+      existingDoc.updated_at = viewedDoc.updated_at
       wasFirstView = true
     }
   }
@@ -317,39 +300,13 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
 export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, context) => {
   const user = await requireRole('student')
   const { id: assignmentId } = await context.params
-  const body = await request.json()
-  const { content, trigger } = body as {
-    content: TiptapContent
-    trigger?: AssignmentDocHistoryTrigger
-  }
-  // Clamp client-reported tracking values to non-negative integers
-  const paste_word_count = Math.max(0, Math.round(Number(body.paste_word_count) || 0))
-  const keystroke_count = Math.max(0, Math.round(Number(body.keystroke_count) || 0))
-
-  if (content === undefined) {
-    return NextResponse.json(
-      { error: 'Content is required' },
-      { status: 400 }
-    )
-  }
-
-  if (trigger && trigger !== 'autosave' && trigger !== 'blur') {
-    return NextResponse.json(
-      { error: 'Invalid trigger' },
-      { status: 400 }
-    )
-  }
-
-  if (!isValidTiptapContent(content)) {
-    return NextResponse.json(
-      { error: 'Invalid content format' },
-      { status: 400 }
-    )
-  }
+  const body = assignmentDocSaveRequestSchema.parse(await request.json())
+  const { content, trigger } = body
+  const isLegacySave = !('save_session_id' in body)
+  const paste_word_count = body.paste_word_count ?? 0
+  const keystroke_count = body.keystroke_count ?? 0
 
   const supabase = getServiceRoleClient()
-  let historyEntry: AssignmentDocHistoryEntry | null = null
-
   // Get assignment and verify enrollment
   const { data: assignment, error: assignmentError } = await supabase
     .from('assignments')
@@ -382,53 +339,12 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
   // Fetch doc to enforce ownership and submission rules
   const { data: existingDoc, error: docFetchError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, is_submitted, content')
+    .select('id, student_id, is_submitted, content, updated_at')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
 
-  if (docFetchError) {
-    if (docFetchError.code === 'PGRST116') {
-      const { data: created, error: createError } = await supabase
-        .from('assignment_docs')
-        .insert({
-          assignment_id: assignmentId,
-          student_id: user.id,
-          content,
-          repo_url: null,
-          github_username: null,
-          is_submitted: false,
-          submitted_at: null,
-        })
-        .select()
-        .single()
-
-      if (createError || !created) {
-        console.error('Error creating assignment doc:', createError)
-        return NextResponse.json(
-          { error: 'Failed to save' },
-          { status: 500 }
-        )
-      }
-
-      try {
-        historyEntry = await insertVersionedBaselineHistory<TiptapContent>({
-          supabase,
-          table: 'assignment_doc_history',
-          ownerColumn: 'assignment_doc_id',
-          ownerId: created.id,
-          content,
-          selectFields: HISTORY_SELECT_FIELDS,
-          trigger: 'baseline',
-          buildMetrics: (currentContent: TiptapContent) =>
-            buildHistoryMetrics(currentContent, paste_word_count, keystroke_count),
-        })
-      } catch (historyError) {
-        console.error('Error saving assignment doc history:', historyError)
-      }
-
-      return NextResponse.json({ doc: created, historyEntry })
-    }
+  if (docFetchError && docFetchError.code !== 'PGRST116') {
     console.error('Error fetching assignment doc:', docFetchError)
     return NextResponse.json(
       { error: 'Failed to fetch assignment doc' },
@@ -436,54 +352,47 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
     )
   }
 
-  if (existingDoc.is_submitted) {
+  if (existingDoc?.is_submitted) {
     return NextResponse.json(
       { error: 'Cannot edit a submitted document' },
       { status: 403 }
     )
   }
 
-  const beforeContent = parseContentField(existingDoc.content)
+  const saveSessionId = isLegacySave ? crypto.randomUUID() : body.save_session_id
+  const saveResult = await saveAssignmentDocAtomic({
+    supabase,
+    assignmentId,
+    studentId: user.id,
+    previousContent: existingDoc
+      ? parseContentField(existingDoc.content)
+      : { type: 'doc', content: [] },
+    content,
+    expectedUpdatedAt: isLegacySave ? existingDoc?.updated_at ?? null : body.expected_updated_at,
+    trigger: trigger ?? 'autosave',
+    pasteWordCount: paste_word_count,
+    keystrokeCount: keystroke_count,
+    saveSessionId,
+    saveSequence: isLegacySave ? 1 : body.save_sequence,
+    metricSessionId: isLegacySave ? saveSessionId : body.metric_session_id,
+  })
 
-  const { data: doc, error } = await supabase
-    .from('assignment_docs')
-    .update({
-      content,
-    })
-    .eq('id', existingDoc.id)
-    .select()
-    .single()
-
-  if (error) {
-    console.error('Error saving assignment doc:', error)
+  if (!saveResult.ok) {
     return NextResponse.json(
-      { error: 'Failed to save' },
-      { status: 500 }
+      { error: saveResult.error, error_code: saveResult.errorCode },
+      { status: saveResult.status }
     )
   }
+
+  const doc = saveResult.doc
 
   // Parse content if it's a string (for backwards compatibility)
   if (doc) {
     doc.content = parseContentField(doc.content)
   }
 
-  try {
-    historyEntry = await persistVersionedHistory<TiptapContent>({
-      supabase,
-      table: 'assignment_doc_history',
-      ownerColumn: 'assignment_doc_id',
-      ownerId: existingDoc.id,
-      previousContent: beforeContent,
-      nextContent: content,
-      selectFields: HISTORY_SELECT_FIELDS,
-      trigger: trigger ?? 'autosave',
-      historyMinIntervalMs: HISTORY_MIN_INTERVAL_MS,
-      buildMetrics: (currentContent: TiptapContent) =>
-        buildHistoryMetrics(currentContent, paste_word_count, keystroke_count),
-    })
-  } catch (historyError) {
-    console.error('Error saving assignment doc history:', historyError)
-  }
-
-  return NextResponse.json({ doc, historyEntry })
+  return NextResponse.json({
+    doc: sanitizeDocForStudent(doc),
+    historyEntry: saveResult.historyEntry,
+  })
 })

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { countCharacters, countWords, parseContentField } from '@/lib/tiptap-content'
+import { parseContentField } from '@/lib/tiptap-content'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { withErrorHandler } from '@/lib/api-handler'
-import { hasAssignmentSubmissionContent } from '@/lib/assignments'
+import { hasAssignmentSubmissionContent, sanitizeDocForStudent } from '@/lib/assignments'
 import {
   getSubmissionRequirementCompletion,
   isSubmissionArtifactPresent,
@@ -15,16 +15,27 @@ import {
   loadAssignmentSubmissionArtifactsForDoc,
   loadAssignmentSubmissionRequirements,
 } from '@/lib/server/assignment-submission-artifacts'
+import { assignmentDocSubmitRequestSchema } from '@/lib/validations/assignment-doc-submissions'
+import { submitAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
+import { createJsonPatch } from '@/lib/json-patch'
 import type { AssignmentDocHistoryEntry, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+const STUDENT_ASSIGNMENT_DOC_SELECT = 'id, assignment_id, student_id, content, repo_url, github_username, is_submitted, submitted_at, viewed_at, score_completion, score_thinking, score_workflow, feedback, feedback_returned_at, teacher_cleared_at, graded_at, graded_by, returned_at, authenticity_score, authenticity_flags, created_at, updated_at' as const
 
 // POST /api/assignment-docs/[id]/submit - Submit assignment
 export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, context) => {
   const user = await requireRole('student')
   const { id: assignmentId } = await context.params
   const supabase = getServiceRoleClient()
+  if (!request.body) {
+    return NextResponse.json(
+      { error: 'Reload this assignment before submitting from an older browser tab.' },
+      { status: 409 }
+    )
+  }
+  const submitRequest = assignmentDocSubmitRequestSchema.parse(await request.json())
 
   // Get assignment and verify enrollment
   const { data: assignment, error: assignmentError } = await supabase
@@ -58,7 +69,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   // Check if doc exists
   const { data: existingDoc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content, is_submitted, submitted_at')
+    .select(STUDENT_ASSIGNMENT_DOC_SELECT)
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -82,6 +93,8 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   if (existingDoc) {
     existingDoc.content = parseContentField(existingDoc.content)
   }
+  const requestedContent = submitRequest.content
+  const submissionContent = requestedContent
 
   const submissionRequirements = existingDoc
     ? await loadAssignmentSubmissionRequirements(supabase, assignmentId)
@@ -100,52 +113,39 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
 
   const hasStructuredArtifacts = submissionArtifacts.some(isSubmissionArtifactPresent)
 
-  if (!existingDoc || (!hasAssignmentSubmissionContent(existingDoc) && !hasStructuredArtifacts)) {
+  if (!existingDoc || (!hasAssignmentSubmissionContent({ content: submissionContent }) && !hasStructuredArtifacts)) {
     return NextResponse.json(
       { error: 'No work to submit. Please write something or add a required submission first.' },
       { status: 400 }
     )
   }
 
-  const submittedAt = existingDoc.is_submitted && existingDoc.submitted_at
-    ? existingDoc.submitted_at
-    : new Date().toISOString()
-
-  // Update to submitted state
-  const { data: doc, error } = await supabase
-    .from('assignment_docs')
-    .update({
-      is_submitted: true,
-      submitted_at: submittedAt
-    })
-    .eq('id', existingDoc.id)
-    .select()
-    .single()
-
-  if (error) {
-    console.error('Error submitting assignment:', error)
-    return NextResponse.json(
-      { error: 'Failed to submit' },
-      { status: 500 }
-    )
+  if (existingDoc.is_submitted) {
+    if (requestedContent && createJsonPatch(existingDoc.content, requestedContent).length > 0) {
+      return NextResponse.json(
+        { error: 'This assignment is already submitted and cannot be changed.' },
+        { status: 409 }
+      )
+    }
   }
+
+  const submitResult = await submitAssignmentDocAtomic({
+    supabase,
+    assignmentId,
+    studentId: user.id,
+    content: submissionContent as TiptapContent,
+    expectedUpdatedAt: submitRequest.expected_updated_at,
+  })
+
+  if (!submitResult.ok) {
+    return NextResponse.json({ error: submitResult.error }, { status: submitResult.status })
+  }
+
+  const doc = submitResult.doc
 
   // Parse content if it's a string (for backwards compatibility)
   if (doc) {
     doc.content = parseContentField(doc.content)
-  }
-
-  try {
-    await supabase.from('assignment_doc_history').insert({
-      assignment_doc_id: existingDoc.id,
-      patch: null,
-      snapshot: existingDoc.content,
-      word_count: countWords(existingDoc.content),
-      char_count: countCharacters(existingDoc.content),
-      trigger: 'submit',
-    })
-  } catch (historyError) {
-    console.error('Error saving assignment doc history:', historyError)
   }
 
   // Compute authenticity score from history.
@@ -177,5 +177,5 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
     console.error('Error computing authenticity score:', authError)
   }
 
-  return NextResponse.json({ doc })
+  return NextResponse.json({ doc: sanitizeDocForStudent(doc) })
 })

--- a/src/app/api/assignment-docs/[id]/unsubmit/route.ts
+++ b/src/app/api/assignment-docs/[id]/unsubmit/route.ts
@@ -2,10 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
-import { canUnsubmitAssignmentDoc, isAssignmentVisibleToStudents } from '@/lib/assignments'
+import { canUnsubmitAssignmentDoc, isAssignmentVisibleToStudents, sanitizeDocForStudent } from '@/lib/assignments'
 import { parseContentField } from '@/lib/tiptap-content'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { TiptapContent } from '@/types'
+import { unsubmitAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -78,33 +79,27 @@ export const POST = withErrorHandler('PostAssignmentDocUnsubmit', async (request
   if (!canUnsubmitAssignmentDoc(existingDoc)) {
     return NextResponse.json(
       { error: 'Returned submissions cannot be unsubmitted' },
-      { status: 400 }
+      { status: 409 }
     )
   }
 
-  // Update to unsubmitted state
-  const { data: doc, error } = await supabase
-    .from('assignment_docs')
-    .update({
-      is_submitted: false,
-      submitted_at: null
-    })
-    .eq('id', existingDoc.id)
-    .select()
-    .single()
-
-  if (error) {
-    console.error('Error unsubmitting assignment:', error)
+  const unsubmitResult = await unsubmitAssignmentDocAtomic({
+    supabase,
+    assignmentId,
+    studentId: user.id,
+  })
+  if (!unsubmitResult.ok) {
     return NextResponse.json(
-      { error: 'Failed to unsubmit' },
-      { status: 500 }
+      { error: unsubmitResult.error },
+      { status: unsubmitResult.status }
     )
   }
+  const doc = unsubmitResult.doc
 
   // Parse content if it's a string (for backwards compatibility)
   if (doc) {
     doc.content = parseContentField(doc.content)
   }
 
-  return NextResponse.json({ doc })
+  return NextResponse.json({ doc: sanitizeDocForStudent(doc) })
 })

--- a/src/app/api/cron/assignment-artifact-storage-cleanup/route.ts
+++ b/src/app/api/cron/assignment-artifact-storage-cleanup/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withErrorHandler } from '@/lib/api-handler'
+import { runAssignmentArtifactStorageCleanup } from '@/lib/server/assignment-artifact-storage-cleanup'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const maxDuration = 60
+
+async function handle(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 500 })
+  }
+  if (request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const result = await runAssignmentArtifactStorageCleanup({
+    supabase: getServiceRoleClient(),
+    limit: 100,
+    leaseSeconds: 120,
+  })
+  return NextResponse.json({ ok: result.failed === 0, ...result }, {
+    status: result.failed === 0 ? 200 : 503,
+  })
+}
+
+export const GET = withErrorHandler(
+  'GetCronAssignmentArtifactStorageCleanup',
+  async (request: NextRequest) => handle(request),
+)
+
+export const POST = withErrorHandler(
+  'PostCronAssignmentArtifactStorageCleanup',
+  async (request: NextRequest) => handle(request),
+)

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -16,6 +16,7 @@ export const revalidate = 0
 const TIMEZONE = 'America/Toronto'
 const DELETE_CHUNK_SIZE = 200
 const CLEANUP_PAGE_SIZE = 1000
+const SAVE_OPERATION_RETENTION_DAYS = 35
 
 type IdRow = { id: string }
 
@@ -70,15 +71,19 @@ async function deleteHistoryByParentIds(
   supabase: any,
   table: string,
   parentColumn: string,
-  parentIds: string[]
+  parentIds: string[],
+  preservedTrigger?: string
 ): Promise<{ deleted: number; error: any }> {
   let deleted = 0
 
   for (const parentIdChunk of chunkValues(parentIds, DELETE_CHUNK_SIZE)) {
-    const { count, error } = await supabase
+    let deleteQuery = supabase
       .from(table)
       .delete({ count: 'exact' })
-      .in(parentColumn, parentIdChunk)
+    if (preservedTrigger) {
+      deleteQuery = deleteQuery.neq('trigger', preservedTrigger)
+    }
+    const { count, error } = await deleteQuery.in(parentColumn, parentIdChunk)
 
     if (error) return { deleted, error }
     deleted += count ?? 0
@@ -149,6 +154,25 @@ async function handle(request: NextRequest) {
     }
   }
 
+  const saveOperationCutoff = subDays(new Date(), SAVE_OPERATION_RETENTION_DAYS).toISOString()
+  const saveOperationCleanup = await supabase.rpc(
+    'cleanup_assignment_doc_save_operations',
+    { p_completed_before: saveOperationCutoff }
+  )
+  const saveOperationCleanupCount = saveOperationCleanup.data
+  if (
+    saveOperationCleanup.error
+    || typeof saveOperationCleanupCount !== 'number'
+    || !Number.isSafeInteger(saveOperationCleanupCount)
+    || saveOperationCleanupCount < 0
+  ) {
+    console.error('Error cleaning assignment save operation digests:', saveOperationCleanup.error)
+    return NextResponse.json(
+      { error: 'Failed to clean assignment save operations' },
+      { status: 500 }
+    )
+  }
+
   const { ids: classroomIds, error: classroomsError } = await loadExpiredClassroomIds(
     supabase,
     cutoffDate
@@ -212,7 +236,8 @@ async function handle(request: NextRequest) {
       supabase,
       'assignment_doc_history',
       'assignment_doc_id',
-      assignmentDocIds
+      assignmentDocIds,
+      'submit'
     )
 
   if (assignmentHistoryError) {

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -20,15 +20,14 @@ import {
   submissionArtifactsToAssignmentArtifacts,
 } from '@/lib/assignment-submission-requirements'
 import {
-  collectAssignmentImageArtifactStoragePaths,
-  collectRemovedImageArtifactStoragePaths,
   loadAssignmentSubmissionArtifactsForDocs,
   loadAssignmentSubmissionRequirements,
-  removeAssignmentArtifactStorageObjects,
-  replaceAssignmentSubmissionRequirements,
+  updateAssignmentWithSubmissionRequirementsAtomic,
 } from '@/lib/server/assignment-submission-artifacts'
+import { runAssignmentArtifactStorageCleanup } from '@/lib/server/assignment-artifact-storage-cleanup'
 import type { AssignmentDoc, AssignmentSubmissionArtifact } from '@/types'
 import type { TableRow } from '@/types/database'
+import { teacherAssignmentPatchSchema } from '@/lib/validations/assignment-authoring'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -350,16 +349,15 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
 export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, context) => {
   const user = await requireRole('teacher')
   const { id } = await context.params
-  const body = await request.json()
-  const { title, instructions_markdown, rich_instructions, due_at, is_draft, released_at, submission_requirements } = body as {
-    title?: string
-    instructions_markdown?: string
-    rich_instructions?: unknown
-    due_at?: string
-    is_draft?: boolean
-    released_at?: string | null
-    submission_requirements?: unknown
-  }
+  const {
+    title,
+    instructions_markdown,
+    rich_instructions,
+    due_at,
+    is_draft,
+    released_at,
+    submission_requirements,
+  } = teacherAssignmentPatchSchema.parse(await request.json())
 
   const supabase = getServiceRoleClient()
 
@@ -495,7 +493,7 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
     )
   }
 
-  const hasSubmissionRequirementsUpdate = Array.isArray(submission_requirements)
+  const hasSubmissionRequirementsUpdate = submission_requirements !== undefined
   if (Object.keys(updates).length === 0 && !hasSubmissionRequirementsUpdate) {
     return NextResponse.json(
       { error: 'No updates provided' },
@@ -503,12 +501,49 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
     )
   }
 
-  const removedRequirementImageStoragePaths = hasSubmissionRequirementsUpdate
-    ? await collectRemovedImageArtifactStoragePaths(supabase, id, submission_requirements as any[])
-    : []
+  if (hasSubmissionRequirementsUpdate) {
+    const { data: submittedDoc, error: submittedDocError } = await supabase
+      .from('assignment_docs')
+      .select('id')
+      .eq('assignment_id', id)
+      .eq('is_submitted', true)
+      .limit(1)
+      .maybeSingle()
+
+    if (submittedDocError) {
+      console.error('Error checking submitted assignment documents:', submittedDocError)
+      return NextResponse.json(
+        { error: 'Failed to verify assignment submissions' },
+        { status: 500 }
+      )
+    }
+
+    if (submittedDoc) {
+      return NextResponse.json(
+        { error: 'Submission requirements cannot be changed after a student submits.' },
+        { status: 409 }
+      )
+    }
+  }
 
   let assignment: TableRow<'assignments'> = existing
-  if (Object.keys(updates).length > 0) {
+  let submissionRequirements
+  if (hasSubmissionRequirementsUpdate) {
+    const atomicUpdate = await updateAssignmentWithSubmissionRequirementsAtomic({
+      supabase,
+      assignmentId: id,
+      updates,
+      requirements: submission_requirements,
+    })
+    if (!atomicUpdate.ok) {
+      return NextResponse.json(
+        { error: atomicUpdate.error },
+        { status: atomicUpdate.status }
+      )
+    }
+    assignment = atomicUpdate.assignment
+    submissionRequirements = atomicUpdate.submissionRequirements
+  } else if (Object.keys(updates).length > 0) {
     const { data: updatedAssignment, error } = await supabase
       .from('assignments')
       .update(updates)
@@ -524,18 +559,17 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
       )
     }
     assignment = updatedAssignment
+    submissionRequirements = await loadAssignmentSubmissionRequirements(supabase, id)
+  } else {
+    submissionRequirements = await loadAssignmentSubmissionRequirements(supabase, id)
   }
 
-  const submissionRequirements = hasSubmissionRequirementsUpdate
-    ? await replaceAssignmentSubmissionRequirements(supabase, id, submission_requirements as any[])
-    : await loadAssignmentSubmissionRequirements(supabase, id)
-
-  if (hasSubmissionRequirementsUpdate && removedRequirementImageStoragePaths.length > 0) {
-    await removeAssignmentArtifactStorageObjects(
-      supabase,
-      removedRequirementImageStoragePaths,
-      `assignment:${id}:removed-submission-requirements`
-    )
+  if (hasSubmissionRequirementsUpdate) {
+    try {
+      await runAssignmentArtifactStorageCleanup({ supabase, limit: 50 })
+    } catch (cleanupError) {
+      console.error('Failed to process queued assignment artifact cleanup:', cleanupError)
+    }
   }
 
   return NextResponse.json({
@@ -586,8 +620,6 @@ export const DELETE = withErrorHandler('DeleteTeacherAssignment', async (request
     )
   }
 
-  const assignmentImageStoragePaths = await collectAssignmentImageArtifactStoragePaths(supabase, id)
-
   const { error } = await supabase
     .from('assignments')
     .delete()
@@ -601,12 +633,10 @@ export const DELETE = withErrorHandler('DeleteTeacherAssignment', async (request
     )
   }
 
-  if (assignmentImageStoragePaths.length > 0) {
-    await removeAssignmentArtifactStorageObjects(
-      supabase,
-      assignmentImageStoragePaths,
-      `assignment:${id}:delete`
-    )
+  try {
+    await runAssignmentArtifactStorageCleanup({ supabase, limit: 50 })
+  } catch (cleanupError) {
+    console.error('Failed to process queued assignment artifact cleanup:', cleanupError)
   }
 
   return NextResponse.json({ success: true })

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -459,6 +459,7 @@ export function StudentAssignmentsTab({
               />
             ) : (
               <StudentAssignmentEditor
+                key={selectedAssignment.id}
                 ref={editorRef}
                 classroomId={classroom.id}
                 assignmentId={selectedAssignment.id}

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -215,6 +215,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const [githubIdentity, setGithubIdentity] = useState<UserGitHubIdentity | null>(null)
   const [content, setContent] = useState<TiptapContent>({ type: 'doc', content: [] })
   const [preservedRecoveryContent, setPreservedRecoveryContent] = useState<TiptapContent | null>(null)
+  const preservedRecoveryContentRef = useRef<TiptapContent | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [saveError, setSaveError] = useState('')
@@ -252,6 +253,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const draftBeforePreviewRef = useRef<TiptapContent | null>(null)
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
   const isMountedRef = useRef(true)
+
+  const updatePreservedRecoveryContent = useCallback((nextContent: TiptapContent | null) => {
+    preservedRecoveryContentRef.current = nextContent
+    setPreservedRecoveryContent(nextContent)
+  }, [])
 
   // Input tracking for authenticity
   const pasteWordCountRef = useRef(0)
@@ -398,7 +404,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       uncertainSaveRef.current = recoveredPendingSave
       shouldReplayRecoveredSaveRef.current = false
       if (!data.doc?.is_submitted && recoveredContent && recoveredContentStr !== serverContentStr) {
-        setPreservedRecoveryContent(null)
+        updatePreservedRecoveryContent(null)
         setContent(recoveredContent)
         pendingContentRef.current = recoveredContent
         setSaveStatus('unsaved')
@@ -406,7 +412,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
           setSaveError('A local draft was recovered after the saved version changed. Review it before continuing.')
         }
       } else if (data.doc?.is_submitted && recoveredContent && recoveredContentStr !== serverContentStr) {
-        setPreservedRecoveryContent(recoveredContent)
+        updatePreservedRecoveryContent(recoveredContent)
         setContent(serverContent)
         pendingContentRef.current = serverContent
         setSaveStatus('saved')
@@ -416,7 +422,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
             : 'A newer local draft is preserved below for review. This returned submission cannot be unsubmitted.'
         )
       } else {
-        setPreservedRecoveryContent(null)
+        updatePreservedRecoveryContent(null)
         setContent(serverContent)
         pendingContentRef.current = serverContent
         if (!data.doc?.is_submitted && recoveredPendingSave) {
@@ -438,13 +444,13 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     } finally {
       setLoading(false)
     }
-  }, [assignmentId, clearLocalDraft, notifications, readRecoveryDraft])
+  }, [assignmentId, clearLocalDraft, notifications, readRecoveryDraft, updatePreservedRecoveryContent])
 
   const applyUnsubmittedDoc = useCallback((nextDoc: AssignmentDoc) => {
     const serverContent = nextDoc.content || { type: 'doc', content: [] }
     const serverContentStr = JSON.stringify(serverContent)
     setDoc(nextDoc)
-    setPreservedRecoveryContent(null)
+    updatePreservedRecoveryContent(null)
     lastSavedContentRef.current = serverContentStr
     lastSavedRevisionRef.current = nextDoc.updated_at ?? null
 
@@ -462,7 +468,57 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     setSaveStatus('saved')
     setSaveError('')
     clearLocalDraft()
-  }, [clearLocalDraft, readRecoveryDraft])
+  }, [clearLocalDraft, readRecoveryDraft, updatePreservedRecoveryContent])
+
+  const applySubmittedDoc = useCallback((
+    nextDoc: AssignmentDoc,
+    latestLocalContent: TiptapContent,
+    source: 'current-tab' | 'other-tab',
+  ) => {
+    const serverContent = nextDoc.content || { type: 'doc', content: [] }
+    const serverContentStr = JSON.stringify(serverContent)
+    const localContentToPreserve = preservedRecoveryContentRef.current ?? latestLocalContent
+    const hasNewerLocalContent = JSON.stringify(localContentToPreserve) !== serverContentStr
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = null
+    }
+    if (throttledSaveTimeoutRef.current) {
+      clearTimeout(throttledSaveTimeoutRef.current)
+      throttledSaveTimeoutRef.current = null
+    }
+
+    setDoc(nextDoc)
+    setContent(serverContent)
+    pendingContentRef.current = serverContent
+    lastSavedContentRef.current = serverContentStr
+    lastSavedRevisionRef.current = nextDoc.updated_at ?? lastSavedRevisionRef.current
+    setSaveStatus('saved')
+
+    if (!hasNewerLocalContent) {
+      setSaveError('')
+      updatePreservedRecoveryContent(null)
+      clearLocalDraft()
+      return
+    }
+
+    persistLocalDraft(localContentToPreserve)
+    updatePreservedRecoveryContent(localContentToPreserve)
+    setSaveError(
+      source === 'other-tab'
+        ? (
+            canUnsubmitAssignmentDoc(nextDoc)
+              ? 'Another tab submitted different work. Your local draft is preserved; unsubmit to review it.'
+              : 'Another tab submitted different work. Your local draft is preserved below for review.'
+          )
+        : (
+            canUnsubmitAssignmentDoc(nextDoc)
+              ? 'Your assignment was submitted, but newer local edits arrived before submission completed. They are preserved; unsubmit to review them.'
+              : 'Your assignment was submitted, but newer local edits arrived before submission completed. They are preserved below for review.'
+          )
+    )
+  }, [clearLocalDraft, persistLocalDraft, updatePreservedRecoveryContent])
 
   const loadHistory = useCallback(async () => {
     setHistoryLoading(true)
@@ -488,7 +544,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     }
   }, [assignmentId])
 
-  const refreshAfterRevisionConflict = useCallback(async (localDraft: TiptapContent) => {
+  const refreshAfterRevisionConflict = useCallback(async (
+    localDraft: TiptapContent,
+    options?: { definitiveConflict?: boolean },
+  ) => {
     try {
       const data = await fetchJSONWithCache<AssignmentDocResponse>(
         `assignment-doc:${assignmentId}`,
@@ -509,14 +568,44 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       if (!data.doc) return false
 
       const serverContent = data.doc.content || { type: 'doc', content: [] }
-      const draftToPreserve = pendingContentRef.current ?? localDraft
+      const draftToPreserve = preservedRecoveryContentRef.current
+        ?? pendingContentRef.current
+        ?? localDraft
       setDoc(data.doc)
       lastSavedContentRef.current = JSON.stringify(serverContent)
       lastSavedRevisionRef.current = data.doc.updated_at ?? null
+      const draftMatchesServer = JSON.stringify(draftToPreserve) === lastSavedContentRef.current
+      const claimedDraft = claimedRecoveryDraftRef.current
+      if (
+        options?.definitiveConflict
+        && draftMatchesServer
+        && claimedDraft
+        && JSON.stringify(claimedDraft.content) === lastSavedContentRef.current
+      ) {
+        if (
+          lastSavedRevisionRef.current
+          && (pasteWordCountRef.current > 0 || keystrokeCountRef.current > 0)
+        ) {
+          const replacementAttempt: SaveAttempt = {
+            content: draftToPreserve,
+            sessionId: saveSessionIdRef.current,
+            sequence: nextSaveSequence(),
+            metricSessionId: claimedDraft.pending_save?.metricSessionId ?? metricSessionIdRef.current,
+            expectedUpdatedAt: lastSavedRevisionRef.current,
+            trigger: claimedDraft.pending_save?.trigger ?? 'autosave',
+            pasteWordCount: pasteWordCountRef.current,
+            keystrokeCount: keystrokeCountRef.current,
+          }
+          uncertainSaveRef.current = replacementAttempt
+          persistLocalDraft(draftToPreserve, replacementAttempt)
+        } else {
+          clearLocalDraft(claimedDraft)
+        }
+      }
       if (data.doc.is_submitted) {
-        if (JSON.stringify(draftToPreserve) !== lastSavedContentRef.current) {
+        if (!draftMatchesServer) {
           persistLocalDraft(draftToPreserve, uncertainSaveRef.current ?? undefined)
-          setPreservedRecoveryContent(draftToPreserve)
+          updatePreservedRecoveryContent(draftToPreserve)
         }
         setContent(serverContent)
         pendingContentRef.current = serverContent
@@ -529,11 +618,14 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         await loadHistory()
         return true
       }
-      setPreservedRecoveryContent(null)
+      updatePreservedRecoveryContent(null)
       setContent(draftToPreserve)
       pendingContentRef.current = draftToPreserve
+      if (!draftMatchesServer) {
+        persistLocalDraft(draftToPreserve, uncertainSaveRef.current ?? undefined)
+      }
       setSaveStatus(
-        JSON.stringify(draftToPreserve) === lastSavedContentRef.current
+        draftMatchesServer
           ? 'saved'
           : 'unsaved'
       )
@@ -543,7 +635,15 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       console.error('Error refreshing assignment after revision conflict:', refreshError)
       return false
     }
-  }, [SAVE_REQUEST_TIMEOUT_MS, assignmentId, loadHistory, persistLocalDraft])
+  }, [
+    SAVE_REQUEST_TIMEOUT_MS,
+    assignmentId,
+    clearLocalDraft,
+    loadHistory,
+    nextSaveSequence,
+    persistLocalDraft,
+    updatePreservedRecoveryContent,
+  ])
 
   useEffect(() => {
     loadAssignment()
@@ -619,6 +719,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       activeSaveControllerRef.current = controller
       inFlightSaveRef.current = saveAttempt
       const attemptRecoveryDraft = persistLocalDraft(newContent, saveAttempt)
+      let reconciledAfterConflict = false
 
       try {
         const response = await fetch(`/api/assignment-docs/${assignmentId}`, {
@@ -648,10 +749,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
               uncertainSaveRef.current = null
             }
             metricSessionIdRef.current = globalThis.crypto.randomUUID()
-            const refreshed = await refreshAfterRevisionConflict(newContent)
+            const refreshed = await refreshAfterRevisionConflict(newContent, { definitiveConflict: true })
             if (!refreshed) {
               throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
             }
+            reconciledAfterConflict = true
             if (JSON.stringify(newContent) !== lastSavedContentRef.current) {
               throw new Error('A newer saved version exists. Review your preserved draft before retrying.')
             }
@@ -667,10 +769,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
             uncertainSaveRef.current = null
           }
           if (response.status === 409 || response.status === 403) {
-            const refreshed = await refreshAfterRevisionConflict(newContent)
+            const refreshed = await refreshAfterRevisionConflict(newContent, { definitiveConflict: true })
             if (!refreshed) {
               throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
             }
+            reconciledAfterConflict = true
             if (response.status === 403) {
               throw new Error('This assignment was submitted in another tab. Your local draft is preserved for review.')
             }
@@ -728,8 +831,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
             uncertainSaveRef.current = saveAttempt
             persistLocalDraft(newContent, saveAttempt)
           }
-        } else if (!isSubmittedRef.current) {
-          persistLocalDraft(newContent, uncertainSaveRef.current ?? undefined)
+        } else if (!reconciledAfterConflict && !isSubmittedRef.current) {
+          persistLocalDraft(
+            pendingContentRef.current ?? newContent,
+            uncertainSaveRef.current ?? undefined,
+          )
         }
         const saveError = didTimeOut
           ? new Error('Save timed out. Check your connection and try again.')
@@ -1012,7 +1118,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
 
       if (!response.ok) {
         if (response.status === 409) {
-          const refreshed = await refreshAfterRevisionConflict(submissionContent)
+          const refreshed = await refreshAfterRevisionConflict(submissionContent, { definitiveConflict: true })
           if (!refreshed) {
             throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
           }
@@ -1020,12 +1126,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         throw new Error(data.error || 'Failed to submit')
       }
 
-      setDoc(data.doc)
-      lastSavedContentRef.current = JSON.stringify(submissionContent)
-      lastSavedRevisionRef.current = data.doc?.updated_at ?? lastSavedRevisionRef.current
-      setSaveStatus('saved')
-      setSaveError('')
-      clearLocalDraft()
+      applySubmittedDoc(
+        data.doc,
+        pendingContentRef.current ?? submissionContent,
+        'current-tab',
+      )
     } catch (err: any) {
       console.error('Error submitting:', err)
       try {
@@ -1037,28 +1142,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         )
         if (refreshResponse.ok && refreshData.doc?.is_submitted) {
           const submittedDoc = refreshData.doc as AssignmentDoc
-          const serverContent = submittedDoc.content || { type: 'doc', content: [] }
-          const serverContentStr = JSON.stringify(serverContent)
           const latestLocalContent = pendingContentRef.current ?? submissionContent
-          setDoc(submittedDoc)
-          setContent(serverContent)
-          pendingContentRef.current = serverContent
-          lastSavedContentRef.current = serverContentStr
-          lastSavedRevisionRef.current = submittedDoc.updated_at ?? lastSavedRevisionRef.current
-          setSaveStatus('saved')
-          if (serverContentStr === JSON.stringify(latestLocalContent)) {
-            setSaveError('')
-            setPreservedRecoveryContent(null)
-            clearLocalDraft()
-          } else {
-            persistLocalDraft(latestLocalContent, uncertainSaveRef.current ?? undefined)
-            setPreservedRecoveryContent(latestLocalContent)
-            setSaveError(
-              canUnsubmitAssignmentDoc(submittedDoc)
-                ? 'Another tab submitted different work. Your local draft is preserved; unsubmit to review it.'
-                : 'Another tab submitted different work. Your local draft is preserved below for review.'
-            )
-          }
+          applySubmittedDoc(submittedDoc, latestLocalContent, 'other-tab')
           setError('')
           return
         }
@@ -1069,7 +1154,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     } finally {
       setSubmitting(false)
     }
-  }, [SAVE_REQUEST_TIMEOUT_MS, assignmentId, clearLocalDraft, content, persistLocalDraft, refreshAfterRevisionConflict, saveContent])
+  }, [SAVE_REQUEST_TIMEOUT_MS, applySubmittedDoc, assignmentId, content, refreshAfterRevisionConflict, saveContent])
 
   const handleUnsubmit = useCallback(async () => {
     setSubmitting(true)

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useImperativeHandle, forwardRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Tooltip } from '@/ui'
+import { ConfirmDialog } from '@/ui/Dialog'
 import { Card } from '@/ui/Card'
 import { EmptyState } from '@/ui/EmptyState'
 import { History } from 'lucide-react'
@@ -20,7 +21,16 @@ import {
   hasAssignmentSubmissionContent,
 } from '@/lib/assignments'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
+import { isValidTiptapContent } from '@/lib/tiptap-content'
 import { fetchJSONWithCache } from '@/lib/request-cache'
+import {
+  safeLocalGetJson,
+  safeLocalRemove,
+  safeLocalSetJson,
+  safeSessionGetJson,
+  safeSessionRemove,
+  safeSessionSetJson,
+} from '@/lib/client-storage'
 import { formatInTimeZone } from 'date-fns-tz'
 import { HistoryList } from '@/components/HistoryList'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
@@ -65,10 +75,132 @@ type AssignmentDocResponse = {
   submission_artifacts?: AssignmentSubmissionArtifact[]
   github_identity?: UserGitHubIdentity | null
   wasFirstView?: boolean
+  student_id?: string
 }
 
 type AssignmentDocHistoryResponse = {
   history?: AssignmentDocHistoryEntry[]
+}
+
+type SaveAttempt = {
+  content: TiptapContent
+  sessionId: string
+  sequence: number
+  metricSessionId: string
+  expectedUpdatedAt: string
+  trigger: 'autosave' | 'blur'
+  pasteWordCount: number
+  keystrokeCount: number
+}
+
+type AssignmentRecoveryDraft = {
+  draft_id?: string
+  generation?: number
+  content?: TiptapContent
+  base_revision?: string | null
+  save_session_id?: string
+  paste_word_count?: number
+  keystroke_count?: number
+  pending_save?: SaveAttempt
+  saved_at?: string
+}
+
+type AssignmentTabWriter = {
+  session_id: string
+  sequence: number
+}
+
+const RECOVERY_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const MAX_PASTE_WORD_COUNT = 32_767
+const MAX_KEYSTROKE_COUNT = 2_147_483_647
+
+function compareRecoveryDrafts(a: AssignmentRecoveryDraft, b: AssignmentRecoveryDraft): number {
+  const aTime = a.saved_at ? Date.parse(a.saved_at) : Number.NEGATIVE_INFINITY
+  const bTime = b.saved_at ? Date.parse(b.saved_at) : Number.NEGATIVE_INFINITY
+  const aGeneration = Number.isFinite(a.generation) ? a.generation! : aTime * 1_000
+  const bGeneration = Number.isFinite(b.generation) ? b.generation! : bTime * 1_000
+  if (aGeneration !== bGeneration) return aGeneration - bGeneration
+  if (aTime !== bTime) return aTime - bTime
+  return (a.draft_id ?? '').localeCompare(b.draft_id ?? '')
+}
+
+function isExpiredRecoveryDraft(draft: AssignmentRecoveryDraft): boolean {
+  if (!draft.saved_at) return true
+  const savedAt = Date.parse(draft.saved_at)
+  return !Number.isFinite(savedAt) || Date.now() - savedAt > RECOVERY_DRAFT_MAX_AGE_MS
+}
+
+function saveAttemptBody(attempt: SaveAttempt) {
+  return {
+    content: attempt.content,
+    trigger: attempt.trigger,
+    paste_word_count: attempt.pasteWordCount,
+    keystroke_count: attempt.keystrokeCount,
+    save_session_id: attempt.sessionId,
+    save_sequence: attempt.sequence,
+    metric_session_id: attempt.metricSessionId,
+    expected_updated_at: attempt.expectedUpdatedAt,
+  }
+}
+
+function isSaveAttempt(value: unknown): value is SaveAttempt {
+  if (!value || typeof value !== 'object') return false
+  const attempt = value as Partial<SaveAttempt>
+  return isValidTiptapContent(attempt.content)
+    && typeof attempt.sessionId === 'string' && UUID_PATTERN.test(attempt.sessionId)
+    && Number.isInteger(attempt.sequence) && (attempt.sequence ?? 0) > 0
+    && typeof attempt.metricSessionId === 'string' && UUID_PATTERN.test(attempt.metricSessionId)
+    && typeof attempt.expectedUpdatedAt === 'string' && Number.isFinite(Date.parse(attempt.expectedUpdatedAt))
+    && (attempt.trigger === 'autosave' || attempt.trigger === 'blur')
+    && Number.isInteger(attempt.pasteWordCount)
+    && (attempt.pasteWordCount ?? -1) >= 0
+    && (attempt.pasteWordCount ?? Number.POSITIVE_INFINITY) <= MAX_PASTE_WORD_COUNT
+    && Number.isInteger(attempt.keystrokeCount)
+    && (attempt.keystrokeCount ?? -1) >= 0
+    && (attempt.keystrokeCount ?? Number.POSITIVE_INFINITY) <= MAX_KEYSTROKE_COUNT
+}
+
+function isAssignmentTabWriter(value: unknown): value is AssignmentTabWriter {
+  if (!value || typeof value !== 'object') return false
+  const writer = value as Partial<AssignmentTabWriter>
+  return typeof writer.session_id === 'string'
+    && UUID_PATTERN.test(writer.session_id)
+    && Number.isInteger(writer.sequence)
+    && (writer.sequence ?? -1) >= 0
+}
+
+function isAmbiguousSaveStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 425 || status === 429
+}
+
+async function fetchJsonWithTimeout<T = any>(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<{ response: Response; payload: T }> {
+  const controller = new AbortController()
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort()
+      reject(new Error(timeoutMessage))
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([
+      (async () => {
+        const response = await fetch(input, { ...init, signal: controller.signal })
+        const payload = await response.json() as T
+        return { response, payload }
+      })(),
+      timeout,
+    ])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
 }
 
 export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle, Props>(function StudentAssignmentEditor({
@@ -84,16 +216,22 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
 
   const AUTOSAVE_DEBOUNCE_MS = 5000
   const AUTOSAVE_MIN_INTERVAL_MS = 15000
+  const SAVE_REQUEST_TIMEOUT_MS = 15000
+  const KEEPALIVE_BODY_LIMIT_BYTES = 60 * 1024
 
   const [assignment, setAssignment] = useState<Assignment | null>(null)
   const [doc, setDoc] = useState<AssignmentDoc | null>(null)
+  const isSubmittedRef = useRef(false)
+  isSubmittedRef.current = Boolean(doc?.is_submitted)
   const [feedbackEntries, setFeedbackEntries] = useState<AssignmentFeedbackEntry[]>([])
   const [submissionRequirements, setSubmissionRequirements] = useState<AssignmentSubmissionRequirement[]>([])
   const [submissionArtifacts, setSubmissionArtifacts] = useState<AssignmentSubmissionArtifact[]>([])
   const [githubIdentity, setGithubIdentity] = useState<UserGitHubIdentity | null>(null)
   const [content, setContent] = useState<TiptapContent>({ type: 'doc', content: [] })
+  const [preservedRecoveryContent, setPreservedRecoveryContent] = useState<TiptapContent | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [saveError, setSaveError] = useState('')
   const [historyEntries, setHistoryEntries] = useState<AssignmentDocHistoryEntry[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
   const [historyError, setHistoryError] = useState('')
@@ -109,18 +247,158 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const [submitting, setSubmitting] = useState(false)
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSavedContentRef = useRef('')
+  const lastSavedRevisionRef = useRef<string | null>(null)
   const throttledSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAttemptAtRef = useRef(0)
   const pendingContentRef = useRef<TiptapContent | null>(null)
+  const inFlightSaveRef = useRef<SaveAttempt | null>(null)
+  const uncertainSaveRef = useRef<SaveAttempt | null>(null)
+  const activeSaveControllerRef = useRef<AbortController | null>(null)
+  const saveSessionIdRef = useRef(globalThis.crypto.randomUUID())
+  const metricSessionIdRef = useRef(globalThis.crypto.randomUUID())
+  const claimedRecoveryDraftRef = useRef<AssignmentRecoveryDraft | null>(null)
+  const recoveryGenerationRef = useRef(0)
+  const saveSequenceRef = useRef(0)
+  const shouldReplayRecoveredSaveRef = useRef(false)
+  const pageHiddenRef = useRef(false)
+  const studentIdRef = useRef<string | null>(null)
   const draftBeforePreviewRef = useRef<TiptapContent | null>(null)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const isMountedRef = useRef(true)
 
   // Input tracking for authenticity
   const pasteWordCountRef = useRef(0)
   const keystrokeCountRef = useRef(0)
 
+  const getDraftStorageKey = useCallback(() => {
+    const studentId = studentIdRef.current
+    return studentId ? `assignment-draft:${studentId}:${assignmentId}` : null
+  }, [assignmentId])
+
+  const getTabWriterStorageKey = useCallback(() => {
+    const studentId = studentIdRef.current
+    return studentId ? `assignment-save-writer:${studentId}:${assignmentId}` : null
+  }, [assignmentId])
+
+  const persistTabWriter = useCallback(() => {
+    const key = getTabWriterStorageKey()
+    if (!key) return
+    safeSessionSetJson(key, {
+      session_id: saveSessionIdRef.current,
+      sequence: saveSequenceRef.current,
+    } satisfies AssignmentTabWriter)
+  }, [getTabWriterStorageKey])
+
+  const restoreTabWriter = useCallback(() => {
+    const key = getTabWriterStorageKey()
+    const writer = key ? safeSessionGetJson<AssignmentTabWriter>(key) : null
+    if (isAssignmentTabWriter(writer)) {
+      saveSessionIdRef.current = writer.session_id
+      saveSequenceRef.current = writer.sequence
+      return
+    }
+    persistTabWriter()
+  }, [getTabWriterStorageKey, persistTabWriter])
+
+  const nextSaveSequence = useCallback(() => {
+    saveSequenceRef.current += 1
+    persistTabWriter()
+    return saveSequenceRef.current
+  }, [persistTabWriter])
+
+  const readRecoveryDraft = useCallback(() => {
+    const key = getDraftStorageKey()
+    if (!key) return null
+
+    let sessionDraft = safeSessionGetJson<AssignmentRecoveryDraft>(key)
+    let durableDraft = safeLocalGetJson<AssignmentRecoveryDraft>(key)
+    if (sessionDraft && isExpiredRecoveryDraft(sessionDraft)) {
+      safeSessionRemove(key)
+      sessionDraft = null
+    }
+    if (durableDraft && isExpiredRecoveryDraft(durableDraft)) {
+      safeLocalRemove(key)
+      durableDraft = null
+    }
+
+    const selected = sessionDraft && durableDraft
+      ? (compareRecoveryDrafts(sessionDraft, durableDraft) >= 0 ? sessionDraft : durableDraft)
+      : sessionDraft ?? durableDraft
+    if (selected) {
+      const selectedTime = selected.saved_at ? Date.parse(selected.saved_at) : 0
+      recoveryGenerationRef.current = Math.max(
+        recoveryGenerationRef.current,
+        selected.generation ?? selectedTime * 1_000,
+      )
+    }
+    claimedRecoveryDraftRef.current = selected
+    return selected
+  }, [getDraftStorageKey])
+
+  const persistLocalDraft = useCallback((draft: TiptapContent, pendingSave?: SaveAttempt) => {
+    const key = getDraftStorageKey()
+    if (!key) return null
+    const existingSession = safeSessionGetJson<AssignmentRecoveryDraft>(key)
+    const existingDurable = safeLocalGetJson<AssignmentRecoveryDraft>(key)
+    const monotonicNow = Math.floor(
+      ((globalThis.performance?.timeOrigin ?? Date.now()) + (globalThis.performance?.now?.() ?? 0)) * 1_000
+    )
+    const nextGeneration = Math.max(
+      monotonicNow,
+      recoveryGenerationRef.current + 1,
+      (existingSession?.generation ?? 0) + 1,
+      (existingDurable?.generation ?? 0) + 1,
+    )
+    recoveryGenerationRef.current = nextGeneration
+    const recoveryDraft: AssignmentRecoveryDraft = {
+      draft_id: globalThis.crypto.randomUUID(),
+      generation: nextGeneration,
+      content: draft,
+      base_revision: lastSavedRevisionRef.current,
+      save_session_id: saveSessionIdRef.current,
+      paste_word_count: pasteWordCountRef.current,
+      keystroke_count: keystrokeCountRef.current,
+      ...(pendingSave ? { pending_save: pendingSave } : {}),
+      saved_at: new Date().toISOString(),
+    }
+    claimedRecoveryDraftRef.current = recoveryDraft
+    const sessionSaved = existingSession && compareRecoveryDrafts(existingSession, recoveryDraft) > 0
+      ? true
+      : safeSessionSetJson(key, recoveryDraft)
+    const durableSaved = existingDurable && compareRecoveryDrafts(existingDurable, recoveryDraft) > 0
+      ? true
+      : safeLocalSetJson(key, recoveryDraft)
+    if (!sessionSaved && !durableSaved && isMountedRef.current) {
+      setSaveError('This browser could not store a local recovery copy. Keep this tab open until saving succeeds.')
+    }
+    return recoveryDraft
+  }, [getDraftStorageKey])
+
+  const clearLocalDraft = useCallback((completedDraft?: AssignmentRecoveryDraft | null) => {
+    const key = getDraftStorageKey()
+    const claimedDraft = completedDraft ?? claimedRecoveryDraftRef.current
+    if (key && claimedDraft) {
+      const sessionDraft = safeSessionGetJson<AssignmentRecoveryDraft>(key)
+      const durableDraft = safeLocalGetJson<AssignmentRecoveryDraft>(key)
+      if (sessionDraft && compareRecoveryDrafts(sessionDraft, claimedDraft) <= 0) {
+        safeSessionRemove(key)
+      }
+      if (durableDraft && compareRecoveryDrafts(durableDraft, claimedDraft) <= 0) {
+        safeLocalRemove(key)
+      }
+    }
+    if (
+      !completedDraft
+      || claimedRecoveryDraftRef.current?.draft_id === completedDraft.draft_id
+    ) {
+      claimedRecoveryDraftRef.current = null
+    }
+  }, [getDraftStorageKey])
+
   const loadAssignment = useCallback(async () => {
     setLoading(true)
     setError('')
+    setSaveError('')
     try {
       const data = await fetchJSONWithCache<AssignmentDocResponse>(
         `assignment-doc:${assignmentId}`,
@@ -143,8 +421,52 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       setSubmissionRequirements(data.submission_requirements || [])
       setSubmissionArtifacts(data.submission_artifacts || [])
       setGithubIdentity(data.github_identity || null)
-      setContent(data.doc?.content || { type: 'doc', content: [] })
-      lastSavedContentRef.current = JSON.stringify(data.doc?.content || { type: 'doc', content: [] })
+      studentIdRef.current = data.doc?.student_id ?? data.student_id ?? null
+      restoreTabWriter()
+      const serverContent = data.doc?.content || { type: 'doc', content: [] }
+      const serverContentStr = JSON.stringify(serverContent)
+      lastSavedRevisionRef.current = data.doc?.updated_at ?? null
+      lastSavedContentRef.current = serverContentStr
+      const localDraft = readRecoveryDraft()
+      const recoveredContent = localDraft?.content
+      const recoveredContentStr = recoveredContent ? JSON.stringify(recoveredContent) : null
+      pasteWordCountRef.current = Math.max(0, localDraft?.paste_word_count ?? 0)
+      keystrokeCountRef.current = Math.max(0, localDraft?.keystroke_count ?? 0)
+      const recoveredPendingSave = isSaveAttempt(localDraft?.pending_save)
+        ? localDraft.pending_save
+        : null
+      uncertainSaveRef.current = recoveredPendingSave
+      shouldReplayRecoveredSaveRef.current = false
+      if (!data.doc?.is_submitted && recoveredContent && recoveredContentStr !== serverContentStr) {
+        setPreservedRecoveryContent(null)
+        setContent(recoveredContent)
+        pendingContentRef.current = recoveredContent
+        setSaveStatus('unsaved')
+        if (localDraft.base_revision !== lastSavedRevisionRef.current) {
+          setSaveError('A local draft was recovered after the saved version changed. Review it before continuing.')
+        }
+      } else if (data.doc?.is_submitted && recoveredContent && recoveredContentStr !== serverContentStr) {
+        setPreservedRecoveryContent(recoveredContent)
+        setContent(serverContent)
+        pendingContentRef.current = serverContent
+        setSaveStatus('saved')
+        setSaveError(
+          canUnsubmitAssignmentDoc(data.doc)
+            ? 'A newer local draft is preserved in this browser. Unsubmit to restore and review it.'
+            : 'A newer local draft is preserved below for review. This returned submission cannot be unsubmitted.'
+        )
+      } else {
+        setPreservedRecoveryContent(null)
+        setContent(serverContent)
+        pendingContentRef.current = serverContent
+        if (!data.doc?.is_submitted && recoveredPendingSave) {
+          shouldReplayRecoveredSaveRef.current = true
+          setSaveStatus('unsaved')
+          setSaveError('Confirming the last save from this browser...')
+        } else {
+          clearLocalDraft(localDraft)
+        }
+      }
 
       // Decrement notification count only if this was the first view (server confirmed)
       if (data.wasFirstView) {
@@ -156,7 +478,31 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     } finally {
       setLoading(false)
     }
-  }, [assignmentId, notifications])
+  }, [assignmentId, clearLocalDraft, notifications, readRecoveryDraft, restoreTabWriter])
+
+  const applyUnsubmittedDoc = useCallback((nextDoc: AssignmentDoc) => {
+    const serverContent = nextDoc.content || { type: 'doc', content: [] }
+    const serverContentStr = JSON.stringify(serverContent)
+    setDoc(nextDoc)
+    setPreservedRecoveryContent(null)
+    lastSavedContentRef.current = serverContentStr
+    lastSavedRevisionRef.current = nextDoc.updated_at ?? null
+
+    const recoveryDraft = readRecoveryDraft()
+    if (recoveryDraft?.content && JSON.stringify(recoveryDraft.content) !== serverContentStr) {
+      setContent(recoveryDraft.content)
+      pendingContentRef.current = recoveryDraft.content
+      setSaveStatus('unsaved')
+      setSaveError('Your preserved local draft was restored after unsubmit. Review it before saving.')
+      return
+    }
+
+    setContent(serverContent)
+    pendingContentRef.current = serverContent
+    setSaveStatus('saved')
+    setSaveError('')
+    clearLocalDraft()
+  }, [clearLocalDraft, readRecoveryDraft])
 
   const loadHistory = useCallback(async () => {
     setHistoryLoading(true)
@@ -182,6 +528,63 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     }
   }, [assignmentId])
 
+  const refreshAfterRevisionConflict = useCallback(async (localDraft: TiptapContent) => {
+    try {
+      const data = await fetchJSONWithCache<AssignmentDocResponse>(
+        `assignment-doc:${assignmentId}`,
+        async () => {
+          const { response, payload } = await fetchJsonWithTimeout<AssignmentDocResponse>(
+            `/api/assignment-docs/${assignmentId}`,
+            {},
+            SAVE_REQUEST_TIMEOUT_MS,
+            'Reloading the saved assignment timed out.',
+          )
+          if (!response.ok) {
+            throw new Error((payload as any).error || 'Failed to reload assignment')
+          }
+          return payload
+        },
+        0,
+      )
+      if (!data.doc) return false
+
+      const serverContent = data.doc.content || { type: 'doc', content: [] }
+      const draftToPreserve = pendingContentRef.current ?? localDraft
+      setDoc(data.doc)
+      lastSavedContentRef.current = JSON.stringify(serverContent)
+      lastSavedRevisionRef.current = data.doc.updated_at ?? null
+      if (data.doc.is_submitted) {
+        if (JSON.stringify(draftToPreserve) !== lastSavedContentRef.current) {
+          persistLocalDraft(draftToPreserve, uncertainSaveRef.current ?? undefined)
+          setPreservedRecoveryContent(draftToPreserve)
+        }
+        setContent(serverContent)
+        pendingContentRef.current = serverContent
+        setSaveStatus('saved')
+        setSaveError(
+          canUnsubmitAssignmentDoc(data.doc)
+            ? 'This assignment was submitted in another tab. Unsubmit it before editing again.'
+            : 'This assignment was submitted and returned while this tab had newer work. The preserved draft is available below for review.'
+        )
+        await loadHistory()
+        return true
+      }
+      setPreservedRecoveryContent(null)
+      setContent(draftToPreserve)
+      pendingContentRef.current = draftToPreserve
+      setSaveStatus(
+        JSON.stringify(draftToPreserve) === lastSavedContentRef.current
+          ? 'saved'
+          : 'unsaved'
+      )
+      await loadHistory()
+      return true
+    } catch (refreshError) {
+      console.error('Error refreshing assignment after revision conflict:', refreshError)
+      return false
+    }
+  }, [SAVE_REQUEST_TIMEOUT_MS, assignmentId, loadHistory, persistLocalDraft])
+
   useEffect(() => {
     loadAssignment()
     loadHistory()
@@ -196,62 +599,367 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   }, [loadAssignment, loadHistory])
 
   // Autosave with debouncing
-  const saveContent = useCallback(async (
+  const saveContent = useCallback((
     newContent: TiptapContent,
     options?: { trigger?: 'autosave' | 'blur' }
   ) => {
-    const newContentStr = JSON.stringify(newContent)
-    if (newContentStr === lastSavedContentRef.current) {
-      setSaveStatus('saved')
+    const savePromise = saveQueueRef.current.then(async () => {
+      if (pageHiddenRef.current) return
+      const newContentStr = JSON.stringify(newContent)
+      const hasPendingMetrics = pasteWordCountRef.current > 0 || keystrokeCountRef.current > 0
+      if (newContentStr === lastSavedContentRef.current && !hasPendingMetrics) {
+        if (isMountedRef.current) {
+          const pendingContent = pendingContentRef.current
+          const hasNewerPendingContent = Boolean(
+            pendingContent && JSON.stringify(pendingContent) !== newContentStr
+          )
+          setSaveStatus(hasNewerPendingContent ? 'unsaved' : 'saved')
+          if (!hasNewerPendingContent) setSaveError('')
+        }
+        return
+      }
+
+      if (isMountedRef.current) {
+        setSaveStatus('saving')
+        setSaveError('')
+      }
+      lastSaveAttemptAtRef.current = Date.now()
+      const pasteWordCount = pasteWordCountRef.current
+      const keystrokeCount = keystrokeCountRef.current
+      const uncertainSave = uncertainSaveRef.current
+      const isExactUncertainRetry = Boolean(
+        uncertainSave
+        && JSON.stringify(uncertainSave.content) === newContentStr
+        && uncertainSave.pasteWordCount === pasteWordCount
+        && uncertainSave.keystrokeCount === keystrokeCount
+      )
+      const expectedUpdatedAt = lastSavedRevisionRef.current
+      if (!expectedUpdatedAt) {
+        throw new Error('The saved draft revision is unavailable. Reload this assignment before retrying.')
+      }
+      const saveAttempt: SaveAttempt = isExactUncertainRetry
+        ? uncertainSave!
+        : {
+            content: newContent,
+            sessionId: saveSessionIdRef.current,
+            sequence: nextSaveSequence(),
+            metricSessionId: uncertainSave?.metricSessionId ?? metricSessionIdRef.current,
+            expectedUpdatedAt,
+            trigger: options?.trigger ?? 'autosave',
+            pasteWordCount,
+            keystrokeCount,
+          }
+      const controller = new AbortController()
+      let didTimeOut = false
+      let hasDefinitiveResponse = false
+      const timeoutId = setTimeout(() => {
+        didTimeOut = true
+        controller.abort()
+      }, SAVE_REQUEST_TIMEOUT_MS)
+      activeSaveControllerRef.current = controller
+      inFlightSaveRef.current = saveAttempt
+      const attemptRecoveryDraft = persistLocalDraft(newContent, saveAttempt)
+
+      try {
+        const response = await fetch(`/api/assignment-docs/${assignmentId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(saveAttemptBody(saveAttempt)),
+          signal: controller.signal,
+        })
+
+        hasDefinitiveResponse = response.ok || !isAmbiguousSaveStatus(response.status)
+        const data = await response.json()
+
+        if (!response.ok) {
+          if (data.error_code === 'assignment_doc_save_replayed' && isExactUncertainRetry) {
+            pasteWordCountRef.current = Math.max(
+              0,
+              pasteWordCountRef.current - saveAttempt.pasteWordCount
+            )
+            keystrokeCountRef.current = Math.max(
+              0,
+              keystrokeCountRef.current - saveAttempt.keystrokeCount
+            )
+            if (
+              uncertainSaveRef.current?.sessionId === saveAttempt.sessionId
+              && uncertainSaveRef.current.sequence === saveAttempt.sequence
+            ) {
+              uncertainSaveRef.current = null
+            }
+            metricSessionIdRef.current = globalThis.crypto.randomUUID()
+            const refreshed = await refreshAfterRevisionConflict(newContent)
+            if (!refreshed) {
+              throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
+            }
+            if (JSON.stringify(newContent) !== lastSavedContentRef.current) {
+              throw new Error('A newer saved version exists. Review your preserved draft before retrying.')
+            }
+            clearLocalDraft(attemptRecoveryDraft)
+            return
+          }
+          if (
+            hasDefinitiveResponse
+            && isExactUncertainRetry
+            && uncertainSaveRef.current?.sessionId === saveAttempt.sessionId
+            && uncertainSaveRef.current.sequence === saveAttempt.sequence
+          ) {
+            uncertainSaveRef.current = null
+          }
+          if (response.status === 409 || response.status === 403) {
+            const refreshed = await refreshAfterRevisionConflict(newContent)
+            if (!refreshed) {
+              throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
+            }
+            if (response.status === 403) {
+              throw new Error('This assignment was submitted in another tab. Your local draft is preserved for review.')
+            }
+          }
+          throw new Error(data.error || 'Failed to save')
+        }
+        hasDefinitiveResponse = true
+
+        const historyEntry = data.historyEntry as AssignmentDocHistoryEntry | null | undefined
+
+        if (isMountedRef.current) {
+          setDoc(data.doc)
+          if (historyEntry) {
+            setHistoryEntries(prev => {
+              const existingIndex = prev.findIndex(entry => entry.id === historyEntry.id)
+              const next = existingIndex === -1 ? [historyEntry, ...prev] : [...prev]
+
+              if (existingIndex !== -1) {
+                next[existingIndex] = historyEntry
+              }
+
+              return next.sort((a, b) => b.created_at.localeCompare(a.created_at))
+            })
+            setPreviewEntry(prev => (prev?.id === historyEntry.id ? historyEntry : prev))
+          }
+          const pendingContent = pendingContentRef.current
+          setSaveStatus(
+            pendingContent && JSON.stringify(pendingContent) !== newContentStr
+              ? 'unsaved'
+              : 'saved'
+          )
+        }
+        lastSavedContentRef.current = newContentStr
+        lastSavedRevisionRef.current = data.doc?.updated_at ?? lastSavedRevisionRef.current
+        if (
+          uncertainSaveRef.current?.sessionId === uncertainSave?.sessionId
+          && uncertainSaveRef.current?.sequence === uncertainSave?.sequence
+        ) {
+          uncertainSaveRef.current = null
+        }
+        pasteWordCountRef.current = Math.max(0, pasteWordCountRef.current - saveAttempt.pasteWordCount)
+        keystrokeCountRef.current = Math.max(0, keystrokeCountRef.current - saveAttempt.keystrokeCount)
+        metricSessionIdRef.current = globalThis.crypto.randomUUID()
+        if (pendingContentRef.current && JSON.stringify(pendingContentRef.current) === newContentStr) {
+          clearLocalDraft(attemptRecoveryDraft)
+        }
+      } catch (err: any) {
+        if (!hasDefinitiveResponse) {
+          const currentUncertain = uncertainSaveRef.current
+          if (
+            !currentUncertain
+            || currentUncertain.sessionId !== saveAttempt.sessionId
+            || currentUncertain.sequence <= saveAttempt.sequence
+          ) {
+            uncertainSaveRef.current = saveAttempt
+            persistLocalDraft(newContent, saveAttempt)
+          }
+        } else if (!isSubmittedRef.current) {
+          persistLocalDraft(newContent, uncertainSaveRef.current ?? undefined)
+        }
+        const saveError = didTimeOut
+          ? new Error('Save timed out. Check your connection and try again.')
+          : err
+        console.error('Error saving:', saveError)
+        if (isMountedRef.current) {
+          setSaveStatus('unsaved')
+          setSaveError(saveError.message || 'Failed to save')
+        }
+        throw saveError
+      } finally {
+        clearTimeout(timeoutId)
+        if (activeSaveControllerRef.current === controller) {
+          activeSaveControllerRef.current = null
+        }
+        if (
+          inFlightSaveRef.current?.sessionId === saveAttempt.sessionId
+          && inFlightSaveRef.current.sequence === saveAttempt.sequence
+        ) {
+          inFlightSaveRef.current = null
+        }
+      }
+    })
+
+    saveQueueRef.current = savePromise.catch(() => undefined)
+    return savePromise
+  }, [
+    SAVE_REQUEST_TIMEOUT_MS,
+    assignmentId,
+    clearLocalDraft,
+    nextSaveSequence,
+    persistLocalDraft,
+    refreshAfterRevisionConflict,
+  ])
+
+  useEffect(() => {
+    if (
+      loading
+      || doc?.is_submitted
+      || !shouldReplayRecoveredSaveRef.current
+      || !uncertainSaveRef.current
+    ) {
       return
     }
 
-    setSaveStatus('saving')
-    lastSaveAttemptAtRef.current = Date.now()
+    shouldReplayRecoveredSaveRef.current = false
+    const recoveredAttempt = uncertainSaveRef.current
+    void saveContent(recoveredAttempt.content, { trigger: recoveredAttempt.trigger }).catch(() => undefined)
+  }, [doc?.is_submitted, loading, saveContent])
 
-    try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}`, {
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+      if (throttledSaveTimeoutRef.current) clearTimeout(throttledSaveTimeoutRef.current)
+      activeSaveControllerRef.current?.abort()
+
+      const latest = pendingContentRef.current
+      if (
+        latest
+        && !isSubmittedRef.current
+        && (
+          JSON.stringify(latest) !== lastSavedContentRef.current
+          || pasteWordCountRef.current > 0
+          || keystrokeCountRef.current > 0
+        )
+      ) {
+        void saveContent(latest, { trigger: 'blur' }).catch(() => undefined)
+      }
+    }
+  }, [saveContent])
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      pageHiddenRef.current = true
+      const latest = pendingContentRef.current
+      const inFlightSave = inFlightSaveRef.current
+      const saveToSupersede = inFlightSave ?? uncertainSaveRef.current
+      const latestStr = latest ? JSON.stringify(latest) : null
+      const inFlightStr = inFlightSave ? JSON.stringify(inFlightSave.content) : null
+      if (
+        !latest
+        || isSubmittedRef.current
+        || (
+          latestStr === lastSavedContentRef.current
+          && (!inFlightSave || inFlightStr === latestStr)
+          && pasteWordCountRef.current === 0
+          && keystrokeCountRef.current === 0
+        )
+      ) {
+        return
+      }
+
+      const saveSequence = nextSaveSequence()
+      const pagehidePasteWordCount = pasteWordCountRef.current
+      const pagehideKeystrokeCount = keystrokeCountRef.current
+      const expectedUpdatedAt = lastSavedRevisionRef.current
+      if (!expectedUpdatedAt) {
+        persistLocalDraft(latest, saveToSupersede ?? undefined)
+        return
+      }
+      const pagehideAttempt: SaveAttempt = {
+        content: latest,
+        sessionId: saveSessionIdRef.current,
+        sequence: saveSequence,
+        metricSessionId: saveToSupersede?.metricSessionId ?? metricSessionIdRef.current,
+        expectedUpdatedAt,
+        trigger: 'blur',
+        pasteWordCount: pagehidePasteWordCount,
+        keystrokeCount: pagehideKeystrokeCount,
+      }
+      const body = JSON.stringify(saveAttemptBody(pagehideAttempt))
+      activeSaveControllerRef.current?.abort()
+      if (new TextEncoder().encode(body).byteLength > KEEPALIVE_BODY_LIMIT_BYTES) {
+        persistLocalDraft(latest, saveToSupersede ?? undefined)
+        return
+      }
+
+      uncertainSaveRef.current = pagehideAttempt
+      const attemptRecoveryDraft = persistLocalDraft(latest, pagehideAttempt)
+      void fetch(`/api/assignment-docs/${assignmentId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          content: newContent,
-          trigger: options?.trigger ?? 'autosave',
-          paste_word_count: pasteWordCountRef.current,
-          keystroke_count: keystrokeCountRef.current,
-        })
-      })
+        keepalive: true,
+        body,
+      }).then(async (response) => {
+        if (!response.ok) return
+        const data = await response.json()
+        const responseRevision = data.doc?.updated_at
+        if (typeof responseRevision !== 'string') return
+        if (
+          uncertainSaveRef.current?.sessionId !== pagehideAttempt.sessionId
+          || uncertainSaveRef.current.sequence !== saveSequence
+        ) {
+          return
+        }
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to save')
-      }
-
-      const historyEntry = data.historyEntry as AssignmentDocHistoryEntry | null | undefined
-
-      setDoc(data.doc)
-      if (historyEntry) {
-        setHistoryEntries(prev => {
-          const existingIndex = prev.findIndex(entry => entry.id === historyEntry.id)
-          const next = existingIndex === -1 ? [historyEntry, ...prev] : [...prev]
-
-          if (existingIndex !== -1) {
-            next[existingIndex] = historyEntry
-          }
-
-          return next.sort((a, b) => b.created_at.localeCompare(a.created_at))
-        })
-        setPreviewEntry(prev => (prev?.id === historyEntry.id ? historyEntry : prev))
-      }
-      lastSavedContentRef.current = newContentStr
-      pasteWordCountRef.current = 0
-      keystrokeCountRef.current = 0
-      setSaveStatus('saved')
-    } catch (err: any) {
-      console.error('Error saving:', err)
-      setSaveStatus('unsaved')
+        pasteWordCountRef.current = Math.max(
+          0,
+          pasteWordCountRef.current - pagehidePasteWordCount
+        )
+        keystrokeCountRef.current = Math.max(
+          0,
+          keystrokeCountRef.current - pagehideKeystrokeCount
+        )
+        metricSessionIdRef.current = globalThis.crypto.randomUUID()
+        uncertainSaveRef.current = null
+        if (
+          !lastSavedRevisionRef.current
+          || responseRevision >= lastSavedRevisionRef.current
+        ) {
+          lastSavedRevisionRef.current = responseRevision
+          lastSavedContentRef.current = latestStr ?? lastSavedContentRef.current
+        }
+        if (
+          pendingContentRef.current
+          && JSON.stringify(pendingContentRef.current) === latestStr
+        ) {
+          clearLocalDraft(attemptRecoveryDraft)
+        }
+      }).catch(() => undefined)
     }
-  }, [assignmentId])
+
+    const handlePageShow = () => {
+      pageHiddenRef.current = false
+      const latest = pendingContentRef.current
+      if (latest && !isSubmittedRef.current) {
+        void refreshAfterRevisionConflict(latest).then((refreshed) => {
+          if (!refreshed && isMountedRef.current) {
+            setSaveError('The latest saved version could not be loaded. Reload this assignment before retrying.')
+          }
+        })
+      }
+    }
+
+    window.addEventListener('pagehide', handlePageHide)
+    window.addEventListener('pageshow', handlePageShow)
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide)
+      window.removeEventListener('pageshow', handlePageShow)
+    }
+  }, [
+    KEEPALIVE_BODY_LIMIT_BYTES,
+    assignmentId,
+    clearLocalDraft,
+    nextSaveSequence,
+    persistLocalDraft,
+    refreshAfterRevisionConflict,
+  ])
 
   const scheduleSave = useCallback((
     newContent: TiptapContent,
@@ -268,7 +976,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     const msSinceLastAttempt = now - lastSaveAttemptAtRef.current
 
     if (options?.force || msSinceLastAttempt >= AUTOSAVE_MIN_INTERVAL_MS) {
-      void saveContent(newContent, { trigger: options?.trigger })
+      void saveContent(newContent, { trigger: options?.trigger }).catch(() => undefined)
       return
     }
 
@@ -277,7 +985,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       throttledSaveTimeoutRef.current = null
       const latest = pendingContentRef.current
       if (latest) {
-        void saveContent(latest, { trigger: options?.trigger })
+        void saveContent(latest, { trigger: options?.trigger }).catch(() => undefined)
       }
     }, waitMs)
   }, [AUTOSAVE_MIN_INTERVAL_MS, saveContent])
@@ -287,6 +995,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     setContent(newContent)
     setSaveStatus('unsaved')
     pendingContentRef.current = newContent
+    persistLocalDraft(newContent, uncertainSaveRef.current ?? undefined)
 
     // Debounce save
     if (saveTimeoutRef.current) {
@@ -299,64 +1008,145 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   }
 
   function flushAutosave() {
-    if (saveStatus === 'unsaved') {
-      scheduleSave(pendingContentRef.current ?? content, { force: true, trigger: 'blur' })
+    const latest = pendingContentRef.current ?? content
+    if (
+      JSON.stringify(latest) !== lastSavedContentRef.current
+      || pasteWordCountRef.current > 0
+      || keystrokeCountRef.current > 0
+    ) {
+      scheduleSave(latest, { force: true, trigger: 'blur' })
     }
   }
 
   const handleSubmit = useCallback(async () => {
-    // Save first if there are unsaved changes
-    if (JSON.stringify(content) !== lastSavedContentRef.current) {
-      await saveContent(content, { trigger: 'autosave' })
-    }
-
     setSubmitting(true)
+    setError('')
+    const submissionContent = pendingContentRef.current ?? content
 
     try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}/submit`, {
-        method: 'POST'
-      })
+      try {
+        await saveContent(submissionContent, { trigger: 'autosave' })
+      } catch (saveFailure: any) {
+        setSaveError(
+          `Your latest changes could not be saved, so this assignment was not submitted. ${
+            saveFailure?.message || 'Save failed.'
+          } Try again.`
+        )
+        return
+      }
 
-      const data = await response.json()
+      const expectedUpdatedAt = lastSavedRevisionRef.current
+      if (!expectedUpdatedAt) {
+        setSaveError('Your saved draft revision could not be verified, so this assignment was not submitted. Try again.')
+        return
+      }
+
+      const { response, payload: data } = await fetchJsonWithTimeout<any>(`/api/assignment-docs/${assignmentId}/submit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: submissionContent,
+          expected_updated_at: expectedUpdatedAt,
+        }),
+      }, SAVE_REQUEST_TIMEOUT_MS, 'Submission timed out. Check your connection and try again.')
 
       if (!response.ok) {
+        if (response.status === 409) {
+          const refreshed = await refreshAfterRevisionConflict(submissionContent)
+          if (!refreshed) {
+            throw new Error('The saved version could not be reloaded. Reload this assignment before retrying.')
+          }
+        }
         throw new Error(data.error || 'Failed to submit')
       }
 
       setDoc(data.doc)
-      // Update lastSavedContentRef to match the current content after successful submit
-      lastSavedContentRef.current = JSON.stringify(content)
+      lastSavedContentRef.current = JSON.stringify(submissionContent)
+      lastSavedRevisionRef.current = data.doc?.updated_at ?? lastSavedRevisionRef.current
       setSaveStatus('saved')
+      setSaveError('')
+      clearLocalDraft()
     } catch (err: any) {
       console.error('Error submitting:', err)
+      try {
+        const { response: refreshResponse, payload: refreshData } = await fetchJsonWithTimeout<any>(
+          `/api/assignment-docs/${assignmentId}`,
+          { method: 'GET', cache: 'no-store' },
+          SAVE_REQUEST_TIMEOUT_MS,
+          'Submission status check timed out.'
+        )
+        if (refreshResponse.ok && refreshData.doc?.is_submitted) {
+          const submittedDoc = refreshData.doc as AssignmentDoc
+          const serverContent = submittedDoc.content || { type: 'doc', content: [] }
+          const serverContentStr = JSON.stringify(serverContent)
+          const latestLocalContent = pendingContentRef.current ?? submissionContent
+          setDoc(submittedDoc)
+          setContent(serverContent)
+          pendingContentRef.current = serverContent
+          lastSavedContentRef.current = serverContentStr
+          lastSavedRevisionRef.current = submittedDoc.updated_at ?? lastSavedRevisionRef.current
+          setSaveStatus('saved')
+          if (serverContentStr === JSON.stringify(latestLocalContent)) {
+            setSaveError('')
+            setPreservedRecoveryContent(null)
+            clearLocalDraft()
+          } else {
+            persistLocalDraft(latestLocalContent, uncertainSaveRef.current ?? undefined)
+            setPreservedRecoveryContent(latestLocalContent)
+            setSaveError(
+              canUnsubmitAssignmentDoc(submittedDoc)
+                ? 'Another tab submitted different work. Your local draft is preserved; unsubmit to review it.'
+                : 'Another tab submitted different work. Your local draft is preserved below for review.'
+            )
+          }
+          setError('')
+          return
+        }
+      } catch (refreshError) {
+        console.error('Error reconciling assignment after submit:', refreshError)
+      }
       setError(err.message || 'Failed to submit')
     } finally {
       setSubmitting(false)
     }
-  }, [assignmentId, content, saveContent])
+  }, [SAVE_REQUEST_TIMEOUT_MS, assignmentId, clearLocalDraft, content, persistLocalDraft, refreshAfterRevisionConflict, saveContent])
 
   const handleUnsubmit = useCallback(async () => {
     setSubmitting(true)
 
     try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}/unsubmit`, {
+      const { response, payload: data } = await fetchJsonWithTimeout<any>(`/api/assignment-docs/${assignmentId}/unsubmit`, {
         method: 'POST'
-      })
-
-      const data = await response.json()
+      }, SAVE_REQUEST_TIMEOUT_MS, 'Unsubmit timed out. Check your connection and try again.')
 
       if (!response.ok) {
         throw new Error(data.error || 'Failed to unsubmit')
       }
 
-      setDoc(data.doc)
+      applyUnsubmittedDoc(data.doc)
+      setError('')
     } catch (err: any) {
       console.error('Error unsubmitting:', err)
+      try {
+        const { response: refreshResponse, payload: refreshData } = await fetchJsonWithTimeout<any>(
+          `/api/assignment-docs/${assignmentId}`,
+          { method: 'GET', cache: 'no-store' },
+          SAVE_REQUEST_TIMEOUT_MS,
+          'Unsubmit status check timed out.'
+        )
+        if (refreshResponse.ok && refreshData.doc && !refreshData.doc.is_submitted) {
+          applyUnsubmittedDoc(refreshData.doc)
+          setError('')
+          return
+        }
+      } catch (refreshError) {
+        console.error('Error reconciling assignment after unsubmit:', refreshError)
+      }
       setError(err.message || 'Failed to unsubmit')
     } finally {
       setSubmitting(false)
     }
-  }, [assignmentId])
+  }, [SAVE_REQUEST_TIMEOUT_MS, applyUnsubmittedDoc, assignmentId])
 
   function updatePreview(entry: AssignmentDocHistoryEntry): boolean {
     if (!draftBeforePreviewRef.current) {
@@ -426,19 +1216,46 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     setRestoringId(previewEntry.id)
     setHistoryError('')
     try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}/restore`, {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
+      }
+      if (throttledSaveTimeoutRef.current) {
+        clearTimeout(throttledSaveTimeoutRef.current)
+        throttledSaveTimeoutRef.current = null
+      }
+      const pendingDraft = pendingContentRef.current
+      if (
+        pendingDraft
+        && (
+          JSON.stringify(pendingDraft) !== lastSavedContentRef.current
+          || pasteWordCountRef.current > 0
+          || keystrokeCountRef.current > 0
+        )
+      ) {
+        await saveContent(pendingDraft, { trigger: 'blur' })
+      } else {
+        await saveQueueRef.current
+      }
+
+      const { response, payload: data } = await fetchJsonWithTimeout<any>(`/api/assignment-docs/${assignmentId}/restore`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ history_id: previewEntry.id })
-      })
-      const data = await response.json()
+      }, SAVE_REQUEST_TIMEOUT_MS, 'Restore timed out. Check your connection and try again.')
       if (!response.ok) {
         throw new Error(data.error || 'Failed to restore')
       }
       setDoc(data.doc)
       setContent(data.doc?.content || { type: 'doc', content: [] })
+      pendingContentRef.current = data.doc?.content || { type: 'doc', content: [] }
       lastSavedContentRef.current = JSON.stringify(data.doc?.content || { type: 'doc', content: [] })
+      lastSavedRevisionRef.current = data.doc?.updated_at ?? null
+      pasteWordCountRef.current = 0
+      keystrokeCountRef.current = 0
       setSaveStatus('saved')
+      setSaveError('')
+      clearLocalDraft()
       await loadHistory()
       handleExitPreview({ restoreDraft: false })
     } catch (err: any) {
@@ -595,6 +1412,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 </span>
               ) : null}
               <div
+                data-testid="assignment-save-status"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
                 className={`text-xs ${
                   saveStatus === 'saved'
                     ? 'text-success'
@@ -640,9 +1461,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
               />
             </div>
 
-            {error && (
+            {(saveError || error) && (
               <div className="mt-4">
-                <p className="text-sm text-danger">{error}</p>
+                {saveError && <p role="alert" className="text-sm text-danger">{saveError}</p>}
+                {error && <p role="alert" className="text-sm text-danger">{error}</p>}
               </div>
             )}
           </div>
@@ -665,7 +1487,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                   </div>
                 ) : historyError ? (
                   <div className="p-4">
-                    <p className="text-xs text-danger">{historyError}</p>
+                    <p role="alert" className="text-xs text-danger">{historyError}</p>
                   </div>
                 ) : historyEntries.length === 0 ? (
                   <div className="p-4">
@@ -722,7 +1544,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                   <Spinner size="sm" />
                 </div>
               ) : historyError ? (
-                <p className="text-xs text-danger">{historyError}</p>
+                <p role="alert" className="text-xs text-danger">{historyError}</p>
               ) : historyEntries.length === 0 ? (
                 <p className="text-xs text-text-muted">No saves yet</p>
               ) : (
@@ -751,29 +1573,37 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         )}
       </div>
 
-      {/* Restore Confirmation Modal */}
-      {showRestoreModal && previewEntry && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface rounded-lg shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-text-default mb-2">
-              Restore this version?
-            </h3>
-            <p className="text-sm text-text-muted mb-4">
-              This will replace your current draft with the version saved on{' '}
-              {formatInTimeZone(new Date(previewEntry.created_at), 'America/Toronto', 'MMM d, yyyy')} at{' '}
-              {formatInTimeZone(new Date(previewEntry.created_at), 'America/Toronto', 'h:mm a')}.
-            </p>
-            <div className="flex gap-3 justify-end">
-              <Button onClick={() => setShowRestoreModal(false)} variant="secondary">
-                Cancel
-              </Button>
-              <Button onClick={confirmRestore} disabled={restoringId !== null}>
-                {restoringId ? 'Restoring...' : 'Restore'}
-              </Button>
-            </div>
+      {isSubmitted && !canUnsubmit && preservedRecoveryContent && (
+        <section
+          aria-labelledby="preserved-assignment-draft-heading"
+          className="border-y border-warning/40 bg-warning/10 px-4 py-4"
+        >
+          <h3 id="preserved-assignment-draft-heading" className="text-sm font-semibold text-text-default">
+            Preserved local draft
+          </h3>
+          <p className="mt-1 text-sm text-text-muted">
+            This work was newer than the submitted version. It is read-only because the assignment has been returned.
+          </p>
+          <div className="mt-3 rounded-md border border-border bg-surface-panel p-3">
+            <RichTextViewer content={preservedRecoveryContent} />
           </div>
-        </div>
+        </section>
       )}
+
+      <ConfirmDialog
+        isOpen={showRestoreModal && Boolean(previewEntry)}
+        title="Restore this version?"
+        description={previewEntry
+          ? `This will replace your current draft with the version saved on ${
+              formatInTimeZone(new Date(previewEntry.created_at), 'America/Toronto', 'MMM d, yyyy')
+            } at ${formatInTimeZone(new Date(previewEntry.created_at), 'America/Toronto', 'h:mm a')}.`
+          : undefined}
+        confirmLabel={restoringId ? 'Restoring...' : 'Restore'}
+        isCancelDisabled={restoringId !== null}
+        isConfirmDisabled={restoringId !== null}
+        onCancel={() => setShowRestoreModal(false)}
+        onConfirm={confirmRestore}
+      />
 
       {/* Comments panel */}
       {feedbackVisible && (

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -105,11 +105,6 @@ type AssignmentRecoveryDraft = {
   saved_at?: string
 }
 
-type AssignmentTabWriter = {
-  session_id: string
-  sequence: number
-}
-
 const RECOVERY_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const MAX_PASTE_WORD_COUNT = 32_767
@@ -159,15 +154,6 @@ function isSaveAttempt(value: unknown): value is SaveAttempt {
     && Number.isInteger(attempt.keystrokeCount)
     && (attempt.keystrokeCount ?? -1) >= 0
     && (attempt.keystrokeCount ?? Number.POSITIVE_INFINITY) <= MAX_KEYSTROKE_COUNT
-}
-
-function isAssignmentTabWriter(value: unknown): value is AssignmentTabWriter {
-  if (!value || typeof value !== 'object') return false
-  const writer = value as Partial<AssignmentTabWriter>
-  return typeof writer.session_id === 'string'
-    && UUID_PATTERN.test(writer.session_id)
-    && Number.isInteger(writer.sequence)
-    && (writer.sequence ?? -1) >= 0
 }
 
 function isAmbiguousSaveStatus(status: number): boolean {
@@ -254,6 +240,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const inFlightSaveRef = useRef<SaveAttempt | null>(null)
   const uncertainSaveRef = useRef<SaveAttempt | null>(null)
   const activeSaveControllerRef = useRef<AbortController | null>(null)
+  // This identity must stay mount-local because sessionStorage can be cloned into another tab.
   const saveSessionIdRef = useRef(globalThis.crypto.randomUUID())
   const metricSessionIdRef = useRef(globalThis.crypto.randomUUID())
   const claimedRecoveryDraftRef = useRef<AssignmentRecoveryDraft | null>(null)
@@ -275,36 +262,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     return studentId ? `assignment-draft:${studentId}:${assignmentId}` : null
   }, [assignmentId])
 
-  const getTabWriterStorageKey = useCallback(() => {
-    const studentId = studentIdRef.current
-    return studentId ? `assignment-save-writer:${studentId}:${assignmentId}` : null
-  }, [assignmentId])
-
-  const persistTabWriter = useCallback(() => {
-    const key = getTabWriterStorageKey()
-    if (!key) return
-    safeSessionSetJson(key, {
-      session_id: saveSessionIdRef.current,
-      sequence: saveSequenceRef.current,
-    } satisfies AssignmentTabWriter)
-  }, [getTabWriterStorageKey])
-
-  const restoreTabWriter = useCallback(() => {
-    const key = getTabWriterStorageKey()
-    const writer = key ? safeSessionGetJson<AssignmentTabWriter>(key) : null
-    if (isAssignmentTabWriter(writer)) {
-      saveSessionIdRef.current = writer.session_id
-      saveSequenceRef.current = writer.sequence
-      return
-    }
-    persistTabWriter()
-  }, [getTabWriterStorageKey, persistTabWriter])
-
   const nextSaveSequence = useCallback(() => {
     saveSequenceRef.current += 1
-    persistTabWriter()
     return saveSequenceRef.current
-  }, [persistTabWriter])
+  }, [])
 
   const readRecoveryDraft = useCallback(() => {
     const key = getDraftStorageKey()
@@ -422,7 +383,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       setSubmissionArtifacts(data.submission_artifacts || [])
       setGithubIdentity(data.github_identity || null)
       studentIdRef.current = data.doc?.student_id ?? data.student_id ?? null
-      restoreTabWriter()
       const serverContent = data.doc?.content || { type: 'doc', content: [] }
       const serverContentStr = JSON.stringify(serverContent)
       lastSavedRevisionRef.current = data.doc?.updated_at ?? null
@@ -478,7 +438,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     } finally {
       setLoading(false)
     }
-  }, [assignmentId, clearLocalDraft, notifications, readRecoveryDraft, restoreTabWriter])
+  }, [assignmentId, clearLocalDraft, notifications, readRecoveryDraft])
 
   const applyUnsubmittedDoc = useCallback((nextDoc: AssignmentDoc) => {
     const serverContent = nextDoc.content || { type: 'doc', content: [] }

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -46,6 +46,24 @@ function isAuthorizationError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AuthorizationError'
 }
 
+function mapRequestJsonSyntaxErrors(request: NextRequest | undefined): void {
+  if (!request || typeof request.json !== 'function') return
+  const parseJson = request.json.bind(request)
+  Object.defineProperty(request, 'json', {
+    configurable: true,
+    value: async () => {
+      try {
+        return await parseJson()
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          throw new ApiError(400, 'Malformed JSON body')
+        }
+        throw error
+      }
+    },
+  })
+}
+
 /**
  * Maps known error types to HTTP status codes.
  */
@@ -109,6 +127,7 @@ function mapErrorToResponse(error: unknown, routeName: string): NextResponse {
 export function withErrorHandler(routeName: string, handler: RouteHandler): RouteHandler {
   return async (request, context) => {
     try {
+      mapRequestJsonSyntaxErrors(request)
       return await handler(request, context)
     } catch (error) {
       return mapErrorToResponse(error, routeName)

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -118,7 +118,11 @@ export function canUnsubmitAssignmentDoc(
 ): boolean {
   if (!doc?.is_submitted) return false
 
-  return !getAssignmentFullReturnAt(doc)
+  const fullReturnAt = getAssignmentFullReturnAt(doc)
+  if (!fullReturnAt) return true
+  if (!doc.submitted_at) return false
+
+  return new Date(doc.submitted_at).getTime() > new Date(fullReturnAt).getTime()
 }
 
 /**

--- a/src/lib/client-storage.ts
+++ b/src/lib/client-storage.ts
@@ -71,11 +71,12 @@ export function safeSessionGetJson<T>(key: string): T | null {
 }
 
 export function safeSessionSetJson(key: string, value: unknown) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined') return false
   try {
     window.sessionStorage.setItem(key, JSON.stringify(value))
+    return true
   } catch {
-    // Ignore sessionStorage quota/unavailable errors.
+    return false
   }
 }
 
@@ -85,5 +86,35 @@ export function safeSessionRemove(key: string) {
     window.sessionStorage.removeItem(key)
   } catch {
     // Ignore sessionStorage unavailable errors.
+  }
+}
+
+export function safeLocalGetJson<T>(key: string): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return null
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+export function safeLocalSetJson(key: string, value: unknown) {
+  if (typeof window === 'undefined') return false
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function safeLocalRemove(key: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(key)
+  } catch {
+    // Ignore localStorage unavailable errors.
   }
 }

--- a/src/lib/server/assignment-artifact-storage-cleanup.ts
+++ b/src/lib/server/assignment-artifact-storage-cleanup.ts
@@ -1,0 +1,389 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+
+const ASSIGNMENT_ARTIFACTS_BUCKET = 'assignment-artifacts'
+const PROVISIONAL_CLEANUP_DELAY_MS = 15 * 60 * 1000
+const cleanupRowSchema = z.object({
+  id: z.string().uuid(),
+  storage_path: z.string().min(1),
+  lease_token: z.string().uuid(),
+}).passthrough()
+const provisionalCleanupSchema = z.object({
+  id: z.string().uuid(),
+  storage_path: z.string().min(1),
+})
+
+type SupabaseLike = any
+
+export type ProvisionalAssignmentArtifactStorageCleanup = z.infer<typeof provisionalCleanupSchema>
+
+export async function assignmentArtifactStoragePathIsReferenced(input: {
+  supabase: SupabaseLike
+  storagePath: string
+}): Promise<boolean | null> {
+  try {
+    const reference = await input.supabase
+      .from('assignment_submission_artifacts')
+      .select('id')
+      .eq('storage_path', input.storagePath)
+      .maybeSingle()
+    if (reference.error) {
+      console.error('Failed to check assignment artifact Storage references:', {
+        path: input.storagePath,
+        error: reference.error,
+      })
+      return null
+    }
+    return Boolean(reference.data)
+  } catch (error) {
+    console.error('Failed to check assignment artifact Storage references:', {
+      path: input.storagePath,
+      error,
+    })
+    return null
+  }
+}
+
+export async function createProvisionalAssignmentArtifactStorageCleanup(input: {
+  supabase: SupabaseLike
+  storagePath: string
+  now?: Date
+}): Promise<ProvisionalAssignmentArtifactStorageCleanup | null> {
+  const nextAttemptAt = new Date(
+    (input.now ?? new Date()).getTime() + PROVISIONAL_CLEANUP_DELAY_MS
+  ).toISOString()
+
+  try {
+    const result = await input.supabase
+      .from('assignment_artifact_storage_cleanup')
+      .insert({
+        storage_path: input.storagePath,
+        status: 'pending',
+        next_attempt_at: nextAttemptAt,
+      })
+      .select('id, storage_path')
+      .single()
+    const parsed = provisionalCleanupSchema.safeParse(result.data)
+    if (!result.error && parsed.success) return parsed.data
+
+    console.error('Failed to create provisional assignment artifact Storage cleanup:', {
+      path: input.storagePath,
+      error: result.error ?? parsed.error,
+    })
+  } catch (error) {
+    console.error('Failed to create provisional assignment artifact Storage cleanup:', {
+      path: input.storagePath,
+      error,
+    })
+  }
+  return null
+}
+
+export async function adoptProvisionalAssignmentArtifactStorageCleanup(input: {
+  supabase: SupabaseLike
+  cleanup: ProvisionalAssignmentArtifactStorageCleanup
+}): Promise<boolean> {
+  try {
+    const result = await input.supabase
+      .from('assignment_artifact_storage_cleanup')
+      .delete()
+      .eq('id', input.cleanup.id)
+      .eq('storage_path', input.cleanup.storage_path)
+      .eq('status', 'pending')
+      .select('id')
+      .maybeSingle()
+    if (!result.error && result.data?.id === input.cleanup.id) return true
+
+    console.error('Failed to adopt provisional assignment artifact Storage cleanup:', {
+      cleanupId: input.cleanup.id,
+      error: result.error,
+    })
+  } catch (error) {
+    console.error('Failed to adopt provisional assignment artifact Storage cleanup:', {
+      cleanupId: input.cleanup.id,
+      error,
+    })
+  }
+  return false
+}
+
+async function releaseAssignmentArtifactStorageCleanupClaim(input: {
+  supabase: SupabaseLike
+  cleanupId: string
+  leaseToken: string
+  error: string
+}): Promise<void> {
+  try {
+    await input.supabase.rpc('fail_assignment_artifact_storage_cleanup', {
+      p_cleanup_id: input.cleanupId,
+      p_lease_token: input.leaseToken,
+      p_error: input.error,
+    })
+  } catch (error) {
+    console.error('Failed to release assignment artifact Storage cleanup claim:', {
+      cleanupId: input.cleanupId,
+      error,
+    })
+  }
+}
+
+export async function removeQueuedAssignmentArtifactStoragePath(input: {
+  supabase: SupabaseLike
+  storagePath: string
+}): Promise<{ completed: boolean }> {
+  const leaseToken = randomUUID()
+  let claim: any
+  try {
+    claim = await input.supabase.rpc(
+      'claim_assignment_artifact_storage_cleanup_path',
+      {
+        p_storage_path: input.storagePath,
+        p_lease_token: leaseToken,
+        p_lease_seconds: 120,
+      }
+    )
+  } catch (error) {
+    console.error('Failed to claim queued assignment artifact Storage path:', {
+      path: input.storagePath,
+      error,
+    })
+    return { completed: false }
+  }
+  const parsedClaim = z.array(cleanupRowSchema).max(1).safeParse(claim.data ?? [])
+  if (claim.error || !parsedClaim.success || parsedClaim.data.length !== 1) {
+    if (claim.error || !parsedClaim.success) {
+      console.error('Failed to claim queued assignment artifact Storage path:', {
+        path: input.storagePath,
+        error: claim.error ?? parsedClaim.error,
+      })
+    }
+    return { completed: false }
+  }
+  const cleanup = parsedClaim.data[0]
+
+  const isReferenced = await assignmentArtifactStoragePathIsReferenced(input)
+  if (isReferenced === null) {
+    await releaseAssignmentArtifactStorageCleanupClaim({
+      supabase: input.supabase,
+      cleanupId: cleanup.id,
+      leaseToken: cleanup.lease_token,
+      error: 'Artifact reference lookup failed',
+    })
+    return { completed: false }
+  }
+
+  let storageError: { message?: string } | null = null
+  if (!isReferenced) {
+    try {
+      const result = await input.supabase.storage
+        .from(ASSIGNMENT_ARTIFACTS_BUCKET)
+        .remove([input.storagePath])
+      storageError = result.error
+    } catch (error) {
+      storageError = error instanceof Error ? { message: error.message } : { message: 'Storage request failed' }
+    }
+  }
+
+  if (storageError) {
+    console.error('Failed to remove queued assignment artifact Storage object:', {
+      path: input.storagePath,
+      error: storageError,
+    })
+    await releaseAssignmentArtifactStorageCleanupClaim({
+      supabase: input.supabase,
+      cleanupId: cleanup.id,
+      leaseToken: cleanup.lease_token,
+      error: storageError.message ?? 'Storage request failed',
+    })
+    return { completed: false }
+  }
+
+  let data: unknown
+  let error: unknown
+  try {
+    const completion = await input.supabase.rpc(
+      'complete_assignment_artifact_storage_cleanup',
+      { p_cleanup_id: cleanup.id, p_lease_token: cleanup.lease_token }
+    )
+    data = completion.data
+    error = completion.error
+  } catch (completionError) {
+    error = completionError
+  }
+  if (error || data !== true) {
+    console.error('Failed to complete assignment artifact Storage cleanup evidence:', {
+      path: input.storagePath,
+      error,
+    })
+    await releaseAssignmentArtifactStorageCleanupClaim({
+      supabase: input.supabase,
+      cleanupId: cleanup.id,
+      leaseToken: cleanup.lease_token,
+      error: 'Failed to record Storage cleanup completion',
+    })
+    return { completed: false }
+  }
+
+  return { completed: true }
+}
+
+export async function enqueueAssignmentArtifactStorageCleanupPath(input: {
+  supabase: SupabaseLike
+  storagePath: string
+}): Promise<boolean> {
+  try {
+    const result = await input.supabase.rpc(
+      'enqueue_assignment_artifact_storage_cleanup_path',
+      { p_storage_path: input.storagePath }
+    )
+    if (!result.error && result.data === true) return true
+    console.error('Failed to enqueue assignment artifact Storage cleanup:', {
+      path: input.storagePath,
+      error: result.error,
+    })
+  } catch (error) {
+    console.error('Failed to enqueue assignment artifact Storage cleanup:', {
+      path: input.storagePath,
+      error,
+    })
+  }
+  return false
+}
+
+export async function runAssignmentArtifactStorageCleanup(input: {
+  supabase: SupabaseLike
+  limit?: number
+  leaseSeconds?: number
+}): Promise<{
+  claimAttempts: number
+  claimFailures: number
+  claimed: number
+  completed: number
+  failed: number
+}> {
+  const limit = input.limit ?? 50
+  let claimAttempts = 0
+  let claimFailures = 0
+  let claimed = 0
+  let completed = 0
+  let failed = 0
+  while (claimAttempts < limit) {
+    claimAttempts += 1
+    const leaseToken = randomUUID()
+    let claimResult: any
+    try {
+      claimResult = await input.supabase.rpc(
+        'claim_assignment_artifact_storage_cleanup',
+        {
+          p_lease_token: leaseToken,
+          p_limit: 1,
+          p_lease_seconds: input.leaseSeconds ?? 120,
+        }
+      )
+    } catch (error) {
+      console.error('Failed to claim assignment artifact Storage cleanup:', error)
+      claimFailures += 1
+      failed += 1
+      continue
+    }
+    if (claimResult.error) {
+      console.error('Failed to claim assignment artifact Storage cleanup:', claimResult.error)
+      claimFailures += 1
+      failed += 1
+      continue
+    }
+
+    const parsed = z.array(cleanupRowSchema).max(1).safeParse(claimResult.data ?? [])
+    if (!parsed.success) {
+      console.error('Invalid assignment artifact cleanup claim result:', parsed.error)
+      claimFailures += 1
+      failed += 1
+      continue
+    }
+    if (parsed.data.length === 0) break
+    const cleanup = parsed.data[0]
+    claimed += 1
+
+    let storageError: { message?: string } | null = null
+    let completionErrorMessage: string | null = null
+    let referencedArtifact: unknown = null
+    try {
+      const reference = await input.supabase
+        .from('assignment_submission_artifacts')
+        .select('id')
+        .eq('storage_path', cleanup.storage_path)
+        .maybeSingle()
+      if (reference.error) {
+        storageError = { message: reference.error.message ?? 'Artifact reference lookup failed' }
+      } else {
+        referencedArtifact = reference.data
+      }
+    } catch (error) {
+      storageError = error instanceof Error
+        ? { message: error.message }
+        : { message: 'Artifact reference lookup failed' }
+    }
+
+    if (!storageError && !referencedArtifact) {
+      try {
+        const result = await input.supabase.storage
+          .from(ASSIGNMENT_ARTIFACTS_BUCKET)
+          .remove([cleanup.storage_path])
+        storageError = result.error
+      } catch (error) {
+        storageError = error instanceof Error ? { message: error.message } : { message: 'Storage request failed' }
+      }
+    }
+
+    if (!storageError) {
+      let completion: any
+      try {
+        completion = await input.supabase.rpc(
+          'complete_assignment_artifact_storage_cleanup',
+          { p_cleanup_id: cleanup.id, p_lease_token: cleanup.lease_token }
+        )
+      } catch (error) {
+        completion = { data: false, error }
+      }
+      if (!completion?.error && completion?.data === true) {
+        completed += 1
+        continue
+      }
+      if (completion?.error) {
+        completionErrorMessage = completion.error instanceof Error
+          ? completion.error.message
+          : completion.error.message ?? 'Completion RPC failed'
+        console.error('Failed to record assignment artifact Storage cleanup completion:', {
+          cleanupId: cleanup.id,
+          error: completion.error,
+        })
+      }
+    }
+
+    failed += 1
+    const failureMessage = storageError?.message
+      || completionErrorMessage
+      || 'Failed to record Storage cleanup completion'
+    let failure: any
+    try {
+      failure = await input.supabase.rpc(
+        'fail_assignment_artifact_storage_cleanup',
+        {
+          p_cleanup_id: cleanup.id,
+          p_lease_token: cleanup.lease_token,
+          p_error: failureMessage,
+        }
+      )
+    } catch (error) {
+      failure = { data: false, error }
+    }
+    if (failure?.error || failure?.data !== true) {
+      console.error('Failed to release assignment artifact cleanup lease:', {
+        cleanupId: cleanup.id,
+        error: failure?.error,
+      })
+    }
+  }
+
+  return { claimAttempts, claimFailures, claimed, completed, failed }
+}

--- a/src/lib/server/assignment-doc-submissions.ts
+++ b/src/lib/server/assignment-doc-submissions.ts
@@ -1,0 +1,256 @@
+import { z } from 'zod'
+import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
+import { countCharacters, countWords } from '@/lib/tiptap-content'
+import { assignmentSubmissionContentSchema } from '@/lib/validations/assignment-doc-submissions'
+import type { AssignmentDoc, AssignmentDocHistoryEntry, TiptapContent } from '@/types'
+
+type SupabaseLike = any
+
+const timestampSchema = z.string().datetime({ offset: true })
+const nullableTimestampSchema = timestampSchema.nullable()
+
+const jsonPatchOperationSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('add'), path: z.string(), value: z.unknown() }).strict(),
+  z.object({ op: z.literal('remove'), path: z.string() }).strict(),
+  z.object({ op: z.literal('replace'), path: z.string(), value: z.unknown() }).strict(),
+  z.object({ op: z.literal('move'), path: z.string(), from: z.string() }).strict(),
+  z.object({ op: z.literal('copy'), path: z.string(), from: z.string() }).strict(),
+  z.object({ op: z.literal('test'), path: z.string(), value: z.unknown() }).strict(),
+])
+
+const assignmentDocSchema = z.object({
+  id: z.string().min(1),
+  assignment_id: z.string().min(1),
+  student_id: z.string().min(1),
+  content: assignmentSubmissionContentSchema,
+  content_legacy: z.string(),
+  is_submitted: z.boolean(),
+  submitted_at: nullableTimestampSchema,
+  created_at: timestampSchema,
+  updated_at: timestampSchema,
+  viewed_at: nullableTimestampSchema,
+  score_completion: z.number().int().nullable(),
+  score_thinking: z.number().int().nullable(),
+  score_workflow: z.number().int().nullable(),
+  feedback: z.string().nullable(),
+  feedback_returned_at: nullableTimestampSchema,
+  graded_at: nullableTimestampSchema,
+  graded_by: z.string().nullable(),
+  returned_at: nullableTimestampSchema,
+  teacher_cleared_at: nullableTimestampSchema,
+  teacher_feedback_draft: z.string().nullable(),
+  teacher_feedback_draft_updated_at: nullableTimestampSchema,
+  ai_feedback_suggestion: z.string().nullable(),
+  ai_feedback_suggested_at: nullableTimestampSchema,
+  ai_feedback_model: z.string().nullable(),
+  authenticity_score: z.number().int().nullable(),
+  authenticity_flags: z.array(z.object({
+    timestamp: timestampSchema,
+    wordDelta: z.number().int(),
+    seconds: z.number().int().nonnegative(),
+    wps: z.number().nonnegative(),
+    reason: z.enum(['paste', 'high_wps']),
+  }).strict()).nullable(),
+  repo_url: z.string().nullable(),
+  github_username: z.string().nullable(),
+  save_session_id: z.string().uuid().nullable(),
+  save_sequence: z.number().int().positive().nullable(),
+}).strip()
+
+const assignmentHistorySchema = z.object({
+  id: z.string().min(1),
+  assignment_doc_id: z.string().min(1),
+  patch: z.array(jsonPatchOperationSchema).nullable(),
+  snapshot: assignmentSubmissionContentSchema.nullable(),
+  word_count: z.number().int().nonnegative(),
+  char_count: z.number().int().nonnegative(),
+  paste_word_count: z.number().int().nonnegative().nullable(),
+  keystroke_count: z.number().int().nonnegative().nullable(),
+  trigger: z.enum(['autosave', 'blur', 'submit', 'baseline', 'restore']),
+  created_at: timestampSchema,
+}).strip()
+
+const atomicErrorSchema = z.object({
+  ok: z.literal(false),
+  status: z.union([z.literal(400), z.literal(403), z.literal(404), z.literal(409), z.literal(500)]),
+  error_code: z.string(),
+  error: z.string(),
+}).strip()
+
+const atomicSaveSuccessSchema = z.object({
+  ok: z.literal(true),
+  created: z.boolean(),
+  doc: assignmentDocSchema,
+  history_entry: assignmentHistorySchema.nullable(),
+}).strip()
+
+const atomicSubmitSuccessSchema = z.object({
+  ok: z.literal(true),
+  idempotent: z.boolean(),
+  doc: assignmentDocSchema,
+  history_entry: assignmentHistorySchema.nullable(),
+}).strip()
+
+const atomicUnsubmitSuccessSchema = z.object({
+  ok: z.literal(true),
+  doc: assignmentDocSchema,
+}).strip()
+
+type AssignmentDocMutationResult =
+  | { ok: true; doc: AssignmentDoc; historyEntry: AssignmentDocHistoryEntry | null; idempotent?: boolean }
+  | { ok: false; status: number; error: string; errorCode: string }
+
+function invalidResult(error: z.ZodError): AssignmentDocMutationResult {
+  console.error('Invalid assignment document atomic RPC result:', error)
+  return { ok: false, status: 500, error: 'Assignment document operation failed', errorCode: 'invalid_rpc_result' }
+}
+
+function mapRpcError(error: any, operation: 'save' | 'submit' | 'unsubmit'): AssignmentDocMutationResult {
+  if (error?.code === '23514' && error?.message?.includes('assignment_submission_requirements_incomplete')) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Complete the required submissions before submitting.',
+      errorCode: 'assignment_submission_requirements_incomplete',
+    }
+  }
+  if (error?.code === '42883' || error?.code === 'PGRST202') {
+    return {
+      ok: false,
+      status: 500,
+      error: 'Assignment submission migration is required',
+      errorCode: 'assignment_submission_migration_required',
+    }
+  }
+  console.error(`Error during atomic assignment document ${operation}:`, error)
+  return {
+    ok: false,
+    status: 500,
+    error: operation === 'save'
+      ? 'Failed to save'
+      : operation === 'submit'
+        ? 'Failed to submit'
+        : 'Failed to unsubmit',
+    errorCode: `assignment_doc_${operation}_failed`,
+  }
+}
+
+export async function unsubmitAssignmentDocAtomic(input: {
+  supabase: SupabaseLike
+  assignmentId: string
+  studentId: string
+}): Promise<AssignmentDocMutationResult> {
+  const { data, error } = await input.supabase.rpc('unsubmit_assignment_doc_atomic', {
+    p_assignment_id: input.assignmentId,
+    p_student_id: input.studentId,
+  })
+
+  if (error) return mapRpcError(error, 'unsubmit')
+
+  const rpcError = atomicErrorSchema.safeParse(data)
+  if (rpcError.success) {
+    return {
+      ok: false,
+      status: rpcError.data.status,
+      error: rpcError.data.error,
+      errorCode: rpcError.data.error_code,
+    }
+  }
+  const parsed = atomicUnsubmitSuccessSchema.safeParse(data)
+  if (!parsed.success) return invalidResult(parsed.error)
+  return {
+    ok: true,
+    doc: parsed.data.doc as unknown as AssignmentDoc,
+    historyEntry: null,
+  }
+}
+
+export async function saveAssignmentDocAtomic(input: {
+  supabase: SupabaseLike
+  assignmentId: string
+  studentId: string
+  previousContent: TiptapContent
+  content: TiptapContent
+  expectedUpdatedAt: string | null
+  trigger: 'autosave' | 'blur' | 'restore'
+  pasteWordCount: number
+  keystrokeCount: number
+  saveSessionId: string
+  saveSequence: number
+  metricSessionId: string
+}): Promise<AssignmentDocMutationResult> {
+  const patch = createJsonPatch(input.previousContent, input.content)
+  const snapshot = shouldStoreSnapshot(patch, input.content) ? input.content : null
+  const { data, error } = await input.supabase.rpc('save_assignment_doc_atomic', {
+    p_assignment_id: input.assignmentId,
+    p_student_id: input.studentId,
+    p_content: input.content,
+    p_expected_updated_at: input.expectedUpdatedAt,
+    p_trigger: input.trigger,
+    p_paste_word_count: input.pasteWordCount,
+    p_keystroke_count: input.keystrokeCount,
+    p_patch: patch,
+    p_snapshot: snapshot,
+    p_word_count: countWords(input.content),
+    p_char_count: countCharacters(input.content),
+    p_save_session_id: input.saveSessionId,
+    p_save_sequence: input.saveSequence,
+    p_metric_session_id: input.metricSessionId,
+  })
+
+  if (error) return mapRpcError(error, 'save')
+
+  const rpcError = atomicErrorSchema.safeParse(data)
+  if (rpcError.success) {
+    return {
+      ok: false,
+      status: rpcError.data.status,
+      error: rpcError.data.error,
+      errorCode: rpcError.data.error_code,
+    }
+  }
+  const parsed = atomicSaveSuccessSchema.safeParse(data)
+  if (!parsed.success) return invalidResult(parsed.error)
+  return {
+    ok: true,
+    doc: parsed.data.doc as unknown as AssignmentDoc,
+    historyEntry: parsed.data.history_entry as AssignmentDocHistoryEntry | null,
+  }
+}
+
+export async function submitAssignmentDocAtomic(input: {
+  supabase: SupabaseLike
+  assignmentId: string
+  studentId: string
+  content: TiptapContent
+  expectedUpdatedAt: string
+}): Promise<AssignmentDocMutationResult> {
+  const { data, error } = await input.supabase.rpc('submit_assignment_doc_atomic', {
+    p_assignment_id: input.assignmentId,
+    p_student_id: input.studentId,
+    p_content: input.content,
+    p_expected_updated_at: input.expectedUpdatedAt,
+    p_word_count: countWords(input.content),
+    p_char_count: countCharacters(input.content),
+  })
+
+  if (error) return mapRpcError(error, 'submit')
+
+  const rpcError = atomicErrorSchema.safeParse(data)
+  if (rpcError.success) {
+    return {
+      ok: false,
+      status: rpcError.data.status,
+      error: rpcError.data.error,
+      errorCode: rpcError.data.error_code,
+    }
+  }
+  const parsed = atomicSubmitSuccessSchema.safeParse(data)
+  if (!parsed.success) return invalidResult(parsed.error)
+  return {
+    ok: true,
+    doc: parsed.data.doc as unknown as AssignmentDoc,
+    historyEntry: parsed.data.history_entry as AssignmentDocHistoryEntry | null,
+    idempotent: parsed.data.idempotent,
+  }
+}

--- a/src/lib/server/assignment-submission-artifacts.ts
+++ b/src/lib/server/assignment-submission-artifacts.ts
@@ -7,10 +7,69 @@ import type {
   AssignmentSubmissionRequirement,
 } from '@/types'
 import { loadChunkedRows } from '@/lib/server/query-chunks'
+import type { TableRow } from '@/types/database'
+import { z } from 'zod'
+import { assignmentSubmissionContentSchema } from '@/lib/validations/assignment-doc-submissions'
 
 const ASSIGNMENT_ARTIFACTS_BUCKET = 'assignment-artifacts'
 const SIGNED_IMAGE_URL_EXPIRES_SECONDS = 60 * 60
 const STORAGE_REMOVE_CHUNK_SIZE = 1000
+const timestampSchema = z.string().datetime({ offset: true })
+
+const assignmentRowSchema = z.object({
+  classroom_id: z.string().min(1),
+  created_at: timestampSchema,
+  created_by: z.string().min(1),
+  description: z.string(),
+  due_at: timestampSchema,
+  gradebook_weight: z.number(),
+  id: z.string().min(1),
+  include_in_final: z.boolean(),
+  instructions_markdown: z.string().nullable(),
+  is_draft: z.boolean(),
+  points_possible: z.number(),
+  position: z.number().int(),
+  released_at: timestampSchema.nullable(),
+  rich_instructions: assignmentSubmissionContentSchema.nullable(),
+  title: z.string(),
+  track_authenticity: z.boolean(),
+  updated_at: timestampSchema,
+}).strip()
+
+const assignmentRequirementRowSchema = z.object({
+  assignment_id: z.string().min(1),
+  created_at: timestampSchema,
+  id: z.string().min(1),
+  instructions: z.string(),
+  label: z.string(),
+  position: z.number().int(),
+  required: z.boolean(),
+  type: z.enum(['repo_link', 'link', 'image']),
+  updated_at: timestampSchema,
+  validation_policy_json: z.record(z.string(), z.unknown()),
+}).strip()
+
+const assignmentRequirementsAtomicErrorSchema = z.object({
+  ok: z.literal(false),
+  status: z.number().int().min(400).max(599),
+  error_code: z.string().min(1),
+  error: z.string().min(1),
+}).strip()
+
+const assignmentRequirementsAtomicSuccessSchema = z.object({
+  ok: z.literal(true),
+  assignment: assignmentRowSchema,
+  submission_requirements: z.array(assignmentRequirementRowSchema),
+}).strip()
+
+const assignmentArtifactDeleteResultSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    deleted: z.boolean(),
+    storage_path: z.string().nullable(),
+  }).strip(),
+  assignmentRequirementsAtomicErrorSchema,
+])
 
 type SupabaseClientLike = any
 type SupabaseSchemaError = {
@@ -287,6 +346,109 @@ export async function replaceAssignmentSubmissionRequirements(
   } catch (error) {
     if (isMissingAssignmentSubmissionSchemaError(error)) return []
     throw error
+  }
+}
+
+export async function updateAssignmentWithSubmissionRequirementsAtomic(input: {
+  supabase: SupabaseClientLike
+  assignmentId: string
+  updates: Record<string, unknown>
+  requirements: AssignmentSubmissionRequirementDraft[]
+}): Promise<
+  | {
+      ok: true
+      assignment: TableRow<'assignments'>
+      submissionRequirements: AssignmentSubmissionRequirement[]
+    }
+  | { ok: false; status: number; error: string }
+> {
+  const normalized = normalizeAssignmentSubmissionRequirementDrafts(input.requirements)
+  const { data, error } = await input.supabase.rpc(
+    'update_assignment_with_submission_requirements_atomic',
+    {
+      p_assignment_id: input.assignmentId,
+      p_updates: input.updates,
+      p_requirements: normalized,
+    }
+  )
+
+  if (error) {
+    if (error.code === 'PGRST202' || error.code === '42883') {
+      return { ok: false, status: 500, error: 'Assignment submission migration is required' }
+    }
+    if (
+      error.code === '23514'
+      && String(error.message).includes('assignment_requirements_submitted_documents_immutable')
+    ) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'Submission requirements cannot be changed after a student submits.',
+      }
+    }
+    console.error('Error updating assignment and submission requirements atomically:', error)
+    return { ok: false, status: 500, error: 'Failed to update assignment' }
+  }
+
+  const parsedError = assignmentRequirementsAtomicErrorSchema.safeParse(data)
+  if (parsedError.success) {
+    return {
+      ok: false,
+      status: parsedError.data.status,
+      error: parsedError.data.error,
+    }
+  }
+
+  const parsed = assignmentRequirementsAtomicSuccessSchema.safeParse(data)
+  if (!parsed.success) {
+    console.error('Invalid assignment requirements atomic RPC result:', parsed.error)
+    return { ok: false, status: 500, error: 'Failed to update assignment' }
+  }
+
+  return {
+    ok: true,
+    assignment: parsed.data.assignment,
+    submissionRequirements: parsed.data.submission_requirements,
+  }
+}
+
+export async function deleteAssignmentSubmissionArtifactAtomic(input: {
+  supabase: SupabaseClientLike
+  assignmentId: string
+  studentId: string
+  requirementId: string
+}): Promise<
+  | { ok: true; deleted: boolean; storagePath: string | null }
+  | { ok: false; status: number; error: string }
+> {
+  const { data, error } = await input.supabase.rpc(
+    'delete_assignment_submission_artifact_atomic',
+    {
+      p_assignment_id: input.assignmentId,
+      p_student_id: input.studentId,
+      p_requirement_id: input.requirementId,
+    }
+  )
+  if (error) {
+    if (error.code === 'PGRST202' || error.code === '42883') {
+      return { ok: false, status: 503, error: 'Assignment submission migration is required' }
+    }
+    console.error('Failed to delete assignment submission artifact atomically:', error)
+    return { ok: false, status: 500, error: 'Failed to delete submission artifact' }
+  }
+
+  const parsed = assignmentArtifactDeleteResultSchema.safeParse(data)
+  if (!parsed.success) {
+    console.error('Invalid assignment artifact deletion RPC result:', parsed.error)
+    return { ok: false, status: 500, error: 'Failed to delete submission artifact' }
+  }
+  if (!parsed.data.ok) {
+    return { ok: false, status: parsed.data.status, error: parsed.data.error }
+  }
+  return {
+    ok: true,
+    deleted: parsed.data.deleted,
+    storagePath: parsed.data.storage_path,
   }
 }
 

--- a/src/lib/server/versioned-history.ts
+++ b/src/lib/server/versioned-history.ts
@@ -41,6 +41,7 @@ type PersistOptions<TContent extends JsonObject> = {
 type LastHistoryRow = {
   id: string
   created_at: string
+  trigger: string
   paste_word_count?: number | null
   keystroke_count?: number | null
 }
@@ -115,7 +116,7 @@ export async function persistVersionedHistory<TContent extends JsonObject>(
 
   const { data: lastHistory, error: lastHistoryError } = await opts.supabase
     .from(opts.table)
-    .select('id, created_at, paste_word_count, keystroke_count')
+    .select('id, created_at, trigger, paste_word_count, keystroke_count')
     .eq(opts.ownerColumn, opts.ownerId)
     .order('created_at', { ascending: false })
     .limit(1)
@@ -143,7 +144,10 @@ export async function persistVersionedHistory<TContent extends JsonObject>(
 
   const lastCreatedAt = new Date(last.created_at).getTime()
   const nowMs = Date.now()
-  const isRateLimited = nowMs - lastCreatedAt < opts.historyMinIntervalMs
+  const isRateLimited = (
+    last.trigger !== 'submit'
+    && nowMs - lastCreatedAt < opts.historyMinIntervalMs
+  )
 
   if (isRateLimited) {
     const { data, error } = await opts.supabase

--- a/src/lib/tiptap-content.ts
+++ b/src/lib/tiptap-content.ts
@@ -30,7 +30,42 @@ export function parseContentField(content: unknown): TiptapContent {
 export function isValidTiptapContent(content: any): content is TiptapContent {
   if (!content || typeof content !== 'object') return false
   if (content.type !== 'doc') return false
-  if (content.content && !Array.isArray(content.content)) return false
+  if (content.content !== undefined && !Array.isArray(content.content)) return false
+
+  const stack: Array<{ node: unknown; depth: number }> = (content.content ?? [])
+    .map((node: unknown) => ({ node, depth: 1 }))
+  let nodeCount = 0
+
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    if (current.depth > 100 || ++nodeCount > 10_000) return false
+    if (!current.node || typeof current.node !== 'object' || Array.isArray(current.node)) return false
+
+    const node = current.node as Record<string, unknown>
+    if (typeof node.type !== 'string' || node.type.length === 0 || node.type.length > 100) return false
+    if (node.text !== undefined && typeof node.text !== 'string') return false
+    if (typeof node.text === 'string' && node.text.length > 1_000_000) return false
+    if (node.attrs !== undefined && (
+      !node.attrs || typeof node.attrs !== 'object' || Array.isArray(node.attrs)
+    )) return false
+    if (node.marks !== undefined) {
+      if (!Array.isArray(node.marks) || node.marks.length > 100) return false
+      for (const mark of node.marks) {
+        if (!mark || typeof mark !== 'object' || Array.isArray(mark)) return false
+        const markRecord = mark as Record<string, unknown>
+        if (typeof markRecord.type !== 'string' || markRecord.type.length === 0) return false
+        if (markRecord.attrs !== undefined && (
+          !markRecord.attrs || typeof markRecord.attrs !== 'object' || Array.isArray(markRecord.attrs)
+        )) return false
+      }
+    }
+    if (node.content !== undefined) {
+      if (!Array.isArray(node.content) || node.content.length > 10_000) return false
+      for (const child of node.content) {
+        stack.push({ node: child, depth: current.depth + 1 })
+      }
+    }
+  }
   return true
 }
 

--- a/src/lib/validations/assignment-authoring.ts
+++ b/src/lib/validations/assignment-authoring.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+import { assignmentSubmissionContentSchema } from '@/lib/validations/assignment-doc-submissions'
+
+const submissionValidationPolicySchema = z.object({
+  mode: z.enum(['format_only', 'reachable', 'expected_domain']).optional(),
+  expected_domains: z.array(z.string().trim().min(1).max(253)).max(20).optional(),
+}).strict()
+
+export const assignmentSubmissionRequirementDraftSchema = z.object({
+  id: z.string().uuid().optional(),
+  type: z.enum(['repo_link', 'link', 'image']),
+  label: z.string().max(500).nullable().optional(),
+  instructions: z.string().max(10_000).nullable().optional(),
+  required: z.boolean().nullable().optional(),
+  position: z.number().int().nonnegative().nullable().optional(),
+  validation_policy_json: submissionValidationPolicySchema.nullable().optional(),
+}).strict()
+
+export const teacherAssignmentPatchSchema = z.object({
+  title: z.string().trim().min(1).max(500).optional(),
+  instructions_markdown: z.string().max(200_000).optional(),
+  rich_instructions: assignmentSubmissionContentSchema.nullable().optional(),
+  due_at: z.string().datetime({ offset: true }).optional(),
+  is_draft: z.boolean().optional(),
+  released_at: z.string().datetime({ offset: true }).nullable().optional(),
+  submission_requirements: z.array(assignmentSubmissionRequirementDraftSchema).max(50).optional(),
+}).strict()
+
+export type TeacherAssignmentPatch = z.infer<typeof teacherAssignmentPatchSchema>

--- a/src/lib/validations/assignment-doc-submissions.ts
+++ b/src/lib/validations/assignment-doc-submissions.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+import { isValidTiptapContent } from '@/lib/tiptap-content'
+import type { TiptapContent } from '@/types'
+
+export const assignmentSubmissionContentSchema = z
+  .unknown()
+  .refine(isValidTiptapContent, 'Invalid content format')
+  .transform((content) => content as TiptapContent)
+
+const pasteWordCountSchema = z.coerce.number().int().min(0).max(32_767)
+const keystrokeCountSchema = z.coerce.number().int().min(0).max(2_147_483_647)
+
+export const assignmentDocSubmitRequestSchema = z.object({
+  content: assignmentSubmissionContentSchema,
+  expected_updated_at: z.string().datetime({ offset: true }),
+}).strict()
+
+export const assignmentDocAtomicSaveRequestSchema = z.object({
+  content: assignmentSubmissionContentSchema,
+  trigger: z.enum(['autosave', 'blur']).optional(),
+  paste_word_count: pasteWordCountSchema.optional(),
+  keystroke_count: keystrokeCountSchema.optional(),
+  expected_updated_at: z.string().datetime({ offset: true }),
+  save_session_id: z.string().uuid(),
+  save_sequence: z.number().int().positive(),
+  metric_session_id: z.string().uuid(),
+}).strict()
+
+export const assignmentDocLegacySaveRequestSchema = z.object({
+  content: assignmentSubmissionContentSchema,
+  trigger: z.enum(['autosave', 'blur']).optional(),
+  paste_word_count: pasteWordCountSchema.optional(),
+  keystroke_count: keystrokeCountSchema.optional(),
+}).strict()
+
+export const assignmentDocSaveRequestSchema = z.union([
+  assignmentDocAtomicSaveRequestSchema,
+  assignmentDocLegacySaveRequestSchema,
+])
+
+export const assignmentArtifactPutRequestSchema = z.object({
+  url: z.string().max(2_048),
+  github_login: z.string().trim().min(1).max(39).optional(),
+  save_github_login: z.boolean().optional(),
+}).strict()
+
+export const assignmentDocRestoreRequestSchema = z.object({
+  history_id: z.string().uuid(),
+}).strict()
+
+export type AssignmentDocSubmitRequest = z.infer<typeof assignmentDocSubmitRequestSchema>

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -342,6 +342,45 @@ export type Database = {
           },
         ]
       }
+      assignment_artifact_storage_cleanup: {
+        Row: {
+          attempt_count: number
+          created_at: string
+          id: string
+          last_error: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          status: string
+          storage_path: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          status?: string
+          storage_path: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          status?: string
+          storage_path?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       assignment_doc_history: {
         Row: {
           assignment_doc_id: string
@@ -389,6 +428,45 @@ export type Database = {
           },
         ]
       }
+      assignment_doc_save_operations: {
+        Row: {
+          assignment_doc_id: string
+          completed_at: string
+          content_sha256: string
+          document_updated_at: string
+          id: string
+          keystroke_count: number
+          metric_session_id: string
+          paste_word_count: number
+          save_sequence: number
+          save_session_id: string
+        }
+        Insert: {
+          assignment_doc_id: string
+          completed_at?: string
+          content_sha256: string
+          document_updated_at: string
+          id?: string
+          keystroke_count: number
+          metric_session_id: string
+          paste_word_count: number
+          save_sequence: number
+          save_session_id: string
+        }
+        Update: {
+          assignment_doc_id?: string
+          completed_at?: string
+          content_sha256?: string
+          document_updated_at?: string
+          id?: string
+          keystroke_count?: number
+          metric_session_id?: string
+          paste_word_count?: number
+          save_sequence?: number
+          save_session_id?: string
+        }
+        Relationships: []
+      }
       assignment_docs: {
         Row: {
           ai_feedback_model: string | null
@@ -409,6 +487,8 @@ export type Database = {
           is_submitted: boolean
           repo_url: string | null
           returned_at: string | null
+          save_sequence: number | null
+          save_session_id: string | null
           score_completion: number | null
           score_thinking: number | null
           score_workflow: number | null
@@ -439,6 +519,8 @@ export type Database = {
           is_submitted?: boolean
           repo_url?: string | null
           returned_at?: string | null
+          save_sequence?: number | null
+          save_session_id?: string | null
           score_completion?: number | null
           score_thinking?: number | null
           score_workflow?: number | null
@@ -469,6 +551,8 @@ export type Database = {
           is_submitted?: boolean
           repo_url?: string | null
           returned_at?: string | null
+          save_sequence?: number | null
+          save_session_id?: string | null
           score_completion?: number | null
           score_thinking?: number | null
           score_workflow?: number | null
@@ -3971,6 +4055,56 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      claim_assignment_artifact_storage_cleanup: {
+        Args: {
+          p_lease_seconds: number
+          p_lease_token: string
+          p_limit: number
+        }
+        Returns: {
+          attempt_count: number
+          created_at: string
+          id: string
+          last_error: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          status: string
+          storage_path: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "assignment_artifact_storage_cleanup"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      claim_assignment_artifact_storage_cleanup_path: {
+        Args: {
+          p_lease_seconds: number
+          p_lease_token: string
+          p_storage_path: string
+        }
+        Returns: {
+          attempt_count: number
+          created_at: string
+          id: string
+          last_error: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          status: string
+          storage_path: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "assignment_artifact_storage_cleanup"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       claim_due_classroom_archive_object_upload_cleanup: {
         Args: {
           p_lease_seconds?: number
@@ -4076,6 +4210,10 @@ export type Database = {
         Args: { p_storage_bucket: string; p_storage_path: string }
         Returns: string
       }
+      cleanup_assignment_doc_save_operations: {
+        Args: { p_completed_before: string }
+        Returns: number
+      }
       cleanup_expired_classroom_archive_snapshots: {
         Args: never
         Returns: number
@@ -4093,6 +4231,10 @@ export type Database = {
       close_test_for_grading_atomic: {
         Args: { p_closed_by: string; p_test_id: string }
         Returns: Json
+      }
+      complete_assignment_artifact_storage_cleanup: {
+        Args: { p_cleanup_id: string; p_lease_token: string }
+        Returns: boolean
       }
       complete_assignment_repo_review_run_atomic: {
         Args: {
@@ -4251,6 +4393,14 @@ export type Database = {
         }
         Returns: Json
       }
+      delete_assignment_submission_artifact_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_requirement_id: string
+          p_student_id: string
+        }
+        Returns: Json
+      }
       delete_student_test_attempt_atomic: {
         Args: { p_student_id: string; p_test_id: string }
         Returns: Json
@@ -4262,6 +4412,14 @@ export type Database = {
       delete_test_atomic: {
         Args: { p_teacher_id: string; p_test_id: string }
         Returns: Json
+      }
+      enqueue_assignment_artifact_storage_cleanup_path: {
+        Args: { p_delay_seconds?: number; p_storage_path: string }
+        Returns: boolean
+      }
+      fail_assignment_artifact_storage_cleanup: {
+        Args: { p_cleanup_id: string; p_error: string; p_lease_token: string }
+        Returns: boolean
       }
       fail_classroom_archive_compaction: {
         Args: {
@@ -4556,6 +4714,25 @@ export type Database = {
         }
         Returns: Json
       }
+      save_assignment_doc_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_char_count: number
+          p_content: Json
+          p_expected_updated_at: string
+          p_keystroke_count: number
+          p_metric_session_id: string
+          p_paste_word_count: number
+          p_patch: Json
+          p_save_sequence: number
+          p_save_session_id: string
+          p_snapshot: Json
+          p_student_id: string
+          p_trigger: string
+          p_word_count: number
+        }
+        Returns: Json
+      }
       save_assignment_grades_atomic: {
         Args: {
           p_apply_comments: boolean
@@ -4635,6 +4812,17 @@ export type Database = {
         }
         Returns: Json
       }
+      submit_assignment_doc_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_char_count: number
+          p_content: Json
+          p_expected_updated_at: string
+          p_student_id: string
+          p_word_count: number
+        }
+        Returns: Json
+      }
       submit_test_attempt_atomic: {
         Args: {
           p_responses: Json
@@ -4644,12 +4832,20 @@ export type Database = {
         }
         Returns: Json
       }
+      unsubmit_assignment_doc_atomic: {
+        Args: { p_assignment_id: string; p_student_id: string }
+        Returns: Json
+      }
       unsubmit_test_attempts_atomic: {
         Args: {
           p_student_ids: string[]
           p_test_id: string
           p_updated_by: string
         }
+        Returns: Json
+      }
+      update_assignment_with_submission_requirements_atomic: {
+        Args: { p_assignment_id: string; p_requirements: Json; p_updates: Json }
         Returns: Json
       }
       update_test_student_access_atomic: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -253,6 +253,51 @@ type TableOverrides = {
 }
 
 type FunctionOverrides = {
+  save_assignment_doc_atomic: {
+    Args: {
+      p_assignment_id: string
+      p_student_id: string
+      p_content: Json
+      p_expected_updated_at: string | null
+      p_trigger: string
+      p_paste_word_count: number
+      p_keystroke_count: number
+      p_patch: Json | null
+      p_snapshot: Json | null
+      p_word_count: number
+      p_char_count: number
+      p_save_session_id: string
+      p_save_sequence: number
+      p_metric_session_id: string
+    }
+    Returns: Json
+  }
+  submit_assignment_doc_atomic: {
+    Args: {
+      p_assignment_id: string
+      p_student_id: string
+      p_content: Json
+      p_expected_updated_at: string
+      p_word_count: number
+      p_char_count: number
+    }
+    Returns: Json
+  }
+  unsubmit_assignment_doc_atomic: {
+    Args: {
+      p_assignment_id: string
+      p_student_id: string
+    }
+    Returns: Json
+  }
+  update_assignment_with_submission_requirements_atomic: {
+    Args: {
+      p_assignment_id: string
+      p_updates: Json
+      p_requirements: Json
+    }
+    Returns: Json
+  }
   claim_assignment_ai_grading_run: FunctionContract<
     'claim_assignment_ai_grading_run',
     TableOverrides['assignment_ai_grading_runs']['Row'][]

--- a/supabase/migrations/099_assignment_submission_integrity_guards.sql
+++ b/supabase/migrations/099_assignment_submission_integrity_guards.sql
@@ -1,0 +1,1840 @@
+-- Serialize assignment draft evidence, history, and submission transitions.
+
+alter table public.assignment_docs
+  add column if not exists save_session_id uuid,
+  add column if not exists save_sequence bigint;
+
+alter table public.assignment_doc_history
+  drop constraint if exists assignment_doc_history_trigger_check;
+alter table public.assignment_doc_history
+  add constraint assignment_doc_history_trigger_check
+  check (trigger in ('autosave', 'blur', 'submit', 'baseline', 'restore'));
+
+alter table public.assignment_docs
+  drop constraint if exists assignment_docs_save_sequence_check;
+alter table public.assignment_docs
+  add constraint assignment_docs_save_sequence_check
+  check (save_sequence is null or save_sequence > 0);
+
+create or replace function private.assignment_content_sha256(p_content jsonb)
+returns text
+language sql
+immutable
+strict
+set search_path = public, extensions, pg_temp
+as $$
+  select encode(
+    extensions.digest(convert_to(p_content::text, 'UTF8'), 'sha256'),
+    'hex'
+  )
+$$;
+
+create table if not exists public.assignment_doc_save_operations (
+  id uuid primary key default gen_random_uuid(),
+  assignment_doc_id uuid not null,
+  save_session_id uuid not null,
+  save_sequence bigint not null check (save_sequence > 0),
+  metric_session_id uuid not null,
+  paste_word_count integer not null check (paste_word_count >= 0),
+  keystroke_count bigint not null check (keystroke_count >= 0),
+  content_sha256 text not null check (content_sha256 ~ '^[0-9a-f]{64}$'),
+  document_updated_at timestamptz not null,
+  completed_at timestamptz not null default clock_timestamp(),
+  unique (assignment_doc_id, save_session_id, save_sequence)
+);
+
+alter table public.assignment_doc_save_operations
+  add column if not exists metric_session_id uuid,
+  add column if not exists paste_word_count integer,
+  add column if not exists keystroke_count bigint,
+  add column if not exists document_updated_at timestamptz;
+update public.assignment_doc_save_operations
+set metric_session_id = coalesce(metric_session_id, save_session_id),
+    paste_word_count = coalesce(paste_word_count, 0),
+    keystroke_count = coalesce(keystroke_count, 0),
+    document_updated_at = coalesce(document_updated_at, completed_at)
+where metric_session_id is null
+  or paste_word_count is null
+  or keystroke_count is null
+  or document_updated_at is null;
+alter table public.assignment_doc_save_operations
+  alter column metric_session_id set not null,
+  alter column paste_word_count set not null,
+  alter column keystroke_count set not null,
+  alter column document_updated_at set not null;
+alter table public.assignment_doc_save_operations
+  drop constraint if exists assignment_doc_save_operations_paste_word_count_check;
+alter table public.assignment_doc_save_operations
+  add constraint assignment_doc_save_operations_paste_word_count_check
+  check (paste_word_count >= 0);
+alter table public.assignment_doc_save_operations
+  drop constraint if exists assignment_doc_save_operations_keystroke_count_check;
+alter table public.assignment_doc_save_operations
+  add constraint assignment_doc_save_operations_keystroke_count_check
+  check (keystroke_count >= 0);
+
+create index if not exists idx_assignment_doc_save_operations_completed
+  on public.assignment_doc_save_operations (completed_at);
+
+alter table public.assignment_doc_save_operations enable row level security;
+
+insert into public.assignment_doc_save_operations (
+  assignment_doc_id, save_session_id, save_sequence, metric_session_id,
+  paste_word_count, keystroke_count, content_sha256, document_updated_at, completed_at
+)
+select id, save_session_id, save_sequence, save_session_id,
+  0, 0, private.assignment_content_sha256(content), updated_at, updated_at
+from public.assignment_docs
+where save_session_id is not null and save_sequence is not null
+on conflict (assignment_doc_id, save_session_id, save_sequence) do nothing;
+
+create or replace function public.cleanup_assignment_doc_save_operations(
+  p_completed_before timestamptz
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_deleted integer;
+begin
+  if p_completed_before is null or p_completed_before > clock_timestamp() then
+    raise exception 'Invalid assignment save operation cleanup cutoff' using errcode = '22023';
+  end if;
+
+  with deleted as (
+    delete from public.assignment_doc_save_operations
+    where completed_at < p_completed_before
+    returning 1
+  )
+  select count(*)::integer into v_deleted from deleted;
+
+  return v_deleted;
+end;
+$$;
+
+create table if not exists public.assignment_artifact_storage_cleanup (
+  id uuid primary key default gen_random_uuid(),
+  storage_path text not null unique,
+  status text not null default 'pending'
+    check (status in ('pending', 'processing')),
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  next_attempt_at timestamptz not null default clock_timestamp(),
+  lease_token uuid,
+  lease_expires_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default clock_timestamp(),
+  updated_at timestamptz not null default clock_timestamp(),
+  check (
+    (status = 'pending' and lease_token is null and lease_expires_at is null)
+    or (status = 'processing' and lease_token is not null and lease_expires_at is not null)
+  )
+);
+
+create index if not exists idx_assignment_artifact_storage_cleanup_due
+  on public.assignment_artifact_storage_cleanup (next_attempt_at, created_at)
+  where status = 'pending';
+
+alter table public.assignment_artifact_storage_cleanup enable row level security;
+
+create or replace function public.update_assignment_docs_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at = greatest(clock_timestamp(), old.updated_at + interval '1 microsecond');
+  return new;
+end;
+$$;
+
+-- Keep the migration-first overlap compatible with the previous archive adapter.
+-- The old app stages 082 assignment rows without the nullable 099 save fence fields.
+create or replace function public.normalize_classroom_archive_restore_row(
+  p_operation_id uuid,
+  p_table_name text,
+  p_row jsonb
+)
+returns jsonb
+language plpgsql
+stable
+set search_path = ''
+as $$
+declare
+  v_response_revision bigint;
+  v_missing_response_revision boolean;
+begin
+  if p_table_name = 'assignment_docs' then
+    if not (p_row ? 'save_session_id') then
+      p_row := p_row || jsonb_build_object('save_session_id', null);
+    end if;
+    if not (p_row ? 'save_sequence') then
+      p_row := p_row || jsonb_build_object('save_sequence', null);
+    end if;
+    return p_row;
+  end if;
+
+  if p_table_name = 'test_responses' then
+    if not (p_row ? 'revision') or jsonb_typeof(p_row->'revision') = 'null' then
+      p_row := p_row || jsonb_build_object('revision', 1);
+    end if;
+    if not (p_row ? 'ai_suggested_score') then
+      p_row := p_row || jsonb_build_object('ai_suggested_score', null);
+    end if;
+    if not (p_row ? 'ai_suggested_feedback') then
+      p_row := p_row || jsonb_build_object('ai_suggested_feedback', null);
+    end if;
+    return p_row;
+  end if;
+
+  if p_table_name = 'test_ai_grading_run_items' then
+    v_missing_response_revision := not (p_row ? 'response_revision')
+      or jsonb_typeof(p_row->'response_revision') = 'null';
+    if v_missing_response_revision then
+      select coalesce((staged.row_data->>'revision')::bigint, 1)
+      into v_response_revision
+      from public.classroom_archive_restore_staging staged
+      where staged.operation_id = p_operation_id
+        and staged.table_name = 'test_responses'
+        and staged.row_id::text = p_row->>'response_id';
+
+      p_row := p_row || jsonb_build_object(
+        'response_revision', coalesce(v_response_revision, 1)
+      );
+    end if;
+    if p_row->>'status' in ('queued', 'processing') then
+      p_row := p_row || jsonb_build_object(
+        'status', 'failed',
+        'next_retry_at', null,
+        'last_error_code', case
+          when v_missing_response_revision then 'revision_baseline_unavailable'
+          when p_row->>'last_error_code' is null then 'archive_restore_invalidated'
+          else p_row->>'last_error_code'
+        end,
+        'last_error_message', 'Retry this response in a new AI grading run',
+        'completed_at', coalesce(p_row->'updated_at', p_row->'created_at')
+      );
+    end if;
+    if not (p_row ? 'question_grading_snapshot') then
+      p_row := p_row || jsonb_build_object('question_grading_snapshot', null);
+    end if;
+    return p_row;
+  end if;
+
+  if p_table_name = 'test_ai_grading_runs'
+    and p_row->>'status' in ('queued', 'running')
+  then
+    p_row := p_row || jsonb_build_object(
+      'status', 'failed',
+      'processed_count', coalesce((p_row->>'queued_response_count')::integer, 0),
+      'failed_count', greatest(
+        coalesce((p_row->>'failed_count')::integer, 0),
+        coalesce((p_row->>'queued_response_count')::integer, 0)
+          - coalesce((p_row->>'completed_count')::integer, 0)
+      ),
+      'lease_token', null,
+      'lease_expires_at', null,
+      'completed_at', coalesce(p_row->'updated_at', p_row->'created_at')
+    );
+    return p_row;
+  end if;
+
+  return p_row;
+end;
+$$;
+
+create or replace function public.guard_assignment_submission_requirement_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_assignment_id uuid;
+  v_artifact_id uuid;
+  v_doc_id uuid;
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  if tg_op = 'UPDATE' and old.assignment_id <> new.assignment_id then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_requirement_move_forbidden';
+  end if;
+
+  v_assignment_id := case when tg_op = 'DELETE' then old.assignment_id else new.assignment_id end;
+
+  -- Parent assignment cascades are destructive operations, not requirement edits.
+  if tg_op = 'DELETE' and not exists (
+    select 1 from public.assignments where id = v_assignment_id
+  ) then
+    return old;
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended('assignment_submission:' || v_assignment_id::text, 0));
+
+  if tg_op = 'DELETE' then
+    for v_artifact_id in
+      select artifact.id
+      from public.assignment_submission_artifacts artifact
+      where artifact.requirement_id = old.id
+      order by artifact.id
+      for update
+    loop
+      null;
+    end loop;
+  end if;
+
+  for v_doc_id in
+    select doc.id
+    from public.assignment_docs doc
+    where doc.assignment_id = v_assignment_id
+    order by doc.id
+    for update
+  loop
+    null;
+  end loop;
+
+  if exists (
+    select 1
+    from public.assignment_docs
+    where assignment_id = v_assignment_id
+      and is_submitted is true
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_requirements_submitted_documents_immutable';
+  end if;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+drop trigger if exists guard_assignment_submission_requirement_mutation
+  on public.assignment_submission_requirements;
+drop trigger if exists aaa_guard_assignment_submission_requirement_mutation
+  on public.assignment_submission_requirements;
+create trigger aaa_guard_assignment_submission_requirement_mutation
+before insert or update or delete on public.assignment_submission_requirements
+for each row
+execute function public.guard_assignment_submission_requirement_mutation();
+
+create or replace function public.guard_assignment_submission_artifact_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc_id uuid;
+  v_is_submitted boolean;
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  if tg_op = 'UPDATE' and old.assignment_doc_id <> new.assignment_doc_id then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_artifact_document_change_forbidden';
+  end if;
+
+  -- Requirement and document parent cascades are legitimate destructive flows.
+  if tg_op = 'DELETE' and not exists (
+    select 1
+    from public.assignment_submission_requirements
+    where id = old.requirement_id
+  ) then
+    return old;
+  end if;
+
+  v_doc_id := case when tg_op = 'DELETE' then old.assignment_doc_id else new.assignment_doc_id end;
+
+  select d.is_submitted
+  into v_is_submitted
+  from public.assignment_docs d
+  where d.id = v_doc_id
+  for update;
+
+  if not found then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+    raise exception using
+      errcode = '23503',
+      message = 'assignment_artifact_document_not_found';
+  end if;
+
+  if v_is_submitted then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_artifact_submitted_document_immutable';
+  end if;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+drop trigger if exists guard_assignment_submission_artifact_mutation
+  on public.assignment_submission_artifacts;
+drop trigger if exists aaa_guard_assignment_submission_artifact_mutation
+  on public.assignment_submission_artifacts;
+create trigger aaa_guard_assignment_submission_artifact_mutation
+before insert or update or delete on public.assignment_submission_artifacts
+for each row
+execute function public.guard_assignment_submission_artifact_mutation();
+
+create or replace function public.enqueue_deleted_assignment_artifact_storage_cleanup()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if (tg_op = 'UPDATE' and old.storage_path is not distinct from new.storage_path)
+    or old.storage_path is null or btrim(old.storage_path) = ''
+    or public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  insert into public.assignment_artifact_storage_cleanup as existing_cleanup (
+    storage_path, status, attempt_count, next_attempt_at,
+    lease_token, lease_expires_at, last_error, updated_at
+  ) values (
+    old.storage_path, 'pending', 0, clock_timestamp(),
+    null, null, null, clock_timestamp()
+  )
+  on conflict (storage_path) do update
+  set status = 'pending',
+      next_attempt_at = clock_timestamp(),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error = null,
+      updated_at = clock_timestamp()
+  where existing_cleanup.status <> 'processing'
+    or existing_cleanup.lease_expires_at <= clock_timestamp();
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+drop trigger if exists enqueue_deleted_assignment_artifact_storage_cleanup
+  on public.assignment_submission_artifacts;
+create trigger enqueue_deleted_assignment_artifact_storage_cleanup
+after delete or update of storage_path on public.assignment_submission_artifacts
+for each row
+execute function public.enqueue_deleted_assignment_artifact_storage_cleanup();
+
+drop function if exists public.enqueue_assignment_artifact_storage_cleanup_path(text);
+create or replace function public.enqueue_assignment_artifact_storage_cleanup_path(
+  p_storage_path text,
+  p_delay_seconds integer default 0
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_storage_path is null or btrim(p_storage_path) = ''
+    or p_delay_seconds is null or p_delay_seconds < 0 or p_delay_seconds > 86400 then
+    raise exception 'Invalid assignment artifact Storage cleanup path' using errcode = '22023';
+  end if;
+
+  insert into public.assignment_artifact_storage_cleanup as existing_cleanup (
+    storage_path, status, attempt_count, next_attempt_at,
+    lease_token, lease_expires_at, last_error, updated_at
+  ) values (
+    p_storage_path, 'pending', 0,
+    clock_timestamp() + make_interval(secs => p_delay_seconds),
+    null, null, null, clock_timestamp()
+  )
+  on conflict (storage_path) do update
+  set status = 'pending',
+      next_attempt_at = clock_timestamp() + make_interval(secs => p_delay_seconds),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error = null,
+      updated_at = clock_timestamp()
+  where existing_cleanup.status <> 'processing'
+    or existing_cleanup.lease_expires_at <= clock_timestamp();
+
+  return true;
+end;
+$$;
+
+create or replace function private.validate_assignment_submission_requirements(p_doc public.assignment_docs)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if exists (
+    select 1
+    from public.assignment_submission_requirements r
+    left join public.assignment_submission_artifacts a
+      on a.requirement_id = r.id
+      and a.assignment_doc_id = p_doc.id
+      and a.student_id = p_doc.student_id
+      and a.type = r.type
+    where r.assignment_id = p_doc.assignment_id
+      and (
+        (
+          r.required
+          and (
+            a.id is null
+            or case
+              when r.type = 'image' then
+                coalesce(nullif(btrim(a.storage_path), ''), nullif(btrim(a.url), '')) is null
+              else nullif(btrim(coalesce(a.url, '')), '') is null
+            end
+            or a.validation_status in ('invalid', 'inaccessible')
+          )
+        )
+        or (
+          a.id is not null
+          and (
+            case
+              when r.type = 'image' then
+                coalesce(nullif(btrim(a.storage_path), ''), nullif(btrim(a.url), '')) is null
+              else nullif(btrim(coalesce(a.url, '')), '') is null
+            end
+            or a.validation_status in ('invalid', 'inaccessible')
+          )
+        )
+      )
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_submission_requirements_incomplete';
+  end if;
+end;
+$$;
+
+create or replace function public.validate_assignment_submission_transition()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform private.validate_assignment_submission_requirements(new);
+  return new;
+end;
+$$;
+
+drop trigger if exists validate_assignment_submission_transition
+  on public.assignment_docs;
+drop trigger if exists aaa_validate_assignment_submission_transition
+  on public.assignment_docs;
+create trigger aaa_validate_assignment_submission_transition
+before update of is_submitted on public.assignment_docs
+for each row
+when (new.is_submitted and not old.is_submitted)
+execute function public.validate_assignment_submission_transition();
+
+create or replace function public.guard_submitted_assignment_doc_content()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return new;
+  end if;
+
+  if old.is_submitted and (
+    old.content is distinct from new.content
+    or old.assignment_id is distinct from new.assignment_id
+    or old.student_id is distinct from new.student_id
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_submitted_document_identity_immutable';
+  end if;
+
+  if old.is_submitted and new.is_submitted
+    and old.submitted_at is distinct from new.submitted_at then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_submitted_at_immutable';
+  end if;
+
+  if new.is_submitted and new.submitted_at is null then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_submitted_at_required';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists aaa_guard_submitted_assignment_doc_content
+  on public.assignment_docs;
+create trigger aaa_guard_submitted_assignment_doc_content
+before update of content, assignment_id, student_id, submitted_at, is_submitted on public.assignment_docs
+for each row
+execute function public.guard_submitted_assignment_doc_content();
+
+create or replace function public.guard_assignment_doc_history_after_submit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc public.assignment_docs;
+  v_doc_id uuid;
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  if tg_op = 'DELETE' then
+    if old.trigger = 'submit' and exists (
+      select 1
+      from public.assignment_docs d
+      where d.id = old.assignment_doc_id
+    ) then
+      -- Compatibility: pre-099 cleanup jobs bulk-delete history without filtering.
+      -- Silently preserve authoritative submit rows while allowing that job to finish.
+      return null;
+    end if;
+    return old;
+  end if;
+
+  if tg_op = 'UPDATE' and (old.trigger = 'submit' or new.trigger = 'submit') then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_submit_history_immutable';
+  end if;
+
+  v_doc_id := new.assignment_doc_id;
+
+  select * into v_doc
+  from public.assignment_docs
+  where id = v_doc_id
+  for update;
+
+  if not found then
+    raise exception using
+      errcode = '23503',
+      message = 'assignment_history_document_not_found';
+  end if;
+
+  if v_doc.is_submitted and new.trigger <> 'submit' then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_history_after_submit_forbidden';
+  end if;
+
+  if tg_op = 'INSERT' and new.trigger = 'submit' then
+    if new.patch is not null
+      or new.snapshot is null
+      or new.snapshot is distinct from v_doc.content then
+      raise exception using
+        errcode = '23514',
+        message = 'assignment_submit_history_snapshot_invalid';
+    end if;
+    new.created_at := greatest(
+      new.created_at,
+      coalesce(v_doc.submitted_at, '-infinity'::timestamptz)
+    );
+    if not v_doc.is_submitted or exists (
+      select 1
+      from public.assignment_doc_history h
+      where h.assignment_doc_id = v_doc.id
+        and h.trigger = 'submit'
+        and h.created_at >= coalesce(v_doc.submitted_at, '-infinity'::timestamptz)
+        and h.patch is null
+        and h.snapshot = v_doc.content
+    ) then
+      raise exception using
+        errcode = '23514',
+        message = 'assignment_submit_history_duplicate';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists guard_assignment_doc_history_after_submit
+  on public.assignment_doc_history;
+drop trigger if exists aaa_guard_assignment_doc_history_after_submit
+  on public.assignment_doc_history;
+create trigger aaa_guard_assignment_doc_history_after_submit
+before insert or update or delete on public.assignment_doc_history
+for each row
+execute function public.guard_assignment_doc_history_after_submit();
+
+create or replace function private.assignment_tiptap_node_text(p_node jsonb)
+returns text
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  v_child jsonb;
+  v_text text := '';
+begin
+  if p_node->>'type' = 'text' then
+    return coalesce(p_node->>'text', '');
+  end if;
+
+  if jsonb_typeof(p_node->'content') = 'array' then
+    for v_child in select value from jsonb_array_elements(p_node->'content')
+    loop
+      v_text := v_text || private.assignment_tiptap_node_text(v_child);
+    end loop;
+  end if;
+  return v_text;
+end;
+$$;
+
+create or replace function private.assignment_tiptap_plain_text(p_content jsonb)
+returns text
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  v_node jsonb;
+  v_item jsonb;
+  v_lines text[] := array[]::text[];
+begin
+  if jsonb_typeof(p_content->'content') <> 'array' then
+    return '';
+  end if;
+
+  for v_node in select value from jsonb_array_elements(p_content->'content')
+  loop
+    if v_node->>'type' in ('paragraph', 'heading', 'codeBlock') then
+      v_lines := array_append(v_lines, private.assignment_tiptap_node_text(v_node));
+    elsif v_node->>'type' in ('bulletList', 'orderedList')
+      and jsonb_typeof(v_node->'content') = 'array' then
+      for v_item in select value from jsonb_array_elements(v_node->'content')
+      loop
+        v_lines := array_append(v_lines, private.assignment_tiptap_node_text(v_item));
+      end loop;
+    end if;
+  end loop;
+  return array_to_string(v_lines, E'\n');
+end;
+$$;
+
+insert into public.assignment_doc_history (
+  assignment_doc_id, patch, snapshot, word_count, char_count,
+  paste_word_count, keystroke_count, trigger, created_at
+)
+select
+  d.id,
+  null,
+  d.content,
+  case
+    when trim(private.assignment_tiptap_plain_text(d.content)) = '' then 0
+    else cardinality(regexp_split_to_array(
+      trim(private.assignment_tiptap_plain_text(d.content)), E'\\s+'
+    ))
+  end,
+  char_length(private.assignment_tiptap_plain_text(d.content)),
+  0,
+  0,
+  'submit',
+  coalesce(d.submitted_at, d.updated_at, d.created_at)
+from public.assignment_docs d
+where d.is_submitted is true
+  and not exists (
+    select 1
+    from public.assignment_doc_history h
+    where h.assignment_doc_id = d.id
+      and h.trigger = 'submit'
+      and h.created_at >= coalesce(d.submitted_at, '-infinity'::timestamptz)
+      and h.patch is null
+      and h.snapshot = d.content
+  );
+
+create or replace function public.ensure_current_assignment_submit_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_plain_text text;
+  v_word_count integer;
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return null;
+  end if;
+
+  if new.is_submitted and not exists (
+    select 1
+    from public.assignment_doc_history h
+    where h.assignment_doc_id = new.id
+      and h.trigger = 'submit'
+      and h.created_at >= coalesce(new.submitted_at, '-infinity'::timestamptz)
+      and h.patch is null
+      and h.snapshot = new.content
+  ) then
+    v_plain_text := private.assignment_tiptap_plain_text(new.content);
+    v_word_count := case
+      when trim(v_plain_text) = '' then 0
+      else cardinality(regexp_split_to_array(trim(v_plain_text), E'\\s+'))
+    end;
+
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count,
+      paste_word_count, keystroke_count, trigger, created_at
+    ) values (
+      new.id, null, new.content, v_word_count, char_length(v_plain_text), 0, 0, 'submit',
+      coalesce(new.submitted_at, clock_timestamp())
+    );
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists ensure_current_assignment_submit_history
+  on public.assignment_docs;
+create constraint trigger ensure_current_assignment_submit_history
+after insert or update of is_submitted, submitted_at, content on public.assignment_docs
+deferrable initially deferred
+for each row
+when (new.is_submitted)
+execute function public.ensure_current_assignment_submit_history();
+
+-- Run deferred submit-history checks while restore maintenance mode is still active.
+create or replace function public.complete_classroom_archive_restore(
+  p_operation_id uuid,
+  p_teacher_id uuid,
+  p_verification jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_prior_restore_mode text := current_setting('pika.classroom_archive_restore', true);
+  v_prior_source_revision text := current_setting(
+    'pika.classroom_archive_source_revision',
+    true
+  );
+  v_result jsonb;
+begin
+  begin
+    v_result := private.complete_classroom_archive_restore(
+      p_operation_id,
+      p_teacher_id,
+      p_verification
+    );
+    set constraints public.ensure_current_assignment_submit_history immediate;
+    set constraints public.ensure_current_assignment_submit_history deferred;
+  exception when others then
+    perform set_config(
+      'pika.classroom_archive_restore',
+      coalesce(v_prior_restore_mode, 'off'),
+      true
+    );
+    perform set_config(
+      'pika.classroom_archive_source_revision',
+      coalesce(v_prior_source_revision, ''),
+      true
+    );
+    raise;
+  end;
+
+  perform set_config(
+    'pika.classroom_archive_restore',
+    coalesce(v_prior_restore_mode, 'off'),
+    true
+  );
+  perform set_config(
+    'pika.classroom_archive_source_revision',
+    coalesce(v_prior_source_revision, ''),
+    true
+  );
+  return v_result;
+end;
+$$;
+
+drop function if exists public.save_assignment_doc_atomic(
+  uuid, uuid, jsonb, timestamptz, text, integer, integer,
+  jsonb, jsonb, integer, integer, jsonb
+);
+drop function if exists public.save_assignment_doc_atomic(
+  uuid, uuid, jsonb, timestamptz, text, integer, integer,
+  jsonb, jsonb, integer, integer, uuid, bigint, uuid, bigint, integer, integer
+);
+drop function if exists public.save_assignment_doc_atomic(
+  uuid, uuid, jsonb, timestamptz, text, integer, integer,
+  jsonb, jsonb, integer, integer, uuid, bigint, bigint, integer, integer
+);
+
+create or replace function public.save_assignment_doc_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid,
+  p_content jsonb,
+  p_expected_updated_at timestamptz,
+  p_trigger text,
+  p_paste_word_count integer,
+  p_keystroke_count integer,
+  p_patch jsonb,
+  p_snapshot jsonb,
+  p_word_count integer,
+  p_char_count integer,
+  p_save_session_id uuid,
+  p_save_sequence bigint,
+  p_metric_session_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc public.assignment_docs;
+  v_history public.assignment_doc_history;
+  v_last_history public.assignment_doc_history;
+  v_prior_operation public.assignment_doc_save_operations;
+  v_created boolean := false;
+  v_revision_conflict boolean := false;
+  v_content_changed boolean;
+  v_fence_superseded_save boolean;
+  v_effective_paste_word_count integer;
+  v_effective_keystroke_count integer;
+  v_committed_paste_word_count integer := 0;
+  v_committed_keystroke_count bigint := 0;
+  v_has_last_history boolean := false;
+  v_content_sha256 text;
+begin
+  if p_assignment_id is null or p_student_id is null or p_content is null
+    or p_save_session_id is null or p_save_sequence is null or p_save_sequence <= 0
+    or p_metric_session_id is null then
+    raise exception 'Invalid assignment document save request' using errcode = '22023';
+  end if;
+  if p_trigger not in ('autosave', 'blur', 'restore') then
+    raise exception 'Invalid assignment document history trigger' using errcode = '22023';
+  end if;
+  if coalesce(p_paste_word_count, 0) < 0
+    or coalesce(p_keystroke_count, 0) < 0
+    or coalesce(p_word_count, 0) < 0
+    or coalesce(p_char_count, 0) < 0 then
+    raise exception 'Invalid assignment document history metrics' using errcode = '22023';
+  end if;
+  v_content_sha256 := private.assignment_content_sha256(p_content);
+
+  perform pg_advisory_xact_lock(hashtextextended(p_assignment_id::text || ':' || p_student_id::text, 0));
+
+  select * into v_doc
+  from public.assignment_docs
+  where assignment_id = p_assignment_id and student_id = p_student_id
+  for update;
+
+  if not found then
+    if p_expected_updated_at is not null then
+      return jsonb_build_object(
+        'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_conflict',
+        'error', 'This draft changed elsewhere before the save completed. Reload and review the latest version.'
+      );
+    end if;
+
+    insert into public.assignment_docs (
+      assignment_id, student_id, content, repo_url, github_username, is_submitted, submitted_at,
+      save_session_id, save_sequence
+    ) values (
+      p_assignment_id, p_student_id, p_content, null, null, false, null,
+      p_save_session_id, p_save_sequence
+    ) returning * into v_doc;
+    v_created := true;
+
+    insert into public.assignment_doc_history (
+      assignment_doc_id, patch, snapshot, word_count, char_count,
+      paste_word_count, keystroke_count, trigger, created_at
+    ) values (
+      v_doc.id, null, p_content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+      coalesce(p_paste_word_count, 0), coalesce(p_keystroke_count, 0), 'baseline', clock_timestamp()
+    ) returning * into v_history;
+
+    insert into public.assignment_doc_save_operations (
+      assignment_doc_id, save_session_id, save_sequence, metric_session_id,
+      paste_word_count, keystroke_count, content_sha256, document_updated_at
+    ) values (
+      v_doc.id, p_save_session_id, p_save_sequence, p_metric_session_id,
+      coalesce(p_paste_word_count, 0), coalesce(p_keystroke_count, 0),
+      v_content_sha256, v_doc.updated_at
+    );
+
+    return jsonb_build_object(
+      'ok', true, 'created', true, 'doc', to_jsonb(v_doc), 'history_entry', to_jsonb(v_history)
+    );
+  end if;
+
+  if v_doc.is_submitted then
+    return jsonb_build_object(
+      'ok', false, 'status', 403, 'error_code', 'assignment_doc_submitted',
+      'error', 'Cannot edit a submitted document'
+    );
+  end if;
+
+  select * into v_prior_operation
+  from public.assignment_doc_save_operations operation
+  where operation.assignment_doc_id = v_doc.id
+    and operation.save_session_id = p_save_session_id
+    and operation.save_sequence = p_save_sequence;
+
+  if found then
+    if v_prior_operation.content_sha256 <> v_content_sha256
+      or v_prior_operation.metric_session_id <> p_metric_session_id
+      or v_prior_operation.paste_word_count <> coalesce(p_paste_word_count, 0)
+      or v_prior_operation.keystroke_count <> coalesce(p_keystroke_count, 0) then
+      return jsonb_build_object(
+        'ok', false, 'status', 409, 'error_code', 'assignment_doc_save_superseded',
+        'error', 'This save identifier was already used for different content.'
+      );
+    end if;
+    if v_doc.save_session_id = p_save_session_id
+      and v_doc.save_sequence = p_save_sequence
+      and v_doc.content = p_content then
+      return jsonb_build_object(
+        'ok', true, 'created', false, 'doc', to_jsonb(v_doc), 'history_entry', null
+      );
+    end if;
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_save_replayed',
+      'error', 'This save completed, but a newer saved version now exists.'
+    );
+  end if;
+
+  if p_expected_updated_at is null then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_required',
+      'error', 'A saved draft revision is required. Reload and try again.'
+    );
+  end if;
+
+  if v_doc.save_session_id = p_save_session_id
+    and coalesce(v_doc.save_sequence, 0) >= p_save_sequence then
+    if v_doc.save_sequence = p_save_sequence and v_doc.content = p_content then
+      return jsonb_build_object(
+        'ok', true, 'created', false, 'doc', to_jsonb(v_doc), 'history_entry', null
+      );
+    end if;
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_save_superseded',
+      'error', 'A newer save from this editor already completed.'
+    );
+  end if;
+
+  v_fence_superseded_save := v_doc.save_session_id = p_save_session_id
+    and p_save_sequence > coalesce(v_doc.save_sequence, 0)
+    and exists (
+      select 1
+      from public.assignment_doc_save_operations operation
+      where operation.assignment_doc_id = v_doc.id
+        and operation.save_session_id = v_doc.save_session_id
+        and operation.save_sequence = v_doc.save_sequence
+        and operation.document_updated_at = v_doc.updated_at
+    );
+
+  if v_doc.updated_at <> p_expected_updated_at then
+    if v_fence_superseded_save then
+      v_revision_conflict := true;
+    else
+      return jsonb_build_object(
+        'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_conflict',
+        'error', 'This draft changed elsewhere before the save completed. Reload and review the latest version.'
+      );
+    end if;
+  end if;
+
+  v_content_changed := v_doc.content is distinct from p_content;
+  select
+    coalesce(max(operation.paste_word_count), 0),
+    coalesce(max(operation.keystroke_count), 0)
+  into v_committed_paste_word_count, v_committed_keystroke_count
+  from public.assignment_doc_save_operations operation
+  where operation.assignment_doc_id = v_doc.id
+    and operation.metric_session_id = p_metric_session_id;
+  v_effective_paste_word_count := greatest(
+    0,
+    coalesce(p_paste_word_count, 0) - v_committed_paste_word_count
+  );
+  v_effective_keystroke_count := greatest(
+    0,
+    coalesce(p_keystroke_count, 0) - v_committed_keystroke_count
+  )::integer;
+
+  if not v_content_changed
+    and v_effective_paste_word_count = 0
+    and v_effective_keystroke_count = 0
+    and not v_fence_superseded_save then
+    insert into public.assignment_doc_save_operations (
+      assignment_doc_id, save_session_id, save_sequence, metric_session_id,
+      paste_word_count, keystroke_count, content_sha256, document_updated_at
+    ) values (
+      v_doc.id, p_save_session_id, p_save_sequence, p_metric_session_id,
+      coalesce(p_paste_word_count, 0), coalesce(p_keystroke_count, 0),
+      v_content_sha256, v_doc.updated_at
+    );
+    return jsonb_build_object(
+      'ok', true, 'created', false, 'doc', to_jsonb(v_doc), 'history_entry', null
+    );
+  end if;
+
+  if v_content_changed
+    or v_effective_paste_word_count > 0
+    or v_effective_keystroke_count > 0 then
+    select * into v_last_history
+    from public.assignment_doc_history
+    where assignment_doc_id = v_doc.id
+    order by created_at desc, id desc
+    limit 1
+    for update;
+    v_has_last_history := found;
+  end if;
+
+  update public.assignment_docs
+  set content = p_content,
+      save_session_id = p_save_session_id,
+      save_sequence = p_save_sequence
+  where id = v_doc.id and is_submitted is false
+  returning * into v_doc;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_conflict',
+      'error', 'This draft changed elsewhere before the save completed. Reload and review the latest version.'
+    );
+  end if;
+
+  if v_content_changed
+    or v_effective_paste_word_count > 0
+    or v_effective_keystroke_count > 0 then
+    if not v_has_last_history then
+      insert into public.assignment_doc_history (
+        assignment_doc_id, patch, snapshot, word_count, char_count,
+        paste_word_count, keystroke_count, trigger, created_at
+      ) values (
+        v_doc.id, null, p_content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+        v_effective_paste_word_count, v_effective_keystroke_count, 'baseline', clock_timestamp()
+      ) returning * into v_history;
+    elsif p_trigger <> 'restore'
+      and v_last_history.trigger not in ('submit', 'restore')
+      and v_last_history.created_at > clock_timestamp() - interval '10 seconds' then
+      update public.assignment_doc_history
+      set patch = null,
+          snapshot = p_content,
+          word_count = coalesce(p_word_count, 0),
+          char_count = coalesce(p_char_count, 0),
+          paste_word_count = coalesce(v_last_history.paste_word_count, 0) + v_effective_paste_word_count,
+          keystroke_count = coalesce(v_last_history.keystroke_count, 0) + v_effective_keystroke_count,
+          trigger = p_trigger,
+          created_at = clock_timestamp()
+      where id = v_last_history.id
+      returning * into v_history;
+    else
+      insert into public.assignment_doc_history (
+        assignment_doc_id, patch, snapshot, word_count, char_count,
+        paste_word_count, keystroke_count, trigger, created_at
+      ) values (
+        v_doc.id,
+        case
+          when v_revision_conflict or p_snapshot is not null or p_patch is null or p_patch = '[]'::jsonb
+            then null
+          else p_patch
+        end,
+        case
+          when v_revision_conflict or p_snapshot is not null or p_patch is null or p_patch = '[]'::jsonb
+            then p_content
+          else null
+        end,
+        coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+        v_effective_paste_word_count, v_effective_keystroke_count, p_trigger, clock_timestamp()
+      ) returning * into v_history;
+    end if;
+  end if;
+
+  insert into public.assignment_doc_save_operations (
+    assignment_doc_id, save_session_id, save_sequence, metric_session_id,
+    paste_word_count, keystroke_count, content_sha256, document_updated_at
+  ) values (
+    v_doc.id, p_save_session_id, p_save_sequence, p_metric_session_id,
+    coalesce(p_paste_word_count, 0), coalesce(p_keystroke_count, 0),
+    v_content_sha256, v_doc.updated_at
+  );
+
+  return jsonb_build_object(
+    'ok', true, 'created', v_created, 'doc', to_jsonb(v_doc),
+    'history_entry', case when v_history.id is null then null else to_jsonb(v_history) end
+  );
+end;
+$$;
+
+create or replace function public.submit_assignment_doc_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid,
+  p_content jsonb,
+  p_expected_updated_at timestamptz,
+  p_word_count integer,
+  p_char_count integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc public.assignment_docs;
+  v_history public.assignment_doc_history;
+begin
+  if p_assignment_id is null or p_student_id is null or p_content is null
+    or p_expected_updated_at is null then
+    raise exception 'Invalid assignment document submission request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('assignment_submission:' || p_assignment_id::text, 0)
+  );
+
+  select * into v_doc
+  from public.assignment_docs
+  where assignment_id = p_assignment_id and student_id = p_student_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 400, 'error_code', 'assignment_doc_missing',
+      'error', 'No work to submit. Please save your work first.'
+    );
+  end if;
+
+  if v_doc.is_submitted then
+    if v_doc.content = p_content then
+      select * into v_history
+      from public.assignment_doc_history
+      where assignment_doc_id = v_doc.id
+        and trigger = 'submit'
+        and created_at >= coalesce(v_doc.submitted_at, '-infinity'::timestamptz)
+        and patch is null
+        and snapshot = v_doc.content
+      order by created_at desc, id desc
+      limit 1;
+
+      if not found then
+        insert into public.assignment_doc_history (
+          assignment_doc_id, patch, snapshot, word_count, char_count,
+          paste_word_count, keystroke_count, trigger, created_at
+        ) values (
+          v_doc.id, null, v_doc.content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+          0, 0, 'submit', clock_timestamp()
+        ) returning * into v_history;
+      end if;
+
+      return jsonb_build_object(
+        'ok', true, 'idempotent', true, 'doc', to_jsonb(v_doc),
+        'history_entry', to_jsonb(v_history)
+      );
+    end if;
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_submitted',
+      'error', 'This assignment is already submitted and cannot be changed.'
+    );
+  end if;
+
+  if v_doc.updated_at <> p_expected_updated_at then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_conflict',
+      'error', 'Your saved draft changed before submission. Review it and try again.'
+    );
+  end if;
+
+  perform private.validate_assignment_submission_requirements(v_doc);
+
+  update public.assignment_docs
+  set content = p_content,
+      is_submitted = true,
+      submitted_at = clock_timestamp()
+  where id = v_doc.id and is_submitted is false
+  returning * into v_doc;
+
+  insert into public.assignment_doc_history (
+    assignment_doc_id, patch, snapshot, word_count, char_count,
+    paste_word_count, keystroke_count, trigger, created_at
+  ) values (
+    v_doc.id, null, p_content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+    0, 0, 'submit', clock_timestamp()
+  ) returning * into v_history;
+
+  return jsonb_build_object(
+    'ok', true, 'idempotent', false, 'doc', to_jsonb(v_doc), 'history_entry', to_jsonb(v_history)
+  );
+end;
+$$;
+
+create or replace function public.unsubmit_assignment_doc_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc public.assignment_docs;
+begin
+  if p_assignment_id is null or p_student_id is null then
+    raise exception 'Invalid assignment document unsubmit request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('assignment_submission:' || p_assignment_id::text, 0)
+  );
+
+  select * into v_doc
+  from public.assignment_docs
+  where assignment_id = p_assignment_id and student_id = p_student_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 404, 'error_code', 'assignment_doc_missing',
+      'error', 'Assignment doc not found'
+    );
+  end if;
+
+  if not v_doc.is_submitted then
+    return jsonb_build_object(
+      'ok', false, 'status', 400, 'error_code', 'assignment_doc_not_submitted',
+      'error', 'Assignment is not submitted'
+    );
+  end if;
+
+  if (
+    v_doc.returned_at is not null
+    and (v_doc.submitted_at is null or v_doc.returned_at >= v_doc.submitted_at)
+  ) or (
+    v_doc.teacher_cleared_at is not null
+    and (v_doc.submitted_at is null or v_doc.teacher_cleared_at >= v_doc.submitted_at)
+  ) then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_returned',
+      'error', 'Returned submissions cannot be unsubmitted'
+    );
+  end if;
+
+  update public.assignment_docs
+  set is_submitted = false,
+      submitted_at = null
+  where id = v_doc.id
+  returning * into v_doc;
+
+  return jsonb_build_object('ok', true, 'doc', to_jsonb(v_doc));
+end;
+$$;
+
+create or replace function public.delete_assignment_submission_artifact_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid,
+  p_requirement_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_doc_id uuid;
+  v_is_submitted boolean;
+  v_storage_path text;
+begin
+  if p_assignment_id is null or p_student_id is null or p_requirement_id is null then
+    raise exception 'Invalid assignment artifact deletion request' using errcode = '22023';
+  end if;
+
+  select artifact.storage_path, doc.id
+  into v_storage_path, v_doc_id
+  from public.assignment_submission_artifacts artifact
+  join public.assignment_docs doc on doc.id = artifact.assignment_doc_id
+  where doc.assignment_id = p_assignment_id
+    and doc.student_id = p_student_id
+    and artifact.requirement_id = p_requirement_id
+  for update of artifact;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', true, 'deleted', false, 'storage_path', null
+    );
+  end if;
+
+  select is_submitted into v_is_submitted
+  from public.assignment_docs
+  where id = v_doc_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_missing',
+      'error', 'Assignment doc changed before the artifact could be deleted'
+    );
+  end if;
+  if v_is_submitted then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_submitted',
+      'error', 'Cannot edit a submitted document'
+    );
+  end if;
+
+  delete from public.assignment_submission_artifacts
+  where assignment_doc_id = v_doc_id
+    and requirement_id = p_requirement_id
+  returning storage_path into v_storage_path;
+
+  return jsonb_build_object(
+    'ok', true,
+    'deleted', found,
+    'storage_path', v_storage_path
+  );
+end;
+$$;
+
+create or replace function public.claim_assignment_artifact_storage_cleanup(
+  p_lease_token uuid,
+  p_limit integer,
+  p_lease_seconds integer
+)
+returns setof public.assignment_artifact_storage_cleanup
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_lease_token is null or p_limit is null or p_limit < 1 or p_limit > 100
+    or p_lease_seconds is null or p_lease_seconds < 30 or p_lease_seconds > 900 then
+    raise exception 'Invalid assignment artifact cleanup claim' using errcode = '22023';
+  end if;
+
+  -- A committed artifact row adopts its provisional object. Removing that
+  -- evidence before claims makes a failed best-effort cancellation harmless.
+  delete from public.assignment_artifact_storage_cleanup cleanup
+  using public.assignment_submission_artifacts artifact
+  where artifact.storage_path = cleanup.storage_path;
+
+  return query
+  with candidates as (
+    select cleanup.id
+    from public.assignment_artifact_storage_cleanup cleanup
+    where ((
+        cleanup.status = 'pending'
+        and cleanup.next_attempt_at <= clock_timestamp()
+      ) or (
+        cleanup.status = 'processing'
+        and cleanup.lease_expires_at <= clock_timestamp()
+      ))
+      and not exists (
+        select 1
+        from public.assignment_submission_artifacts artifact
+        where artifact.storage_path = cleanup.storage_path
+      )
+    order by cleanup.next_attempt_at, cleanup.created_at, cleanup.id
+    limit p_limit
+    for update skip locked
+  )
+  update public.assignment_artifact_storage_cleanup cleanup
+  set status = 'processing',
+      attempt_count = cleanup.attempt_count + 1,
+      lease_token = p_lease_token,
+      lease_expires_at = clock_timestamp() + make_interval(secs => p_lease_seconds),
+      last_error = null,
+      updated_at = clock_timestamp()
+  from candidates
+  where cleanup.id = candidates.id
+  returning cleanup.*;
+end;
+$$;
+
+create or replace function public.claim_assignment_artifact_storage_cleanup_path(
+  p_storage_path text,
+  p_lease_token uuid,
+  p_lease_seconds integer
+)
+returns setof public.assignment_artifact_storage_cleanup
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_storage_path is null or btrim(p_storage_path) = '' or p_lease_token is null
+    or p_lease_seconds is null or p_lease_seconds < 30 or p_lease_seconds > 900 then
+    raise exception 'Invalid assignment artifact cleanup path claim' using errcode = '22023';
+  end if;
+
+  return query
+  update public.assignment_artifact_storage_cleanup cleanup
+  set status = 'processing',
+      attempt_count = cleanup.attempt_count + 1,
+      lease_token = p_lease_token,
+      lease_expires_at = clock_timestamp() + make_interval(secs => p_lease_seconds),
+      last_error = null,
+      updated_at = clock_timestamp()
+  where cleanup.storage_path = p_storage_path
+    and (
+      cleanup.status = 'pending'
+      or (
+        cleanup.status = 'processing'
+        and cleanup.lease_expires_at <= clock_timestamp()
+      )
+    )
+  returning cleanup.*;
+end;
+$$;
+
+create or replace function public.complete_assignment_artifact_storage_cleanup(
+  p_cleanup_id uuid,
+  p_lease_token uuid
+)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  delete from public.assignment_artifact_storage_cleanup
+  where id = p_cleanup_id
+    and status = 'processing'
+    and lease_token = p_lease_token
+    and lease_expires_at > clock_timestamp()
+  returning true;
+$$;
+
+drop function if exists public.complete_assignment_artifact_storage_cleanup_path(text);
+
+create or replace function public.fail_assignment_artifact_storage_cleanup(
+  p_cleanup_id uuid,
+  p_lease_token uuid,
+  p_error text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.assignment_artifact_storage_cleanup cleanup
+  set status = 'pending',
+      next_attempt_at = clock_timestamp()
+        + make_interval(
+          secs => least(3600, (power(2::numeric, least(cleanup.attempt_count, 6)) * 60)::integer)
+        ),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error = left(coalesce(p_error, 'Storage cleanup failed'), 1000),
+      updated_at = clock_timestamp()
+  where cleanup.id = p_cleanup_id
+    and cleanup.status = 'processing'
+    and cleanup.lease_token = p_lease_token
+    and cleanup.lease_expires_at > clock_timestamp();
+  return found;
+end;
+$$;
+
+-- Old app instances call this RPC directly during migration-first rollout.
+-- Acquire the same assignment lock as the combined authoring RPC before row DML.
+create or replace function public.replace_assignment_submission_requirements_atomic(
+  p_assignment_id uuid,
+  p_requirements jsonb
+)
+returns setof public.assignment_submission_requirements
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_requirement jsonb;
+  v_requirement_id uuid;
+  v_existing_id uuid;
+  v_type text;
+  v_label text;
+  v_instructions text;
+  v_required boolean;
+  v_position integer;
+  v_policy jsonb;
+  v_preserved_ids uuid[] := array[]::uuid[];
+  v_index integer := 0;
+begin
+  if p_requirements is null or jsonb_typeof(p_requirements) <> 'array' then
+    raise exception 'p_requirements must be a JSON array';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('assignment_submission:' || p_assignment_id::text, 0)
+  );
+
+  for v_requirement in select value from jsonb_array_elements(p_requirements)
+  loop
+    v_type := v_requirement->>'type';
+    if v_type not in ('repo_link', 'link', 'image') then
+      raise exception 'Invalid assignment submission requirement type: %', coalesce(v_type, '<null>');
+    end if;
+
+    begin
+      v_requirement_id := nullif(v_requirement->>'id', '')::uuid;
+    exception when invalid_text_representation then
+      v_requirement_id := null;
+    end;
+
+    v_label := nullif(btrim(coalesce(v_requirement->>'label', '')), '');
+    if v_label is null then
+      v_label := case v_type
+        when 'repo_link' then 'Repo link'
+        when 'image' then 'Screenshot'
+        else 'Public link'
+      end;
+    end if;
+
+    v_instructions := btrim(coalesce(v_requirement->>'instructions', ''));
+    v_required := coalesce((v_requirement->>'required')::boolean, true);
+    v_position := coalesce((v_requirement->>'position')::integer, v_index);
+    v_policy := case
+      when jsonb_typeof(v_requirement->'validation_policy_json') = 'object'
+        then v_requirement->'validation_policy_json'
+      else '{}'::jsonb
+    end;
+
+    v_existing_id := null;
+    if v_requirement_id is not null then
+      update public.assignment_submission_requirements
+      set label = v_label,
+          instructions = v_instructions,
+          required = v_required,
+          position = v_position,
+          validation_policy_json = v_policy
+      where id = v_requirement_id
+        and assignment_id = p_assignment_id
+        and type = v_type
+      returning id into v_existing_id;
+    end if;
+
+    if v_existing_id is null then
+      insert into public.assignment_submission_requirements (
+        assignment_id, type, label, instructions, required, position, validation_policy_json
+      ) values (
+        p_assignment_id, v_type, v_label, v_instructions, v_required, v_position, v_policy
+      ) returning id into v_existing_id;
+    end if;
+
+    v_preserved_ids := array_append(v_preserved_ids, v_existing_id);
+    v_index := v_index + 1;
+  end loop;
+
+  delete from public.assignment_submission_requirements
+  where assignment_id = p_assignment_id
+    and not (id = any(v_preserved_ids));
+
+  return query
+  select *
+  from public.assignment_submission_requirements
+  where assignment_id = p_assignment_id
+  order by position asc, created_at asc;
+end;
+$$;
+
+create or replace function public.update_assignment_with_submission_requirements_atomic(
+  p_assignment_id uuid,
+  p_updates jsonb,
+  p_requirements jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_assignment public.assignments;
+  v_requirements jsonb;
+  v_artifact_id uuid;
+  v_doc_id uuid;
+begin
+  if p_assignment_id is null
+    or p_updates is null
+    or jsonb_typeof(p_updates) <> 'object'
+    or p_requirements is null
+    or jsonb_typeof(p_requirements) <> 'array' then
+    raise exception 'Invalid assignment requirement update request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('assignment_submission:' || p_assignment_id::text, 0)
+  );
+
+  select * into v_assignment
+  from public.assignments
+  where id = p_assignment_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 404, 'error_code', 'assignment_not_found',
+      'error', 'Assignment not found'
+    );
+  end if;
+
+  for v_artifact_id in
+    select artifact.id
+    from public.assignment_submission_artifacts artifact
+    join public.assignment_docs doc on doc.id = artifact.assignment_doc_id
+    where doc.assignment_id = p_assignment_id
+    order by artifact.id
+    for update of artifact
+  loop
+    null;
+  end loop;
+
+  for v_doc_id in
+    select doc.id
+    from public.assignment_docs doc
+    where doc.assignment_id = p_assignment_id
+    order by doc.id
+    for update
+  loop
+    null;
+  end loop;
+
+  if exists (
+    select 1 from public.assignment_docs
+    where assignment_id = p_assignment_id and is_submitted is true
+  ) then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_requirements_submitted',
+      'error', 'Submission requirements cannot be changed after a student submits.'
+    );
+  end if;
+
+  if p_updates <> '{}'::jsonb then
+    update public.assignments
+    set title = case when p_updates ? 'title' then p_updates->>'title' else title end,
+      instructions_markdown = case
+        when p_updates ? 'instructions_markdown' then p_updates->>'instructions_markdown'
+        else instructions_markdown
+      end,
+      description = case
+        when p_updates ? 'description' then p_updates->>'description'
+        else description
+      end,
+      rich_instructions = case
+        when p_updates ? 'rich_instructions' then p_updates->'rich_instructions'
+        else rich_instructions
+      end,
+      due_at = case
+        when p_updates ? 'due_at' then (p_updates->>'due_at')::timestamptz
+        else due_at
+      end,
+      is_draft = case
+        when p_updates ? 'is_draft' then (p_updates->>'is_draft')::boolean
+        else is_draft
+      end,
+      released_at = case
+        when not (p_updates ? 'released_at') then released_at
+        when p_updates->'released_at' = 'null'::jsonb then null
+        else (p_updates->>'released_at')::timestamptz
+      end
+    where id = p_assignment_id
+    returning * into v_assignment;
+  end if;
+
+  select coalesce(jsonb_agg(to_jsonb(r) order by r.position, r.created_at, r.id), '[]'::jsonb)
+  into v_requirements
+  from public.replace_assignment_submission_requirements_atomic(
+    p_assignment_id,
+    p_requirements
+  ) r;
+
+  return jsonb_build_object(
+    'ok', true,
+    'assignment', to_jsonb(v_assignment),
+    'submission_requirements', v_requirements
+  );
+end;
+$$;
+
+revoke all on function public.guard_assignment_submission_requirement_mutation() from public, anon, authenticated, service_role;
+revoke all on function public.guard_assignment_submission_artifact_mutation() from public, anon, authenticated, service_role;
+revoke all on function private.validate_assignment_submission_requirements(public.assignment_docs) from public, anon, authenticated, service_role;
+revoke all on function public.validate_assignment_submission_transition() from public, anon, authenticated, service_role;
+revoke all on function public.guard_assignment_doc_history_after_submit() from public, anon, authenticated, service_role;
+revoke all on function public.guard_submitted_assignment_doc_content() from public, anon, authenticated, service_role;
+revoke all on function public.enqueue_deleted_assignment_artifact_storage_cleanup() from public, anon, authenticated, service_role;
+revoke all on function public.ensure_current_assignment_submit_history() from public, anon, authenticated, service_role;
+revoke all on function private.assignment_content_sha256(jsonb) from public, anon, authenticated, service_role;
+revoke all on function private.assignment_tiptap_node_text(jsonb) from public, anon, authenticated, service_role;
+revoke all on function private.assignment_tiptap_plain_text(jsonb) from public, anon, authenticated, service_role;
+revoke all on function public.save_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, text, integer, integer, jsonb, jsonb, integer, integer, uuid, bigint, uuid) from public, anon, authenticated;
+revoke all on function public.submit_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, integer, integer) from public, anon, authenticated;
+revoke all on function public.unsubmit_assignment_doc_atomic(uuid, uuid) from public, anon, authenticated;
+revoke all on function public.delete_assignment_submission_artifact_atomic(uuid, uuid, uuid) from public, anon, authenticated;
+revoke all on function public.claim_assignment_artifact_storage_cleanup(uuid, integer, integer) from public, anon, authenticated;
+revoke all on function public.claim_assignment_artifact_storage_cleanup_path(text, uuid, integer) from public, anon, authenticated;
+revoke all on function public.complete_assignment_artifact_storage_cleanup(uuid, uuid) from public, anon, authenticated;
+revoke all on function public.fail_assignment_artifact_storage_cleanup(uuid, uuid, text) from public, anon, authenticated;
+revoke all on function public.enqueue_assignment_artifact_storage_cleanup_path(text, integer) from public, anon, authenticated;
+revoke all on function public.cleanup_assignment_doc_save_operations(timestamptz) from public, anon, authenticated;
+revoke all on function public.update_assignment_with_submission_requirements_atomic(uuid, jsonb, jsonb) from public, anon, authenticated;
+revoke all on function public.normalize_classroom_archive_restore_row(uuid, text, jsonb) from public, anon, authenticated;
+revoke all on table public.assignment_artifact_storage_cleanup from anon, authenticated;
+revoke all on table public.assignment_doc_save_operations from anon, authenticated;
+grant select, insert, delete on table public.assignment_artifact_storage_cleanup to service_role;
+
+grant execute on function public.save_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, text, integer, integer, jsonb, jsonb, integer, integer, uuid, bigint, uuid) to service_role;
+grant execute on function public.submit_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, integer, integer) to service_role;
+grant execute on function public.unsubmit_assignment_doc_atomic(uuid, uuid) to service_role;
+grant execute on function public.delete_assignment_submission_artifact_atomic(uuid, uuid, uuid) to service_role;
+grant execute on function public.claim_assignment_artifact_storage_cleanup(uuid, integer, integer) to service_role;
+grant execute on function public.claim_assignment_artifact_storage_cleanup_path(text, uuid, integer) to service_role;
+grant execute on function public.complete_assignment_artifact_storage_cleanup(uuid, uuid) to service_role;
+grant execute on function public.fail_assignment_artifact_storage_cleanup(uuid, uuid, text) to service_role;
+grant execute on function public.enqueue_assignment_artifact_storage_cleanup_path(text, integer) to service_role;
+grant execute on function public.cleanup_assignment_doc_save_operations(timestamptz) to service_role;
+grant execute on function public.update_assignment_with_submission_requirements_atomic(uuid, jsonb, jsonb) to service_role;
+grant execute on function public.normalize_classroom_archive_restore_row(uuid, text, jsonb) to service_role;
+grant select, insert, update, delete on table public.assignment_artifact_storage_cleanup to service_role;
+grant select, insert, update, delete on table public.assignment_doc_save_operations to service_role;
+
+comment on function public.guard_assignment_submission_requirement_mutation() is
+  'Prevents requirement changes from invalidating existing submitted assignment documents.';
+comment on function public.guard_assignment_submission_artifact_mutation() is
+  'Locks the owning assignment document and rejects artifact mutations after submission.';
+comment on function private.validate_assignment_submission_requirements(public.assignment_docs) is
+  'Validates structured assignment evidence for a locked assignment document.';
+comment on function public.guard_assignment_doc_history_after_submit() is
+  'Serializes history writes with submission and preserves authoritative submit entries.';
+comment on function public.save_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, text, integer, integer, jsonb, jsonb, integer, integer, uuid, bigint, uuid) is
+  'Atomically saves one assignment draft and its versioned history evidence.';
+comment on table public.assignment_doc_save_operations is
+  'Compact assignment save idempotency digests retained slightly longer than browser recovery drafts.';
+comment on function public.submit_assignment_doc_atomic(uuid, uuid, jsonb, timestamptz, integer, integer) is
+  'Atomically submits one assignment document and records its authoritative snapshot.';
+comment on function public.unsubmit_assignment_doc_atomic(uuid, uuid) is
+  'Atomically unsubmits one assignment document unless teacher return state has already won the row lock.';
+comment on function public.delete_assignment_submission_artifact_atomic(uuid, uuid, uuid) is
+  'Deletes one unsubmitted assignment artifact and durably queues its Storage object for cleanup.';
+comment on function public.claim_assignment_artifact_storage_cleanup(uuid, integer, integer) is
+  'Claims due assignment artifact Storage cleanup rows with an expiring lease.';
+comment on function public.claim_assignment_artifact_storage_cleanup_path(text, uuid, integer) is
+  'Claims one exact assignment artifact Storage path without revoking another worker lease.';
+comment on function public.update_assignment_with_submission_requirements_atomic(uuid, jsonb, jsonb) is
+  'Atomically updates assignment fields and submission requirements before any student submission.';
+comment on function public.normalize_classroom_archive_restore_row(uuid, text, jsonb) is
+  'Adapts verified archive rows to the current schema, including pre-099 assignment document save fences.';

--- a/tests/api/assignment-docs/artifacts.test.ts
+++ b/tests/api/assignment-docs/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
-import { POST } from '@/app/api/assignment-docs/[id]/artifacts/[requirementId]/route'
+import { DELETE, POST, PUT } from '@/app/api/assignment-docs/[id]/artifacts/[requirementId]/route'
 
 const mocks = vi.hoisted(() => ({
   supabase: null as any,
@@ -35,25 +35,36 @@ function chainSingle(data: unknown, error: unknown = null) {
 function makeArtifactTable(opts: {
   previousStoragePath?: string | null
   upsertError?: unknown
+  upsertThrowsAfterCommit?: boolean
+  deleteError?: unknown
+  artifactReferenceExists?: boolean
+  previousLookupError?: unknown
 }) {
   return {
     select: vi.fn(() => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          maybeSingle: vi.fn(async () => ({
-            data: opts.previousStoragePath
-              ? { id: 'artifact-old', storage_path: opts.previousStoragePath }
-              : null,
-            error: null,
-          })),
-        })),
-      })),
+      eq: vi.fn((column: string) => column === 'storage_path'
+        ? {
+            maybeSingle: vi.fn(async () => ({
+              data: opts.artifactReferenceExists ? { id: 'artifact-new' } : null,
+              error: null,
+            })),
+          }
+        : {
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({
+                data: opts.previousStoragePath
+                  ? { id: 'artifact-old', storage_path: opts.previousStoragePath }
+                  : null,
+                error: opts.previousLookupError ?? null,
+              })),
+            })),
+          }),
     })),
     upsert: vi.fn((row: any) => ({
       select: vi.fn(() => ({
-        single: vi.fn(async () => opts.upsertError
-          ? { data: null, error: opts.upsertError }
-          : {
+        single: vi.fn(async () => {
+          if (opts.upsertThrowsAfterCommit) throw new Error('response lost after commit')
+          return opts.upsertError ? { data: null, error: opts.upsertError } : {
               data: {
                 id: 'artifact-new',
                 assignment_doc_id: row.assignment_doc_id,
@@ -67,12 +78,13 @@ function makeArtifactTable(opts: {
                 validation_message: row.validation_message,
               },
               error: null,
-            }),
+            }
+        }),
       })),
     })),
     delete: vi.fn(() => ({
       eq: vi.fn(() => ({
-        eq: vi.fn(async () => ({ error: null })),
+        eq: vi.fn(async () => ({ error: opts.deleteError ?? null })),
       })),
     })),
   }
@@ -81,19 +93,96 @@ function makeArtifactTable(opts: {
 function makeSupabase(opts: {
   previousStoragePath?: string | null
   upsertError?: unknown
+  upsertThrowsAfterCommit?: boolean
+  deleteError?: unknown
+  storageRemoveError?: unknown
+  cleanupCompletionData?: boolean
+  requirementType?: 'image' | 'link'
+  provisionalInsertError?: unknown
+  provisionalAdoptError?: unknown
+  artifactReferenceExists?: boolean
+  uploadError?: unknown
+  previousLookupError?: unknown
 }) {
-  const upload = vi.fn(async () => ({ error: null }))
+  const upload = vi.fn(async () => ({ error: opts.uploadError ?? null }))
   const createSignedUrl = vi.fn(async () => ({ data: { signedUrl: 'https://signed.example/image.png' }, error: null }))
-  const remove = vi.fn(async () => ({ error: null }))
+  const remove = vi.fn(async () => ({ error: opts.storageRemoveError ?? null }))
   const artifactTable = makeArtifactTable({
     previousStoragePath: opts.previousStoragePath,
     upsertError: opts.upsertError,
+    upsertThrowsAfterCommit: opts.upsertThrowsAfterCommit,
+    deleteError: opts.deleteError,
+    artifactReferenceExists: opts.artifactReferenceExists,
+    previousLookupError: opts.previousLookupError,
+  })
+  const cleanupInsert = vi.fn((row: Record<string, unknown>) => ({
+    select: vi.fn(() => ({
+      single: vi.fn(async () => opts.provisionalInsertError
+        ? { data: null, error: opts.provisionalInsertError }
+        : {
+            data: {
+              id: '10000000-0000-4000-8000-000000000001',
+              storage_path: row.storage_path,
+            },
+            error: null,
+          }),
+    })),
+  }))
+  const cleanupDelete = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => opts.provisionalAdoptError
+              ? { data: null, error: opts.provisionalAdoptError }
+              : { data: { id: '10000000-0000-4000-8000-000000000001' }, error: null }),
+          })),
+        })),
+      })),
+    })),
+  }))
+  const cleanupTable = { insert: cleanupInsert, delete: cleanupDelete }
+  const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
+    if (name === 'delete_assignment_submission_artifact_atomic') {
+      return {
+        data: {
+          ok: true,
+          deleted: Boolean(opts.previousStoragePath),
+          storage_path: opts.previousStoragePath ?? null,
+        },
+        error: null,
+      }
+    }
+    if (name === 'claim_assignment_artifact_storage_cleanup_path') {
+      return {
+        data: [{
+          id: '10000000-0000-4000-8000-000000000099',
+          storage_path: args.p_storage_path,
+          lease_token: args.p_lease_token,
+        }],
+        error: null,
+      }
+    }
+    if (name === 'complete_assignment_artifact_storage_cleanup') {
+      return { data: opts.cleanupCompletionData ?? true, error: null }
+    }
+    if (name === 'fail_assignment_artifact_storage_cleanup') {
+      return { data: true, error: null }
+    }
+    if (name === 'enqueue_assignment_artifact_storage_cleanup_path') {
+      return { data: true, error: null }
+    }
+    throw new Error(`Unexpected RPC ${name}: ${JSON.stringify(args)}`)
   })
 
   return {
     upload,
     createSignedUrl,
     remove,
+    artifactTable,
+    cleanupDelete,
+    cleanupInsert,
+    rpc,
     from: vi.fn((table: string) => {
       if (table === 'assignments') {
         return chainSingle({ id: 'assignment-1', classroom_id: 'class-1', is_draft: false, released_at: '2026-05-01T00:00:00.000Z' })
@@ -107,7 +196,7 @@ function makeSupabase(opts: {
                   data: {
                     id: 'req-image',
                     assignment_id: 'assignment-1',
-                    type: 'image',
+                    type: opts.requirementType ?? 'image',
                     label: 'Screenshot',
                     instructions: '',
                     required: true,
@@ -138,6 +227,7 @@ function makeSupabase(opts: {
         }
       }
       if (table === 'assignment_submission_artifacts') return artifactTable
+      if (table === 'assignment_artifact_storage_cleanup') return cleanupTable
       throw new Error(`Unexpected table ${table}`)
     }),
     storage: {
@@ -162,6 +252,62 @@ async function postImage() {
   )
 }
 
+async function deleteArtifact() {
+  return DELETE(
+    {} as NextRequest,
+    { params: Promise.resolve({ id: 'assignment-1', requirementId: 'req-image' }) }
+  )
+}
+
+async function putArtifact(body: unknown) {
+  return putRawArtifact(JSON.stringify(body))
+}
+
+async function putRawArtifact(body: string) {
+  return PUT(
+    new NextRequest('http://localhost/api/assignment-docs/assignment-1/artifacts/req-image', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    }),
+    { params: Promise.resolve({ id: 'assignment-1', requirementId: 'req-image' }) }
+  )
+}
+
+describe('PUT /api/assignment-docs/[id]/artifacts/[requirementId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects non-object JSON at the strict request boundary', async () => {
+    mocks.supabase = makeSupabase({ requirementType: 'link' })
+
+    const response = await putArtifact(null)
+
+    expect(response.status).toBe(400)
+    expect(mocks.supabase.from).not.toHaveBeenCalled()
+  })
+
+  it('maps a raw malformed JSON body to 400 through the shared handler', async () => {
+    mocks.supabase = makeSupabase({ requirementType: 'link' })
+
+    const response = await putRawArtifact('{"url":')
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'Malformed JSON body' })
+    expect(mocks.supabase.from).not.toHaveBeenCalled()
+  })
+
+  it('accepts a strict link artifact payload', async () => {
+    mocks.supabase = makeSupabase({ requirementType: 'link' })
+
+    const response = await putArtifact({ url: 'https://example.com/evidence' })
+
+    expect(response.status).toBe(200)
+  })
+})
+
 describe('POST /api/assignment-docs/[id]/artifacts/[requirementId]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -174,6 +320,28 @@ describe('POST /api/assignment-docs/[id]/artifacts/[requirementId]', () => {
 
     expect(response.status).toBe(200)
     expect(mocks.supabase.remove).toHaveBeenCalledWith(['student-1/assignment-1/old.png'])
+  })
+
+  it('records delayed provisional evidence before upload and adopts it after row commit', async () => {
+    mocks.supabase = makeSupabase({})
+
+    const response = await postImage()
+
+    expect(response.status).toBe(200)
+    expect(mocks.supabase.cleanupInsert).toHaveBeenCalledWith(expect.objectContaining({
+      storage_path: expect.stringContaining('student-1/assignment-1/req-image-'),
+      status: 'pending',
+      next_attempt_at: expect.any(String),
+    }))
+    expect(mocks.supabase.upload.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.supabase.cleanupInsert.mock.invocationCallOrder[0]
+    )
+    expect(mocks.supabase.artifactTable.upsert.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.supabase.upload.mock.invocationCallOrder[0]
+    )
+    expect(mocks.supabase.cleanupDelete.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.supabase.artifactTable.upsert.mock.invocationCallOrder[0]
+    )
   })
 
   it('removes the newly uploaded screenshot if the artifact row cannot be saved', async () => {
@@ -189,5 +357,132 @@ describe('POST /api/assignment-docs/[id]/artifacts/[requirementId]', () => {
       expect.stringContaining('student-1/assignment-1/req-image-'),
     ])
     expect(mocks.supabase.remove).not.toHaveBeenCalledWith(['student-1/assignment-1/old.png'])
+  })
+
+  it('does not upload when provisional cleanup evidence cannot be created', async () => {
+    mocks.supabase = makeSupabase({
+      provisionalInsertError: { message: 'provisional write failed' },
+    })
+
+    const response = await postImage()
+
+    expect(response.status).toBe(500)
+    expect(mocks.supabase.upload).not.toHaveBeenCalled()
+    expect(mocks.supabase.remove).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an artifact when the previous-path lookup fails', async () => {
+    mocks.supabase = makeSupabase({
+      previousLookupError: { message: 'lookup unavailable' },
+    })
+
+    const response = await postImage()
+
+    expect(response.status).toBe(500)
+    expect(mocks.supabase.cleanupInsert).not.toHaveBeenCalled()
+    expect(mocks.supabase.upload).not.toHaveBeenCalled()
+    expect(mocks.supabase.artifactTable.upsert).not.toHaveBeenCalled()
+  })
+
+  it('retains provisional cleanup evidence when the upload response is an error', async () => {
+    mocks.supabase = makeSupabase({
+      uploadError: { message: 'upload response lost' },
+    })
+
+    const response = await postImage()
+
+    expect(response.status).toBe(500)
+    expect(mocks.supabase.upload).toHaveBeenCalled()
+    expect(mocks.supabase.cleanupDelete).not.toHaveBeenCalled()
+    expect(mocks.supabase.remove).not.toHaveBeenCalled()
+  })
+
+  it('returns a conflict and keeps the previous artifact when submission wins the race', async () => {
+    mocks.supabase = makeSupabase({
+      previousStoragePath: 'student-1/assignment-1/old.png',
+      upsertError: {
+        code: '23514',
+        message: 'assignment_artifact_submitted_document_immutable',
+      },
+    })
+
+    const response = await postImage()
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe('Cannot edit a submitted document')
+    expect(mocks.supabase.remove).toHaveBeenCalledWith([
+      expect.stringContaining('student-1/assignment-1/req-image-'),
+    ])
+    expect(mocks.supabase.remove).not.toHaveBeenCalledWith(['student-1/assignment-1/old.png'])
+  })
+
+  it('does not compensate a committed artifact when the upsert response is lost', async () => {
+    mocks.supabase = makeSupabase({
+      upsertThrowsAfterCommit: true,
+      artifactReferenceExists: true,
+    })
+
+    const response = await postImage()
+
+    expect(response.status).toBe(500)
+    expect(mocks.supabase.remove).not.toHaveBeenCalled()
+    expect(mocks.supabase.cleanupDelete).toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/assignment-docs/[id]/artifacts/[requirementId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deletes the artifact row atomically before cleaning up Storage', async () => {
+    mocks.supabase = makeSupabase({ previousStoragePath: 'student-1/assignment-1/old.png' })
+
+    const response = await deleteArtifact()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ ok: true, cleanup_pending: false })
+    const deleteCallOrder = mocks.supabase.rpc.mock.invocationCallOrder[0]
+    expect(mocks.supabase.remove.mock.invocationCallOrder[0]).toBeGreaterThan(deleteCallOrder)
+    expect(mocks.supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000099' })
+    )
+  })
+
+  it('returns accepted with durable cleanup pending when Storage deletion fails', async () => {
+    mocks.supabase = makeSupabase({
+      previousStoragePath: 'student-1/assignment-1/old.png',
+      storageRemoveError: { message: 'storage unavailable' },
+    })
+
+    const response = await deleteArtifact()
+    const data = await response.json()
+
+    expect(response.status).toBe(202)
+    expect(data).toEqual({ ok: true, cleanup_pending: true })
+    expect(mocks.supabase.rpc).toHaveBeenCalledWith(
+      'delete_assignment_submission_artifact_atomic',
+      expect.objectContaining({ p_requirement_id: 'req-image' })
+    )
+    expect(mocks.supabase.rpc).not.toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.anything()
+    )
+  })
+
+  it('returns accepted while durable cleanup completion evidence is still pending', async () => {
+    mocks.supabase = makeSupabase({
+      previousStoragePath: 'student-1/assignment-1/old.png',
+      cleanupCompletionData: false,
+    })
+
+    const response = await deleteArtifact()
+    const data = await response.json()
+
+    expect(response.status).toBe(202)
+    expect(data).toEqual({ ok: true, cleanup_pending: true })
   })
 })

--- a/tests/api/assignment-docs/assignment-docs-id.test.ts
+++ b/tests/api/assignment-docs/assignment-docs-id.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PATCH } from '@/app/api/assignment-docs/[id]/route'
 import { NextRequest } from 'next/server'
 import * as auth from '@/lib/auth'
+import { saveAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({
@@ -17,6 +18,9 @@ vi.mock('@/lib/server/classrooms', () => ({
     ok: true,
     classroom: { id: 'class-1', archived_at: null },
   })),
+}))
+vi.mock('@/lib/server/assignment-doc-submissions', () => ({
+  saveAssignmentDocAtomic: vi.fn(),
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -109,8 +113,16 @@ describe('GET /api/assignment-docs/[id]', () => {
   })
 
   it('refreshes viewed_at when returned feedback is newer than the last view', async () => {
+    const refreshedRevision = '2026-01-03T00:00:00.000Z'
     const viewedUpdate = vi.fn(() => ({
-      eq: vi.fn().mockResolvedValue({ error: null }),
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: { updated_at: refreshedRevision },
+            error: null,
+          }),
+        })),
+      })),
     }))
     const existingDoc = {
       id: 'doc-1',
@@ -161,6 +173,7 @@ describe('GET /api/assignment-docs/[id]', () => {
 
     expect(response.status).toBe(200)
     expect(data.wasFirstView).toBe(true)
+    expect(data.doc.updated_at).toBe(refreshedRevision)
     expect(viewedUpdate).toHaveBeenCalledWith({
       viewed_at: expect.stringMatching(/^20/),
     })
@@ -414,42 +427,20 @@ describe('PATCH /api/assignment-docs/[id]', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/doc-1', {
       method: 'PATCH',
-      body: JSON.stringify({ content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'new content' }] }] } }),
+      body: JSON.stringify({
+        content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'new content' }] }] },
+        expected_updated_at: '2025-01-01T00:00:00.000Z',
+        save_session_id: '10000000-0000-4000-8000-000000000001',
+        save_sequence: 1,
+        metric_session_id: '10000000-0000-4000-8000-000000000002',
+      }),
     })
 
     const response = await PATCH(request, { params: { id: 'doc-1' } })
     expect(response.status).toBe(403)
   })
 
-  it('updates last history entry when rate-limited', async () => {
-    const now = new Date('2025-01-01T00:00:05Z').getTime()
-    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
-
-    const historyUpdate = vi.fn(() => ({
-      eq: vi.fn(() => ({
-        select: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({
-            data: {
-              id: 'history-1',
-              assignment_doc_id: 'doc-1',
-              patch: null,
-              snapshot: null,
-              word_count: 3,
-              char_count: 3,
-              trigger: 'autosave',
-              created_at: new Date(now).toISOString(),
-            },
-            error: null,
-          }),
-        })),
-      })),
-    }))
-    const historyInsert = vi.fn(() => ({
-      select: vi.fn(() => ({
-        single: vi.fn().mockResolvedValue({ data: null, error: null }),
-      })),
-    }))
-
+  it('saves content and history through the atomic assignment operation', async () => {
     const beforeContent = {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Old' }] }],
@@ -458,6 +449,29 @@ describe('PATCH /api/assignment-docs/[id]', () => {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New' }] }],
     }
+    const savedRevision = '2025-01-01T00:00:00.000Z'
+    const historyEntry = {
+      id: 'history-1',
+      assignment_doc_id: 'doc-1',
+      patch: null,
+      snapshot: newContent,
+      word_count: 1,
+      char_count: 3,
+      trigger: 'autosave',
+      created_at: '2025-01-01T00:00:05.000Z',
+    }
+    vi.mocked(saveAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: {
+        id: 'doc-1',
+        content: newContent,
+        updated_at: '2025-01-01T00:00:05.000Z',
+        teacher_feedback_draft: 'Private teacher draft',
+        ai_feedback_suggestion: 'Private AI suggestion',
+        authenticity_score: 91,
+      } as any,
+      historyEntry: historyEntry as any,
+    })
 
     const mockFrom = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -489,33 +503,6 @@ describe('PATCH /api/assignment-docs/[id]', () => {
               error: null,
             }),
           })),
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: { id: 'doc-1', content: newContent },
-                  error: null,
-                }),
-              })),
-            })),
-          })),
-        }
-      }
-      if (table === 'assignment_doc_history') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn(() => ({
-              limit: vi.fn(() => ({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: { id: 'history-1', created_at: new Date(now - 5000).toISOString(), snapshot: null },
-                  error: null,
-                }),
-              })),
-            })),
-          })),
-          update: historyUpdate,
-          insert: historyInsert,
         }
       }
     })
@@ -523,14 +510,156 @@ describe('PATCH /api/assignment-docs/[id]', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1', {
       method: 'PATCH',
-      body: JSON.stringify({ content: newContent }),
+      body: JSON.stringify({
+        content: newContent,
+        expected_updated_at: savedRevision,
+        save_session_id: '10000000-0000-4000-8000-000000000001',
+        save_sequence: 1,
+        metric_session_id: '10000000-0000-4000-8000-000000000002',
+      }),
     })
 
     const response = await PATCH(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
     expect(response.status).toBe(200)
-    expect(historyUpdate).toHaveBeenCalled()
-    expect(historyInsert).not.toHaveBeenCalled()
-    dateSpy.mockRestore()
+    expect(data.historyEntry).toEqual(historyEntry)
+    expect(data.doc).toEqual(expect.objectContaining({
+      teacher_feedback_draft: null,
+      ai_feedback_suggestion: null,
+      authenticity_score: null,
+    }))
+    expect(saveAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assign-1',
+      studentId: 'student-1',
+      previousContent: beforeContent,
+      content: newContent,
+      expectedUpdatedAt: savedRevision,
+    }))
+  })
+
+  it('does not overwrite a document submitted while its save was in flight', async () => {
+    vi.mocked(saveAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      error: 'This draft changed elsewhere before the save completed. Reload and review the latest version.',
+      errorCode: 'assignment_doc_revision_conflict',
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                is_submitted: false,
+                content: { type: 'doc', content: [] },
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          content: {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Late save' }] }],
+          },
+          expected_updated_at: '2025-01-01T00:00:00.000Z',
+          save_session_id: '10000000-0000-4000-8000-000000000001',
+          save_sequence: 1,
+          metric_session_id: '10000000-0000-4000-8000-000000000002',
+        }),
+      }),
+      { params: { id: 'assign-1' } },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe(
+      'This draft changed elsewhere before the save completed. Reload and review the latest version.',
+    )
+    expect(data.error_code).toBe('assignment_doc_revision_conflict')
+    expect(saveAssignmentDocAtomic).toHaveBeenCalledOnce()
+  })
+
+  it('adapts a strict legacy save payload during the rollout window', async () => {
+    const revision = '2025-01-01T00:00:00.000Z'
+    const content = { type: 'doc', content: [] }
+    vi.mocked(saveAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: { id: 'doc-1', content, updated_at: revision } as any,
+      historyEntry: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                is_submitted: false,
+                content,
+                updated_at: revision,
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ content }),
+      }),
+      { params: { id: 'assign-1' } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(saveAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      expectedUpdatedAt: revision,
+      saveSessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      saveSequence: 1,
+    }))
   })
 
   it('keeps assignment doc content updates student-only', async () => {

--- a/tests/api/assignment-docs/restore.test.ts
+++ b/tests/api/assignment-docs/restore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { POST } from '@/app/api/assignment-docs/[id]/restore/route'
 import { NextRequest } from 'next/server'
+import { saveAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1', role: 'student' })) }))
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
@@ -10,8 +11,12 @@ vi.mock('@/lib/server/classrooms', () => ({
     classroom: { id: 'class-1', archived_at: null },
   })),
 }))
+vi.mock('@/lib/server/assignment-doc-submissions', () => ({
+  saveAssignmentDocAtomic: vi.fn(),
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
+const HISTORY_ID = '10000000-0000-4000-8000-000000000001'
 
 describe('POST /api/assignment-docs/[id]/restore', () => {
   it('returns 400 when history_id is missing', async () => {
@@ -24,13 +29,27 @@ describe('POST /api/assignment-docs/[id]/restore', () => {
     expect(response.status).toBe(400)
   })
 
+  it('returns 400 when history_id is not a UUID', async () => {
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/restore', {
+      method: 'POST',
+      body: JSON.stringify({ history_id: 'history-1' })
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(400)
+  })
+
   it('records a restore snapshot after restoring', async () => {
     const restoredContent = {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Restored' }] }],
     }
 
-    const historyInsert = vi.fn().mockResolvedValue({ data: null, error: null })
+    vi.mocked(saveAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: { id: 'doc-1', content: restoredContent } as any,
+      historyEntry: null,
+    })
 
     const mockFrom = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -58,19 +77,14 @@ describe('POST /api/assignment-docs/[id]/restore', () => {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({
-              data: { id: 'doc-1', is_submitted: false },
+              data: {
+                id: 'doc-1',
+                is_submitted: false,
+                content: { type: 'doc', content: [] },
+                updated_at: '2025-01-01T00:00:00.000Z',
+              },
               error: null,
             }),
-          })),
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: { id: 'doc-1', content: restoredContent },
-                  error: null,
-                }),
-              })),
-            })),
           })),
         }
       }
@@ -81,7 +95,7 @@ describe('POST /api/assignment-docs/[id]/restore', () => {
               order: vi.fn().mockResolvedValue({
                 data: [
                   {
-                    id: 'history-1',
+                    id: HISTORY_ID,
                     assignment_doc_id: 'doc-1',
                     patch: null,
                     snapshot: restoredContent,
@@ -95,7 +109,6 @@ describe('POST /api/assignment-docs/[id]/restore', () => {
               }),
             })),
           })),
-          insert: historyInsert,
         }
       }
     })
@@ -103,17 +116,17 @@ describe('POST /api/assignment-docs/[id]/restore', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/restore', {
       method: 'POST',
-      body: JSON.stringify({ history_id: 'history-1' })
+      body: JSON.stringify({ history_id: HISTORY_ID })
     })
 
     const response = await POST(request, { params: { id: 'assign-1' } })
     expect(response.status).toBe(200)
-    expect(historyInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assignment_doc_id: 'doc-1',
-        snapshot: restoredContent,
-        trigger: 'restore',
-      })
-    )
+    expect(saveAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assign-1',
+      previousContent: { type: 'doc', content: [] },
+      content: restoredContent,
+      expectedUpdatedAt: '2025-01-01T00:00:00.000Z',
+      trigger: 'restore',
+    }))
   })
 })

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '@/app/api/assignment-docs/[id]/submit/route'
 import { NextRequest } from 'next/server'
+import { submitAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1', role: 'student' })) }))
@@ -15,7 +16,19 @@ vi.mock('@/lib/server/classrooms', () => ({
   })),
 }))
 vi.mock('@/lib/authenticity', () => ({
-  analyzeAuthenticity: vi.fn(() => ({ score: 0.82, flags: ['steady_revision'] })),
+  analyzeAuthenticity: vi.fn(() => ({
+    score: 0.82,
+    flags: [{
+      timestamp: '2026-07-16T12:00:00.000Z',
+      wordDelta: 10,
+      seconds: 2,
+      wps: 5,
+      reason: 'high_wps',
+    }],
+  })),
+}))
+vi.mock('@/lib/server/assignment-doc-submissions', () => ({
+  submitAssignmentDocAtomic: vi.fn(),
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -24,6 +37,36 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.from = vi.fn()
+  })
+
+  it('rejects invalid submitted content before reading assignment data', async () => {
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: null }),
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('content: Invalid content format')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed nested Tiptap nodes before reading assignment data', async () => {
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: { type: 'doc', content: [{ type: 'paragraph', content: [null] }] },
+        expected_updated_at: '2026-04-20T14:00:00.000Z',
+      }),
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(400)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
   })
 
   it('should return 400 when doc does not exist', async () => {
@@ -64,6 +107,11 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: { type: 'doc', content: [] },
+        expected_updated_at: '2026-04-20T14:00:00.000Z',
+      }),
     })
 
     const response = await POST(request, { params: { id: 'assign-1' } })
@@ -111,6 +159,11 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: { type: 'doc', content: [] },
+        expected_updated_at: '2026-04-20T14:00:00.000Z',
+      }),
     })
 
     const response = await POST(request, { params: { id: 'assign-1' } })
@@ -138,7 +191,6 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
         })),
       })),
     }))
-
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
         return {
@@ -197,6 +249,11 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: emptyContent,
+        expected_updated_at: '2026-04-20T14:00:00.000Z',
+      }),
     }), { params: { id: 'assign-1' } })
 
     expect(response.status).toBe(400)
@@ -204,13 +261,43 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     expect(historyInsert).not.toHaveBeenCalled()
   })
 
-  it('submits work, records history, and attaches authenticity results', async () => {
+  it('submits work atomically and keeps private authenticity results out of the response', async () => {
     const historyInsert = vi.fn(async () => ({ error: null }))
     const authenticityUpdate = vi.fn(async () => ({ error: null }))
+    const savedRevision = '2026-04-20T14:00:00.000Z'
+    const submittedRevision = '2026-04-20T14:30:00.000Z'
+    const submitFilters: Array<[string, unknown]> = []
+    const savedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Older saved work' }] }],
+    }
     const submittedContent = {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Finished work' }] }],
     }
+    const submitUpdate = vi.fn()
+    vi.mocked(submitAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: {
+        id: 'doc-1',
+        assignment_id: 'assign-1',
+        student_id: 'student-1',
+        content: submittedContent,
+        is_submitted: true,
+        submitted_at: submittedRevision,
+        updated_at: submittedRevision,
+      } as any,
+      historyEntry: {
+        id: 'h-2',
+        assignment_doc_id: 'doc-1',
+        snapshot: submittedContent,
+        patch: null,
+        word_count: 2,
+        char_count: 13,
+        trigger: 'submit',
+        created_at: submittedRevision,
+      } as any,
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -232,7 +319,14 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
             eq: vi.fn(() => ({
               eq: vi.fn(() => ({
                 single: vi.fn().mockResolvedValue({
-                  data: { id: 'doc-1', student_id: 'student-1', content: submittedContent },
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: savedContent,
+                    is_submitted: false,
+                    submitted_at: null,
+                    updated_at: savedRevision,
+                  },
                   error: null,
                 }),
               })),
@@ -240,21 +334,28 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
           })),
           update: vi.fn((payload: Record<string, unknown>) => {
             if ('is_submitted' in payload) {
-              return {
-                eq: vi.fn(() => ({
-                  select: vi.fn(() => ({
-                    single: vi.fn().mockResolvedValue({
-                      data: {
-                        id: 'doc-1',
-                        student_id: 'student-1',
-                        content: submittedContent,
-                        is_submitted: true,
-                        submitted_at: payload.submitted_at,
-                      },
-                      error: null,
-                    }),
-                  })),
+              submitUpdate(payload)
+              const submitChain = {
+                eq: vi.fn((column: string, value: unknown) => {
+                  submitFilters.push([column, value])
+                  return submitChain
+                }),
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: {
+                      id: 'doc-1',
+                      student_id: 'student-1',
+                      content: payload.content,
+                      is_submitted: true,
+                      submitted_at: payload.submitted_at,
+                      updated_at: submittedRevision,
+                    },
+                    error: null,
+                  }),
                 })),
+              }
+              return {
+                ...submitChain,
               }
             }
             return { eq: authenticityUpdate }
@@ -284,6 +385,11 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: submittedContent,
+        expected_updated_at: savedRevision,
+      }),
     })
 
     const response = await POST(request, { params: { id: 'assign-1' } })
@@ -292,21 +398,26 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     expect(response.status).toBe(200)
     expect(data.doc).toEqual(expect.objectContaining({
       id: 'doc-1',
+      content: submittedContent,
       is_submitted: true,
-      authenticity_score: 0.82,
-      authenticity_flags: ['steady_revision'],
+      authenticity_score: null,
+      authenticity_flags: null,
+      teacher_feedback_draft: null,
+      ai_feedback_suggestion: null,
     }))
-    expect(historyInsert).toHaveBeenCalledWith(expect.objectContaining({
-      assignment_doc_id: 'doc-1',
-      snapshot: submittedContent,
-      word_count: 2,
-      char_count: 13,
-      trigger: 'submit',
+    expect(submitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assign-1',
+      studentId: 'student-1',
+      content: submittedContent,
+      expectedUpdatedAt: savedRevision,
     }))
+    expect(historyInsert).not.toHaveBeenCalled()
+    expect(submitUpdate).not.toHaveBeenCalled()
+    expect(submitFilters).toEqual([])
     expect(authenticityUpdate).toHaveBeenCalledWith('id', 'doc-1')
   })
 
-  it('preserves the first submitted_at timestamp on duplicate submit', async () => {
+  it('returns an already-submitted document idempotently without changing its timestamp', async () => {
     const historyInsert = vi.fn(async () => ({ error: null }))
     const originalSubmittedAt = '2026-04-20T14:30:00.000Z'
     const submittedContent = {
@@ -329,6 +440,24 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
         })),
       })),
     }))
+    vi.mocked(submitAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: {
+        id: 'doc-1',
+        student_id: 'student-1',
+        content: submittedContent,
+        is_submitted: true,
+        submitted_at: originalSubmittedAt,
+        updated_at: originalSubmittedAt,
+      } as any,
+      historyEntry: {
+        id: 'history-submit',
+        assignment_doc_id: 'doc-1',
+        trigger: 'submit',
+        snapshot: submittedContent,
+      } as any,
+      idempotent: true,
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -356,6 +485,7 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
                     content: submittedContent,
                     is_submitted: true,
                     submitted_at: originalSubmittedAt,
+                    updated_at: originalSubmittedAt,
                   },
                   error: null,
                 }),
@@ -380,24 +510,192 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
       throw new Error(`Unexpected table: ${table}`)
     })
 
+    const semanticallyIdenticalContent = {
+      content: [{ content: [{ text: 'Finished work', type: 'text' }], type: 'paragraph' }],
+      type: 'doc',
+    }
     const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: semanticallyIdenticalContent,
+        expected_updated_at: originalSubmittedAt,
+      }),
     }), { params: { id: 'assign-1' } })
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(updateDoc).toHaveBeenCalledWith({
-      is_submitted: true,
-      submitted_at: originalSubmittedAt,
-    })
+    expect(updateDoc).not.toHaveBeenCalled()
     expect(data.doc.submitted_at).toBe(originalSubmittedAt)
+    expect(submitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      expectedUpdatedAt: originalSubmittedAt,
+    }))
   })
 
-  it('still returns the submitted doc when history or authenticity side effects fail', async () => {
+  it('rejects content changes to an already-submitted document', async () => {
+    const savedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Submitted work' }] }],
+    }
+    const changedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Changed afterward' }] }],
+    }
+    const updateDoc = vi.fn()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1', is_draft: false, released_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: savedContent,
+                    is_submitted: true,
+                    submitted_at: '2026-04-20T14:30:00.000Z',
+                    updated_at: '2026-04-20T14:30:00.000Z',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: updateDoc,
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: changedContent,
+        expected_updated_at: '2026-04-20T14:30:00.000Z',
+      }),
+    }), { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe('This assignment is already submitted and cannot be changed.')
+    expect(updateDoc).not.toHaveBeenCalled()
+  })
+
+  it('rejects submission when the saved document revision changed', async () => {
+    const content = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Ready to submit' }] }],
+    }
+    const submitFilters: Array<[string, unknown]> = []
+    const submitChain = {
+      eq: vi.fn((column: string, value: unknown) => {
+        submitFilters.push([column, value])
+        return submitChain
+      }),
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+      })),
+    }
+    const historyInsert = vi.fn()
+    vi.mocked(submitAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      error: 'Your saved draft changed before submission. Review it and try again.',
+      errorCode: 'assignment_doc_revision_conflict',
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1', is_draft: false, released_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content,
+                    is_submitted: false,
+                    submitted_at: null,
+                    updated_at: '2026-04-20T14:31:00.000Z',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: vi.fn(() => submitChain),
+        }
+      }
+      if (table === 'assignment_doc_history') {
+        return { insert: historyInsert }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const staleRevision = '2026-04-20T14:30:00.000Z'
+    const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, expected_updated_at: staleRevision }),
+    }), { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe('Your saved draft changed before submission. Review it and try again.')
+    expect(submitFilters).toEqual([])
+    expect(submitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      expectedUpdatedAt: staleRevision,
+    }))
+    expect(historyInsert).not.toHaveBeenCalled()
+  })
+
+  it('still returns the atomically submitted doc when authenticity side effects fail', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const submittedContent = {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Finished work' }] }],
     }
+    vi.mocked(submitAssignmentDocAtomic).mockResolvedValueOnce({
+      ok: true,
+      doc: {
+        id: 'doc-1',
+        assignment_id: 'assign-1',
+        student_id: 'student-1',
+        content: submittedContent,
+        is_submitted: true,
+        submitted_at: '2026-04-25T12:00:00.000Z',
+        updated_at: '2026-04-25T12:00:00.000Z',
+      } as any,
+      historyEntry: null,
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -414,41 +712,44 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
       }
 
       if (table === 'assignment_docs') {
+        const submitChain = {
+          eq: vi.fn(() => submitChain),
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                content: submittedContent,
+                is_submitted: true,
+                submitted_at: '2026-04-25T12:00:00.000Z',
+              },
+              error: null,
+            }),
+          })),
+        }
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
               eq: vi.fn(() => ({
                 single: vi.fn().mockResolvedValue({
-                  data: { id: 'doc-1', student_id: 'student-1', content: submittedContent },
-                  error: null,
-                }),
-              })),
-            })),
-          })),
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
                   data: {
                     id: 'doc-1',
                     student_id: 'student-1',
                     content: submittedContent,
-                    is_submitted: true,
-                    submitted_at: '2026-04-25T12:00:00.000Z',
+                    updated_at: '2026-04-25T11:59:00.000Z',
                   },
                   error: null,
                 }),
               })),
             })),
           })),
+          update: vi.fn(() => submitChain),
         }
       }
 
       if (table === 'assignment_doc_history') {
         return {
-          insert: vi.fn(async () => {
-            throw new Error('history failed')
-          }),
+          insert: vi.fn(async () => ({ error: { message: 'history failed' } })),
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
               order: vi.fn(async () => {
@@ -464,6 +765,11 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: submittedContent,
+        expected_updated_at: '2026-04-25T11:59:00.000Z',
+      }),
     }), { params: { id: 'assign-1' } })
     const data = await response.json()
 
@@ -472,5 +778,24 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
       id: 'doc-1',
       is_submitted: true,
     }))
+    expect(submitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      content: submittedContent,
+      expectedUpdatedAt: '2026-04-25T11:59:00.000Z',
+    }))
+    expect(consoleError).toHaveBeenCalledWith('Error computing authenticity score:', expect.any(Error))
+    consoleError.mockRestore()
+  })
+
+  it('rejects bodyless submissions from cached legacy clients', async () => {
+    const response = await POST(new NextRequest(
+      'http://localhost:3000/api/assignment-docs/assign-1/submit',
+      { method: 'POST' }
+    ), { params: { id: 'assign-1' } })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Reload this assignment before submitting from an older browser tab.',
+    })
+    expect(submitAssignmentDocAtomic).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/assignment-docs/unsubmit.test.ts
+++ b/tests/api/assignment-docs/unsubmit.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '@/app/api/assignment-docs/[id]/unsubmit/route'
 import { NextRequest } from 'next/server'
 
+const mockUnsubmitAssignmentDocAtomic = vi.hoisted(() => vi.fn())
+
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1', role: 'student' })) }))
 vi.mock('@/lib/server/classrooms', () => ({
@@ -14,11 +16,28 @@ vi.mock('@/lib/server/classrooms', () => ({
     classroom: { id: 'class-1', archived_at: null },
   })),
 }))
+vi.mock('@/lib/server/assignment-doc-submissions', () => ({
+  unsubmitAssignmentDocAtomic: mockUnsubmitAssignmentDocAtomic,
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
 
 describe('POST /api/assignment-docs/[id]/unsubmit', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUnsubmitAssignmentDocAtomic.mockResolvedValue({
+      ok: true,
+      doc: {
+        id: 'doc-1',
+        is_submitted: false,
+        content: { type: 'doc', content: [] },
+        teacher_feedback_draft: 'Private teacher draft',
+        ai_feedback_suggestion: 'Private AI suggestion',
+        authenticity_score: 88,
+      },
+      historyEntry: null,
+    })
+  })
 
   it('should return 404 when doc does not exist', async () => {
     const mockFrom = vi.fn((table: string) => {
@@ -106,16 +125,6 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
               error: null,
             }),
           })),
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: { id: 'doc-1', is_submitted: false },
-                  error: null,
-                }),
-              })),
-            })),
-          })),
         }
       }
     })
@@ -126,11 +135,20 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
     })
 
     const response = await POST(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
     expect(response.status).toBe(200)
+    expect(data.doc).toEqual(expect.objectContaining({
+      teacher_feedback_draft: null,
+      ai_feedback_suggestion: null,
+      authenticity_score: null,
+    }))
+    expect(mockUnsubmitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assign-1',
+      studentId: 'student-1',
+    }))
   })
 
-  it('rejects unsubmit after a returned assignment has been resubmitted', async () => {
-    const update = vi.fn()
+  it('allows unsubmit after a returned assignment has been resubmitted', async () => {
     const mockFrom = vi.fn((table: string) => {
       if (table === 'assignments') {
         return {
@@ -161,7 +179,6 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
               error: null,
             }),
           })),
-          update,
         }
       }
     })
@@ -174,8 +191,62 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
     const response = await POST(request, { params: { id: 'assign-1' } })
     const body = await response.json()
 
-    expect(response.status).toBe(400)
-    expect(body.error).toBe('Returned submissions cannot be unsubmitted')
-    expect(update).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(body.doc.is_submitted).toBe(false)
+    expect(mockUnsubmitAssignmentDocAtomic).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assign-1',
+      studentId: 'student-1',
+    }))
+  })
+
+  it('rejects when teacher return wins after the route preflight', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                is_submitted: true,
+                submitted_at: '2026-05-02T12:00:00.000Z',
+                returned_at: null,
+                teacher_cleared_at: null,
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+    })
+    mockUnsubmitAssignmentDocAtomic.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: 'Returned submissions cannot be unsubmitted',
+      errorCode: 'assignment_doc_returned',
+    })
+
+    const response = await POST(new NextRequest(
+      'http://localhost:3000/api/assignment-docs/assign-1/unsubmit',
+      { method: 'POST' }
+    ), { params: { id: 'assign-1' } })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Returned submissions cannot be unsubmitted',
+    })
   })
 })

--- a/tests/api/auth/login.test.ts
+++ b/tests/api/auth/login.test.ts
@@ -326,7 +326,7 @@ describe('POST /api/auth/login', () => {
       expect(data.error).toBe('Invalid email or password')
     })
 
-    it('should return 500 when JSON parsing fails', async () => {
+    it('should return 400 when JSON parsing fails', async () => {
       const request = new NextRequest('http://localhost:3000/api/auth/login', {
         method: 'POST',
         body: 'invalid json',
@@ -336,8 +336,8 @@ describe('POST /api/auth/login', () => {
       const response = await POST(request)
       const data = await response.json()
 
-      expect(response.status).toBe(500)
-      expect(data.error).toBe('Internal server error')
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('Malformed JSON body')
     })
   })
 })

--- a/tests/api/cron/assignment-artifact-storage-cleanup.test.ts
+++ b/tests/api/cron/assignment-artifact-storage-cleanup.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  run: vi.fn(),
+  supabase: {},
+}))
+
+vi.mock('@/lib/server/assignment-artifact-storage-cleanup', () => ({
+  runAssignmentArtifactStorageCleanup: mocks.run,
+}))
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mocks.supabase),
+}))
+
+import { GET } from '@/app/api/cron/assignment-artifact-storage-cleanup/route'
+
+function request(secret?: string) {
+  return new NextRequest('http://localhost:3000/api/cron/assignment-artifact-storage-cleanup', {
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  })
+}
+
+describe('assignment artifact Storage cleanup cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'cron-secret'
+    mocks.run.mockResolvedValue({ claimed: 2, completed: 2, failed: 0 })
+  })
+
+  it('rejects unauthorized requests', async () => {
+    const response = await GET(request())
+    expect(response.status).toBe(401)
+    expect(mocks.run).not.toHaveBeenCalled()
+  })
+
+  it('runs a bounded cleanup batch', async () => {
+    const response = await GET(request('cron-secret'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ ok: true, claimed: 2, completed: 2, failed: 0 })
+    expect(mocks.run).toHaveBeenCalledWith({
+      supabase: mocks.supabase,
+      limit: 100,
+      leaseSeconds: 120,
+    })
+  })
+
+  it('returns unhealthy when any claimed cleanup fails', async () => {
+    mocks.run.mockResolvedValueOnce({ claimed: 1, completed: 0, failed: 1 })
+    const response = await GET(request('cron-secret'))
+    expect(response.status).toBe(503)
+  })
+})

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -93,18 +93,26 @@ function createDeleteTable(
   log: QueryLog,
   error: unknown = null
 ) {
+  let preservedTrigger: string | null = null
+  const query = {
+    neq: vi.fn((column: string, value: string) => {
+      if (column === 'trigger') preservedTrigger = value
+      return query
+    }),
+    in: vi.fn(async (column: string, values: string[]) => {
+      const stringValues = values.map(String)
+      log.deleteCalls.push({ table, column, values: stringValues })
+      if (error) return { count: null, error }
+      const count = rows.filter((row) =>
+        column === parentColumn
+        && stringValues.includes(String(row[parentColumn]))
+        && (!preservedTrigger || row.trigger !== preservedTrigger)
+      ).length
+      return { count, error: null }
+    }),
+  }
   return {
-    delete: vi.fn(() => ({
-      in: vi.fn(async (column: string, values: string[]) => {
-        const stringValues = values.map(String)
-        log.deleteCalls.push({ table, column, values: stringValues })
-        if (error) return { count: null, error }
-        const count = rows.filter((row) =>
-          column === parentColumn && stringValues.includes(String(row[parentColumn]))
-        ).length
-        return { count, error: null }
-      }),
-    })),
+    delete: vi.fn(() => query),
   }
 }
 
@@ -235,6 +243,22 @@ describe('cron cleanup-history route', () => {
     await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 0 })
     expect(mock.from).toHaveBeenCalledTimes(1)
     expect(log.rangeCalls).toEqual([{ table: 'classrooms', from: 0, to: 999 }])
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'cleanup_assignment_doc_save_operations',
+      { p_completed_before: expect.any(String) }
+    )
+  })
+
+  it('fails when assignment save operation retention cannot be recorded', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    mockSupabaseClient.rpc.mockResolvedValueOnce({ data: null, error: { message: 'failed' } })
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to clean assignment save operations',
+    })
   })
 
   it('cleans expired archive staging through the authenticated daily cron when enabled', async () => {

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -12,11 +12,23 @@ vi.mock('@/lib/server/assignment-ai-grading-runs', () => ({
   getActiveAssignmentAiGradingRunSummary: vi.fn(async () => null),
 }))
 
+const mockRunAssignmentArtifactStorageCleanup = vi.hoisted(() => vi.fn(async () => ({
+  claimed: 0,
+  completed: 0,
+  failed: 0,
+})))
+vi.mock('@/lib/server/assignment-artifact-storage-cleanup', () => ({
+  runAssignmentArtifactStorageCleanup: mockRunAssignmentArtifactStorageCleanup,
+}))
+
 const mockSupabaseClient = {
   from: vi.fn(),
   rpc: vi.fn(),
   storage: { from: vi.fn() },
 }
+
+const LINK_REQUIREMENT_ID = '10000000-0000-4000-8000-000000000001'
+const IMAGE_REQUIREMENT_ID = '10000000-0000-4000-8000-000000000002'
 
 function makeAssignment(overrides: Record<string, unknown> = {}) {
   return {
@@ -38,9 +50,20 @@ function makeAssignment(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function makeAssignmentRpcRow(overrides: Record<string, unknown> = {}) {
+  const { classrooms: _classrooms, ...assignment } = makeAssignment({
+    classroom_id: 'classroom-1',
+    gradebook_weight: 1,
+    include_in_final: true,
+    points_possible: 100,
+    ...overrides,
+  })
+  return assignment
+}
+
 function makeRequirement(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'req-link',
+    id: LINK_REQUIREMENT_ID,
     assignment_id: 'a-1',
     type: 'link',
     label: 'Public link',
@@ -605,6 +628,22 @@ describe('GET /api/teacher/assignments/[id]', () => {
 describe('PATCH /api/teacher/assignments/[id]', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
+  it('rejects malformed submission requirements before database or storage work', async () => {
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        submission_requirements: [{ type: 'repo', label: 'Repository' }],
+      }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.storage.from).not.toHaveBeenCalled()
+  })
+
   it('should return 400 when no fields to update', async () => {
     const mockFrom = vi.fn(() => ({
       select: vi.fn(() => ({
@@ -816,9 +855,13 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
 
   it('removes image artifact storage after an image requirement is removed', async () => {
     const remove = vi.fn(async () => ({ error: null }))
-    const remainingRequirement = makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link' })
+    const remainingRequirement = makeRequirement({ id: LINK_REQUIREMENT_ID, type: 'link', label: 'Demo link' })
     ;(mockSupabaseClient.rpc as any) = vi.fn(async () => ({
-      data: [remainingRequirement],
+      data: {
+        ok: true,
+        assignment: makeAssignmentRpcRow(),
+        submission_requirements: [remainingRequirement],
+      },
       error: null,
     }))
     ;(mockSupabaseClient.storage as any) = {
@@ -826,10 +869,19 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     }
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') return makeAssignmentSelectTable()
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
+        }
+      }
       if (table === 'assignment_submission_requirements') {
         return makeRequirementsTable([
-          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot', position: 0 }),
-          makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link', position: 1 }),
+          makeRequirement({ id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Screenshot', position: 0 }),
+          makeRequirement({ id: LINK_REQUIREMENT_ID, type: 'link', label: 'Demo link', position: 1 }),
         ])
       }
       if (table === 'assignment_submission_artifacts') {
@@ -842,8 +894,9 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
       method: 'PATCH',
       body: JSON.stringify({
+        instructions_markdown: 'Updated instructions',
         submission_requirements: [
-          { id: 'req-link', type: 'link', label: 'Demo link', position: 0 },
+          { id: LINK_REQUIREMENT_ID, type: 'link', label: 'Demo link', position: 0 },
         ],
       }),
     })
@@ -851,14 +904,30 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     const response = await PATCH(request, { params: { id: 'a-1' } })
 
     expect(response.status).toBe(200)
-    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
+    expect(remove).not.toHaveBeenCalled()
+    expect(mockRunAssignmentArtifactStorageCleanup).toHaveBeenCalledWith(expect.objectContaining({
+      limit: 50,
+    }))
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'update_assignment_with_submission_requirements_atomic',
+      expect.objectContaining({
+        p_updates: expect.objectContaining({
+          instructions_markdown: 'Updated instructions',
+          description: 'Updated instructions',
+        }),
+      })
+    )
   })
 
   it('preserves image artifact storage when the image requirement id is kept', async () => {
     const remove = vi.fn(async () => ({ error: null }))
-    const updatedRequirement = makeRequirement({ id: 'req-image', type: 'image', label: 'Updated screenshot' })
+    const updatedRequirement = makeRequirement({ id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Updated screenshot' })
     ;(mockSupabaseClient.rpc as any) = vi.fn(async () => ({
-      data: [updatedRequirement],
+      data: {
+        ok: true,
+        assignment: makeAssignmentRpcRow(),
+        submission_requirements: [updatedRequirement],
+      },
       error: null,
     }))
     ;(mockSupabaseClient.storage as any) = {
@@ -866,9 +935,18 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     }
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') return makeAssignmentSelectTable()
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
+        }
+      }
       if (table === 'assignment_submission_requirements') {
         return makeRequirementsTable([
-          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot', position: 0 }),
+          makeRequirement({ id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Screenshot', position: 0 }),
         ])
       }
 
@@ -879,7 +957,7 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
       method: 'PATCH',
       body: JSON.stringify({
         submission_requirements: [
-          { id: 'req-image', type: 'image', label: 'Updated screenshot', position: 1 },
+          { id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Updated screenshot', position: 1 },
         ],
       }),
     })
@@ -889,6 +967,96 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     expect(response.status).toBe(200)
     expect(remove).not.toHaveBeenCalled()
     expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('assignment_submission_artifacts')
+  })
+
+  it('rejects requirement changes before updating assignment fields once a student submitted', async () => {
+    const updateAssignment = vi.fn()
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          ...makeAssignmentSelectTable(),
+          update: updateAssignment,
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'doc-1' }, error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        title: 'Should not persist',
+        submission_requirements: [
+          { type: 'link', label: 'New requirement', position: 0 },
+        ],
+      }),
+    }), { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toContain('cannot be changed')
+    expect(updateAssignment).not.toHaveBeenCalled()
+  })
+
+  it('keeps assignment fields unchanged when submission wins after the preflight check', async () => {
+    const updateAssignment = vi.fn()
+    ;(mockSupabaseClient.rpc as any) = vi.fn().mockResolvedValue({
+      data: {
+        ok: false,
+        status: 409,
+        error_code: 'assignment_requirements_submitted',
+        error: 'Submission requirements cannot be changed after a student submits.',
+      },
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          ...makeAssignmentSelectTable(),
+          update: updateAssignment,
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
+        }
+      }
+      if (table === 'assignment_submission_requirements') {
+        return makeRequirementsTable([])
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        title: 'Should remain atomic',
+        submission_requirements: [
+          { type: 'link', label: 'New requirement', position: 0 },
+        ],
+      }),
+    }), { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(409)
+    expect(updateAssignment).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'update_assignment_with_submission_requirements_atomic',
+      expect.objectContaining({
+        p_updates: expect.objectContaining({ title: 'Should remain atomic' }),
+      })
+    )
   })
 })
 
@@ -941,8 +1109,8 @@ describe('DELETE /api/teacher/assignments/[id]', () => {
       }
       if (table === 'assignment_submission_requirements') {
         return makeRequirementsTable([
-          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot' }),
-          makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link' }),
+          makeRequirement({ id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Screenshot' }),
+          makeRequirement({ id: LINK_REQUIREMENT_ID, type: 'link', label: 'Demo link' }),
         ])
       }
       if (table === 'assignment_submission_artifacts') {
@@ -960,15 +1128,16 @@ describe('DELETE /api/teacher/assignments/[id]', () => {
 
     expect(response.status).toBe(200)
     expect(deleteEq).toHaveBeenCalledWith('id', 'a-1')
-    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
-    expect(remove.mock.invocationCallOrder[0]).toBeGreaterThan(deleteEq.mock.invocationCallOrder[0])
+    expect(remove).not.toHaveBeenCalled()
+    expect(mockRunAssignmentArtifactStorageCleanup.mock.invocationCallOrder[0])
+      .toBeGreaterThan(deleteEq.mock.invocationCallOrder[0])
   })
 
   it('logs storage removal failures without failing a successful assignment delete', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const removeError = { message: 'storage unavailable' }
-    const remove = vi.fn(async () => ({ error: removeError }))
+    const remove = vi.fn(async () => ({ error: null }))
     const deleteEq = vi.fn(async () => ({ error: null }))
+    mockRunAssignmentArtifactStorageCleanup.mockRejectedValueOnce(new Error('storage unavailable'))
     ;(mockSupabaseClient.storage as any) = {
       from: vi.fn(() => ({ remove })),
     }
@@ -987,7 +1156,7 @@ describe('DELETE /api/teacher/assignments/[id]', () => {
       }
       if (table === 'assignment_submission_requirements') {
         return makeRequirementsTable([
-          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot' }),
+          makeRequirement({ id: IMAGE_REQUIREMENT_ID, type: 'image', label: 'Screenshot' }),
         ])
       }
       if (table === 'assignment_submission_artifacts') {
@@ -1004,14 +1173,10 @@ describe('DELETE /api/teacher/assignments/[id]', () => {
     const response = await DELETE(request, { params: { id: 'a-1' } })
 
     expect(response.status).toBe(200)
-    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
+    expect(remove).not.toHaveBeenCalled()
     expect(consoleError).toHaveBeenCalledWith(
-      'Failed to remove assignment artifact storage objects:',
-      expect.objectContaining({
-        context: 'assignment:a-1:delete',
-        error: removeError,
-        paths: ['student-1/a-1/req-image.png'],
-      })
+      'Failed to process queued assignment artifact cleanup:',
+      expect.any(Error)
     )
     consoleError.mockRestore()
   })

--- a/tests/architecture/api-zod-boundary-baseline.json
+++ b/tests/architecture/api-zod-boundary-baseline.json
@@ -1,8 +1,5 @@
 [
   "src/app/api/account/github-identity/route.ts",
-  "src/app/api/assignment-docs/[id]/artifacts/[requirementId]/route.ts",
-  "src/app/api/assignment-docs/[id]/restore/route.ts",
-  "src/app/api/assignment-docs/[id]/route.ts",
   "src/app/api/classrooms/[classroomId]/class-days/route.ts",
   "src/app/api/feedback/route.ts",
   "src/app/api/student/classrooms/join/route.ts",
@@ -11,7 +8,6 @@
   "src/app/api/student/tests/[id]/focus-events/route.ts",
   "src/app/api/teacher/assignments/[id]/release/route.ts",
   "src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts",
-  "src/app/api/teacher/assignments/[id]/route.ts",
   "src/app/api/teacher/assignments/bulk/route.ts",
   "src/app/api/teacher/assignments/reorder/route.ts",
   "src/app/api/teacher/assignments/route.ts",

--- a/tests/components/StudentAssignmentEditor.save-submit.test.tsx
+++ b/tests/components/StudentAssignmentEditor.save-submit.test.tsx
@@ -2220,7 +2220,7 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBe(newerGeneration)
   })
 
-  it('keeps the writer fence and sequence across remounts in the same tab', async () => {
+  it('uses a fresh writer fence after remount even when tab writer state was cloned', async () => {
     const patchBodies: any[] = []
     const fetchMock = global.fetch as ReturnType<typeof vi.fn>
     fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -2262,6 +2262,13 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     await user.click(screen.getByRole('button', { name: 'Blur response' }))
     await waitFor(() => expect(patchBodies).toHaveLength(1))
     first.unmount()
+    window.sessionStorage.setItem(
+      'assignment-save-writer:student-1:assignment-1',
+      JSON.stringify({
+        session_id: patchBodies[0].save_session_id,
+        sequence: patchBodies[0].save_sequence,
+      })
+    )
 
     render(
       <StudentAssignmentEditor
@@ -2275,8 +2282,8 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     await user.click(screen.getByRole('button', { name: 'Blur response' }))
     await waitFor(() => expect(patchBodies).toHaveLength(2))
 
-    expect(patchBodies[1].save_session_id).toBe(patchBodies[0].save_session_id)
-    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 2])
+    expect(patchBodies[1].save_session_id).not.toBe(patchBodies[0].save_session_id)
+    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 1])
   })
 
   it('refreshes the saved revision after a pre-submit save conflict so retry can succeed', async () => {

--- a/tests/components/StudentAssignmentEditor.save-submit.test.tsx
+++ b/tests/components/StudentAssignmentEditor.save-submit.test.tsx
@@ -1,0 +1,3174 @@
+import { act, createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  StudentAssignmentEditor,
+  type StudentAssignmentEditorHandle,
+} from '@/components/StudentAssignmentEditor'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}))
+
+vi.mock('@/components/StudentNotificationsProvider', () => ({
+  useStudentNotifications: () => null,
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}))
+
+vi.mock('@/components/HistoryList', () => ({
+  HistoryList: ({ entries, onEntryClick }: any) => (
+    <div data-testid="history-list">
+      {entries[0] && (
+        <button type="button" onClick={() => onEntryClick(entries[0])}>
+          Select saved version
+        </button>
+      )}
+    </div>
+  ),
+}))
+
+vi.mock('@/lib/assignment-doc-history', () => ({
+  reconstructAssignmentDocContent: () => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Restored answer' }] }],
+  }),
+}))
+
+const latestDraft = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Latest unsaved answer' }] }],
+}
+
+const olderInFlightDraft = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Older in-flight answer' }] }],
+}
+
+const savedDraft = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Older saved answer' }] }],
+}
+
+const largeDraft = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'x'.repeat(70_000) }] }],
+}
+
+vi.mock('@/components/editor', () => ({
+  RichTextEditor: ({ content, onBlur, onChange, onKeystroke }: any) => (
+    <div>
+      <output data-testid="editor-content">{JSON.stringify(content)}</output>
+      <button type="button" onClick={() => onChange(olderInFlightDraft)}>Edit older response</button>
+      <button type="button" onClick={() => onChange(latestDraft)}>Edit response</button>
+      <button type="button" onClick={() => onChange(savedDraft)}>Revert response</button>
+      <button type="button" onClick={() => onChange(largeDraft)}>Edit large response</button>
+      <button type="button" onClick={onKeystroke}>Record keystroke</button>
+      <button type="button" onClick={onBlur}>Blur response</button>
+    </div>
+  ),
+  RichTextViewer: () => <div data-testid="rich-text-viewer" />,
+}))
+
+vi.mock('@/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    isCancelDisabled,
+    isConfirmDisabled,
+    onCancel,
+    onConfirm,
+  }: any) => isOpen ? (
+    <div role="dialog" aria-modal="true" aria-label={title}>
+      <p>{description}</p>
+      <button type="button" disabled={isCancelDisabled} onClick={onCancel}>Cancel</button>
+      <button type="button" disabled={isConfirmDisabled} onClick={onConfirm}>{confirmLabel}</button>
+    </div>
+  ) : null,
+  Tooltip: ({ children }: any) => <>{children}</>,
+}))
+
+function makeAssignment() {
+  return {
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    title: 'Assignment Title',
+    description: '',
+    instructions_markdown: '',
+    due_at: '2026-08-01T03:59:59.000Z',
+    created_at: '2026-07-01T12:00:00.000Z',
+    updated_at: '2026-07-01T12:00:00.000Z',
+  } as any
+}
+
+function makeDoc() {
+  return {
+    id: 'doc-1',
+    assignment_id: 'assignment-1',
+    student_id: 'student-1',
+    content: savedDraft,
+    is_submitted: false,
+    submitted_at: null,
+    viewed_at: '2026-07-01T12:00:00.000Z',
+    created_at: '2026-07-01T12:00:00.000Z',
+    updated_at: '2026-07-01T12:00:00.000Z',
+  } as any
+}
+
+describe('StudentAssignmentEditor save-before-submit integrity', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    window.sessionStorage.clear()
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the current draft unsubmitted when its pre-submit save fails', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    let saveAttempts = 0
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        saveAttempts += 1
+        if (saveAttempts === 1) {
+          return { ok: false, json: async () => ({ error: 'Save service unavailable' }) }
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: latestDraft },
+            historyEntry: null,
+          }),
+        }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }),
+        }
+      }
+
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/assignment-docs/assignment-1',
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/assignment-docs/assignment-1/submit',
+      expect.anything(),
+    )
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByTestId('assignment-save-status')).toHaveTextContent('Unsaved')
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/not submitted.*try again/i)
+    })
+
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(saveAttempts).toBe(2)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(1)
+    await waitFor(() => {
+      expect(ref.current?.isSubmitted).toBe(true)
+    })
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.queryByText(/not submitted.*try again/i)).not.toBeInTheDocument()
+  })
+
+  it('submits the pending editor snapshot before React rerenders', async () => {
+    const patchBodies: any[] = []
+    const submitBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        const body = JSON.parse(String(init?.body))
+        submitBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, is_submitted: true, updated_at: '2026-07-01T12:02:00.000Z' },
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit response' }))
+      await ref.current?.submit()
+    })
+
+    expect(patchBodies[0]?.content).toEqual(latestDraft)
+    expect(submitBodies[0]?.content).toEqual(latestDraft)
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+  })
+
+  it('preserves an edit made while submit reconciliation is in flight', async () => {
+    let docReads = 0
+    let rejectSubmit: ((error: Error) => void) | undefined
+    const submitResponse = new Promise<never>((_, reject) => {
+      rejectSubmit = reject
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        docReads += 1
+        const submitted = docReads > 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: submitted ? latestDraft : savedDraft,
+              is_submitted: submitted,
+              submitted_at: submitted ? '2026-07-01T12:02:00.000Z' : null,
+              updated_at: submitted ? '2026-07-01T12:02:00.000Z' : makeDoc().updated_at,
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) return submitResponse
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+
+    let submission: Promise<void> | undefined
+    act(() => {
+      submission = ref.current?.submit()
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith('/submit'))).toBe(true)
+    })
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    rejectSubmit?.(new TypeError('submit response lost'))
+    await act(async () => {
+      await submission
+    })
+
+    const recovery = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(recovery.content).toEqual(olderInFlightDraft)
+    await waitFor(() => {
+      expect(screen.getByText(/local draft is preserved/i)).toBeInTheDocument()
+    })
+  })
+
+  it('bounds a hung pre-submit save and does not deadlock submission', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return new Promise((_, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'))
+          })
+        })
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/timed out.*try again/i)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith('/submit'))).toBe(false)
+  })
+
+  it('waits for an older autosave before saving and submitting the latest draft', async () => {
+    let resolveOlderSave: ((response: any) => void) | undefined
+    const olderSaveResponse = new Promise<any>((resolve) => {
+      resolveOlderSave = resolve
+    })
+    let resolveLatestSave: ((response: any) => void) | undefined
+    const latestSaveResponse = new Promise<any>((resolve) => {
+      resolveLatestSave = resolve
+    })
+    let latestSaveAttempts = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const requestContent = JSON.parse(String(init.body)).content
+        if (JSON.stringify(requestContent) === JSON.stringify(olderInFlightDraft)) {
+          return olderSaveResponse
+        }
+
+        latestSaveAttempts += 1
+        if (latestSaveAttempts === 1) {
+          return latestSaveResponse
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: requestContent },
+            historyEntry: null,
+          }),
+        }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }),
+        }
+      }
+
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(1)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    let submitPromise: Promise<void> | undefined
+    await act(async () => {
+      submitPromise = ref.current?.submit()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(1)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(0)
+
+    resolveOlderSave?.({
+      ok: true,
+      json: async () => ({
+        doc: { ...makeDoc(), content: olderInFlightDraft },
+        historyEntry: null,
+      }),
+    })
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(2)
+    })
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(0)
+
+    resolveLatestSave?.({
+      ok: false,
+      json: async () => ({ error: 'Latest save failed' }),
+    })
+
+    await act(async () => {
+      await submitPromise
+    })
+
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(0)
+    expect(screen.getByRole('alert')).toHaveTextContent(/not submitted.*try again/i)
+
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    const patchCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')
+    expect(patchCalls).toHaveLength(3)
+    expect(JSON.parse(String(patchCalls[2]?.[1]?.body)).content).toEqual(latestDraft)
+    expect(JSON.parse(String(patchCalls[2]?.[1]?.body)).keystroke_count).toBe(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/assignment-docs/assignment-1/submit',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          content: latestDraft,
+          expected_updated_at: '2026-07-01T12:00:00.000Z',
+        }),
+      }),
+    )
+  })
+
+  it('waits for an older autosave before submitting a draft reverted to the prior saved content', async () => {
+    let resolveOlderSave: ((response: any) => void) | undefined
+    const olderSaveResponse = new Promise<any>((resolve) => {
+      resolveOlderSave = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const requestContent = JSON.parse(String(init.body)).content
+        if (JSON.stringify(requestContent) === JSON.stringify(olderInFlightDraft)) {
+          return olderSaveResponse
+        }
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: requestContent }, historyEntry: null }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: savedDraft, is_submitted: true } }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(1)
+    })
+    await user.click(screen.getByRole('button', { name: 'Revert response' }))
+
+    let submitPromise: Promise<void> | undefined
+    await act(async () => {
+      submitPromise = ref.current?.submit()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(1)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(0)
+
+    resolveOlderSave?.({
+      ok: true,
+      json: async () => ({ doc: { ...makeDoc(), content: olderInFlightDraft }, historyEntry: null }),
+    })
+    await act(async () => {
+      await submitPromise
+    })
+
+    const patchCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')
+    expect(patchCalls).toHaveLength(2)
+    expect(JSON.parse(String(patchCalls[1]?.[1]?.body)).content).toEqual(savedDraft)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(1)
+  })
+
+  it('flushes the latest unsaved draft when the editor unmounts', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const requestContent = JSON.parse(String(init.body)).content
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: requestContent }, historyEntry: null }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    const { unmount } = render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    unmount()
+
+    await waitFor(() => {
+      const patchCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')
+      expect(patchCalls).toHaveLength(1)
+      expect(JSON.parse(String(patchCalls[0]?.[1]?.body)).content).toEqual(latestDraft)
+    })
+  })
+
+  it('flushes metrics-only activity when the editor unmounts', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: body.content }, historyEntry: null }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    const { unmount } = render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    unmount()
+
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+    expect(patchBodies[0]).toEqual(expect.objectContaining({
+      content: savedDraft,
+      keystroke_count: 1,
+    }))
+  })
+
+  it('keeps newer edits unsaved when an older in-flight save completes', async () => {
+    let resolveOlderSave: ((response: any) => void) | undefined
+    const olderSaveResponse = new Promise<any>((resolve) => {
+      resolveOlderSave = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const requestContent = JSON.parse(String(init.body)).content
+        if (JSON.stringify(requestContent) === JSON.stringify(olderInFlightDraft)) {
+          return olderSaveResponse
+        }
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: requestContent }, historyEntry: null }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => {
+      expect(screen.getByText('Saving...')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+
+    resolveOlderSave?.({
+      ok: true,
+      json: async () => ({ doc: { ...makeDoc(), content: olderInFlightDraft }, historyEntry: null }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+  })
+
+  it('records input metrics when edits return to the already saved content', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), is_submitted: true } }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Revert response' }))
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(patchBodies).toHaveLength(1)
+    expect(patchBodies[0]).toEqual(expect.objectContaining({
+      content: savedDraft,
+      keystroke_count: 1,
+    }))
+  })
+
+  it('reuses an ambiguous save sequence when retrying the same content and metrics', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    let saveTimeoutCount = 0
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000 && saveTimeoutCount++ === 0) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) {
+          return new Promise((_, reject) => {
+            init.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+          })
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+    await act(async () => { await ref.current?.submit() })
+
+    expect(patchBodies).toHaveLength(2)
+    expect(patchBodies[0].save_sequence).toBe(1)
+    expect(patchBodies[1].save_sequence).toBe(1)
+    expect(patchBodies[1].keystroke_count).toBe(1)
+    expect(patchBodies[1].metric_session_id).toBe(patchBodies[0].metric_session_id)
+  })
+
+  it('retires an ambiguous attempt after a definitive revision conflict', async () => {
+    let docReads = 0
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: docReads > 1 ? latestDraft : savedDraft,
+              updated_at: docReads > 1 ? '2026-07-01T12:01:00.000Z' : makeDoc().updated_at,
+            },
+            feedback_entries: [], submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) throw new TypeError('connection reset')
+        if (patchBodies.length === 2) {
+          return {
+            ok: false,
+            status: 409,
+            json: async () => ({ error: 'This draft changed elsewhere.' }),
+          }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:02:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return { ok: true, json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+    await act(async () => { await ref.current?.submit() })
+    await act(async () => { await ref.current?.submit() })
+
+    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 1, 2])
+    expect(patchBodies.map((body) => body.expected_updated_at)).toEqual([
+      makeDoc().updated_at,
+      makeDoc().updated_at,
+      '2026-07-01T12:01:00.000Z',
+    ])
+  })
+
+  it('reuses an ambiguous save sequence after a non-abort network failure', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) throw new TypeError('Connection closed after request upload')
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+    const persistedAttempt = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    ))).pending_save
+    await act(async () => { await ref.current?.submit() })
+
+    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 1])
+    expect(patchBodies[1]).toEqual(patchBodies[0])
+    expect(persistedAttempt).toEqual(expect.objectContaining({
+      sequence: 1,
+      keystrokeCount: 1,
+      expectedUpdatedAt: makeDoc().updated_at,
+    }))
+    expect(patchBodies[1].keystroke_count).toBe(1)
+    expect(patchBodies[1].metric_session_id).toBe(patchBodies[0].metric_session_id)
+  })
+
+  it('preserves the immutable save identity across a transient HTTP failure', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(), doc: makeDoc(), feedback_entries: [],
+            submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) {
+          return { ok: false, status: 503, json: async () => ({ error: 'Gateway unavailable' }) }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return { ok: true, json: async () => ({ doc: { ...makeDoc(), content: latestDraft, is_submitted: true } }) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+    await act(async () => { await ref.current?.submit() })
+
+    expect(patchBodies).toHaveLength(2)
+    expect(patchBodies[1]).toEqual(patchBodies[0])
+  })
+
+  it('stops submission when an ambiguous save committed before another editor save', async () => {
+    let docReads = 0
+    const patchBodies: any[] = []
+    const submit = vi.fn()
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: docReads === 1 ? savedDraft : olderInFlightDraft,
+              updated_at: docReads === 1
+                ? makeDoc().updated_at
+                : '2026-07-01T12:02:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) throw new TypeError('Connection closed after commit')
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            error: 'This save completed, but a newer saved version now exists.',
+            error_code: 'assignment_doc_save_replayed',
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        submit()
+        return { ok: true, json: async () => ({ doc: makeDoc() }) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+    await act(async () => { await ref.current?.submit() })
+
+    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 1])
+    expect(submit).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/newer saved version exists.*review/i)
+  })
+
+  it('preserves a newer in-memory draft when an older save conflicts', async () => {
+    let resolveOlderSave: ((response: any) => void) | undefined
+    const olderSaveResponse = new Promise<any>((resolve) => {
+      resolveOlderSave = resolve
+    })
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: docReads === 1 ? savedDraft : olderInFlightDraft,
+              updated_at: docReads === 1
+                ? makeDoc().updated_at
+                : '2026-07-01T12:01:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return olderSaveResponse
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await screen.findByText('Saving...')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+
+    resolveOlderSave?.({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'This draft changed elsewhere before the save completed.' }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('changed elsewhere')
+    })
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+  })
+
+  it('uses a keepalive save for the latest draft on pagehide', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const requestContent = JSON.parse(String(init.body)).content
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: requestContent }, historyEntry: null }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    fireEvent(window, new Event('pagehide'))
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([, init]) => (
+        init?.method === 'PATCH'
+        && init.keepalive === true
+        && JSON.parse(String(init.body)).content.content[0].content[0].text === 'Latest unsaved answer'
+      ))).toBe(true)
+    })
+  })
+
+  it('uses a keepalive save for metrics-only activity on pagehide', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({ doc: { ...makeDoc(), content: body.content }, historyEntry: null }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    fireEvent(window, new Event('pagehide'))
+
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+    expect(patchBodies[0]).toEqual(expect.objectContaining({
+      content: savedDraft,
+      keystroke_count: 1,
+    }))
+  })
+
+  it('does not resend metrics already committed by a pagehide save', async () => {
+    let docReads = 0
+    const patchBodies: any[] = []
+    let resolveKeepalive: ((response: any) => void) | undefined
+    const keepaliveResponse = new Promise<any>((resolve) => {
+      resolveKeepalive = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: docReads > 1 ? latestDraft : savedDraft,
+              updated_at: docReads > 1
+                ? '2026-07-01T12:01:00.000Z'
+                : '2026-07-01T12:00:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (init.keepalive) return keepaliveResponse
+        return {
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: body.content,
+              updated_at: init.keepalive
+                ? '2026-07-01T12:01:00.000Z'
+                : '2026-07-01T12:02:00.000Z',
+            },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    fireEvent(window, new Event('pagehide'))
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+
+    fireEvent(window, new Event('pageshow'))
+    await waitFor(() => expect(docReads).toBe(2))
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(2))
+
+    expect(patchBodies[0].keystroke_count).toBe(1)
+    expect(patchBodies[1].keystroke_count).toBe(2)
+    expect(patchBodies[1].metric_session_id).toBe(patchBodies[0].metric_session_id)
+
+    await act(async () => {
+      resolveKeepalive?.({
+        ok: true,
+        json: async () => ({
+          doc: {
+            ...makeDoc(),
+            content: latestDraft,
+            updated_at: '2026-07-01T12:01:00.000Z',
+          },
+          historyEntry: null,
+        }),
+      })
+      await Promise.resolve()
+    })
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(3))
+    expect(patchBodies[2].keystroke_count).toBe(1)
+  })
+
+  it('fences all older queued saves when pagehide restores the saved draft', async () => {
+    let resolveOlderSave: ((response: any) => void) | undefined
+    const olderSaveResponse = new Promise<any>((resolve) => {
+      resolveOlderSave = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        if (init.keepalive) {
+          const body = JSON.parse(String(init.body))
+          return {
+            ok: true,
+            json: async () => ({ doc: { ...makeDoc(), content: body.content }, historyEntry: null }),
+          }
+        }
+        return olderSaveResponse
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await screen.findByText('Saving...')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await user.click(screen.getByRole('button', { name: 'Revert response' }))
+    fireEvent(window, new Event('pagehide'))
+
+    await waitFor(() => {
+      const keepaliveCall = fetchMock.mock.calls.find(([, init]) => init?.keepalive === true)
+      expect(keepaliveCall).toBeDefined()
+      const body = JSON.parse(String(keepaliveCall?.[1]?.body))
+      expect(body.content).toEqual(savedDraft)
+      expect(body.save_session_id).toMatch(/^[0-9a-f-]{36}$/)
+      expect(body.save_sequence).toBe(2)
+      expect(body.keystroke_count).toBe(2)
+      const firstPatchCall = fetchMock.mock.calls.find(([, init]) => (
+        init?.method === 'PATCH' && init.keepalive !== true
+      ))
+      const firstPatchBody = JSON.parse(String(firstPatchCall?.[1]?.body))
+      expect(body.metric_session_id).toBe(firstPatchBody.metric_session_id)
+      expect(body.expected_updated_at).toBe(makeDoc().updated_at)
+    })
+
+    expect(fetchMock.mock.calls.filter(([, init]) => (
+      init?.method === 'PATCH' && init.keepalive !== true
+    ))).toHaveLength(1)
+
+    resolveOlderSave?.({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'Superseded by the pagehide save' }),
+    })
+  })
+
+  it('keeps an oversized pagehide draft in durable storage instead of exceeding keepalive quota', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit large response' }))
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    fireEvent(window, new Event('pagehide'))
+
+    expect(fetchMock.mock.calls.some(([, init]) => init?.keepalive === true)).toBe(false)
+    const stored = JSON.parse(String(window.sessionStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(stored.content).toEqual(largeDraft)
+    const durable = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(durable.content).toEqual(largeDraft)
+    expect(durable.keystroke_count).toBe(1)
+  })
+
+  it('recovers a durable draft after the prior tab is gone', async () => {
+    window.localStorage.setItem(
+      'assignment-draft:student-1:assignment-1',
+      JSON.stringify({
+        content: latestDraft,
+        base_revision: '2026-06-30T12:00:00.000Z',
+        saved_at: new Date().toISOString(),
+      })
+    )
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByRole('alert')).toHaveTextContent(/local draft was recovered.*review/i)
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+  })
+
+  it('replays a recovered metrics-only operation before clearing matching content', async () => {
+    const pendingSave = {
+      content: savedDraft,
+      sessionId: '10000000-0000-4000-8000-000000000091',
+      sequence: 4,
+      metricSessionId: '10000000-0000-4000-8000-000000000092',
+      expectedUpdatedAt: makeDoc().updated_at,
+      trigger: 'blur',
+      pasteWordCount: 0,
+      keystrokeCount: 3,
+    }
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', JSON.stringify({
+      draft_id: '10000000-0000-4000-8000-000000000093',
+      generation: Date.now() * 1_000,
+      content: savedDraft,
+      base_revision: makeDoc().updated_at,
+      paste_word_count: 0,
+      keystroke_count: 3,
+      pending_save: pendingSave,
+      saved_at: new Date().toISOString(),
+    }))
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(), doc: makeDoc(), feedback_entries: [],
+            submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        patchBodies.push(JSON.parse(String(init.body)))
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+    expect(patchBodies[0]).toEqual(expect.objectContaining({
+      save_session_id: pendingSave.sessionId,
+      save_sequence: pendingSave.sequence,
+      metric_session_id: pendingSave.metricSessionId,
+      keystroke_count: 3,
+    }))
+    await screen.findByText('Saved')
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+  })
+
+  it('expires recovery records without a valid timestamp', async () => {
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', JSON.stringify({
+      content: latestDraft,
+      saved_at: 'not-a-date',
+    }))
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      return {
+        ok: true,
+        json: async () => ({
+          assignment: makeAssignment(), doc: makeDoc(), feedback_entries: [],
+          submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+        }),
+      }
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Older saved answer')
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+  })
+
+  it('selects the newest recovery generation across both browser stores', async () => {
+    const now = Date.now()
+    window.sessionStorage.setItem('assignment-draft:student-1:assignment-1', JSON.stringify({
+      draft_id: '10000000-0000-4000-8000-000000000001',
+      content: olderInFlightDraft,
+      saved_at: new Date(now - 1_000).toISOString(),
+    }))
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', JSON.stringify({
+      draft_id: '10000000-0000-4000-8000-000000000002',
+      content: latestDraft,
+      saved_at: new Date(now).toISOString(),
+    }))
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+  })
+
+  it('replays a recovered operation identity without adopting it for new tab saves', async () => {
+    const recoveredSessionId = '10000000-0000-4000-8000-000000000099'
+    window.localStorage.setItem(
+      'assignment-draft:student-1:assignment-1',
+      JSON.stringify({
+        draft_id: '10000000-0000-4000-8000-000000000098',
+        content: latestDraft,
+        base_revision: makeDoc().updated_at,
+        save_session_id: recoveredSessionId,
+        paste_word_count: 0,
+        keystroke_count: 0,
+        saved_at: new Date().toISOString(),
+        pending_save: {
+          content: latestDraft,
+          sessionId: recoveredSessionId,
+          sequence: 7,
+          metricSessionId: '10000000-0000-4000-8000-000000000097',
+          expectedUpdatedAt: makeDoc().updated_at,
+          trigger: 'blur',
+          pasteWordCount: 0,
+          keystrokeCount: 0,
+        },
+      })
+    )
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:02:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+
+    expect(patchBodies[0].save_session_id).not.toBe(recoveredSessionId)
+    expect(patchBodies[0].metric_session_id).toBe('10000000-0000-4000-8000-000000000097')
+  })
+
+  it('ignores a recovered operation whose counters exceed the API contract', async () => {
+    const recoveredSessionId = '10000000-0000-4000-8000-000000000099'
+    window.localStorage.setItem(
+      'assignment-draft:student-1:assignment-1',
+      JSON.stringify({
+        draft_id: '10000000-0000-4000-8000-000000000098',
+        content: latestDraft,
+        saved_at: new Date().toISOString(),
+        pending_save: {
+          content: latestDraft,
+          sessionId: recoveredSessionId,
+          sequence: 7,
+          metricSessionId: '10000000-0000-4000-8000-000000000097',
+          expectedUpdatedAt: makeDoc().updated_at,
+          trigger: 'blur',
+          pasteWordCount: 32_768,
+          keystrokeCount: 0,
+        },
+      })
+    )
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:02:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+
+    expect(patchBodies[0].save_session_id).not.toBe(recoveredSessionId)
+    expect(patchBodies[0].metric_session_id).not.toBe('10000000-0000-4000-8000-000000000097')
+  })
+
+  it('preserves a newer recovery draft while the server document is submitted', async () => {
+    window.localStorage.setItem(
+      'assignment-draft:student-1:assignment-1',
+      JSON.stringify({
+        content: latestDraft,
+        base_revision: makeDoc().updated_at,
+        save_session_id: '10000000-0000-4000-8000-000000000099',
+        saved_at: new Date().toISOString(),
+      })
+    )
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: { ...makeDoc(), is_submitted: true, submitted_at: '2026-07-01T12:01:00.000Z' },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    expect(screen.getByRole('alert')).toHaveTextContent(/local draft is preserved/i)
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).not.toBeNull()
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Older saved answer')
+  })
+
+  it('shows a preserved local draft when a returned submission cannot be unsubmitted', async () => {
+    window.localStorage.setItem(
+      'assignment-draft:student-1:assignment-1',
+      JSON.stringify({
+        content: latestDraft,
+        base_revision: makeDoc().updated_at,
+        save_session_id: '10000000-0000-4000-8000-000000000099',
+        saved_at: new Date().toISOString(),
+      })
+    )
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              is_submitted: true,
+              submitted_at: '2026-07-01T12:01:00.000Z',
+              returned_at: '2026-07-01T12:02:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Preserved local draft')
+    expect(screen.getByRole('alert')).toHaveTextContent(/preserved below for review/i)
+    expect(screen.getByTestId('rich-text-viewer')).toBeInTheDocument()
+  })
+
+  it('clears matching recovery drafts from both browser stores', async () => {
+    const recovery = JSON.stringify({
+      content: savedDraft,
+      base_revision: makeDoc().updated_at,
+    })
+    window.sessionStorage.setItem('assignment-draft:student-1:assignment-1', recovery)
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', recovery)
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    expect(window.sessionStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+  })
+
+  it('does not clear a durable recovery draft owned by another editor session', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    const claimedDraft = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    const otherSessionDraft = JSON.stringify({
+      content: olderInFlightDraft,
+      base_revision: makeDoc().updated_at,
+      save_session_id: '10000000-0000-4000-8000-000000000099',
+      draft_id: '10000000-0000-4000-8000-000000000099',
+      saved_at: new Date(Date.parse(claimedDraft.saved_at) + 1_000).toISOString(),
+    })
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', otherSessionDraft)
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await screen.findByText('Saved')
+
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBe(otherSessionDraft)
+  })
+
+  it('does not clear a newer durable draft generation from the same editor session', async () => {
+    let resolveSave: ((response: any) => void) | undefined
+    const saveResponse = new Promise<any>((resolve) => {
+      resolveSave = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return saveResponse
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PATCH')).toHaveLength(1)
+    })
+    const claimedDraft = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    const newerGeneration = JSON.stringify({
+      ...claimedDraft,
+      draft_id: '10000000-0000-4000-8000-000000000099',
+      generation: claimedDraft.generation + 1,
+      content: olderInFlightDraft,
+      saved_at: new Date(Date.parse(claimedDraft.saved_at) + 1_000).toISOString(),
+    })
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', newerGeneration)
+    resolveSave?.({
+      ok: true,
+      json: async () => ({
+        doc: { ...makeDoc(), content: latestDraft, updated_at: '2026-07-01T12:01:00.000Z' },
+        historyEntry: null,
+      }),
+    })
+    await screen.findByText('Saved')
+
+    expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBe(newerGeneration)
+  })
+
+  it('keeps the writer fence and sequence across remounts in the same tab', async () => {
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(), doc: makeDoc(), feedback_entries: [],
+            submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: `2026-07-01T12:0${patchBodies.length}:00.000Z` },
+            historyEntry: null,
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    const first = render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+    first.unmount()
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(2))
+
+    expect(patchBodies[1].save_session_id).toBe(patchBodies[0].save_session_id)
+    expect(patchBodies.map((body) => body.save_sequence)).toEqual([1, 2])
+  })
+
+  it('refreshes the saved revision after a pre-submit save conflict so retry can succeed', async () => {
+    const serverDraft = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Saved in another tab' }] }],
+    }
+    const revisions = {
+      initial: '2026-07-01T12:00:00.000Z',
+      conflict: '2026-07-01T12:02:00.000Z',
+      retrySave: '2026-07-01T12:03:00.000Z',
+      submitted: '2026-07-01T12:04:00.000Z',
+    }
+    let docGetCount = 0
+    let patchCount = 0
+    let submitCount = 0
+    const patchBodies: any[] = []
+    const submitBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docGetCount += 1
+        const refreshed = docGetCount > 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              content: refreshed ? serverDraft : savedDraft,
+              updated_at: refreshed ? revisions.conflict : revisions.initial,
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        patchCount += 1
+        patchBodies.push(JSON.parse(String(init.body)))
+        if (patchCount === 1) {
+          return {
+            ok: false,
+            status: 409,
+            json: async () => ({ error: 'This draft changed elsewhere before the save completed.' }),
+          }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: latestDraft,
+              updated_at: revisions.retrySave,
+            },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        submitCount += 1
+        submitBodies.push(JSON.parse(String(init?.body)))
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: latestDraft,
+              is_submitted: true,
+              updated_at: revisions.submitted,
+            },
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('changed elsewhere')
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(patchBodies.map((body) => body.expected_updated_at)).toEqual([
+      revisions.initial,
+      revisions.conflict,
+    ])
+    expect(submitBodies.map((body) => body.expected_updated_at)).toEqual([
+      revisions.retrySave,
+    ])
+    await waitFor(() => expect(ref.current?.isSubmitted).toBe(true))
+  })
+
+  it('requires reload when a revision conflict cannot refresh the saved document', async () => {
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        if (docReads > 1) {
+          return { ok: false, status: 503, json: async () => ({ error: 'Unavailable' }) }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ error: 'This draft changed elsewhere.' }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not be reloaded.*reload/i)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith('/submit'))).toBe(false)
+  })
+
+  it('bounds a hung revision-conflict reconciliation read', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    let requestTimeoutCount = 0
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000 && requestTimeoutCount++ === 1) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        if (docReads > 1) {
+          return { ok: true, status: 200, json: async () => new Promise(() => undefined) }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(), doc: makeDoc(), feedback_entries: [],
+            submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ error: 'This draft changed elsewhere.' }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not be reloaded.*reload/i)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith('/submit'))).toBe(false)
+  })
+
+  it('refreshes submitted state and preserves the local draft when another tab submits first', async () => {
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              is_submitted: docReads > 1,
+              submitted_at: docReads > 1 ? '2026-07-01T12:01:00.000Z' : null,
+              updated_at: docReads > 1 ? '2026-07-01T12:01:00.000Z' : makeDoc().updated_at,
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return {
+          ok: false,
+          status: 403,
+          json: async () => ({ error: 'Cannot edit a submitted document' }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/unsubmit')) {
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), is_submitted: false, updated_at: '2026-07-01T12:02:00.000Z' },
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await act(async () => { await ref.current?.submit() })
+
+    await waitFor(() => expect(ref.current?.isSubmitted).toBe(true))
+    expect(screen.getByRole('alert')).toHaveTextContent(/submitted in another tab/i)
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Older saved answer')
+    const recovery = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(recovery.content).toEqual(latestDraft)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith('/submit'))).toBe(false)
+
+    await act(async () => { await ref.current?.unsubmit() })
+    expect(ref.current?.isSubmitted).toBe(false)
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(/preserved local draft was restored/i)
+  })
+
+  it('requires reload when a submit conflict cannot refresh the saved document', async () => {
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        if (docReads > 1) {
+          return { ok: false, status: 503, json: async () => ({ error: 'Unavailable' }) }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ error: 'Your saved draft changed before submission.' }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not be reloaded.*reload/i)
+  })
+
+  it('bounds a hung submit request', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return { ok: true, status: 200, json: async () => new Promise(() => undefined) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await act(async () => {
+      await ref.current?.submit()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/submission timed out/i)
+  })
+
+  it('reconciles a committed submission after its response is lost', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    let requestTimeoutCount = 0
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000 && requestTimeoutCount++ === 0) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        docReads += 1
+        const submitted = docReads > 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              is_submitted: submitted,
+              submitted_at: submitted ? '2026-07-01T12:01:00.000Z' : null,
+              updated_at: submitted
+                ? '2026-07-01T12:01:00.000Z'
+                : makeDoc().updated_at,
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) {
+        return new Promise(() => undefined)
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await act(async () => { await ref.current?.submit() })
+
+    expect(ref.current?.isSubmitted).toBe(true)
+    expect(screen.queryByText(/submission timed out/i)).not.toBeInTheDocument()
+    expect(docReads).toBe(2)
+  })
+
+  it('bounds a hung unsubmit request', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        docReads += 1
+        if (docReads > 1) return new Promise(() => undefined)
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              is_submitted: true,
+              submitted_at: '2026-07-01T12:01:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/unsubmit')) {
+        return { ok: true, status: 200, json: async () => new Promise(() => undefined) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await act(async () => { await ref.current?.unsubmit() })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/unsubmit timed out/i)
+    expect(ref.current?.submitting).toBe(false)
+  })
+
+  it('reconciles a committed unsubmit after its response is lost', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    let requestTimeoutCount = 0
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000 && requestTimeoutCount++ === 0) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+
+    let docReads = 0
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (
+        url.endsWith('/assignment-docs/assignment-1')
+        && (!init?.method || init.method === 'GET')
+      ) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              is_submitted: docReads === 1,
+              submitted_at: docReads === 1 ? '2026-07-01T12:01:00.000Z' : null,
+              updated_at: docReads === 1
+                ? '2026-07-01T12:01:00.000Z'
+                : '2026-07-01T12:02:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/unsubmit')) {
+        return new Promise(() => undefined)
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await act(async () => { await ref.current?.unsubmit() })
+
+    expect(ref.current?.isSubmitted).toBe(false)
+    expect(screen.queryByText(/unsubmit timed out/i)).not.toBeInTheDocument()
+    expect(docReads).toBe(2)
+  })
+
+  it('saves a debounce-pending draft before restoring history', async () => {
+    const operations: string[] = []
+    const patchBodies: any[] = []
+    const historyEntry = {
+      id: 'history-1',
+      assignment_doc_id: 'doc-1',
+      patch: null,
+      snapshot: savedDraft,
+      word_count: 3,
+      char_count: 18,
+      paste_word_count: 0,
+      keystroke_count: 0,
+      trigger: 'autosave',
+      created_at: '2026-07-01T11:00:00.000Z',
+    }
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [historyEntry] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        operations.push('save')
+        patchBodies.push(body)
+        return {
+          ok: true,
+          json: async () => ({
+            doc: { ...makeDoc(), content: body.content, updated_at: '2026-07-01T12:01:00.000Z' },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/restore')) {
+        operations.push('restore')
+        return {
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: savedDraft,
+              updated_at: '2026-07-01T12:02:00.000Z',
+            },
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getAllByRole('button', { name: 'Select saved version' })[0])
+    await user.click(screen.getAllByRole('button', { name: 'Restore' })[0])
+    const restoreDialog = screen.getByRole('dialog', { name: 'Restore this version?' })
+    expect(restoreDialog).toHaveAttribute('aria-modal', 'true')
+    await user.click(within(restoreDialog).getByRole('button', { name: 'Restore' }))
+
+    await waitFor(() => expect(operations).toEqual(['save', 'restore']))
+    expect(patchBodies[0].content).toEqual(latestDraft)
+  })
+
+  it('bounds a hung history restore request', async () => {
+    const nativeSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      if (delay === 15000) {
+        queueMicrotask(() => typeof callback === 'function' && callback(...args))
+        return 999 as any
+      }
+      return nativeSetTimeout(callback, delay, ...args)
+    }) as typeof setTimeout)
+    const historyEntry = {
+      id: 'history-1',
+      assignment_doc_id: 'doc-1',
+      patch: null,
+      snapshot: savedDraft,
+      word_count: 3,
+      char_count: 18,
+      paste_word_count: 0,
+      keystroke_count: 0,
+      trigger: 'autosave',
+      created_at: '2026-07-01T11:00:00.000Z',
+    }
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [historyEntry] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/restore')) {
+        return { ok: true, status: 200, json: async () => new Promise(() => undefined) }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getAllByRole('button', { name: 'Select saved version' })[0])
+    await user.click(screen.getAllByRole('button', { name: 'Restore' })[0])
+    const restoreDialog = screen.getByRole('dialog', { name: 'Restore this version?' })
+    expect(restoreDialog).toHaveAttribute('aria-modal', 'true')
+    await user.click(within(restoreDialog).getByRole('button', { name: 'Restore' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert')[0]).toHaveTextContent(/restore timed out/i)
+    })
+  })
+
+  it('waits for an in-flight save before restoring history', async () => {
+    let resolveSave: ((response: any) => void) | undefined
+    const saveResponse = new Promise<any>((resolve) => {
+      resolveSave = resolve
+    })
+    let restoreCalls = 0
+    const patchBodies: any[] = []
+    const historyEntry = {
+      id: 'history-1',
+      assignment_doc_id: 'doc-1',
+      patch: null,
+      snapshot: savedDraft,
+      word_count: 3,
+      char_count: 18,
+      paste_word_count: 0,
+      keystroke_count: 0,
+      trigger: 'autosave',
+      created_at: '2026-07-01T11:00:00.000Z',
+    }
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [historyEntry] }) }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        patchBodies.push(JSON.parse(String(init.body)))
+        return saveResponse
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/restore')) {
+        restoreCalls += 1
+        return {
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: {
+                type: 'doc',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Restored answer' }] }],
+              },
+              updated_at: '2026-07-01T12:05:00.000Z',
+            },
+          }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Record keystroke' }))
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(screen.getByText('Saving...')).toBeInTheDocument())
+    await user.click(screen.getAllByRole('button', { name: 'Select saved version' })[0])
+    await user.click(screen.getAllByRole('button', { name: 'Restore' })[0])
+    const restoreDialog = screen.getByRole('dialog', { name: 'Restore this version?' })
+    expect(restoreDialog).toHaveAttribute('aria-modal', 'true')
+    await user.click(within(restoreDialog).getByRole('button', { name: 'Restore' }))
+
+    expect(restoreCalls).toBe(0)
+
+    resolveSave?.({
+      ok: true,
+      json: async () => ({ doc: { ...makeDoc(), content: latestDraft }, historyEntry: null }),
+    })
+
+    await waitFor(() => expect(restoreCalls).toBe(1))
+    await waitFor(() => {
+      expect(screen.getByTestId('editor-content')).toHaveTextContent('Restored answer')
+    })
+    await user.click(screen.getByRole('button', { name: 'Edit older response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchBodies).toHaveLength(2))
+    expect(patchBodies[0].keystroke_count).toBe(1)
+    expect(patchBodies[1].keystroke_count).toBe(0)
+  })
+
+  it('keeps a background autosave rejection visible and handled', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/history')) {
+        return { ok: true, json: async () => ({ history: [] }) }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        return { ok: false, json: async () => ({ error: 'Save service unavailable' }) }
+      }
+
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    await user.click(screen.getByRole('button', { name: 'Blur response' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Save service unavailable')
+    })
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(0)
+  })
+})

--- a/tests/components/StudentAssignmentEditor.save-submit.test.tsx
+++ b/tests/components/StudentAssignmentEditor.save-submit.test.tsx
@@ -1301,6 +1301,201 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     })
     expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
     expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    const recovery = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(recovery.content).toEqual(latestDraft)
+  })
+
+  it('preserves edits that arrive while a successful submission is in flight', async () => {
+    let resolveSubmit: ((response: any) => void) | undefined
+    const submitResponse = new Promise<any>((resolve) => {
+      resolveSubmit = resolve
+    })
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: makeDoc(),
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        return {
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeDoc(),
+              content: body.content,
+              updated_at: '2026-07-01T12:01:00.000Z',
+            },
+            historyEntry: null,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) return submitResponse
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    let submitPromise: Promise<void> | undefined
+    await act(async () => {
+      submitPromise = ref.current?.submit()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(1)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit older response' }))
+    resolveSubmit?.({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        doc: {
+          ...makeDoc(),
+          content: latestDraft,
+          is_submitted: true,
+          submitted_at: '2026-07-01T12:02:00.000Z',
+          updated_at: '2026-07-01T12:02:00.000Z',
+        },
+      }),
+    })
+    await act(async () => {
+      await submitPromise
+    })
+
+    expect(ref.current?.isSubmitted).toBe(true)
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    expect(screen.getByRole('alert')).toHaveTextContent(/newer local edits.*preserved/i)
+    const recovery = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(recovery.content).toEqual(olderInFlightDraft)
+  })
+
+  it('keeps a queued-save recovery draft after the earlier submission response succeeds', async () => {
+    let resolveSubmit: ((response: any) => void) | undefined
+    const submitResponse = new Promise<any>((resolve) => {
+      resolveSubmit = resolve
+    })
+    let docReads = 0
+    let patchCount = 0
+    const submittedDoc = {
+      ...makeDoc(),
+      content: latestDraft,
+      is_submitted: true,
+      submitted_at: '2026-07-01T12:02:00.000Z',
+      updated_at: '2026-07-01T12:02:00.000Z',
+    }
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: docReads === 1 ? makeDoc() : submittedDoc,
+            feedback_entries: [],
+            submission_requirements: [],
+            submission_artifacts: [],
+            wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        patchCount += 1
+        const body = JSON.parse(String(init.body))
+        if (patchCount === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              doc: {
+                ...makeDoc(),
+                content: body.content,
+                updated_at: '2026-07-01T12:01:00.000Z',
+              },
+              historyEntry: null,
+            }),
+          }
+        }
+        return {
+          ok: false,
+          status: 403,
+          json: async () => ({ error: 'Cannot edit a submitted document' }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1/submit')) return submitResponse
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    const ref = createRef<StudentAssignmentEditorHandle>()
+    const user = userEvent.setup()
+    render(
+      <StudentAssignmentEditor
+        ref={ref}
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+
+    await screen.findByText('Assignment Title')
+    await user.click(screen.getByRole('button', { name: 'Edit response' }))
+    let submitPromise: Promise<void> | undefined
+    await act(async () => {
+      submitPromise = ref.current?.submit()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith('/submit'))).toHaveLength(1)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit older response' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Blur response' }))
+    await waitFor(() => expect(patchCount).toBe(2))
+    await waitFor(() => expect(docReads).toBe(2))
+
+    resolveSubmit?.({
+      ok: true,
+      status: 200,
+      json: async () => ({ doc: submittedDoc }),
+    })
+    await act(async () => {
+      await submitPromise
+    })
+
+    expect(ref.current?.isSubmitted).toBe(true)
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
+    const recovery = JSON.parse(String(window.localStorage.getItem(
+      'assignment-draft:student-1:assignment-1'
+    )))
+    expect(recovery.content).toEqual(olderInFlightDraft)
   })
 
   it('uses a keepalive save for the latest draft on pagehide', async () => {
@@ -1742,6 +1937,112 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     }))
     await screen.findByText('Saved')
     expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+  })
+
+  it('replaces an equal-content recovered operation after a definitive conflict', async () => {
+    const pendingSave = {
+      content: savedDraft,
+      sessionId: '10000000-0000-4000-8000-000000000081',
+      sequence: 5,
+      metricSessionId: '10000000-0000-4000-8000-000000000082',
+      expectedUpdatedAt: makeDoc().updated_at,
+      trigger: 'blur',
+      pasteWordCount: 0,
+      keystrokeCount: 1,
+    }
+    window.localStorage.setItem('assignment-draft:student-1:assignment-1', JSON.stringify({
+      draft_id: '10000000-0000-4000-8000-000000000083',
+      generation: Date.now() * 1_000,
+      content: savedDraft,
+      base_revision: makeDoc().updated_at,
+      paste_word_count: 0,
+      keystroke_count: 1,
+      pending_save: pendingSave,
+      saved_at: new Date().toISOString(),
+    }))
+    let docReads = 0
+    const patchBodies: any[] = []
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/history')) return { ok: true, json: async () => ({ history: [] }) }
+      if (url.endsWith('/assignment-docs/assignment-1') && !init?.method) {
+        docReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignment(),
+            doc: {
+              ...makeDoc(),
+              updated_at: docReads === 1
+                ? makeDoc().updated_at
+                : '2026-07-01T12:01:00.000Z',
+            },
+            feedback_entries: [],
+            submission_requirements: [], submission_artifacts: [], wasFirstView: false,
+          }),
+        }
+      }
+      if (url.endsWith('/assignment-docs/assignment-1') && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length > 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              doc: {
+                ...makeDoc(),
+                updated_at: '2026-07-01T12:02:00.000Z',
+              },
+              historyEntry: null,
+            }),
+          }
+        }
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ error: 'This draft changed elsewhere.' }),
+        }
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`)
+    })
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await waitFor(() => expect(patchBodies).toHaveLength(1))
+    let replacement: any
+    await waitFor(() => {
+      replacement = JSON.parse(String(window.localStorage.getItem(
+        'assignment-draft:student-1:assignment-1'
+      )))
+      expect(replacement.pending_save.sessionId).not.toBe(pendingSave.sessionId)
+    })
+    expect(replacement.pending_save.expectedUpdatedAt).toBe('2026-07-01T12:01:00.000Z')
+    expect(replacement.pending_save.keystrokeCount).toBe(1)
+    expect(replacement.pending_save.metricSessionId).toBe(pendingSave.metricSessionId)
+
+    render(
+      <StudentAssignmentEditor
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        variant="embedded"
+      />,
+    )
+    await waitFor(() => expect(patchBodies).toHaveLength(2))
+    expect(patchBodies[1]).toEqual(expect.objectContaining({
+      save_session_id: replacement.pending_save.sessionId,
+      expected_updated_at: '2026-07-01T12:01:00.000Z',
+      keystroke_count: 1,
+    }))
+    await waitFor(() => {
+      expect(window.localStorage.getItem('assignment-draft:student-1:assignment-1')).toBeNull()
+    })
   })
 
   it('expires recovery records without a valid timestamp', async () => {

--- a/tests/lib/server/assignment-artifact-storage-cleanup.test.ts
+++ b/tests/lib/server/assignment-artifact-storage-cleanup.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  adoptProvisionalAssignmentArtifactStorageCleanup,
+  createProvisionalAssignmentArtifactStorageCleanup,
+  removeQueuedAssignmentArtifactStoragePath,
+  runAssignmentArtifactStorageCleanup,
+} from '@/lib/server/assignment-artifact-storage-cleanup'
+
+function makeSupabase(opts: {
+  storageErrors?: Array<unknown>
+  claimed?: Array<Record<string, unknown>>
+  completionData?: boolean
+  completionError?: unknown
+  referencedStoragePaths?: string[]
+}) {
+  const claimed = [...(opts.claimed ?? [])]
+  const remove = vi.fn(async () => ({
+    error: opts.storageErrors?.shift() ?? null,
+  }))
+  const rpc = vi.fn(async (name: string, args?: Record<string, unknown>) => {
+    if (name === 'claim_assignment_artifact_storage_cleanup') {
+      const next = claimed.shift()
+      return { data: next ? [next] : [], error: null }
+    }
+    if (name === 'claim_assignment_artifact_storage_cleanup_path') {
+      return {
+        data: [{
+          id: '10000000-0000-4000-8000-000000000099',
+          storage_path: args?.p_storage_path,
+          lease_token: args?.p_lease_token,
+        }],
+        error: null,
+      }
+    }
+    if (name === 'complete_assignment_artifact_storage_cleanup') {
+      return { data: opts.completionData ?? true, error: opts.completionError ?? null }
+    }
+    if (name === 'fail_assignment_artifact_storage_cleanup') {
+      return { data: true, error: null }
+    }
+    throw new Error(`Unexpected RPC ${name}`)
+  })
+  return {
+    remove,
+    rpc,
+    from: vi.fn((table: string) => {
+      if (table !== 'assignment_submission_artifacts') {
+        throw new Error(`Unexpected table ${table}`)
+      }
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((_column: string, storagePath: string) => ({
+            maybeSingle: vi.fn(async () => ({
+              data: opts.referencedStoragePaths?.includes(storagePath) ? { id: 'artifact-1' } : null,
+              error: null,
+            })),
+          })),
+        })),
+      }
+    }),
+    storage: { from: vi.fn(() => ({ remove })) },
+  }
+}
+
+describe('assignment artifact Storage cleanup', () => {
+  it('creates delayed provisional evidence and adopts that exact record', async () => {
+    const cleanup = {
+      id: '10000000-0000-4000-8000-000000000001',
+      storage_path: 'student/assignment/image.png',
+    }
+    const single = vi.fn(async () => ({ data: cleanup, error: null }))
+    const insert = vi.fn(() => ({
+      select: vi.fn(() => ({ single })),
+    }))
+    const maybeSingle = vi.fn(async () => ({ data: { id: cleanup.id }, error: null }))
+    const selectDeleted = vi.fn(() => ({ maybeSingle }))
+    const eqStatus = vi.fn(() => ({ select: selectDeleted }))
+    const eqPath = vi.fn(() => ({ eq: eqStatus }))
+    const deleteRow = vi.fn(() => ({
+      eq: vi.fn(() => ({ eq: eqPath })),
+    }))
+    const supabase = {
+      from: vi.fn(() => ({ insert, delete: deleteRow })),
+    }
+    const now = new Date('2026-07-16T12:00:00.000Z')
+
+    const provisional = await createProvisionalAssignmentArtifactStorageCleanup({
+      supabase,
+      storagePath: cleanup.storage_path,
+      now,
+    })
+
+    expect(provisional).toEqual(cleanup)
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      storage_path: cleanup.storage_path,
+      status: 'pending',
+      next_attempt_at: '2026-07-16T12:15:00.000Z',
+    }))
+    await expect(adoptProvisionalAssignmentArtifactStorageCleanup({
+      supabase,
+      cleanup,
+    })).resolves.toBe(true)
+    expect(deleteRow).toHaveBeenCalled()
+  })
+
+  it('removes an exact queued path and completes its durable evidence', async () => {
+    const supabase = makeSupabase({})
+
+    await expect(removeQueuedAssignmentArtifactStoragePath({
+      supabase,
+      storagePath: 'student/assignment/image.png',
+    })).resolves.toEqual({ completed: true })
+
+    expect(supabase.remove).toHaveBeenCalledWith(['student/assignment/image.png'])
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000099' })
+    )
+  })
+
+  it('keeps a shared Storage object while completing obsolete cleanup evidence', async () => {
+    const storagePath = 'student/assignment/shared.png'
+    const supabase = makeSupabase({ referencedStoragePaths: [storagePath] })
+
+    await expect(removeQueuedAssignmentArtifactStoragePath({
+      supabase,
+      storagePath,
+    })).resolves.toEqual({ completed: true })
+
+    expect(supabase.remove).not.toHaveBeenCalled()
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000099' })
+    )
+  })
+
+  it('leaves durable evidence pending when immediate Storage removal fails', async () => {
+    const supabase = makeSupabase({ storageErrors: [{ message: 'unavailable' }] })
+
+    await expect(removeQueuedAssignmentArtifactStoragePath({
+      supabase,
+      storagePath: 'student/assignment/image.png',
+    })).resolves.toEqual({ completed: false })
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'fail_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000099' })
+    )
+  })
+
+  it('reports immediate cleanup as pending when durable completion is not recorded', async () => {
+    const supabase = makeSupabase({ completionData: false })
+
+    await expect(removeQueuedAssignmentArtifactStoragePath({
+      supabase,
+      storagePath: 'student/assignment/image.png',
+    })).resolves.toEqual({ completed: false })
+  })
+
+  it('completes successful claims and releases failed claims for retry', async () => {
+    const supabase = makeSupabase({
+      storageErrors: [null, { message: 'temporary failure' }],
+      claimed: [
+        {
+          id: '10000000-0000-4000-8000-000000000001',
+          storage_path: 'student/assignment/one.png',
+          lease_token: '10000000-0000-4000-8000-000000000010',
+        },
+        {
+          id: '10000000-0000-4000-8000-000000000002',
+          storage_path: 'student/assignment/two.png',
+          lease_token: '10000000-0000-4000-8000-000000000010',
+        },
+      ],
+    })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 2 })).resolves.toEqual({
+      claimAttempts: 2,
+      claimFailures: 0,
+      claimed: 2,
+      completed: 1,
+      failed: 1,
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000001' })
+    )
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'fail_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000002' })
+    )
+  })
+
+  it('releases a claim after Storage rejects and continues the remaining batch', async () => {
+    const supabase = makeSupabase({
+      claimed: [
+        {
+          id: '10000000-0000-4000-8000-000000000001',
+          storage_path: 'student/assignment/one.png',
+          lease_token: '10000000-0000-4000-8000-000000000010',
+        },
+        {
+          id: '10000000-0000-4000-8000-000000000002',
+          storage_path: 'student/assignment/two.png',
+          lease_token: '10000000-0000-4000-8000-000000000010',
+        },
+      ],
+    })
+    supabase.remove
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce({ error: null })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 2 })).resolves.toEqual({
+      claimAttempts: 2,
+      claimFailures: 0,
+      claimed: 2,
+      completed: 1,
+      failed: 1,
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'fail_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000001' })
+    )
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000002' })
+    )
+  })
+
+  it('does not count a cleanup complete when the lease completion returns false', async () => {
+    const supabase = makeSupabase({
+      completionData: false,
+      claimed: [{
+        id: '10000000-0000-4000-8000-000000000001',
+        storage_path: 'student/assignment/one.png',
+        lease_token: '10000000-0000-4000-8000-000000000010',
+      }],
+    })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 1 })).resolves.toEqual({
+      claimAttempts: 1,
+      claimFailures: 0,
+      claimed: 1,
+      completed: 0,
+      failed: 1,
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'fail_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000001' })
+    )
+  })
+
+  it('continues after completion and failure-recording RPC promises reject', async () => {
+    const supabase = makeSupabase({
+      claimed: [
+        {
+          id: '10000000-0000-4000-8000-000000000001',
+          storage_path: 'student/assignment/one.png',
+          lease_token: '10000000-0000-4000-8000-000000000010',
+        },
+        {
+          id: '10000000-0000-4000-8000-000000000002',
+          storage_path: 'student/assignment/two.png',
+          lease_token: '10000000-0000-4000-8000-000000000011',
+        },
+      ],
+    })
+    const baseRpc = supabase.rpc.getMockImplementation()!
+    supabase.rpc.mockImplementation(async (name: string, args: unknown) => {
+      if (name === 'complete_assignment_artifact_storage_cleanup'
+        && (args as any).p_cleanup_id.endsWith('0001')) {
+        throw new Error('completion transport failed')
+      }
+      if (name === 'fail_assignment_artifact_storage_cleanup'
+        && (args as any).p_cleanup_id.endsWith('0001')) {
+        throw new Error('failure transport failed')
+      }
+      return baseRpc(name, args)
+    })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 2 })).resolves.toEqual({
+      claimAttempts: 2,
+      claimFailures: 0,
+      claimed: 2,
+      completed: 1,
+      failed: 1,
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000002' })
+    )
+  })
+
+  it('bounds claim attempts, exposes a transport rejection, and continues independent claims', async () => {
+    const supabase = makeSupabase({
+      claimed: [{
+        id: '10000000-0000-4000-8000-000000000001',
+        storage_path: 'student/assignment/one.png',
+        lease_token: '10000000-0000-4000-8000-000000000010',
+      }],
+    })
+    const baseRpc = supabase.rpc.getMockImplementation()!
+    let rejected = false
+    supabase.rpc.mockImplementation(async (name: string, args: unknown) => {
+      if (name === 'claim_assignment_artifact_storage_cleanup' && !rejected) {
+        rejected = true
+        throw new Error('claim transport rejected')
+      }
+      return baseRpc(name, args)
+    })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 2 })).resolves.toEqual({
+      claimAttempts: 2,
+      claimFailures: 1,
+      claimed: 1,
+      completed: 1,
+      failed: 1,
+    })
+    expect(supabase.rpc.mock.calls.filter(([name]) => (
+      name === 'claim_assignment_artifact_storage_cleanup'
+    ))).toHaveLength(2)
+  })
+
+  it('adopts a delayed cleanup whose uploaded path is now committed', async () => {
+    const storagePath = 'student/assignment/committed.png'
+    const supabase = makeSupabase({
+      referencedStoragePaths: [storagePath],
+      claimed: [{
+        id: '10000000-0000-4000-8000-000000000001',
+        storage_path: storagePath,
+        lease_token: '10000000-0000-4000-8000-000000000010',
+      }],
+    })
+
+    await expect(runAssignmentArtifactStorageCleanup({ supabase, limit: 1 })).resolves.toEqual({
+      claimAttempts: 1,
+      claimFailures: 0,
+      claimed: 1,
+      completed: 1,
+      failed: 0,
+    })
+    expect(supabase.remove).not.toHaveBeenCalled()
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'complete_assignment_artifact_storage_cleanup',
+      expect.objectContaining({ p_cleanup_id: '10000000-0000-4000-8000-000000000001' })
+    )
+  })
+})

--- a/tests/lib/server/assignment-doc-submissions-atomic.test.ts
+++ b/tests/lib/server/assignment-doc-submissions-atomic.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  saveAssignmentDocAtomic,
+  submitAssignmentDocAtomic,
+  unsubmitAssignmentDocAtomic,
+} from '@/lib/server/assignment-doc-submissions'
+
+const beforeContent = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Before' }] }],
+}
+const afterContent = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'After' }] }],
+}
+
+function makeDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'doc-1',
+    assignment_id: 'assignment-1',
+    student_id: 'student-1',
+    content: afterContent,
+    content_legacy: '',
+    is_submitted: false,
+    submitted_at: null,
+    created_at: '2026-07-16T12:00:00.000Z',
+    updated_at: '2026-07-16T12:01:00.000Z',
+    viewed_at: null,
+    score_completion: null,
+    score_thinking: null,
+    score_workflow: null,
+    feedback: null,
+    feedback_returned_at: null,
+    graded_at: null,
+    graded_by: null,
+    returned_at: null,
+    teacher_cleared_at: null,
+    teacher_feedback_draft: null,
+    teacher_feedback_draft_updated_at: null,
+    ai_feedback_suggestion: null,
+    ai_feedback_suggested_at: null,
+    ai_feedback_model: null,
+    authenticity_score: null,
+    authenticity_flags: null,
+    repo_url: null,
+    github_username: null,
+    save_session_id: '10000000-0000-4000-8000-000000000001',
+    save_sequence: 1,
+    ...overrides,
+  }
+}
+
+describe('atomic assignment document operations', () => {
+  it('passes revision, history, and metric-session evidence to the save RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        created: false,
+        doc: makeDoc(),
+        history_entry: null,
+      },
+      error: null,
+    })
+
+    const result = await saveAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      previousContent: beforeContent,
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:00:00.000Z',
+      trigger: 'blur',
+      pasteWordCount: 2,
+      keystrokeCount: 7,
+      saveSessionId: '10000000-0000-4000-8000-000000000001',
+      saveSequence: 2,
+      metricSessionId: '10000000-0000-4000-8000-000000000009',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('save_assignment_doc_atomic', expect.objectContaining({
+      p_assignment_id: 'assignment-1',
+      p_student_id: 'student-1',
+      p_expected_updated_at: '2026-07-16T12:00:00.000Z',
+      p_trigger: 'blur',
+      p_paste_word_count: 2,
+      p_keystroke_count: 7,
+      p_save_session_id: '10000000-0000-4000-8000-000000000001',
+      p_save_sequence: 2,
+      p_metric_session_id: '10000000-0000-4000-8000-000000000009',
+      p_patch: expect.any(Array),
+      p_word_count: 1,
+      p_char_count: 5,
+    }))
+  })
+
+  it('preserves structured conflicts returned by the save RPC', async () => {
+    const result = await saveAssignmentDocAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: false,
+            status: 409,
+            error_code: 'assignment_doc_revision_required',
+            error: 'A saved draft revision is required. Reload and try again.',
+          },
+          error: null,
+        }),
+      },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      previousContent: beforeContent,
+      content: afterContent,
+      expectedUpdatedAt: null,
+      trigger: 'autosave',
+      pasteWordCount: 0,
+      keystrokeCount: 0,
+      saveSessionId: '10000000-0000-4000-8000-000000000001',
+      saveSequence: 1,
+      metricSessionId: '10000000-0000-4000-8000-000000000002',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: 'A saved draft revision is required. Reload and try again.',
+      errorCode: 'assignment_doc_revision_required',
+    })
+  })
+
+  it('returns the submitted document from the atomic submit RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        idempotent: false,
+        doc: makeDoc({ is_submitted: true, submitted_at: '2026-07-16T12:02:00.000Z' }),
+        history_entry: {
+          id: 'history-1',
+          assignment_doc_id: 'doc-1',
+          patch: null,
+          snapshot: afterContent,
+          word_count: 1,
+          char_count: 5,
+          paste_word_count: 0,
+          keystroke_count: 0,
+          trigger: 'submit',
+          created_at: '2026-07-16T12:02:00.000Z',
+        },
+      },
+      error: null,
+    })
+
+    const result = await submitAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('submit_assignment_doc_atomic', expect.objectContaining({
+      p_expected_updated_at: '2026-07-16T12:01:00.000Z',
+      p_word_count: 1,
+      p_char_count: 5,
+    }))
+  })
+
+  it('accepts production-shaped authenticity flags from every mutation RPC', async () => {
+    const flaggedDoc = makeDoc({
+      authenticity_flags: [{
+        timestamp: '2026-07-16T12:01:00.000Z',
+        wordDelta: 12,
+        seconds: 2,
+        wps: 6,
+        reason: 'high_wps',
+      }],
+    })
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'save_assignment_doc_atomic') {
+        return { data: { ok: true, created: false, doc: flaggedDoc, history_entry: null }, error: null }
+      }
+      if (name === 'submit_assignment_doc_atomic') {
+        return { data: { ok: true, idempotent: false, doc: flaggedDoc, history_entry: null }, error: null }
+      }
+      return { data: { ok: true, doc: flaggedDoc }, error: null }
+    })
+
+    const saved = await saveAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      previousContent: beforeContent,
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:00:00.000Z',
+      trigger: 'autosave',
+      pasteWordCount: 0,
+      keystrokeCount: 1,
+      saveSessionId: '10000000-0000-4000-8000-000000000001',
+      saveSequence: 2,
+      metricSessionId: '10000000-0000-4000-8000-000000000002',
+    })
+    const submitted = await submitAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+    })
+    const unsubmitted = await unsubmitAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+    })
+
+    expect(saved.ok).toBe(true)
+    expect(submitted.ok).toBe(true)
+    expect(unsubmitted.ok).toBe(true)
+  })
+
+  it('accepts and strips additive RPC fields during migration-first rollout', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        created: false,
+        future_envelope_field: 'new-server-metadata',
+        doc: makeDoc({ future_doc_field: 'new-column' }),
+        history_entry: null,
+      },
+      error: null,
+    })
+
+    const result = await saveAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      previousContent: beforeContent,
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:00:00.000Z',
+      trigger: 'autosave',
+      pasteWordCount: 0,
+      keystrokeCount: 1,
+      saveSessionId: '10000000-0000-4000-8000-000000000001',
+      saveSequence: 2,
+      metricSessionId: '10000000-0000-4000-8000-000000000002',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.doc).not.toHaveProperty('future_doc_field')
+  })
+
+  it('reports a missing atomic migration without falling back to split writes', async () => {
+    const result = await submitAssignmentDocAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST202' } }),
+      },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: 'Assignment submission migration is required',
+      errorCode: 'assignment_submission_migration_required',
+    })
+  })
+
+  it('returns a structured conflict when atomic unsubmit loses to teacher return', async () => {
+    const result = await unsubmitAssignmentDocAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: false,
+            status: 409,
+            error_code: 'assignment_doc_returned',
+            error: 'Returned submissions cannot be unsubmitted',
+          },
+          error: null,
+        }),
+      },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: 'Returned submissions cannot be unsubmitted',
+      errorCode: 'assignment_doc_returned',
+    })
+  })
+
+  it('rejects malformed RPC documents instead of casting them into the domain', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const result = await submitAssignmentDocAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: true,
+            idempotent: false,
+            doc: makeDoc({ content: { invalid: true }, updated_at: 'not-a-timestamp' }),
+            history_entry: null,
+          },
+          error: null,
+        }),
+      },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: 'Assignment document operation failed',
+      errorCode: 'invalid_rpc_result',
+    })
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('rejects malformed JSON Patch history returned by the RPC', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const result = await submitAssignmentDocAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: true,
+            idempotent: false,
+            doc: makeDoc({ is_submitted: true, submitted_at: '2026-07-16T12:02:00.000Z' }),
+            history_entry: {
+              id: 'history-1',
+              assignment_doc_id: 'doc-1',
+              patch: [{ op: 'replace', path: '/content', unexpected: true }],
+              snapshot: null,
+              word_count: 1,
+              char_count: 5,
+              paste_word_count: 0,
+              keystroke_count: 0,
+              trigger: 'submit',
+              created_at: '2026-07-16T12:02:00.000Z',
+            },
+          },
+          error: null,
+        }),
+      },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: 'Assignment document operation failed',
+      errorCode: 'invalid_rpc_result',
+    })
+    expect(consoleError).toHaveBeenCalled()
+  })
+})

--- a/tests/lib/server/assignment-submission-artifacts-atomic.test.ts
+++ b/tests/lib/server/assignment-submission-artifacts-atomic.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { updateAssignmentWithSubmissionRequirementsAtomic } from '@/lib/server/assignment-submission-artifacts'
+
+function makeAssignment() {
+  return {
+    classroom_id: 'classroom-1',
+    created_at: '2026-07-16T12:00:00.000Z',
+    created_by: 'teacher-1',
+    description: 'Instructions',
+    due_at: '2026-08-01T03:59:59.000Z',
+    gradebook_weight: 1,
+    id: 'assignment-1',
+    include_in_final: true,
+    instructions_markdown: 'Instructions',
+    is_draft: false,
+    points_possible: 100,
+    position: 0,
+    released_at: null,
+    rich_instructions: null,
+    title: 'Assignment',
+    track_authenticity: true,
+    updated_at: '2026-07-16T12:01:00.000Z',
+  }
+}
+
+describe('atomic assignment and requirement updates', () => {
+  it('parses a complete successful RPC result', async () => {
+    const assignment = makeAssignment()
+    const result = await updateAssignmentWithSubmissionRequirementsAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: { ok: true, assignment, submission_requirements: [] },
+          error: null,
+        }),
+      },
+      assignmentId: assignment.id,
+      updates: { title: assignment.title },
+      requirements: [],
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      assignment,
+      submissionRequirements: [],
+    })
+  })
+
+  it('accepts and strips additive assignment fields during migration-first rollout', async () => {
+    const assignment = { ...makeAssignment(), future_assignment_field: 'new-column' }
+    const result = await updateAssignmentWithSubmissionRequirementsAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: true,
+            future_envelope_field: 'new-server-metadata',
+            assignment,
+            submission_requirements: [],
+          },
+          error: null,
+        }),
+      },
+      assignmentId: assignment.id,
+      updates: { title: assignment.title },
+      requirements: [],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.assignment).not.toHaveProperty('future_assignment_field')
+  })
+
+  it('rejects malformed successful RPC data', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const result = await updateAssignmentWithSubmissionRequirementsAtomic({
+      supabase: {
+        rpc: vi.fn().mockResolvedValue({
+          data: {
+            ok: true,
+            assignment: { ...makeAssignment(), due_at: 'not-a-timestamp' },
+            submission_requirements: [{ type: 'repo' }],
+          },
+          error: null,
+        }),
+      },
+      assignmentId: 'assignment-1',
+      updates: {},
+      requirements: [],
+    })
+
+    expect(result).toEqual({ ok: false, status: 500, error: 'Failed to update assignment' })
+    expect(consoleError).toHaveBeenCalled()
+  })
+})

--- a/tests/lib/server/classroom-archive-restore.test.ts
+++ b/tests/lib/server/classroom-archive-restore.test.ts
@@ -196,6 +196,8 @@ describe('classroom archive restore planning', () => {
 
     expect(plan.targetSchemaMigration).toBe(CLASSROOM_ARCHIVE_RESTORE_TARGET_MIGRATION)
     expect(plan.adapterChain).toEqual(['classroom-archive-v1-082-to-083'])
+    expect(plan.resources.assignment_docs[0]).not.toHaveProperty('save_session_id')
+    expect(plan.resources.assignment_docs[0]).not.toHaveProperty('save_sequence')
     expect(plan.preflight.unresolved_actor_ids).toEqual([])
     expect(plan.storageObjects).toHaveLength(4)
     expect(plan.storageObjects.every((object) =>

--- a/tests/lib/server/versioned-history.test.ts
+++ b/tests/lib/server/versioned-history.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { persistVersionedHistory } from '@/lib/server/versioned-history'
+
+describe('persistVersionedHistory', () => {
+  it('never coalesces an autosave into an authoritative submit entry', async () => {
+    const update = vi.fn()
+    const insert = vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(async () => ({
+          data: { id: 'history-autosave', trigger: 'autosave' },
+          error: null,
+        })),
+      })),
+    }))
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => ({
+              limit: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({
+                  data: {
+                    id: 'history-submit',
+                    created_at: new Date().toISOString(),
+                    trigger: 'submit',
+                    paste_word_count: 0,
+                    keystroke_count: 0,
+                  },
+                  error: null,
+                })),
+              })),
+            })),
+          })),
+        })),
+        update,
+        insert,
+      })),
+    }
+
+    const result = await persistVersionedHistory({
+      supabase,
+      table: 'assignment_doc_history',
+      ownerColumn: 'assignment_doc_id',
+      ownerId: 'doc-1',
+      previousContent: { value: 'submitted' },
+      nextContent: { value: 'new draft' },
+      selectFields: '*',
+      trigger: 'autosave',
+      historyMinIntervalMs: 15_000,
+      buildMetrics: () => ({ word_count: 2, char_count: 9 }),
+    })
+
+    expect(update).not.toHaveBeenCalled()
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      assignment_doc_id: 'doc-1',
+      trigger: 'autosave',
+    }))
+    expect(result).toEqual({ id: 'history-autosave', trigger: 'autosave' })
+  })
+})

--- a/tests/lib/validations/assignment-authoring.test.ts
+++ b/tests/lib/validations/assignment-authoring.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { teacherAssignmentPatchSchema } from '@/lib/validations/assignment-authoring'
+
+describe('teacherAssignmentPatchSchema', () => {
+  it('accepts a strict assignment and requirement update', () => {
+    const input = {
+      title: 'Updated assignment',
+      due_at: '2026-08-01T03:59:59.000Z',
+      submission_requirements: [{
+        id: '10000000-0000-4000-8000-000000000001',
+        type: 'link',
+        label: 'Published work',
+        required: true,
+        position: 0,
+        validation_policy_json: {
+          mode: 'expected_domain',
+          expected_domains: ['example.com'],
+        },
+      }],
+    }
+
+    expect(teacherAssignmentPatchSchema.parse(input)).toEqual(input)
+  })
+
+  it('rejects unknown requirement types instead of normalizing them away', () => {
+    expect(teacherAssignmentPatchSchema.safeParse({
+      submission_requirements: [{ type: 'repo', label: 'Repository' }],
+    }).success).toBe(false)
+  })
+
+  it('rejects malformed requirement identifiers', () => {
+    expect(teacherAssignmentPatchSchema.safeParse({
+      submission_requirements: [{ id: 'requirement-1', type: 'link' }],
+    }).success).toBe(false)
+  })
+
+  it('rejects unknown assignment fields', () => {
+    expect(teacherAssignmentPatchSchema.safeParse({ unexpected: true }).success).toBe(false)
+  })
+})

--- a/tests/lib/validations/assignment-doc-submissions.test.ts
+++ b/tests/lib/validations/assignment-doc-submissions.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assignmentDocSaveRequestSchema,
+  assignmentDocRestoreRequestSchema,
+  assignmentDocSubmitRequestSchema,
+} from '@/lib/validations/assignment-doc-submissions'
+
+describe('assignmentDocSubmitRequestSchema', () => {
+  it('accepts Tiptap content with an offset-aware saved revision', () => {
+    const input = {
+      content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Ready' }] }],
+      },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+    }
+
+    expect(assignmentDocSubmitRequestSchema.parse(input)).toEqual(input)
+  })
+
+  it('rejects malformed content and revisions', () => {
+    expect(assignmentDocSubmitRequestSchema.safeParse({
+      content: null,
+      expected_updated_at: 'not-a-timestamp',
+    }).success).toBe(false)
+    expect(assignmentDocSubmitRequestSchema.safeParse({
+      content: { type: 'doc', content: [null] },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+    }).success).toBe(false)
+    expect(assignmentDocSubmitRequestSchema.safeParse({
+      content: { type: 'doc', content: [{ type: 'paragraph', content: [null] }] },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+    }).success).toBe(false)
+  })
+
+  it('rejects unknown submit fields', () => {
+    expect(assignmentDocSubmitRequestSchema.safeParse({
+      content: { type: 'doc', content: [] },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      unexpected: true,
+    }).success).toBe(false)
+  })
+
+  it('accepts a revision-guarded autosave payload', () => {
+    expect(assignmentDocSaveRequestSchema.parse({
+      content: { type: 'doc', content: [] },
+      trigger: 'autosave',
+      paste_word_count: 2,
+      keystroke_count: 7,
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      save_session_id: '10000000-0000-4000-8000-000000000001',
+      save_sequence: 1,
+      metric_session_id: '10000000-0000-4000-8000-000000000002',
+    })).toEqual({
+      content: { type: 'doc', content: [] },
+      trigger: 'autosave',
+      paste_word_count: 2,
+      keystroke_count: 7,
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      save_session_id: '10000000-0000-4000-8000-000000000001',
+      save_sequence: 1,
+      metric_session_id: '10000000-0000-4000-8000-000000000002',
+    })
+  })
+
+  it('validates cumulative metric-session evidence and metric bounds', () => {
+    const content = { type: 'doc', content: [] }
+    expect(assignmentDocSaveRequestSchema.parse({
+      content,
+      save_session_id: '10000000-0000-4000-8000-000000000001',
+      save_sequence: 2,
+      metric_session_id: '10000000-0000-4000-8000-000000000009',
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      paste_word_count: '2',
+      keystroke_count: 7,
+    })).toEqual({
+      content,
+      save_session_id: '10000000-0000-4000-8000-000000000001',
+      save_sequence: 2,
+      metric_session_id: '10000000-0000-4000-8000-000000000009',
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      paste_word_count: 2,
+      keystroke_count: 7,
+    })
+
+    expect(assignmentDocSaveRequestSchema.safeParse({
+      content,
+      paste_word_count: 32_768,
+    }).success).toBe(false)
+  })
+
+  it('accepts the strict rollout-only legacy shape and rejects partial atomic evidence', () => {
+    expect(assignmentDocSaveRequestSchema.safeParse({
+      content: { type: 'doc', content: [] },
+    }).success).toBe(true)
+    expect(assignmentDocSaveRequestSchema.safeParse({
+      content: { type: 'doc', content: [] },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+    }).success).toBe(false)
+  })
+
+  it('rejects unknown save fields', () => {
+    expect(assignmentDocSaveRequestSchema.safeParse({
+      content: { type: 'doc', content: [] },
+      expected_updated_at: '2026-07-16T12:00:00.000Z',
+      save_session_id: '10000000-0000-4000-8000-000000000001',
+      save_sequence: 1,
+      metric_session_id: '10000000-0000-4000-8000-000000000002',
+      unexpected: true,
+    }).success).toBe(false)
+  })
+})
+
+describe('assignmentDocRestoreRequestSchema', () => {
+  it('accepts only a UUID history identifier', () => {
+    const input = { history_id: '10000000-0000-4000-8000-000000000002' }
+    expect(assignmentDocRestoreRequestSchema.parse(input)).toEqual(input)
+    expect(assignmentDocRestoreRequestSchema.safeParse({ history_id: 'history-1' }).success).toBe(false)
+    expect(assignmentDocRestoreRequestSchema.safeParse({ ...input, unexpected: true }).success).toBe(false)
+  })
+})

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -397,6 +397,36 @@ describe('AI startup docs', () => {
     }
   })
 
+  it('allows the canonical parseContentField definition to change', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+    const canonicalPath = join(repoRoot, 'src/lib/tiptap-content.ts')
+    const canonicalFunction = 'parseContent' + 'Field'
+
+    mkdirSync(join(repoRoot, 'src/lib'), { recursive: true })
+    writeFileSync(
+      canonicalPath,
+      `export function ${canonicalFunction}(content: unknown) { return content }\n`,
+    )
+    commitAll(repoRoot, 'add canonical content parser')
+    writeFileSync(
+      canonicalPath,
+      `export function ${canonicalFunction}(content: unknown) { return content ?? null }\n`,
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain('duplicate-parseContentField')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('makes the audit script reject risky changes with only unrelated changed tests', () => {
     const repoRoot = makeFixtureWorktree()
     const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')

--- a/tests/unit/api-handler.test.ts
+++ b/tests/unit/api-handler.test.ts
@@ -165,6 +165,41 @@ describe('withErrorHandler', () => {
     expect(console.error).not.toHaveBeenCalled()
   })
 
+  it('maps malformed request JSON to 400 without route-local handling', async () => {
+    const handler = withErrorHandler('TestRoute', async (request) => {
+      await request.json()
+      return NextResponse.json({})
+    })
+    const request = new NextRequest('http://localhost/api/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"broken":',
+    })
+
+    const result = await handler(request, { params: Promise.resolve({}) })
+
+    expect(result.status).toBe(400)
+    await expect(result.json()).resolves.toEqual({ error: 'Malformed JSON body' })
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('does not misclassify unrelated SyntaxErrors as malformed request JSON', async () => {
+    const error = new SyntaxError('application parser failed')
+    const handler = withErrorHandler('TestRoute', async () => {
+      throw error
+    })
+    const request = new NextRequest('http://localhost/api/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+
+    const result = await handler(request, { params: Promise.resolve({}) })
+
+    expect(result.status).toBe(500)
+    expect(console.error).toHaveBeenCalledWith('TestRoute error:', error)
+  })
+
   it('forwards request and params to the inner handler', async () => {
     const innerHandler = vi.fn(async (_request: NextRequest, context: any) => {
       const params = await context.params

--- a/tests/unit/assignment-submission-integrity-migration.test.ts
+++ b/tests/unit/assignment-submission-integrity-migration.test.ts
@@ -1,0 +1,234 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/099_assignment_submission_integrity_guards.sql'),
+  'utf8',
+).toLowerCase()
+const atomicHarness = readFileSync(
+  resolve(process.cwd(), 'scripts/check-atomic-assignment-submissions.sh'),
+  'utf8',
+).toLowerCase()
+const concurrencyHarness = readFileSync(
+  resolve(process.cwd(), 'scripts/check-assignment-submission-concurrency.sh'),
+  'utf8',
+).toLowerCase()
+const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/ci.yml'), 'utf8').toLowerCase()
+const rolloutGuide = readFileSync(
+  resolve(process.cwd(), 'docs/guidance/atomic-assignment-submission-rollout.md'),
+  'utf8',
+).toLowerCase()
+const restoreSource = readFileSync(
+  resolve(process.cwd(), 'src/lib/server/classroom-archive-restore.ts'),
+  'utf8',
+).toLowerCase()
+const recoveryDrill = readFileSync(
+  resolve(process.cwd(), 'scripts/run-classroom-archive-recovery-drill.ts'),
+  'utf8',
+).toLowerCase()
+const vercelConfig = readFileSync(resolve(process.cwd(), 'vercel.json'), 'utf8').toLowerCase()
+
+describe('assignment submission integrity migration', () => {
+  it('locks the owning document before accepting artifact mutations', () => {
+    expect(migration).toContain('guard_assignment_submission_artifact_mutation')
+    expect(migration).toContain('from public.assignment_docs d')
+    expect(migration).toContain('for update;')
+    expect(migration).toContain('assignment_artifact_submitted_document_immutable')
+    expect(migration).toContain(
+      'before insert or update or delete on public.assignment_submission_artifacts',
+    )
+    expect(migration).toContain('create trigger aaa_guard_assignment_submission_artifact_mutation')
+  })
+
+  it('revalidates required and blocking artifacts during submission', () => {
+    expect(migration).toContain('validate_assignment_submission_transition')
+    expect(migration).toContain('assignment_submission_requirements_incomplete')
+    expect(migration).toContain("a.validation_status in ('invalid', 'inaccessible')")
+    expect(migration).toContain('when (new.is_submitted and not old.is_submitted)')
+  })
+
+  it('serializes history writes and preserves submit entries', () => {
+    expect(migration).toContain('guard_assignment_doc_history_after_submit')
+    expect(migration).toContain("old.trigger = 'submit' or new.trigger = 'submit'")
+    expect(migration).toContain('assignment_history_after_submit_forbidden')
+    expect(migration).toContain('before insert or update or delete on public.assignment_doc_history')
+    expect(migration).toContain('submit_assignment_doc_atomic')
+    expect(migration).toContain("'history_entry', to_jsonb(v_history)")
+    expect(migration).toContain('assignment_submit_history_snapshot_invalid')
+    expect(migration).toContain('and h.snapshot = v_doc.content')
+    expect(migration).toContain("check (trigger in ('autosave', 'blur', 'submit', 'baseline', 'restore'))")
+    expect(migration).toContain('create constraint trigger ensure_current_assignment_submit_history')
+    expect(migration).toContain('deferrable initially deferred')
+  })
+
+  it('keeps archive maintenance and destructive parent cascades valid', () => {
+    expect(migration).toContain("is_classroom_archive_maintenance_mode('restore')")
+    expect(migration).toContain("is_classroom_archive_maintenance_mode('compaction')")
+    expect(migration).toContain("if tg_op = 'delete' then\n      return old;")
+    expect(migration).toContain("if p_table_name = 'assignment_docs' then")
+    expect(migration).toContain("jsonb_build_object('save_session_id', null)")
+    expect(migration).toContain("jsonb_build_object('save_sequence', null)")
+  })
+
+  it('attaches recovery-drill artifacts before submitting the fixture document', () => {
+    const createFixture = recoveryDrill.slice(
+      recoveryDrill.indexOf('async function createfixture'),
+      recoveryDrill.indexOf('async function removefixture'),
+    )
+    const artifactInsert = createFixture.indexOf(
+      "await insertfixturerow(args.supabase, 'assignment_submission_artifacts'",
+    )
+    const documentSubmit = createFixture.indexOf('const submitresponse = await args.supabase')
+    const submitMutation = createFixture.slice(documentSubmit)
+    const snapshotLoader = recoveryDrill.slice(
+      recoveryDrill.indexOf('async function loadfixturesnapshot'),
+      recoveryDrill.indexOf('async function readstoragebytes'),
+    )
+    const restoreEquality = recoveryDrill.slice(
+      recoveryDrill.indexOf('const expectedrestoredrows'),
+      recoveryDrill.indexOf('const restoredobjectbytes'),
+    )
+    const removeFixture = recoveryDrill.slice(
+      recoveryDrill.indexOf('async function removefixture'),
+      recoveryDrill.indexOf('async function runrecoverydrill'),
+    )
+    const classroomDelete = removeFixture.indexOf("await deleterows('classrooms'")
+    const cleanupDelete = removeFixture.indexOf(
+      "await deleterows('assignment_artifact_storage_cleanup'",
+    )
+    const cleanupAbsenceCheck = removeFixture.indexOf('for (const cleanuppath of cleanuppaths)')
+
+    expect(createFixture).toContain('is_submitted: false')
+    expect(artifactInsert).toBeGreaterThan(-1)
+    expect(documentSubmit).toBeGreaterThan(artifactInsert)
+    expect(submitMutation).toContain('is_submitted: true')
+    expect(submitMutation).toContain(".eq('id', args.ids.assignment_docs)")
+    expect(submitMutation).toContain(".select('id')\n    .single()")
+    expect(snapshotLoader).toContain(".from('assignment_doc_history')")
+    expect(snapshotLoader).toContain(".eq('assignment_doc_id', ids.assignment_docs)")
+    expect(snapshotLoader).toContain('assignment_doc_history: z.record')
+    expect(restoreEquality).toContain('const actualrestoredrows = await loadfixturesnapshot')
+    expect(restoreEquality).toContain('canonicaljsonstringify(actualrestoredrows)')
+    expect(classroomDelete).toBeGreaterThan(-1)
+    expect(cleanupDelete).toBeGreaterThan(classroomDelete)
+    expect(cleanupAbsenceCheck).toBeGreaterThan(cleanupDelete)
+    expect(removeFixture.slice(cleanupAbsenceCheck)).toContain(
+      "'assignment_artifact_storage_cleanup',\n        'storage_path',\n        cleanuppath",
+    )
+  })
+
+  it('saves draft content and history in one database transaction', () => {
+    expect(migration).toContain('save_assignment_doc_atomic')
+    expect(migration).toContain('assignment_doc_revision_required')
+    expect(migration).toContain('p_save_session_id')
+    expect(migration).toContain('p_metric_session_id')
+    expect(migration).toContain(
+      'jsonb, jsonb, integer, integer, uuid, bigint, bigint, integer, integer',
+    )
+    expect(migration).toContain('insert into public.assignment_doc_history')
+    expect(migration).toContain("elsif p_trigger <> 'restore'")
+    expect(migration).toContain('or v_effective_keystroke_count > 0')
+    expect(migration).toContain('create table if not exists public.assignment_doc_save_operations')
+    expect(migration).toContain('content_sha256 text not null')
+    expect(migration).toContain('document_updated_at timestamptz not null')
+    expect(migration).toContain('metric_session_id uuid not null')
+    expect(migration).toContain('cleanup_assignment_doc_save_operations')
+    expect(migration).toContain('max(operation.keystroke_count)')
+    expect(migration).toContain("'error_code', 'assignment_doc_save_replayed'")
+  })
+
+  it('locks requirement artifacts before archive revision triggers and unsubmits atomically', () => {
+    expect(migration).toContain('where artifact.requirement_id = old.id')
+    expect(migration).toContain('order by artifact.id')
+    expect(migration).toContain('unsubmit_assignment_doc_atomic')
+    expect(migration).toContain('assignment_doc_returned')
+    expect(migration).toContain('assignment_submitted_document_identity_immutable')
+    expect(migration).toContain('assignment_submitted_at_immutable')
+  })
+
+  it('deletes artifact rows before durable, leased Storage cleanup', () => {
+    expect(migration).toContain('create table if not exists public.assignment_artifact_storage_cleanup')
+    expect(migration).toContain('after delete or update of storage_path on public.assignment_submission_artifacts')
+    expect(migration).toContain('delete_assignment_submission_artifact_atomic')
+    expect(migration).toContain('claim_assignment_artifact_storage_cleanup')
+    expect(migration).toContain('for update skip locked')
+    expect(migration).toContain('fail_assignment_artifact_storage_cleanup')
+    expect(migration).toContain('p_delay_seconds integer default 0')
+    expect(migration).toContain('artifact.storage_path = cleanup.storage_path')
+    expect(migration).toContain(
+      'grant select, insert, delete on table public.assignment_artifact_storage_cleanup to service_role',
+    )
+    expect(migration).toContain('least(cleanup.attempt_count, 6)')
+    expect(vercelConfig).toContain('/api/cron/assignment-artifact-storage-cleanup')
+  })
+
+  it('uses artifact-before-document locking for student and teacher mutations', () => {
+    const combinedUpdate = migration.slice(
+      migration.indexOf('create or replace function public.update_assignment_with_submission_requirements_atomic'),
+    )
+    expect(combinedUpdate.indexOf('for v_artifact_id in')).toBeGreaterThanOrEqual(0)
+    expect(combinedUpdate.indexOf('for v_artifact_id in')).toBeLessThan(
+      combinedUpdate.indexOf('for v_doc_id in'),
+    )
+    expect(concurrencyHarness).toContain('run_teacher_artifact_race')
+    expect(concurrencyHarness).toContain('run_old_replace_new_combined_race')
+  })
+
+  it('keeps restore and migration-first teacher lock ordering deterministic', () => {
+    const restoreWrapper = migration.slice(
+      migration.indexOf('create or replace function public.complete_classroom_archive_restore'),
+      migration.indexOf('drop function if exists public.save_assignment_doc_atomic'),
+    )
+    expect(restoreWrapper.indexOf('set constraints public.ensure_current_assignment_submit_history immediate')).toBeLessThan(
+      restoreWrapper.indexOf("set_config(\n    'pika.classroom_archive_restore'"),
+    )
+    const legacyReplace = migration.slice(
+      migration.indexOf('create or replace function public.replace_assignment_submission_requirements_atomic'),
+      migration.indexOf('create or replace function public.update_assignment_with_submission_requirements_atomic'),
+    )
+    expect(legacyReplace.indexOf('pg_advisory_xact_lock')).toBeLessThan(
+      legacyReplace.indexOf('update public.assignment_submission_requirements'),
+    )
+  })
+
+  it('backfills the current authoritative submission and keeps description in combined updates', () => {
+    expect(migration).toContain("h.created_at >= coalesce(d.submitted_at, '-infinity'::timestamptz)")
+    expect(migration).toContain('and h.snapshot = d.content')
+    expect(migration).toContain("when p_updates ? 'description' then p_updates->>'description'")
+    expect(migration).toContain('silently preserve authoritative submit rows')
+  })
+
+  it('does not expose trigger functions as callable APIs', () => {
+    expect(migration).toContain(
+      'revoke all on function public.guard_assignment_submission_artifact_mutation() from public, anon, authenticated, service_role;',
+    )
+    expect(migration).toContain(
+      'revoke all on function public.validate_assignment_submission_transition() from public, anon, authenticated, service_role;',
+    )
+    expect(migration).toContain(
+      'revoke all on function public.guard_assignment_doc_history_after_submit() from public, anon, authenticated, service_role;',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.save_assignment_doc_atomic',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.submit_assignment_doc_atomic',
+    )
+  })
+
+  it('proves the migration-first compatibility and CI rollout contract', () => {
+    expect(rolloutGuide).toContain('migration 099 must be applied and verified before the application is deployed')
+    expect(rolloutGuide).toContain('drain every previous-version application instance')
+    expect(rolloutGuide).toContain('previous-version archive restores are accepted')
+    expect(rolloutGuide).toContain('leave migration 099 in place if the application is rolled back')
+    expect(concurrencyHarness).toContain('for migration in "$root"/supabase/migrations/*.sql')
+    expect(concurrencyHarness).toContain('run_old_submit_new_requirement_rpc_race')
+    expect(atomicHarness).toContain('assignment rpc privilege contract is invalid')
+    expect(atomicHarness).toContain('pre-099 assignment archive row was not normalized')
+    expect(workflow).toContain('bash scripts/check-atomic-assignment-submissions.sh')
+    expect(workflow).toContain('bash scripts/check-assignment-submission-concurrency.sh')
+    expect(restoreSource).toContain("'083_resumable_classroom_archive_restore' as const")
+    expect(restoreSource).toContain("id: 'classroom-archive-v1-082-to-083'")
+  })
+})

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -477,6 +477,19 @@ describe('assignment utilities', () => {
       expect(isAssignmentLive(assignment, now)).toBe(false)
     })
 
+    it('uses the current time when release helpers omit the comparison date', () => {
+      vi.setSystemTime(now)
+      const assignment = {
+        is_draft: false,
+        released_at: '2026-03-01T13:00:01.000Z',
+      }
+
+      expect(getAssignmentReleaseState(assignment)).toBe('scheduled')
+      expect(isAssignmentVisibleToStudents(assignment)).toBe(false)
+      expect(isAssignmentScheduledForFuture(assignment)).toBe(true)
+      expect(isAssignmentLive(assignment)).toBe(false)
+    })
+
     it('falls back to current time when the comparison date is malformed', () => {
       vi.setSystemTime(now)
       const assignment = {
@@ -838,12 +851,30 @@ describe('assignment utilities', () => {
       })).toBe(true)
     })
 
-    it('blocks unsubmit after a teacher return, including resubmitted work', () => {
+    it('allows unsubmit after a student resubmits returned work', () => {
       expect(canUnsubmitAssignmentDoc({
         is_submitted: true,
         submitted_at: '2026-04-21T12:00:00.000Z',
         returned_at: '2026-04-20T13:00:00.000Z',
         teacher_cleared_at: '2026-04-20T13:00:00.000Z',
+      })).toBe(true)
+    })
+
+    it('blocks unsubmit when the teacher return is newer than the submission', () => {
+      expect(canUnsubmitAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2026-04-20T12:00:00.000Z',
+        returned_at: '2026-04-20T13:00:00.000Z',
+        teacher_cleared_at: null,
+      })).toBe(false)
+    })
+
+    it('blocks unsubmit when returned work has no submission timestamp', () => {
+      expect(canUnsubmitAssignmentDoc({
+        is_submitted: true,
+        submitted_at: null,
+        returned_at: '2026-04-20T13:00:00.000Z',
+        teacher_cleared_at: null,
       })).toBe(false)
     })
   })

--- a/tests/unit/client-storage.test.ts
+++ b/tests/unit/client-storage.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
+  safeLocalGetJson,
+  safeLocalRemove,
+  safeLocalSetJson,
   readCookieValue,
   safeSessionGetJson,
   safeSessionSetJson,
@@ -8,6 +11,7 @@ import {
 describe('client-storage', () => {
   beforeEach(() => {
     window.sessionStorage.clear()
+    window.localStorage.clear()
   })
 
   describe('readCookieValue', () => {
@@ -31,5 +35,23 @@ describe('client-storage', () => {
       expect(safeSessionGetJson('k')).toBeNull()
     })
   })
-})
 
+  describe('durable JSON helpers', () => {
+    it('round-trips and removes local recovery data', () => {
+      expect(safeLocalSetJson('draft', { content: 'work' })).toBe(true)
+      expect(safeLocalGetJson('draft')).toEqual({ content: 'work' })
+      safeLocalRemove('draft')
+      expect(safeLocalGetJson('draft')).toBeNull()
+    })
+
+    it('reports unavailable browser storage', () => {
+      const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('Quota exceeded', 'QuotaExceededError')
+      })
+
+      expect(safeLocalSetJson('draft', { content: 'work' })).toBe(false)
+      expect(safeSessionSetJson('draft', { content: 'work' })).toBe(false)
+      setItem.mockRestore()
+    })
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
     {
       "path": "/api/cron/cleanup-history",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/cron/assignment-artifact-storage-cleanup",
+      "schedule": "30 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- make assignment draft save, submit, unsubmit, and combined assignment/requirement updates atomic and revision-fenced
- add durable retry/recovery evidence, authenticity metric checkpoints, submitted-content guards, and leased artifact Storage cleanup
- harden student autosave/reconciliation behavior, validate API/RPC boundaries with Zod, and add database concurrency gates

## Deployment order
1. Apply and verify migration `099_assignment_submission_integrity_guards.sql` before deploying this application version.
2. Deploy the application and drain previous-version instances.
3. Run a controlled non-production save, submit, unsubmit, requirement edit, and history restore canary.

Do not deploy the new writers before migration 099. Leave migration 099 in place if the app rolls back. Production remains at migration 098; this PR did not modify production.

## Validation
- `pnpm test` (375 files / 3,481 tests)
- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm run check:architecture` (604 modules / 0 allowances)
- atomic assignment SQL transaction harness
- assignment concurrency harness against disposable migrations 001-099
- generated database types match normalized disposable migrations 001-099
- Pika pre-commit audit
- Playwright: student editor and restore dialog, desktop/mobile, light/dark; teacher assignment list regression, desktop/mobile, light/dark

The local database intentionally remains at migration 098. For visual verification only, the student PATCH response was fulfilled by a browser route mock after the real read; no database write was sent in the final captures.

## Accessibility
- composite widget checklist reviewed: yes
- keyboard behavior covered: yes
- semantic state covered by tests: yes
- remaining manual follow-up: none