### PR TITLE
Enforce chronological session log retention

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13837,3 +13837,18 @@
 - Classroom schema audit (105 public foreign-key relationships)
 - Supabase lint: one existing migration-082 false positive for the function-local `classroom_archive_actor_ids` temporary table; both executable database contracts pass
 - `git diff --check`
+
+## 2026-07-13 — Deidentified Gradex artifact transformer
+
+**Completed:**
+- Added a server-only pure transformer that derives a deterministic Gradex tar+gzip artifact only from a strictly verified classroom archive.
+- Added explicit projections for every allowlisted assignment/test resource, per-extract HMAC relationship references, relative structured timestamps, shared direct-identifier redaction plus known-actor redaction, and exclusion of storage/external references.
+- Added independent verification for canonical manifests/NDJSON, resource/content checksums, HMAC shapes, projected relationships, exact resource inventory, and zero detected direct identifiers.
+- Capped version 1 extract retention at 90 days and documented that runtime operations, upload/finalization, deletion automation, and production canaries remain unfinished.
+
+**Validation:**
+- Focused Gradex, artifact-contract, and startup-policy suites (43 tests)
+- `pnpm test`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -5,25 +5,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Rules:**
 - Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.
 - CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.
-- Use `node scripts/trim-session-log.mjs --check` to verify the log is within the 60-entry cap.
+- Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
-
-## 2026-07-13 — Deidentified Gradex artifact transformer
-
-**Completed:**
-- Added a server-only pure transformer that derives a deterministic Gradex tar+gzip artifact only from a strictly verified classroom archive.
-- Added explicit projections for every allowlisted assignment/test resource, per-extract HMAC relationship references, relative structured timestamps, shared direct-identifier redaction plus known-actor redaction, and exclusion of storage/external references.
-- Added independent verification for canonical manifests/NDJSON, resource/content checksums, HMAC shapes, projected relationships, exact resource inventory, and zero detected direct identifiers.
-- Capped version 1 extract retention at 90 days and documented that runtime operations, upload/finalization, deletion automation, and production canaries remain unfinished.
-
-**Validation:**
-- Focused Gradex, artifact-contract, and startup-policy suites (43 tests)
-- `pnpm test`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
 
 ## 2026-07-13 — Durable Gradex operations and cleanup contract
 
@@ -113,56 +98,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-15 — Production classroom archive canary runner
-
-**Completed:**
-- Added a production-only prepare/execute/resume CLI bound to one hosted project, teacher,
-  archived-hot classroom, immutable mode-0600 plan, clean deployed commit, exact acknowledgement,
-  and deterministic export/compact/restore operation UUIDs.
-- Added exact pre/archive/restored-projection evidence across all 42 classroom resources and every
-  source object, full manifest and operation metadata auditing, original/restored object byte checks,
-  source-revision equality, pre/post database sizing, and a conservative restore safety margin.
-- Kept every source/Gradex cleanup gate disabled and proved cleanup rows, reservations, restore
-  staging, and upload-cleanup state remain untouched or empty after immediate restore.
-- Added crash recovery for cold state, transient state/archive reads, ambiguous coordinator results,
-  journal failure, and hot state after restore completion. Evidence files reject symlink traversal and
-  unsafe permissions.
-- Updated lifecycle/testing/operator documentation and current context. Production migrations 001-096,
-  read-only inventory, and hosted catalog audit were previously verified; no mutation canary ran in
-  this branch.
-- Completed repeated independent production-safety/data-integrity review and fix rounds.
-
-**Validation:**
-- Production canary contract suite (14 tests)
-- `pnpm vitest run` (363 files / 3,329 tests)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm db:types:check`
-- `pnpm lint`
-- `pnpm check:architecture` (600 modules / 0 allowances)
-- Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-14 — Atomic test grading contracts
-
-**Completed:**
-- Moved manual, bulk-clear, unanswered, and AI test grading writes behind typed atomic database RPCs with optimistic response/item revisions, exact-cohort validation, deterministic lock ordering, leases, and signed AI provenance.
-- Added shared test-scoped advisory locking and an atomic test-deletion boundary so grading, finalization, and deletion serialize without deadlocks or partial writes.
-- Added bounded client conflict recovery that reloads canonical revisions while preserving the teacher's latest draft, plus Zod validation at changed API/server boundaries.
-- Hardened classroom archive restore context scoping and added database-backed CI coverage for both grading concurrency and archive restore contracts.
-- Added migrations `089` through `095`, generated Supabase types, rollout guidance, focused API/server/component/architecture tests, and multi-session database regression harnesses.
-
-**Validation:**
-- `pnpm exec supabase db reset --local`
-- `pnpm run db:types:check`
-- `bash scripts/check-atomic-test-grading.sh`
-- `bash scripts/check-classroom-archive-restore-database.sh`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm vitest run` (359 files, 3,287 tests)
-- `pnpm build`
 - `git diff --check`
 
 ## 2026-07-13 — Atomic classroom cold-compaction database contract
@@ -295,37 +230,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - CI pending after push
 
-## 2026-07-14 — Archive stack review findings fixed
-
-**Completed:**
-- Ran repeated independent SQL, runtime, Gradex, and cross-layer review loops and fixed every actionable finding.
-- Hardened export/restore upload cleanup, exact restore object descriptors, actor-role reconciliation, transactional compaction dry runs, canonical paths, expiry/retry state transitions, and fail-closed source cleanup.
-- Tightened Gradex v2 with strict per-table Zod contracts, required relationships and projected fields, safe analytic enum preservation, Unicode-aware identifier scanning, pseudonymized unknown tokens, exact cleanup canaries, and retention fences.
-- Updated database contract drills, lifecycle guidance, cron integration, and environment documentation. No production database, migration, row, object, environment, deployment, or schedule was read or modified.
-
-**Validation:**
-- Fresh local Supabase reset through migrations 001–086
-- Archive export, restore, compaction, and Gradex database contract scripts
-- Full Vitest suite (339 files / 3,037 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-14 — Archive stack consolidation CI fix
-
-**Completed:**
-- Fast-forward merged reviewed archive PRs 852–866 into the final stack base without changing commit history.
-- Fixed the consolidated recovery drill after CI exposed a stale duplicate of the restore object-path algorithm; the drill now calls the production canonical path helper.
-- Kept PR 851 unmerged from `main` until its refreshed required checks pass. No production state was accessed or modified.
-
-**Validation:**
-- Local full archive recovery drill passed twice, including row equality, object equality, and idempotent replays
-- Focused restore unit suite (1 file / 9 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-
 ## 2026-07-13 — Phase 1 API boundary validation foundation
 
 **Risk profile:** runtime-platform
@@ -366,6 +270,57 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm run lint`
 - `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-07-14 — Atomic test grading contracts
+
+**Completed:**
+- Moved manual, bulk-clear, unanswered, and AI test grading writes behind typed atomic database RPCs with optimistic response/item revisions, exact-cohort validation, deterministic lock ordering, leases, and signed AI provenance.
+- Added shared test-scoped advisory locking and an atomic test-deletion boundary so grading, finalization, and deletion serialize without deadlocks or partial writes.
+- Added bounded client conflict recovery that reloads canonical revisions while preserving the teacher's latest draft, plus Zod validation at changed API/server boundaries.
+- Hardened classroom archive restore context scoping and added database-backed CI coverage for both grading concurrency and archive restore contracts.
+- Added migrations `089` through `095`, generated Supabase types, rollout guidance, focused API/server/component/architecture tests, and multi-session database regression harnesses.
+
+**Validation:**
+- `pnpm exec supabase db reset --local`
+- `pnpm run db:types:check`
+- `bash scripts/check-atomic-test-grading.sh`
+- `bash scripts/check-classroom-archive-restore-database.sh`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm vitest run` (359 files, 3,287 tests)
+- `pnpm build`
+- `git diff --check`
+
+## 2026-07-14 — Archive stack review findings fixed
+
+**Completed:**
+- Ran repeated independent SQL, runtime, Gradex, and cross-layer review loops and fixed every actionable finding.
+- Hardened export/restore upload cleanup, exact restore object descriptors, actor-role reconciliation, transactional compaction dry runs, canonical paths, expiry/retry state transitions, and fail-closed source cleanup.
+- Tightened Gradex v2 with strict per-table Zod contracts, required relationships and projected fields, safe analytic enum preservation, Unicode-aware identifier scanning, pseudonymized unknown tokens, exact cleanup canaries, and retention fences.
+- Updated database contract drills, lifecycle guidance, cron integration, and environment documentation. No production database, migration, row, object, environment, deployment, or schedule was read or modified.
+
+**Validation:**
+- Fresh local Supabase reset through migrations 001–086
+- Archive export, restore, compaction, and Gradex database contract scripts
+- Full Vitest suite (339 files / 3,037 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-14 — Archive stack consolidation CI fix
+
+**Completed:**
+- Fast-forward merged reviewed archive PRs 852–866 into the final stack base without changing commit history.
+- Fixed the consolidated recovery drill after CI exposed a stale duplicate of the restore object-path algorithm; the drill now calls the production canonical path helper.
+- Kept PR 851 unmerged from `main` until its refreshed required checks pass. No production state was accessed or modified.
+
+**Validation:**
+- Local full archive recovery drill passed twice, including row equality, object equality, and idempotent replays
+- Focused restore unit suite (1 file / 9 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
 
 ## 2026-07-14 — Read-only production classroom archive inventory
 
@@ -518,6 +473,36 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm check:architecture` (596 modules / 0 allowances)
 - `bash -n` and `shellcheck` for the database harness
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-15 — Production classroom archive canary runner
+
+**Completed:**
+- Added a production-only prepare/execute/resume CLI bound to one hosted project, teacher,
+  archived-hot classroom, immutable mode-0600 plan, clean deployed commit, exact acknowledgement,
+  and deterministic export/compact/restore operation UUIDs.
+- Added exact pre/archive/restored-projection evidence across all 42 classroom resources and every
+  source object, full manifest and operation metadata auditing, original/restored object byte checks,
+  source-revision equality, pre/post database sizing, and a conservative restore safety margin.
+- Kept every source/Gradex cleanup gate disabled and proved cleanup rows, reservations, restore
+  staging, and upload-cleanup state remain untouched or empty after immediate restore.
+- Added crash recovery for cold state, transient state/archive reads, ambiguous coordinator results,
+  journal failure, and hot state after restore completion. Evidence files reject symlink traversal and
+  unsafe permissions.
+- Updated lifecycle/testing/operator documentation and current context. Production migrations 001-096,
+  read-only inventory, and hosted catalog audit were previously verified; no mutation canary ran in
+  this branch.
+- Completed repeated independent production-safety/data-integrity review and fix rounds.
+
+**Validation:**
+- Production canary contract suite (14 tests)
+- `pnpm vitest run` (363 files / 3,329 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm db:types:check`
+- `pnpm lint`
+- `pnpm check:architecture` (600 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
 
@@ -854,3 +839,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Merge PR #891 to deploy the application version that uses migration 099, then continue the product-experience program.
+
+## 2026-07-18 — Enforce chronological session-log retention
+
+**Completed:**
+- Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them, while preserving source order for same-day entries and leaving undated legacy entries in place.
+- Made check mode reject chronological drift so CI catches future merge-order mistakes.
+- Repaired the rolling log's existing July 13-15 ordering drift and added focused regression coverage.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (2 files / 38 tests)
+- `pnpm lint`
+- `node --check scripts/trim-session-log.mjs`
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -846,7 +846,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them while preserving source order for same-day entries.
 - Made check mode reject chronological drift so CI catches future merge-order mistakes.
-- Made archive appends idempotent with deterministic per-trim batch markers so a failed output write can be retried without duplicating history or collapsing identical entries; added forced-failure and duplicate-entry recovery coverage after independent review.
+- Made archive appends idempotent with deterministic path-normalized per-trim batch markers so failed output writes can be retried without duplicating history or collapsing identical entries; added forced-failure, duplicate-entry, and equivalent-path recovery coverage after independent review.
 - Made trim and check modes reject undated or invalid entry headings instead of guessing whether they belong in the latest retention window; aligned startup guidance after independent review.
 - Repaired the rolling log's existing July 13-15 ordering drift and added focused regression coverage.
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -4,6 +4,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Rules:**
 - Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.
+- Start each entry heading with a valid ISO date (`## YYYY-MM-DD ...`) so retention can identify the latest entries.
 - CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.
 - Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
@@ -846,11 +847,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them, while preserving source order for same-day entries and leaving undated legacy entries in place.
 - Made check mode reject chronological drift so CI catches future merge-order mistakes.
 - Made archive appends idempotent by exact entry content so a failed output write can be retried without duplicating history; added a forced-failure recovery regression after independent review.
+- Made trim and check modes reject undated or invalid entry headings instead of guessing whether they belong in the latest retention window; aligned startup guidance after independent review.
 - Repaired the rolling log's existing July 13-15 ordering drift and added focused regression coverage.
 
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (2 files / 40 tests)
+- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (2 files / 41 tests)
 - `pnpm lint`
 - `node --check scripts/trim-session-log.mjs`
 - `node scripts/trim-session-log.mjs --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -844,9 +844,9 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 ## 2026-07-18 — Enforce chronological session-log retention
 
 **Completed:**
-- Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them, while preserving source order for same-day entries and leaving undated legacy entries in place.
+- Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them while preserving source order for same-day entries.
 - Made check mode reject chronological drift so CI catches future merge-order mistakes.
-- Made archive appends idempotent by exact entry content so a failed output write can be retried without duplicating history; added a forced-failure recovery regression after independent review.
+- Made archive appends idempotent with deterministic per-trim batch markers so a failed output write can be retried without duplicating history or collapsing identical entries; added forced-failure and duplicate-entry recovery coverage after independent review.
 - Made trim and check modes reject undated or invalid entry headings instead of guessing whether they belong in the latest retention window; aligned startup guidance after independent review.
 - Repaired the rolling log's existing July 13-15 ordering drift and added focused regression coverage.
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -845,11 +845,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Updated the session-log trimmer to order ISO-dated entries chronologically before retaining or archiving them, while preserving source order for same-day entries and leaving undated legacy entries in place.
 - Made check mode reject chronological drift so CI catches future merge-order mistakes.
+- Made archive appends idempotent by exact entry content so a failed output write can be retried without duplicating history; added a forced-failure recovery regression after independent review.
 - Repaired the rolling log's existing July 13-15 ordering drift and added focused regression coverage.
 
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (2 files / 38 tests)
+- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (2 files / 40 tests)
 - `pnpm lint`
 - `node --check scripts/trim-session-log.mjs`
 - `node scripts/trim-session-log.mjs --check`

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -41,8 +41,8 @@ All agents operate from exactly one current repo checkout/worktree.
 
 ## End of Session (MANDATORY)
 
-1. Append a concise session entry to `.ai/SESSION-LOG.md`.
-2. Immediately run `node scripts/trim-session-log.mjs` in the same change. CI caps the log at 60; default trim keeps 40. Use `node scripts/trim-session-log.mjs --check` to verify the cap.
+1. Append a concise session entry to `.ai/SESSION-LOG.md` with a valid ISO-date heading (`## YYYY-MM-DD ...`).
+2. Immediately run `node scripts/trim-session-log.mjs` in the same change. CI caps the log at 60; default trim keeps 40. Use `node scripts/trim-session-log.mjs --check` to verify heading dates, chronological order, and the cap.
 3. Update `.ai/features.json` if anything changed:
    ```bash
    node scripts/features.mjs pass <feature-id>

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -205,8 +205,15 @@ function trimSessionLog({ keep, source, output, archive }) {
 
   let archivedEntries = 0
   if (archive && removedEntries.length > 0) {
-    const batchId = createArchiveBatchId({ archive, entries, keep, output, source })
-    archivedEntries = appendToArchive(resolve(repoRoot, archive), removedEntries, batchId)
+    const archivePath = resolve(repoRoot, archive)
+    const batchId = createArchiveBatchId({
+      archive: archivePath,
+      entries,
+      keep,
+      output: outputPath,
+      source: sourcePath,
+    })
+    archivedEntries = appendToArchive(archivePath, removedEntries, batchId)
   }
 
   writeFileSync(outputPath, buildSessionLog(retainedEntries))

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -93,6 +93,17 @@ function extractEntryDate(entry) {
   return isoDate === headingDate ? headingDate : null
 }
 
+function assertDatedEntries(entries, source) {
+  const invalidEntry = entries.find((entry) => extractEntryDate(entry) === null)
+
+  if (invalidEntry) {
+    const heading = invalidEntry.split('\n', 1)[0]
+    throw new Error(
+      `${source} entry headings must start with a valid ISO date (YYYY-MM-DD); found: ${heading}`,
+    )
+  }
+}
+
 function orderEntriesChronologically(entries) {
   const records = entries.map((entry, index) => ({
     date: extractEntryDate(entry),
@@ -104,7 +115,7 @@ function orderEntriesChronologically(entries) {
     .sort((left, right) => left.date.localeCompare(right.date) || left.index - right.index)
   let datedIndex = 0
 
-  // Leave legacy undated entries in place instead of guessing where they belong.
+  // Same-day entries retain source order through the explicit index tie-breaker.
   return records.map((record) => record.date === null ? record.entry : datedRecords[datedIndex++].entry)
 }
 
@@ -133,6 +144,7 @@ function buildSessionLog(entries) {
     '',
     '**Rules:**',
     '- Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.',
+    '- Start each entry heading with a valid ISO date (`## YYYY-MM-DD ...`) so retention can identify the latest entries.',
     '- CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.',
     '- Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.',
     '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
@@ -187,6 +199,7 @@ function trimSessionLog({ keep, source, output, archive }) {
     throw new Error(`No session entries found in ${source}`)
   }
 
+  assertDatedEntries(entries, source)
   const orderedEntries = orderEntriesChronologically(entries)
   const retainedEntries = orderedEntries.slice(-keep)
   const removedEntries = orderedEntries.slice(0, orderedEntries.length - retainedEntries.length)
@@ -217,6 +230,7 @@ function checkSessionLog({ maxEntries, source }) {
     throw new Error(`No session entries found in ${source}`)
   }
 
+  assertDatedEntries(entries, source)
   if (!entriesAreChronological(entries)) {
     throw new Error(
       `${source} dated entries are not in chronological order; run node scripts/trim-session-log.mjs to repair the order.`,

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -63,7 +63,7 @@ function usage() {
     '',
     'Keeps the latest session entries, where each entry starts with a markdown "## " heading.',
     'Trimmed entries are appended to the archive file so history is preserved; pass --no-archive to discard them instead.',
-    'Use --check to fail when the source has more entries than the check cap.',
+    'Use --check to fail when dated entries are out of order or the source has more entries than the check cap.',
   ].join('\n')
 }
 
@@ -78,6 +78,53 @@ function extractEntries(markdown) {
   })
 }
 
+function extractEntryDate(entry) {
+  const match = /^## (\d{4})-(\d{2})-(\d{2})(?:\s|$)/.exec(entry)
+
+  if (!match) {
+    return null
+  }
+
+  const [, year, month, day] = match
+  const parsed = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+  const isoDate = parsed.toISOString().slice(0, 10)
+  const headingDate = `${year}-${month}-${day}`
+
+  return isoDate === headingDate ? headingDate : null
+}
+
+function orderEntriesChronologically(entries) {
+  const records = entries.map((entry, index) => ({
+    date: extractEntryDate(entry),
+    entry,
+    index,
+  }))
+  const datedRecords = records
+    .filter((record) => record.date !== null)
+    .sort((left, right) => left.date.localeCompare(right.date) || left.index - right.index)
+  let datedIndex = 0
+
+  // Leave legacy undated entries in place instead of guessing where they belong.
+  return records.map((record) => record.date === null ? record.entry : datedRecords[datedIndex++].entry)
+}
+
+function entriesAreChronological(entries) {
+  let previousDate = null
+
+  for (const entry of entries) {
+    const date = extractEntryDate(entry)
+
+    if (date !== null && previousDate !== null && date < previousDate) {
+      return false
+    }
+    if (date !== null) {
+      previousDate = date
+    }
+  }
+
+  return true
+}
+
 function buildSessionLog(entries) {
   const header = [
     '# Pika Session Log',
@@ -87,7 +134,7 @@ function buildSessionLog(entries) {
     '**Rules:**',
     '- Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.',
     '- CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.',
-    '- Use `node scripts/trim-session-log.mjs --check` to verify the log is within the 60-entry cap.',
+    '- Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.',
     '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
     '- The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.',
     '- Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.',
@@ -124,8 +171,9 @@ function trimSessionLog({ keep, source, output, archive }) {
     throw new Error(`No session entries found in ${source}`)
   }
 
-  const retainedEntries = entries.slice(-keep)
-  const removedEntries = entries.slice(0, entries.length - retainedEntries.length)
+  const orderedEntries = orderEntriesChronologically(entries)
+  const retainedEntries = orderedEntries.slice(-keep)
+  const removedEntries = orderedEntries.slice(0, orderedEntries.length - retainedEntries.length)
 
   if (archive && removedEntries.length > 0) {
     appendToArchive(resolve(repoRoot, archive), removedEntries)
@@ -150,6 +198,12 @@ function checkSessionLog({ maxEntries, source }) {
 
   if (entries.length === 0) {
     throw new Error(`No session entries found in ${source}`)
+  }
+
+  if (!entriesAreChronological(entries)) {
+    throw new Error(
+      `${source} dated entries are not in chronological order; run node scripts/trim-session-log.mjs to repair the order.`,
+    )
   }
 
   if (entries.length > maxEntries) {

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -157,7 +158,13 @@ function buildSessionLog(entries) {
   return `${header}${entries.join('\n\n')}\n`
 }
 
-function appendToArchive(archivePath, entries) {
+function createArchiveBatchId({ archive, entries, keep, output, source }) {
+  return createHash('sha256')
+    .update(JSON.stringify({ archive, entries, keep, output, source }))
+    .digest('hex')
+}
+
+function appendToArchive(archivePath, entries, batchId) {
   const archiveHeader = [
     '# Pika Project Journal',
     '',
@@ -168,25 +175,17 @@ function appendToArchive(archivePath, entries) {
     '',
   ].join('\n')
   const existing = existsSync(archivePath) ? readFileSync(archivePath, 'utf8') : ''
-  const archivedEntries = new Set(extractEntries(existing))
-  const entriesToAppend = entries.filter((entry) => {
-    if (archivedEntries.has(entry)) {
-      return false
-    }
+  const batchMarker = `<!-- pika-session-log-archive-batch:${batchId} -->`
 
-    archivedEntries.add(entry)
-    return true
-  })
-
-  if (entriesToAppend.length === 0) {
+  if (existing.includes(batchMarker)) {
     return 0
   }
 
   const base = existing.trim().length > 0 ? `${existing.replace(/\n+$/, '')}\n\n` : archiveHeader
 
-  writeFileSync(archivePath, `${base}${entriesToAppend.join('\n\n')}\n`)
+  writeFileSync(archivePath, `${base}${batchMarker}\n${entries.join('\n\n')}\n`)
 
-  return entriesToAppend.length
+  return entries.length
 }
 
 function trimSessionLog({ keep, source, output, archive }) {
@@ -206,7 +205,8 @@ function trimSessionLog({ keep, source, output, archive }) {
 
   let archivedEntries = 0
   if (archive && removedEntries.length > 0) {
-    archivedEntries = appendToArchive(resolve(repoRoot, archive), removedEntries)
+    const batchId = createArchiveBatchId({ archive, entries, keep, output, source })
+    archivedEntries = appendToArchive(resolve(repoRoot, archive), removedEntries, batchId)
   }
 
   writeFileSync(outputPath, buildSessionLog(retainedEntries))

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -156,9 +156,25 @@ function appendToArchive(archivePath, entries) {
     '',
   ].join('\n')
   const existing = existsSync(archivePath) ? readFileSync(archivePath, 'utf8') : ''
+  const archivedEntries = new Set(extractEntries(existing))
+  const entriesToAppend = entries.filter((entry) => {
+    if (archivedEntries.has(entry)) {
+      return false
+    }
+
+    archivedEntries.add(entry)
+    return true
+  })
+
+  if (entriesToAppend.length === 0) {
+    return 0
+  }
+
   const base = existing.trim().length > 0 ? `${existing.replace(/\n+$/, '')}\n\n` : archiveHeader
 
-  writeFileSync(archivePath, `${base}${entries.join('\n\n')}\n`)
+  writeFileSync(archivePath, `${base}${entriesToAppend.join('\n\n')}\n`)
+
+  return entriesToAppend.length
 }
 
 function trimSessionLog({ keep, source, output, archive }) {
@@ -175,8 +191,9 @@ function trimSessionLog({ keep, source, output, archive }) {
   const retainedEntries = orderedEntries.slice(-keep)
   const removedEntries = orderedEntries.slice(0, orderedEntries.length - retainedEntries.length)
 
+  let archivedEntries = 0
   if (archive && removedEntries.length > 0) {
-    appendToArchive(resolve(repoRoot, archive), removedEntries)
+    archivedEntries = appendToArchive(resolve(repoRoot, archive), removedEntries)
   }
 
   writeFileSync(outputPath, buildSessionLog(retainedEntries))
@@ -187,7 +204,7 @@ function trimSessionLog({ keep, source, output, archive }) {
     archive,
     total: entries.length,
     retained: retainedEntries.length,
-    archived: archive ? removedEntries.length : 0,
+    archived: archivedEntries,
   }
 }
 

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -107,6 +107,7 @@ describe('AI startup docs', () => {
   })
 
   it('keeps the rolling session log bounded while preserving weekly evidence', () => {
+    const startHere = readRepoFile('.ai/START-HERE.md')
     const sessionLog = readRepoFile('.ai/SESSION-LOG.md')
     const entryCount = sessionLog.match(/^## /gm)?.length ?? 0
 
@@ -114,7 +115,10 @@ describe('AI startup docs', () => {
     expect(sessionLog).toContain('CI allows at most 60 entries')
     expect(sessionLog).toContain('compacts to the latest 40 entries')
     expect(sessionLog).toContain('immediately run `node scripts/trim-session-log.mjs`')
+    expect(sessionLog).toContain('valid ISO date (`## YYYY-MM-DD ...`)')
     expect(sessionLog).toContain('node scripts/trim-session-log.mjs --check')
+    expect(startHere).toContain('valid ISO-date heading (`## YYYY-MM-DD ...`)')
+    expect(startHere).toContain('verify heading dates, chronological order, and the cap')
     expect(entryCount).toBeGreaterThan(0)
     if (entryCount > 60) {
       throw new Error(

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -61,6 +61,57 @@ describe('trim-session-log script', () => {
     }
   })
 
+  it('orders entries chronologically before retaining the latest entries', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-order-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+
+      writeFileSync(
+        sourcePath,
+        [
+          '# Pika Session Log',
+          '',
+          '## 2026-05-03 - Third',
+          'third entry',
+          '',
+          '## 2026-05-01 - First',
+          'first entry',
+          '',
+          '## 2026-05-02 - Second A',
+          'second entry A',
+          '',
+          '## 2026-05-02 - Second B',
+          'second entry B',
+          '',
+        ].join('\n'),
+      )
+
+      execFileSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '3'],
+        { cwd: repoRoot },
+      )
+
+      const output = readFileSync(outputPath, 'utf8')
+      const archived = readFileSync(archivePath, 'utf8')
+
+      expect(output).not.toContain('## 2026-05-01 - First')
+      expect(output.indexOf('## 2026-05-02 - Second A')).toBeLessThan(
+        output.indexOf('## 2026-05-02 - Second B'),
+      )
+      expect(output.indexOf('## 2026-05-02 - Second B')).toBeLessThan(
+        output.indexOf('## 2026-05-03 - Third'),
+      )
+      expect(archived).toContain('## 2026-05-01 - First')
+      expect(archived).not.toContain('## 2026-05-03 - Third')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('defaults to compacting below the CI cap', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-buffer-'))
 
@@ -68,8 +119,8 @@ describe('trim-session-log script', () => {
       const sourcePath = join(repoRoot, 'source.md')
       const outputPath = join(repoRoot, 'SESSION-LOG.md')
       const entries = Array.from({ length: 61 }, (_, index) => {
-        const day = String((index % 28) + 1).padStart(2, '0')
-        return [`## 2026-05-${day} - Entry ${index + 1}`, `entry ${index + 1}`].join('\n')
+        const date = new Date(Date.UTC(2026, 4, index + 1)).toISOString().slice(0, 10)
+        return [`## ${date} - Entry ${index + 1}`, `entry ${index + 1}`].join('\n')
       })
 
       writeFileSync(sourcePath, ['# Pika Session Log', '', ...entries].join('\n\n'))
@@ -259,6 +310,38 @@ describe('trim-session-log script', () => {
       })
 
       expect(output).toContain('source.md is within cap: 3/3 entries')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a session log whose dated entries are out of order', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-order-check-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const original = [
+        '# Pika Session Log',
+        '',
+        '## 2026-05-02 - Second',
+        'second entry',
+        '',
+        '## 2026-05-01 - First',
+        'first entry',
+        '',
+      ].join('\n')
+
+      writeFileSync(sourcePath, original)
+
+      const result = spawnSync('node', [scriptPath, '--check', '--source', sourcePath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('dated entries are not in chronological order')
+      expect(result.stderr).toContain('run node scripts/trim-session-log.mjs')
+      expect(readFileSync(sourcePath, 'utf8')).toBe(original)
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
     }

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -310,6 +310,9 @@ describe('trim-session-log script', () => {
       const sourcePath = join(repoRoot, 'source.md')
       const outputPath = join(repoRoot, 'missing', 'SESSION-LOG.md')
       const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+      const equivalentSourcePath = `${repoRoot}/./source.md`
+      const equivalentOutputPath = `${repoRoot}/missing/./SESSION-LOG.md`
+      const equivalentArchivePath = `${repoRoot}/./JOURNAL-ARCHIVE.md`
       const source = [
         '# Pika Session Log',
         '',
@@ -339,7 +342,13 @@ describe('trim-session-log script', () => {
       mkdirSync(dirname(outputPath), { recursive: true })
       execFileSync(
         'node',
-        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '1'],
+        [
+          scriptPath,
+          '--source', equivalentSourcePath,
+          '--output', equivalentOutputPath,
+          '--archive', equivalentArchivePath,
+          '--keep', '1',
+        ],
         { cwd: repoRoot },
       )
 

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -316,6 +316,9 @@ describe('trim-session-log script', () => {
         '## 2026-05-01 - First',
         'first entry',
         '',
+        '## 2026-05-01 - First',
+        'first entry',
+        '',
         '## 2026-05-02 - Second',
         'second entry',
         '',
@@ -331,7 +334,7 @@ describe('trim-session-log script', () => {
 
       expect(failedRun.status).toBe(1)
       expect(readFileSync(sourcePath, 'utf8')).toBe(source)
-      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(1)
+      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(2)
 
       mkdirSync(dirname(outputPath), { recursive: true })
       execFileSync(
@@ -341,7 +344,7 @@ describe('trim-session-log script', () => {
       )
 
       expect(readFileSync(outputPath, 'utf8')).toContain('## 2026-05-02 - Second')
-      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(1)
+      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(2)
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
     }

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -263,6 +263,50 @@ describe('trim-session-log script', () => {
     }
   })
 
+  it('does not duplicate archived entries when the output write is retried', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-output-retry-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'missing', 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+      const source = [
+        '# Pika Session Log',
+        '',
+        '## 2026-05-01 - First',
+        'first entry',
+        '',
+        '## 2026-05-02 - Second',
+        'second entry',
+        '',
+      ].join('\n')
+
+      writeFileSync(sourcePath, source)
+
+      const failedRun = spawnSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '1'],
+        { cwd: repoRoot, encoding: 'utf8' },
+      )
+
+      expect(failedRun.status).toBe(1)
+      expect(readFileSync(sourcePath, 'utf8')).toBe(source)
+      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(1)
+
+      mkdirSync(dirname(outputPath), { recursive: true })
+      execFileSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '1'],
+        { cwd: repoRoot },
+      )
+
+      expect(readFileSync(outputPath, 'utf8')).toContain('## 2026-05-02 - Second')
+      expect(readFileSync(archivePath, 'utf8').match(/^## 2026-05-01 - First$/gm)).toHaveLength(1)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('defaults to a weekly evidence-sized retention window', () => {
     const script = readFileSync(scriptPath, 'utf8')
 

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -112,6 +112,46 @@ describe('trim-session-log script', () => {
     }
   })
 
+  it('rejects undated entries instead of guessing whether they are latest', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-undated-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+      const source = [
+        '# Pika Session Log',
+        '',
+        '## 2026-05-01 - First',
+        'first entry',
+        '',
+        '## 2026-05-02 - Second',
+        'second entry',
+        '',
+        '## Legacy heading',
+        'unknown date',
+        '',
+      ].join('\n')
+
+      writeFileSync(sourcePath, source)
+
+      const result = spawnSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '2'],
+        { cwd: repoRoot, encoding: 'utf8' },
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('entry headings must start with a valid ISO date (YYYY-MM-DD)')
+      expect(result.stderr).toContain('## Legacy heading')
+      expect(readFileSync(sourcePath, 'utf8')).toBe(source)
+      expect(existsSync(outputPath)).toBe(false)
+      expect(existsSync(archivePath)).toBe(false)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('defaults to compacting below the CI cap', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-buffer-'))
 


### PR DESCRIPTION
## Summary
- sort valid ISO-dated session entries chronologically before retention and archival
- reject undated or invalid headings rather than guessing their retention age
- make archive appends retry-safe with deterministic, path-normalized trim-batch markers
- preserve legitimate duplicate entries while preventing duplicate retry batches
- make check mode reject ordering drift and align startup guidance
- repair the current rolling log while preserving append-only archive history

## Validation
- pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts (41 tests)
- pnpm lint
- node --check scripts/trim-session-log.mjs
- node scripts/trim-session-log.mjs --check
- git diff --check

## Independent review
- GPT-5.6 Luna medium found output-retry duplication; fixed and targeted re-review reports no findings
- GPT-5.6 Terra high found retry recovery, duplicate-occurrence, equivalent-path, undated-retention, and startup-guidance issues across iterative passes
- Terra final targeted re-review at 25068b37 reports all blockers resolved and no new findings; it reproduced failed output, equivalent-path retry, and duplicate removed entries with exactly one batch marker and both legitimate occurrences preserved