### PR TITLE
Fix local seed ordering for migration 099

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13852,3 +13852,23 @@
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm build`
+
+<!-- pika-session-log-archive-batch:bc6705b3b8c0bf7e482293cd4ece0e38d4f85f3af416f0ec7786a9d190614c46 -->
+## 2026-07-13 — Durable Gradex operations and cleanup contract
+
+**Completed:**
+- Added stacked migration 084 with a service-role-only Gradex resource allowlist, idempotent begin/finalize/fail operations, immutable verified extract metadata, and a separate mutable retention-cleanup ledger.
+- Serialized generation per immutable source archive, capped retention and file size, required exact resource counts and verification evidence, and scheduled older extracts immediately when superseded.
+- Added lease-based cleanup claiming, stale-lease rejection, exponential retry, and durable deletion evidence without deleting audit metadata.
+- Tightened final review invariants for typed verification evidence, bounded verification timestamps, conflicting finalization replays, failure metadata, and cleanup lease inputs.
+- Kept the database contract unreachable from browser roles and added no API, cron, upload, deletion, or production execution path.
+
+**Validation:**
+- Fresh isolated Supabase replay through migration 084
+- Expanded rollback-only service-role Gradex database contract
+- Focused migration, transformer, artifact-contract, and startup-policy suites (47 tests)
+- Full Vitest suite (326 files / 2,874 tests)
+- `bash -n scripts/check-classroom-gradex-database.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- Pika pre-commit audit

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,25 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Durable Gradex operations and cleanup contract
-
-**Completed:**
-- Added stacked migration 084 with a service-role-only Gradex resource allowlist, idempotent begin/finalize/fail operations, immutable verified extract metadata, and a separate mutable retention-cleanup ledger.
-- Serialized generation per immutable source archive, capped retention and file size, required exact resource counts and verification evidence, and scheduled older extracts immediately when superseded.
-- Added lease-based cleanup claiming, stale-lease rejection, exponential retry, and durable deletion evidence without deleting audit metadata.
-- Tightened final review invariants for typed verification evidence, bounded verification timestamps, conflicting finalization replays, failure metadata, and cleanup lease inputs.
-- Kept the database contract unreachable from browser roles and added no API, cron, upload, deletion, or production execution path.
-
-**Validation:**
-- Fresh isolated Supabase replay through migration 084
-- Expanded rollback-only service-role Gradex database contract
-- Focused migration, transformer, artifact-contract, and startup-policy suites (47 tests)
-- Full Vitest suite (326 files / 2,874 tests)
-- `bash -n scripts/check-classroom-gradex-database.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- Pika pre-commit audit
-
 ## 2026-07-13 — Gated Gradex runtime coordinator
 
 **Completed:**
@@ -857,3 +838,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `node --check scripts/trim-session-log.mjs`
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
+
+## 2026-07-20 — Migration 099 local seed compatibility
+
+**Completed:**
+- Fixed `pnpm seed` for databases with migration 099 by creating assignment documents as editable, inserting their baseline/autosave/blur history, and only then finalizing submitted documents.
+- Let migration 099's deferred constraint trigger create each authoritative submit snapshot, preserving the database invariant that editable history cannot be written after submission.
+- Aligned the synthetic writing timelines with the existing 4-day and 2-day submission dates so grading fixtures remain chronologically valid.
+- Added unit and source-order regression coverage for history partitioning and seed lifecycle ordering.
+- Derived the earliest returned-feedback timestamp from the generated submission time after review found an early-day chronology edge case.
+- Re-ran `pnpm seed` against the authorized loopback database; the complete classroom, assignment-review, and test fixtures now seed successfully. No production resources were accessed or modified.
+
+**Validation:**
+- `pnpm test` (376 files / 3,495 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm seed` against the loopback Supabase database through migration 099
+- Direct loopback database checks: one submit row per submitted document, matching content snapshots, all editable history before submission, and returned feedback after submission
+- `git diff --check`
+
+**Audit note:**
+- The Pika pre-commit audit reports the existing CLI progress `console.log` calls throughout `scripts/seed.ts` after that file is touched. No new production logging path was introduced; this is a whole-file false positive for the development seed CLI.

--- a/scripts/lib/assignment-history-seed.ts
+++ b/scripts/lib/assignment-history-seed.ts
@@ -1,0 +1,51 @@
+export type AssignmentHistorySeedEntry = {
+  assignment_doc_id: string
+  trigger: string
+  created_at: string
+  snapshot: unknown
+}
+
+export type AssignmentHistorySeedSubmission = {
+  assignmentDocId: string
+  submittedAt: string
+}
+
+export function ensureSeedTimestampAfter(candidate: string, preceding: string): string {
+  const candidateMs = Date.parse(candidate)
+  const precedingMs = Date.parse(preceding)
+  if (!Number.isFinite(candidateMs) || !Number.isFinite(precedingMs)) {
+    throw new Error('Seed assignment chronology requires valid timestamps')
+  }
+
+  return new Date(Math.max(candidateMs, precedingMs + 60_000)).toISOString()
+}
+
+export function splitAssignmentHistoryAtSubmission<
+  TEntry extends AssignmentHistorySeedEntry,
+>(entries: readonly TEntry[]): {
+  historyEntries: TEntry[]
+  submission: AssignmentHistorySeedSubmission | null
+} {
+  const submitIndex = entries.findIndex(entry => entry.trigger === 'submit')
+
+  if (submitIndex === -1) {
+    return { historyEntries: [...entries], submission: null }
+  }
+
+  if (submitIndex !== entries.length - 1) {
+    throw new Error('Seed assignment submit history must be the final entry')
+  }
+
+  const submitEntry = entries[submitIndex]!
+  if (submitEntry.snapshot == null) {
+    throw new Error('Seed assignment submit history requires a snapshot')
+  }
+
+  return {
+    historyEntries: entries.slice(0, submitIndex),
+    submission: {
+      assignmentDocId: submitEntry.assignment_doc_id,
+      submittedAt: submitEntry.created_at,
+    },
+  }
+}

--- a/scripts/seed-assignment-review-fixtures.ts
+++ b/scripts/seed-assignment-review-fixtures.ts
@@ -1,4 +1,5 @@
 import type { TiptapContent } from '../src/types'
+import { ensureSeedTimestampAfter } from './lib/assignment-history-seed'
 
 type SupabaseLike = {
   from: (table: string) => {
@@ -53,8 +54,17 @@ export async function seedAssignmentReviewFixtures(opts: {
   students: SeedStudent[]
   assignments: SeedAssignments
   now: Date
+  narrativeStudent1SubmittedAt?: string
 }) {
-  const { supabase, classroomId, teacherId, students, assignments, now } = opts
+  const {
+    supabase,
+    classroomId,
+    teacherId,
+    students,
+    assignments,
+    now,
+    narrativeStudent1SubmittedAt,
+  } = opts
   const [student1, student2] = students
   if (!student1 || !student2) {
     throw new Error('seedAssignmentReviewFixtures requires two students')
@@ -70,6 +80,9 @@ export async function seedAssignmentReviewFixtures(opts: {
   const threeDaysAgoIso = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString()
   const fourDaysAgoIso = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000).toISOString()
   const fiveDaysAgoIso = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+  const student1FirstFeedbackAt = narrativeStudent1SubmittedAt
+    ? ensureSeedTimestampAfter(fourDaysAgoIso, narrativeStudent1SubmittedAt)
+    : fourDaysAgoIso
 
   const letterStudent1Content: TiptapContent = {
     type: 'doc',
@@ -205,7 +218,7 @@ export async function seedAssignmentReviewFixtures(opts: {
           entry_kind: 'teacher_feedback',
           author_type: 'teacher',
           body: 'Your first draft had a strong voice. Revise the ending so it reflects more directly on what you learned.',
-          returned_at: fourDaysAgoIso,
+          returned_at: student1FirstFeedbackAt,
           created_by: teacherId,
         },
         {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -18,6 +18,7 @@ import { hashPassword } from '../src/lib/crypto'
 import { getTodayInToronto } from '../src/lib/timezone'
 import { seedAssignmentReviewFixtures } from './seed-assignment-review-fixtures'
 import { seedSampleTests } from './seed-tests'
+import { splitAssignmentHistoryAtSubmission } from './lib/assignment-history-seed'
 import { config } from 'dotenv'
 import { addDays, format, parse, subDays } from 'date-fns'
 import { resolve } from 'path'
@@ -502,7 +503,7 @@ async function seed() {
     const letter = createdAssignments[1]!
 
     const assignmentDocs = [
-      // Student 1 submitted the narrative essay
+      // Submitted documents start editable so their pre-submit history can be seeded first.
       {
         assignment_id: narrative.id,
         student_id: students[0]!.id,
@@ -514,10 +515,10 @@ async function seed() {
             { type: 'paragraph', content: [{ type: 'text', text: 'Now, whenever I bake bread, I think of her. The recipe is more than flour and water — it\'s a connection to my family\'s history. That summer taught me that the most important things are passed down not through books, but through hands and hearts.' }] },
           ],
         },
-        is_submitted: true,
-        submitted_at: new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+        is_submitted: false,
+        submitted_at: null,
       },
-      // Student 2 submitted the narrative essay (late, shorter)
+      // Student 2's narrative is finalized after its writing history is inserted.
       {
         assignment_id: narrative.id,
         student_id: students[1]!.id,
@@ -528,8 +529,8 @@ async function seed() {
             { type: 'paragraph', content: [{ type: 'text', text: 'By the end of the season I scored my first goal. It felt amazing. I learned that trying new things is worth it even when it\'s scary at first.' }] },
           ],
         },
-        is_submitted: true,
-        submitted_at: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(), // late
+        is_submitted: false,
+        submitted_at: null,
       },
       // Student 1 started the persuasive letter but hasn't submitted
       {
@@ -614,6 +615,27 @@ async function seed() {
         paste_word_count: number | null
         keystroke_count: number | null
       }[] = []
+      const submissions: {
+        assignmentDocId: string
+        submittedAt: string
+      }[] = []
+
+      function addHistorySteps(docId: string, baseDateMs: number, steps: HistoryStep[]) {
+        const entries = steps.map(step => ({
+          assignment_doc_id: docId,
+          patch: null as null,
+          snapshot: step.snapshot,
+          word_count: step.wordCount,
+          char_count: step.charCount,
+          trigger: step.trigger,
+          created_at: torontoTime(baseDateMs, step.day, step.hour, step.min, step.sec),
+          paste_word_count: step.paste,
+          keystroke_count: step.keys,
+        }))
+        const prepared = splitAssignmentHistoryAtSubmission(entries)
+        historyEntries.push(...prepared.historyEntries)
+        if (prepared.submission) submissions.push(prepared.submission)
+      }
 
       // ── Student 1 narrative essay — 10 days of realistic writing ──
       // Scenarios tested:
@@ -631,8 +653,8 @@ async function seed() {
         d => d.student_id === students[0]!.id && d.assignment_id === narrative.id
       )
       if (s1NarrativeDoc) {
-        // Base: 10 days ago at midnight Toronto time
-        const baseDateMs = new Date(now.getTime() - 10 * 86400000).setUTCHours(0, 0, 0, 0)
+        // Base: 13 days ago so the Day 9 submission remains 4 days ago.
+        const baseDateMs = new Date(now.getTime() - 13 * 86400000).setUTCHours(0, 0, 0, 0)
 
         const steps: HistoryStep[] = [
           // ── Day 0: Afternoon start (3:00–3:16 PM) — 4 entries ──
@@ -788,19 +810,7 @@ async function seed() {
           { charCount: 680, wordCount: 126, trigger: 'submit',   day: 9, hour: 15, min: 20, paste: null, keys: 6,
             snapshot: tiptapDoc(['The summer I turned twelve, my grandmother taught me how to bake bread. I remember the warm kitchen, the smell of yeast rising, and her flour-dusted hands guiding mine as I kneaded the dough. "Feel the dough," she said. "It will tell you when it\'s ready."', 'That afternoon we sat on the porch waiting for the bread to rise. She told me stories about her childhood in Portugal, about olive groves and fishing boats. I listened carefully, trying to memorize every detail. The bread came out golden and perfect.', 'Now, whenever I bake bread, I think of her. The recipe is more than flour and water — it\'s a connection to my family\'s history. That summer taught me that the most important things are passed down not through books, but through hands and hearts.']) },
         ]
-        for (const step of steps) {
-          historyEntries.push({
-            assignment_doc_id: s1NarrativeDoc.id,
-            patch: null,
-            snapshot: step.snapshot,
-            word_count: step.wordCount,
-            char_count: step.charCount,
-            trigger: step.trigger,
-            created_at: torontoTime(baseDateMs, step.day, step.hour, step.min, step.sec),
-            paste_word_count: step.paste,
-            keystroke_count: step.keys,
-          })
-        }
+        addHistorySteps(s1NarrativeDoc.id, baseDateMs, steps)
       }
 
       // ── Student 2 narrative essay — paste-heavy with huge paste + huge delete ──
@@ -813,7 +823,7 @@ async function seed() {
         d => d.student_id === students[1]!.id && d.assignment_id === narrative.id
       )
       if (s2NarrativeDoc) {
-        const baseDateMs = new Date(now.getTime() - 5 * 86400000).setUTCHours(0, 0, 0, 0)
+        const baseDateMs = new Date(now.getTime() - 6 * 86400000).setUTCHours(0, 0, 0, 0)
 
         const steps: HistoryStep[] = [
           // Day 0: Slow start (4:00–4:10 PM)
@@ -866,19 +876,7 @@ async function seed() {
           { charCount: 380, wordCount: 70,  trigger: 'submit',   day: 4, hour: 8,  min: 10, paste: null, keys: 14,
             snapshot: tiptapDoc(['Last year I joined the soccer team even though I was scared. The first practice was really hard and I wanted to quit. But my coach said to give it one more week.', 'By the end of the season I scored my first goal. It felt amazing. I learned that trying new things is worth it even when it\'s scary at first.']) },
         ]
-        for (const step of steps) {
-          historyEntries.push({
-            assignment_doc_id: s2NarrativeDoc.id,
-            patch: null,
-            snapshot: step.snapshot,
-            word_count: step.wordCount,
-            char_count: step.charCount,
-            trigger: step.trigger,
-            created_at: torontoTime(baseDateMs, step.day, step.hour, step.min, step.sec),
-            paste_word_count: step.paste,
-            keystroke_count: step.keys,
-          })
-        }
+        addHistorySteps(s2NarrativeDoc.id, baseDateMs, steps)
       }
 
       // ── Student 1 persuasive letter — in-progress, 3 days ──
@@ -931,19 +929,7 @@ async function seed() {
           { charCount: 325, wordCount: 60, trigger: 'blur',     day: 2, hour: 15, min: 10, paste: null, keys: 14,
             snapshot: null },
         ]
-        for (const step of steps) {
-          historyEntries.push({
-            assignment_doc_id: s1LetterDoc.id,
-            patch: null,
-            snapshot: step.snapshot,
-            word_count: step.wordCount,
-            char_count: step.charCount,
-            trigger: step.trigger,
-            created_at: torontoTime(baseDateMs, step.day, step.hour, step.min, step.sec),
-            paste_word_count: step.paste,
-            keystroke_count: step.keys,
-          })
-        }
+        addHistorySteps(s1LetterDoc.id, baseDateMs, steps)
       }
 
       if (historyEntries.length > 0) {
@@ -951,8 +937,23 @@ async function seed() {
           await supabase.from('assignment_doc_history').insert(historyEntries),
           'Insert assignment_doc_history'
         )
-        console.log(`✓ Created ${historyEntries.length} history entries across 10 days\n`)
       }
+
+      for (const submission of submissions) {
+        ensureOk(
+          await supabase
+            .from('assignment_docs')
+            .update({
+              is_submitted: true,
+              submitted_at: submission.submittedAt,
+            })
+            .eq('id', submission.assignmentDocId),
+          'Finalize submitted assignment_doc'
+        )
+      }
+      console.log(
+        `✓ Created ${historyEntries.length + submissions.length} history entries across realistic writing timelines\n`
+      )
 
       await seedAssignmentReviewFixtures({
         supabase,
@@ -967,6 +968,9 @@ async function seed() {
           letter,
         },
         now,
+        narrativeStudent1SubmittedAt: submissions.find(
+          submission => submission.assignmentDocId === s1NarrativeDoc?.id
+        )?.submittedAt,
       })
       console.log('✓ Added repo artifact, repo review, and feedback-return fixtures\n')
     }

--- a/tests/unit/assignment-history-seed.test.ts
+++ b/tests/unit/assignment-history-seed.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  ensureSeedTimestampAfter,
+  splitAssignmentHistoryAtSubmission,
+} from '../../scripts/lib/assignment-history-seed'
+
+const seedSource = readFileSync(resolve(process.cwd(), 'scripts/seed.ts'), 'utf8')
+
+const baseline = {
+  assignment_doc_id: 'doc-1',
+  trigger: 'baseline',
+  created_at: '2026-07-16T12:00:00.000Z',
+  snapshot: { type: 'doc', content: [] },
+}
+
+const submit = {
+  assignment_doc_id: 'doc-1',
+  trigger: 'submit',
+  created_at: '2026-07-17T12:00:00.000Z',
+  snapshot: { type: 'doc', content: [] },
+}
+
+describe('splitAssignmentHistoryAtSubmission', () => {
+  it('separates the final submit transition from editable history', () => {
+    expect(splitAssignmentHistoryAtSubmission([baseline, submit])).toEqual({
+      historyEntries: [baseline],
+      submission: {
+        assignmentDocId: 'doc-1',
+        submittedAt: '2026-07-17T12:00:00.000Z',
+      },
+    })
+  })
+
+  it('keeps an in-progress document history unchanged', () => {
+    expect(splitAssignmentHistoryAtSubmission([baseline])).toEqual({
+      historyEntries: [baseline],
+      submission: null,
+    })
+  })
+
+  it('rejects history after the submit transition', () => {
+    expect(() => splitAssignmentHistoryAtSubmission([submit, baseline])).toThrow(
+      'Seed assignment submit history must be the final entry',
+    )
+  })
+
+  it('requires the submit transition to carry a snapshot', () => {
+    expect(() => splitAssignmentHistoryAtSubmission([{ ...submit, snapshot: null }])).toThrow(
+      'Seed assignment submit history requires a snapshot',
+    )
+  })
+
+  it('seeds editable documents and history before finalizing submissions', () => {
+    const documentsStart = seedSource.indexOf('const assignmentDocs = [')
+    const documentsInsert = seedSource.indexOf(".from('assignment_docs')", documentsStart)
+    const historyInsert = seedSource.indexOf(
+      "await supabase.from('assignment_doc_history').insert(historyEntries)",
+    )
+    const submissionFinalization = seedSource.indexOf('for (const submission of submissions)')
+    const documentSeed = seedSource.slice(documentsStart, documentsInsert)
+
+    expect(documentsStart).toBeGreaterThan(-1)
+    expect(documentsInsert).toBeGreaterThan(documentsStart)
+    expect(documentSeed).not.toContain('is_submitted: true')
+    expect(seedSource).toContain('splitAssignmentHistoryAtSubmission(entries)')
+    expect(historyInsert).toBeGreaterThan(documentsInsert)
+    expect(submissionFinalization).toBeGreaterThan(historyInsert)
+  })
+})
+
+describe('ensureSeedTimestampAfter', () => {
+  it('moves an earlier fixture event one minute after its prerequisite', () => {
+    expect(
+      ensureSeedTimestampAfter(
+        '2026-07-16T17:00:00.000Z',
+        '2026-07-16T20:20:00.000Z',
+      ),
+    ).toBe('2026-07-16T20:21:00.000Z')
+  })
+
+  it('preserves a fixture event that is already later', () => {
+    expect(
+      ensureSeedTimestampAfter(
+        '2026-07-16T21:00:00.000Z',
+        '2026-07-16T20:20:00.000Z',
+      ),
+    ).toBe('2026-07-16T21:00:00.000Z')
+  })
+
+  it('rejects invalid chronology inputs', () => {
+    expect(() => ensureSeedTimestampAfter('invalid', submit.created_at)).toThrow(
+      'Seed assignment chronology requires valid timestamps',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- seed assignment documents as editable before inserting their writing history
- finalize submitted documents afterward so migration 099 creates the authoritative submit snapshot
- align synthetic timelines with the existing submission and grading dates
- add unit and source-order regression coverage

## Why
Migration 099 correctly rejects editable assignment history written after a document is submitted. The development seed still inserted submitted documents first, so `pnpm seed` failed with `assignment_history_after_submit_forbidden` and never reached the assignment-review or test fixtures.

## Validation
- `pnpm test` (376 files, 3,495 tests)
- `pnpm exec vitest run tests/unit/assignment-history-seed.test.ts tests/unit/assignment-submission-integrity-migration.test.ts` (18 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm seed` against local Supabase through migration 099
- direct local SQL verification: one matching submit snapshot per submitted document and no editable history at or after submission
- `git diff --check`

## Audit note
The Pika audit reports the existing `console.log` progress output throughout `scripts/seed.ts` whenever that CLI file is touched. This change adds no production logging path; it relocates the existing history-count message after submission finalization.

No production resources were accessed or modified.
