### PR TITLE
Fix teacher dashboard entry authorization

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,8 +7,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Product-experience Safety Wave progress: legacy classroom deletion is retired (#890), assignment submission integrity and migration 099 are deployed (#891), and local seeding is migration-099 compatible (#893).
-- The current Safety Wave slice replaces the teacher dashboard's student-only entry read with an owned teacher contract. Blueprint package v2/v3 reconciliation remains before Phase 2 shared experience foundation work.
+- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), and local seeding supports migration 099 (#893). The dashboard teacher-entry contract is current; blueprint v2/v3 reconciliation remains before Phase 2.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,8 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- PR #891 assignment integrity is reviewed and green: atomic writes, recovery-safe retries, mount-local writer fences, cleanup, and concurrency checks. Migration 099 is verified in production; merge and deploy the application version next.
+- Product-experience Safety Wave progress: legacy classroom deletion is retired (#890), assignment submission integrity and migration 099 are deployed (#891), and local seeding is migration-099 compatible (#893).
+- The current Safety Wave slice replaces the teacher dashboard's student-only entry read with an owned teacher contract. Blueprint package v2/v3 reconciliation remains before Phase 2 shared experience foundation work.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13872,3 +13872,20 @@
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - Pika pre-commit audit
+
+<!-- pika-session-log-archive-batch:7b6d256d00e97656782a9b602c89c04a8f56a23bc16bc5b0a24f5bccf4e70322 -->
+## 2026-07-13 — Gated Gradex runtime coordinator
+
+**Completed:**
+- Added a server-only coordinator that verifies immutable classroom archives before building Gradex extracts, then performs private no-overwrite upload, full read-back, independent integrity/privacy verification, and exact durable finalization.
+- Added explicit enablement, teacher allowlisting, a minimum-strength HMAC secret, HMAC-key fingerprint request binding, deterministic operation paths, strict Zod RPC contracts, and privacy-safe metrics.
+- Added safe replay, concurrent-upload reuse, terminal cleanup, and transient-finalization retry behavior without exposing any API, cron, or production execution path.
+- Documented the runtime boundary and configuration while keeping deletion automation, cold compaction, teacher UI, and production canaries unfinished. No production database, migration, row, or storage object was modified.
+
+**Validation:**
+- Full Vitest suite (327 files / 2,889 tests)
+- Focused archive/Gradex/runtime suites (4 files / 36 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -863,4 +863,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 
 **Remaining:**
-- Open and independently review the focused PR. After merge, reconcile the blueprint package v2/v3 contract as the final uncompleted Safety Wave item before Phase 2.
+- Independently review PR #894. After merge, reconcile the blueprint package v2/v3 contract as the final uncompleted Safety Wave item before Phase 2.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,22 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Gated Gradex runtime coordinator
-
-**Completed:**
-- Added a server-only coordinator that verifies immutable classroom archives before building Gradex extracts, then performs private no-overwrite upload, full read-back, independent integrity/privacy verification, and exact durable finalization.
-- Added explicit enablement, teacher allowlisting, a minimum-strength HMAC secret, HMAC-key fingerprint request binding, deterministic operation paths, strict Zod RPC contracts, and privacy-safe metrics.
-- Added safe replay, concurrent-upload reuse, terminal cleanup, and transient-finalization retry behavior without exposing any API, cron, or production execution path.
-- Documented the runtime boundary and configuration while keeping deletion automation, cold compaction, teacher UI, and production canaries unfinished. No production database, migration, row, or storage object was modified.
-
-**Validation:**
-- Full Vitest suite (327 files / 2,889 tests)
-- Focused archive/Gradex/runtime suites (4 files / 36 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-07-13 — Doubly gated Gradex teacher trigger
 
 **Completed:**
@@ -859,3 +843,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Audit note:**
 - The Pika pre-commit audit reports the existing CLI progress `console.log` calls throughout `scripts/seed.ts` after that file is touched. No new production logging path was introduced; this is a whole-file false positive for the development seed CLI.
+
+## 2026-07-20 — Teacher dashboard entry authorization contract
+
+**Completed:**
+- Replaced the teacher dashboard's unauthorized `/api/student/entries` read with an exact student/day query through the teacher-owned student-history route.
+- Added a named Zod query contract for classroom, student, exact/paged date, and bounded limit inputs while preserving authentication-first handling.
+- Kept classroom ownership and enrollment checks ahead of entry access, and added regressions for foreign classrooms, unenrolled students, exact-date filtering, and the dashboard endpoint choice.
+- Verified the route against local Supabase with a teacher session: the teacher endpoint returned the selected entry and the old student endpoint returned HTTP 403.
+- No schema, migration, production data, or visible UI layout changed.
+
+**Validation:**
+- `pnpm test` (376 files / 3,501 tests)
+- Focused dashboard, teacher entry/history, consumer, and API boundary suites (5 files / 23 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (605 modules / 0 allowances)
+- Live loopback teacher authorization and exact-entry query
+- `git diff --check`
+
+**Remaining:**
+- Open and independently review the focused PR. After merge, reconcile the blueprint package v2/v3 contract as the final uncompleted Safety Wave item before Phase 2.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -850,6 +850,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Replaced the teacher dashboard's unauthorized `/api/student/entries` read with an exact student/day query through the teacher-owned student-history route.
 - Added a named Zod query contract for classroom, student, exact/paged date, and bounded limit inputs while preserving authentication-first handling.
 - Kept classroom ownership and enrollment checks ahead of entry access, and added regressions for foreign classrooms, unenrolled students, exact-date filtering, and the dashboard endpoint choice.
+- Preserved the existing 50-row cap for oversized history limits and rejected ambiguous exact/paged date filters after independent review.
 - Verified the route against local Supabase with a teacher session: the teacher endpoint returned the selected entry and the old student endpoint returned HTTP 403.
 - No schema, migration, production data, or visible UI layout changed.
 

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/src/app/api/teacher/student-history/route.ts
+++ b/src/app/api/teacher/student-history/route.ts
@@ -3,35 +3,32 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { teacherStudentHistoryQuerySchema } from '@/lib/validations/teacher-student-history'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 /**
  * GET /api/teacher/student-history?classroom_id=xxx&student_id=xxx&before_date=YYYY-MM-DD&limit=10
- * Returns past entries for a student in reverse chronological order.
+ * Returns entries for a student in reverse chronological order, optionally for one exact date.
  */
 export const GET = withErrorHandler('GetStudentHistory', async (request: NextRequest) => {
   const user = await requireRole('teacher')
   const { searchParams } = new URL(request.url)
-  const classroomId = searchParams.get('classroom_id')
-  const studentId = searchParams.get('student_id')
-  const beforeDate = searchParams.get('before_date')
-  const limit = Math.min(parseInt(searchParams.get('limit') || '10', 10) || 10, 50)
-
-  if (!classroomId || !studentId) {
-    return NextResponse.json(
-      { error: 'classroom_id and student_id are required' },
-      { status: 400 }
-    )
-  }
-
-  if (beforeDate && !/^\d{4}-\d{2}-\d{2}$/.test(beforeDate)) {
-    return NextResponse.json(
-      { error: 'Invalid before_date format (use YYYY-MM-DD)' },
-      { status: 400 }
-    )
-  }
+  const queryInput = teacherStudentHistoryQuerySchema.parse({
+    classroom_id: searchParams.get('classroom_id') ?? undefined,
+    student_id: searchParams.get('student_id') ?? undefined,
+    before_date: searchParams.get('before_date') ?? undefined,
+    date: searchParams.get('date') ?? undefined,
+    limit: searchParams.get('limit') ?? undefined,
+  })
+  const {
+    classroom_id: classroomId,
+    student_id: studentId,
+    before_date: beforeDate,
+    date,
+    limit,
+  } = queryInput
 
   const supabase = getServiceRoleClient()
   const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
@@ -57,19 +54,21 @@ export const GET = withErrorHandler('GetStudentHistory', async (request: NextReq
     )
   }
 
-  let query = supabase
+  let entriesQuery = supabase
     .from('entries')
     .select('*')
     .eq('student_id', studentId)
     .eq('classroom_id', classroomId)
-    .order('date', { ascending: false })
-    .limit(limit)
 
-  if (beforeDate) {
-    query = query.lt('date', beforeDate)
+  if (date) {
+    entriesQuery = entriesQuery.eq('date', date)
+  } else if (beforeDate) {
+    entriesQuery = entriesQuery.lt('date', beforeDate)
   }
 
-  const { data: entries, error: entriesError } = await query
+  const { data: entries, error: entriesError } = await entriesQuery
+    .order('date', { ascending: false })
+    .limit(limit)
 
   if (entriesError) {
     console.error('Error fetching student history:', entriesError)

--- a/src/app/teacher/dashboard/page.tsx
+++ b/src/app/teacher/dashboard/page.tsx
@@ -12,7 +12,7 @@ import { getAttendanceIcon } from '@/lib/attendance'
 import { PageActionBar, PageContent, PageLayout, type ActionBarItem } from '@/components/PageLayout'
 import {
   fetchTeacherDashboardAttendance,
-  fetchTeacherDashboardEntries,
+  fetchTeacherDashboardEntry,
   invalidateTeacherDashboardAttendance,
 } from '@/lib/teacher-dashboard-client'
 import { fetchTeacherClassrooms, invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
@@ -96,11 +96,7 @@ export default function TeacherDashboardPage() {
     setLoadingEntry(true)
 
     try {
-      const entries = await fetchTeacherDashboardEntries(selectedClassroom.id)
-
-      const entry = entries.find(
-        (e: Entry) => e.student_id === studentId && e.date === date
-      )
+      const entry = await fetchTeacherDashboardEntry(selectedClassroom.id, studentId, date)
 
       if (entry) {
         setSelectedEntry({ ...entry, student_email: studentEmail })

--- a/src/lib/teacher-dashboard-client.ts
+++ b/src/lib/teacher-dashboard-client.ts
@@ -36,14 +36,24 @@ export async function fetchTeacherDashboardAttendance(classroomId: string): Prom
   }
 }
 
-export async function fetchTeacherDashboardEntries(classroomId: string): Promise<Entry[]> {
-  const response = await fetch(`/api/student/entries?classroom_id=${classroomId}`)
+export async function fetchTeacherDashboardEntry(
+  classroomId: string,
+  studentId: string,
+  date: string,
+): Promise<Entry | null> {
+  const searchParams = new URLSearchParams({
+    classroom_id: classroomId,
+    student_id: studentId,
+    date,
+    limit: '1',
+  })
+  const response = await fetch(`/api/teacher/student-history?${searchParams}`)
   const data = await response.json().catch(() => ({ entries: [] }))
   if (!response.ok) {
-    const message = typeof data.error === 'string' ? data.error : 'Failed to load entries'
+    const message = typeof data.error === 'string' ? data.error : 'Failed to load entry'
     throw new Error(message)
   }
-  return data.entries || []
+  return data.entries?.[0] || null
 }
 
 export function invalidateTeacherDashboardAttendance(classroomId: string) {

--- a/src/lib/validations/teacher-student-history.ts
+++ b/src/lib/validations/teacher-student-history.ts
@@ -10,7 +10,7 @@ export const teacherStudentHistoryQuerySchema = z.object({
   student_id: z.string().trim().min(1, 'student_id is required'),
   before_date: entryDateSchema.optional(),
   date: entryDateSchema.optional(),
-  limit: z.coerce.number().int().min(1).max(50).default(10),
+  limit: z.coerce.number().int().min(1).transform(value => Math.min(value, 50)).default(10),
 }).refine(
   value => !(value.before_date && value.date),
   { message: 'before_date and date cannot be used together' },

--- a/src/lib/validations/teacher-student-history.ts
+++ b/src/lib/validations/teacher-student-history.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+const entryDateSchema = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}$/,
+  'Invalid date format (use YYYY-MM-DD)',
+)
+
+export const teacherStudentHistoryQuerySchema = z.object({
+  classroom_id: z.string().trim().min(1, 'classroom_id is required'),
+  student_id: z.string().trim().min(1, 'student_id is required'),
+  before_date: entryDateSchema.optional(),
+  date: entryDateSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+}).refine(
+  value => !(value.before_date && value.date),
+  { message: 'before_date and date cannot be used together' },
+)

--- a/tests/api/teacher/student-history.test.ts
+++ b/tests/api/teacher/student-history.test.ts
@@ -46,6 +46,12 @@ describe('GET /api/teacher/student-history', () => {
       new NextRequest('http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&date=03-16-2026')
     )
     expect(invalidExactDate.status).toBe(400)
+
+    const ambiguousDate = await GET(new NextRequest(
+      'http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&date=2026-03-15&before_date=2026-03-16',
+    ))
+    expect(ambiguousDate.status).toBe(400)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
   })
 
   it('returns 403 when the classroom belongs to another teacher', async () => {
@@ -73,6 +79,7 @@ describe('GET /api/teacher/student-history', () => {
   })
 
   it('returns paged entries for an enrolled student', async () => {
+    let entryLimit: ReturnType<typeof vi.fn> | undefined
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'classrooms') {
         return {
@@ -114,6 +121,7 @@ describe('GET /api/teacher/student-history', () => {
             )
           ),
         }
+        entryLimit = entryQuery.limit
         return entryQuery
       }
       throw new Error(`Unexpected table: ${table}`)
@@ -127,6 +135,51 @@ describe('GET /api/teacher/student-history', () => {
     expect(response.status).toBe(200)
     expect(data.entries).toHaveLength(1)
     expect(data.entries[0].id).toBe('e1')
+    expect(entryLimit).toHaveBeenCalledWith(5)
+  })
+
+  it('caps oversized history limits at 50 for compatibility', async () => {
+    let entryLimit: ReturnType<typeof vi.fn> | undefined
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        const enrollmentQuery: any = {
+          eq: vi.fn(() => enrollmentQuery),
+          single: vi.fn().mockResolvedValue({ data: { student_id: 's1' }, error: null }),
+        }
+        return { select: vi.fn(() => enrollmentQuery) }
+      }
+      if (table === 'entries') {
+        const entryQuery: any = {
+          select: vi.fn(() => entryQuery),
+          eq: vi.fn(() => entryQuery),
+          order: vi.fn(() => entryQuery),
+          limit: vi.fn(() => entryQuery),
+          then: vi.fn((resolve: any) => Promise.resolve(resolve({ data: [], error: null }))),
+        }
+        entryLimit = entryQuery.limit
+        return entryQuery
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(new NextRequest(
+      'http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&limit=500',
+    ))
+
+    expect(response.status).toBe(200)
+    expect(entryLimit).toHaveBeenCalledWith(50)
   })
 
   it('returns only the requested student entry for an exact date', async () => {

--- a/tests/api/teacher/student-history.test.ts
+++ b/tests/api/teacher/student-history.test.ts
@@ -41,6 +41,11 @@ describe('GET /api/teacher/student-history', () => {
       new NextRequest('http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&before_date=03-16-2026')
     )
     expect(invalidDate.status).toBe(400)
+
+    const invalidExactDate = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&date=03-16-2026')
+    )
+    expect(invalidExactDate.status).toBe(400)
   })
 
   it('returns 403 when the classroom belongs to another teacher', async () => {
@@ -122,5 +127,88 @@ describe('GET /api/teacher/student-history', () => {
     expect(response.status).toBe(200)
     expect(data.entries).toHaveLength(1)
     expect(data.entries[0].id).toBe('e1')
+  })
+
+  it('returns only the requested student entry for an exact date', async () => {
+    const entryQuery: any = {
+      select: vi.fn(() => entryQuery),
+      eq: vi.fn(() => entryQuery),
+      order: vi.fn(() => entryQuery),
+      limit: vi.fn(() => entryQuery),
+      then: vi.fn((resolve: any) => Promise.resolve(resolve({
+        data: [{ id: 'e1', student_id: 's1', date: '2026-03-15', text: 'Worked hard' }],
+        error: null,
+      }))),
+    }
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        const enrollmentQuery: any = {
+          eq: vi.fn(() => enrollmentQuery),
+          single: vi.fn().mockResolvedValue({ data: { student_id: 's1' }, error: null }),
+        }
+        return { select: vi.fn(() => enrollmentQuery) }
+      }
+      if (table === 'entries') return entryQuery
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(new NextRequest(
+      'http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=s1&date=2026-03-15&limit=1',
+    ))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.entries).toEqual([
+      { id: 'e1', student_id: 's1', date: '2026-03-15', text: 'Worked hard' },
+    ])
+    expect(entryQuery.eq).toHaveBeenCalledWith('student_id', 's1')
+    expect(entryQuery.eq).toHaveBeenCalledWith('classroom_id', 'c1')
+    expect(entryQuery.eq).toHaveBeenCalledWith('date', '2026-03-15')
+    expect(entryQuery.limit).toHaveBeenCalledWith(1)
+  })
+
+  it('returns 404 before querying entries when the student is not enrolled', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        const enrollmentQuery: any = {
+          eq: vi.fn(() => enrollmentQuery),
+          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+        }
+        return { select: vi.fn(() => enrollmentQuery) }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(new NextRequest(
+      'http://localhost:3000/api/teacher/student-history?classroom_id=c1&student_id=other-student&date=2026-03-15&limit=1',
+    ))
+
+    expect(response.status).toBe(404)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('entries')
   })
 })

--- a/tests/components/TeacherDashboardPage.test.tsx
+++ b/tests/components/TeacherDashboardPage.test.tsx
@@ -166,17 +166,23 @@ function installFetchMock(options?: {
       }))
     }
 
-    if (url.startsWith('/api/student/entries?classroom_id=') && method === 'GET') {
-      const classroomId = new URL(url, 'http://localhost').searchParams.get('classroom_id') || ''
+    if (url.startsWith('/api/teacher/student-history?') && method === 'GET') {
+      const searchParams = new URL(url, 'http://localhost').searchParams
+      const classroomId = searchParams.get('classroom_id') || ''
+      const studentId = searchParams.get('student_id')
+      const date = searchParams.get('date')
+      const entries = options?.entriesByClassroom?.[classroomId] ?? [
+        entry({
+          studentId: 's1',
+          classroomId,
+          date: '2026-06-01',
+          text: 'Focused entry text',
+        }),
+      ]
       return Promise.resolve(jsonResponse({
-        entries: options?.entriesByClassroom?.[classroomId] ?? [
-          entry({
-            studentId: 's1',
-            classroomId,
-            date: '2026-06-01',
-            text: 'Focused entry text',
-          }),
-        ],
+        entries: entries.filter(candidate => (
+          candidate.student_id === studentId && candidate.date === date
+        )),
       }))
     }
 
@@ -237,7 +243,11 @@ describe('Teacher dashboard page', () => {
     fireEvent.click(screen.getByText('🟢'))
 
     expect(await screen.findByText('Focused entry text')).toBeInTheDocument()
-    expect(fetchMock).toHaveBeenCalledWith('/api/student/entries?classroom_id=c1')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/teacher/student-history?classroom_id=c1&student_id=s1&date=2026-06-01&limit=1',
+    )
+    expect(fetchMock.mock.calls.some(([input]) => String(input).startsWith('/api/student/entries')))
+      .toBe(false)
   })
 
   it('invalidates and reloads attendance after roster upload', async () => {


### PR DESCRIPTION
## Summary
- replace the teacher dashboard's student-only entry read with the teacher-owned student-history contract
- add exact student/day filtering and a named Zod query schema
- preserve classroom ownership and enrollment checks before querying entries
- add API and dashboard regressions for endpoint choice, exact filtering, foreign classrooms, and unenrolled students

## Why
The dashboard previously called `/api/student/entries` while authenticated as a teacher. Production correctly rejects that role, but the component test mocked the unauthorized request as successful, leaving entry drill-down broken.

## Boundaries
- UI: endpoint wiring only; no visible layout or interaction change
- API: `GET /api/teacher/student-history` accepts optional exact `date`, mutually exclusive with `before_date`
- Database: no schema or migration changes
- Production: not accessed or modified

## Validation
- `pnpm test` (376 files, 3,501 tests)
- focused dashboard, teacher entry/history, consumer, and API boundary suites (5 files, 23 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (605 modules, 0 allowances)
- Pika pre-commit audit
- live loopback check with teacher session: teacher endpoint 200, old student endpoint 403
- `git diff --check`
