### PR TITLE
Reconcile blueprint package version contract

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), and the dashboard teacher-entry contract is merged (#894). Blueprint package v3 reconciliation is in review as the final item before Phase 2.
+- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), and the dashboard teacher-entry contract is merged (#894). Blueprint package v3 reconciliation is in PR #895 as the final item before Phase 2.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), and local seeding supports migration 099 (#893). The dashboard teacher-entry contract is current; blueprint v2/v3 reconciliation remains before Phase 2.
+- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), and the dashboard teacher-entry contract is merged (#894). Blueprint package v3 reconciliation is in review as the final item before Phase 2.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13889,3 +13889,24 @@
 - `pnpm lint`
 - `pnpm build`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:c3f9f86aa9f27904900f14beea4412846508e3db3437a54eccfce7f9df60dfb0 -->
+## 2026-07-13 — Doubly gated Gradex teacher trigger
+
+**Completed:**
+- Added a teacher-authenticated Gradex generation route requiring an explicit UUID idempotency key and a future deletion timestamp bounded by the 90-day artifact contract.
+- Kept deployment fail-closed behind both the existing teacher coordinator allowlist and a separate exact source-archive canary flag/allowlist; no UI, cron, or automatic caller was added.
+- Delegated generation, immutable archive ownership, transformation, storage, read-back, privacy verification, and durable finalization to the existing coordinator and migration 084 boundaries.
+- Extended the rollback-only database contract and static migration guard to reject foreign-teacher and wrong-classroom archive requests without creating an operation.
+- Updated environment, lifecycle, test, and current-context documentation. No production database, migration, row, storage object, or environment setting was modified.
+
+**Validation:**
+- Full Vitest suite (328 files / 2,899 tests)
+- Focused trigger/coordinator/transformer/artifact/startup suites (5 files / 67 tests)
+- Focused route/coordinator/migration suite after ownership review (3 files / 29 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash -n scripts/check-classroom-gradex-database.sh`
+- Local executable database contract unavailable because the running Supabase container predates migration 082; migrations were not applied or modified
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -867,4 +867,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 
 **Remaining:**
-- Complete independent review and broad verification, then publish and merge the blueprint contract PR. Phase 2 begins after that merge.
+- Merge PR #895 after required checks/review. Phase 2 begins after that merge.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Doubly gated Gradex teacher trigger
-
-**Completed:**
-- Added a teacher-authenticated Gradex generation route requiring an explicit UUID idempotency key and a future deletion timestamp bounded by the 90-day artifact contract.
-- Kept deployment fail-closed behind both the existing teacher coordinator allowlist and a separate exact source-archive canary flag/allowlist; no UI, cron, or automatic caller was added.
-- Delegated generation, immutable archive ownership, transformation, storage, read-back, privacy verification, and durable finalization to the existing coordinator and migration 084 boundaries.
-- Extended the rollback-only database contract and static migration guard to reject foreign-teacher and wrong-classroom archive requests without creating an operation.
-- Updated environment, lifecycle, test, and current-context documentation. No production database, migration, row, storage object, or environment setting was modified.
-
-**Validation:**
-- Full Vitest suite (328 files / 2,899 tests)
-- Focused trigger/coordinator/transformer/artifact/startup suites (5 files / 67 tests)
-- Focused route/coordinator/migration suite after ownership review (3 files / 29 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash -n scripts/check-classroom-gradex-database.sh`
-- Local executable database contract unavailable because the running Supabase container predates migration 082; migrations were not applied or modified
-- `git diff --check`
-
 ## 2026-07-13 — Verified Gradex retention cleanup runtime
 
 **Completed:**
@@ -865,3 +845,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Independently review PR #894. After merge, reconcile the blueprint package v2/v3 contract as the final uncompleted Safety Wave item before Phase 2.
+
+## 2026-07-20 — Blueprint package version contract reconciliation
+
+**Completed:**
+- Merged PR #894, fast-forwarded the hub to `origin/main`, and removed its clean feature worktree and local branch.
+- Made course package version 3 the shared canonical export and lifecycle contract while explicitly retaining version 2 import compatibility.
+- Added a focused Zod boundary for package manifests and files so malformed and unsupported versions fail before operation planning; server operations now consume validated manifest metadata rather than the original request value.
+- Preserved legacy version 2 course content while intentionally ignoring retired `quizzes.md` content, with a checked-in compatibility fixture and bundle/tar regressions.
+- Made v3 file membership strict, bounded HTTP and tar input size/counts, and rejected unknown or duplicate archive entries after independent review; removed the import route from the API validation debt baseline.
+- Added byte-aware per-file limits for both JSON and tar imports after rereview; the final independent rereview reported no actionable findings.
+- Updated package and classroom lifecycle guidance to agree on current and supported versions. No database migration, production access, or visible UI change was required.
+
+**Validation:**
+- `pnpm test` (376 files / 3,514 tests)
+- Focused package, artifact, server, API, documentation, and route-standard suites (6 files / 52 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (606 modules / 0 allowances)
+- `pnpm build`
+- `git diff --check`
+
+**Remaining:**
+- Complete independent review and broad verification, then publish and merge the blueprint contract PR. Phase 2 begins after that merge.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -78,11 +78,13 @@ The three artifacts solve different problems and must not be substituted for eac
 | Classroom archive | Recover the complete classroom | Yes | Yes | Private `classroom-archives` bucket |
 | Gradex extract | Improve and evaluate grading behavior | Deidentified subset | No | Private `gradex-analytics-extracts` bucket |
 
-The existing `.course-package.tar` manifest remains version 2. It includes teacher-authored course
-content, assignment and assessment templates, lesson templates, grading configuration, submission
-requirement templates, and planned-site configuration. It excludes rosters, students, submissions,
-grades, attendance, journals, telemetry, join credentials, runtime publication state, and storage
-objects. A course package is never evidence that classroom data is recoverable.
+The canonical `.course-package.tar` export manifest is version 3. Import accepts versions 2 and 3;
+legacy version 2 `quizzes.md` content is intentionally ignored because quizzes are no longer a product
+surface. The package includes teacher-authored course content, assignment and test templates, lesson
+templates, grading configuration, submission requirement templates, and planned-site configuration.
+It excludes rosters, students, submissions, grades, attendance, journals, telemetry, join credentials,
+runtime publication state, and storage objects. A course package is never evidence that classroom data
+is recoverable.
 
 ## Lifecycle States
 

--- a/docs/guidance/course-blueprint-packages.md
+++ b/docs/guidance/course-blueprint-packages.md
@@ -22,7 +22,11 @@ A course package is a tar archive with these root files:
 
 `manifest.json` stores package metadata and planned-site publishing settings. The Markdown files store the editable teacher-authored course content.
 
-The current manifest version is `3`. The version identifies the portable content contract; it is independent of the database migration number.
+The canonical export manifest version is `3`. Pika imports versions `2` and `3`, and rejects other
+versions. Version `2` packages may contain the retired `quizzes.md` file; Pika imports their reusable
+course, assignment, test, and lesson-plan content but intentionally ignores that legacy quiz content.
+The version identifies the portable content contract; it is independent of the database migration
+number.
 
 ## Included
 

--- a/src/app/api/teacher/course-blueprints/import/route.ts
+++ b/src/app/api/teacher/course-blueprints/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
-import { withErrorHandler } from '@/lib/api-handler'
+import { ApiError, withErrorHandler } from '@/lib/api-handler'
+import { COURSE_BLUEPRINT_PACKAGE_MAX_BYTES } from '@/lib/contracts/course-blueprint-package'
 import {
   importCourseBlueprintArchive,
   importCourseBlueprintBundle,
@@ -10,13 +11,58 @@ import { resolveBlueprintOperationId } from '@/lib/server/course-blueprint-opera
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+async function readCoursePackageBody(request: Request): Promise<Uint8Array> {
+  const contentLength = Number(request.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > COURSE_BLUEPRINT_PACKAGE_MAX_BYTES) {
+    throw new ApiError(413, 'Course package exceeds the 8 MiB limit')
+  }
+  if (!request.body) return new Uint8Array()
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > COURSE_BLUEPRINT_PACKAGE_MAX_BYTES) {
+        await reader.cancel()
+        throw new ApiError(413, 'Course package exceeds the 8 MiB limit')
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return body
+}
+
 export const POST = withErrorHandler('PostTeacherCourseBlueprintImport', async (request) => {
   const user = await requireRole('teacher')
   const contentType = request.headers.get('content-type') || ''
   const operationId = resolveBlueprintOperationId(request.headers.get('idempotency-key'))
+  const body = await readCoursePackageBody(request)
+  let bundle: unknown
+  if (contentType.includes('application/json')) {
+    try {
+      bundle = JSON.parse(new TextDecoder().decode(body))
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new ApiError(400, 'Malformed JSON body')
+      throw error
+    }
+  }
   const result = contentType.includes('application/json')
-    ? await importCourseBlueprintBundle(user.id, await request.json(), { operationId })
-    : await importCourseBlueprintArchive(user.id, await request.arrayBuffer(), { operationId })
+    ? await importCourseBlueprintBundle(user.id, bundle, { operationId })
+    : await importCourseBlueprintArchive(user.id, body, { operationId })
 
   if (!result.ok) {
     return NextResponse.json({

--- a/src/lib/contracts/classroom-artifacts.ts
+++ b/src/lib/contracts/classroom-artifacts.ts
@@ -3,6 +3,12 @@ import {
   CLASSROOM_RELATIONAL_RESOURCES,
   GRADEX_RESOURCE_TABLES,
 } from '@/lib/contracts/classroom-data'
+import {
+  COURSE_BLUEPRINT_PACKAGE_EXTENSION,
+  COURSE_BLUEPRINT_PACKAGE_FORMAT,
+  COURSE_BLUEPRINT_PACKAGE_VERSION,
+  COURSE_BLUEPRINT_SUPPORTED_PACKAGE_VERSIONS,
+} from '@/lib/contracts/course-blueprint-package'
 
 export const CLASSROOM_ARCHIVE_FORMAT = 'pika.classroom-archive' as const
 export const CLASSROOM_ARCHIVE_VERSION = 1 as const
@@ -274,9 +280,10 @@ export function isClassroomArchiveRestoreReady(
 }
 
 export const COURSE_BLUEPRINT_TRANSFER_CONTRACT = {
-  format: 'pika.course-package',
-  extension: '.course-package.tar',
-  manifest_version: '2',
+  format: COURSE_BLUEPRINT_PACKAGE_FORMAT,
+  extension: COURSE_BLUEPRINT_PACKAGE_EXTENSION,
+  manifest_version: COURSE_BLUEPRINT_PACKAGE_VERSION,
+  supported_import_versions: COURSE_BLUEPRINT_SUPPORTED_PACKAGE_VERSIONS,
   recoverable_classroom_backup: false,
   included_data: [
     'course_metadata',

--- a/src/lib/contracts/course-blueprint-package.ts
+++ b/src/lib/contracts/course-blueprint-package.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+
+export const COURSE_BLUEPRINT_PACKAGE_FORMAT = 'pika.course-package' as const
+export const COURSE_BLUEPRINT_PACKAGE_EXTENSION = '.course-package.tar' as const
+export const COURSE_BLUEPRINT_PACKAGE_VERSION = '3' as const
+export const COURSE_BLUEPRINT_SUPPORTED_PACKAGE_VERSIONS = ['2', '3'] as const
+export const COURSE_BLUEPRINT_PACKAGE_MAX_BYTES = 8 * 1024 * 1024
+export const COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES = 2 * 1024 * 1024
+export const COURSE_BLUEPRINT_PACKAGE_MAX_FILE_COUNT = 8
+
+const textEncoder = new TextEncoder()
+const coursePackageFileContentSchema = z.string().refine(
+  (value) => textEncoder.encode(value).byteLength <= COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES,
+  'Course package file exceeds the 2 MiB limit',
+)
+
+const plannedCourseSiteConfigSchema = z.object({
+  overview: z.boolean(),
+  outline: z.boolean(),
+  resources: z.boolean(),
+  assignments: z.boolean(),
+  quizzes: z.boolean(),
+  tests: z.boolean(),
+  lesson_plans: z.boolean(),
+}).strict()
+
+const coursePackageManifestShape = {
+  exported_at: z.string().datetime({ offset: true }),
+  title: z.string(),
+  subject: z.string(),
+  grade_level: z.string(),
+  course_code: z.string(),
+  term_template: z.string(),
+  planned_site_slug: z.string().nullable().optional(),
+  planned_site_published: z.boolean().optional(),
+  planned_site_config: plannedCourseSiteConfigSchema.optional(),
+}
+
+const coursePackageManifestV2Schema = z.object({
+  version: z.literal('2'),
+  ...coursePackageManifestShape,
+}).strict()
+
+const coursePackageManifestV3Schema = z.object({
+  version: z.literal('3'),
+  ...coursePackageManifestShape,
+}).strict()
+
+export const coursePackageManifestSchema = z.discriminatedUnion('version', [
+  coursePackageManifestV2Schema,
+  coursePackageManifestV3Schema,
+])
+
+const coursePackageFilesShape = {
+  'course-overview.md': coursePackageFileContentSchema.default(''),
+  'course-outline.md': coursePackageFileContentSchema.default(''),
+  'resources.md': coursePackageFileContentSchema.default(''),
+  'assignments.md': coursePackageFileContentSchema.default(''),
+  'tests.md': coursePackageFileContentSchema.default(''),
+  'lesson-plans.md': coursePackageFileContentSchema.default(''),
+}
+
+const coursePackageV2BundleSchema = z.object({
+  manifest: coursePackageManifestV2Schema,
+  files: z.object({
+    ...coursePackageFilesShape,
+    'quizzes.md': coursePackageFileContentSchema.default(''),
+  }).strict(),
+}).strict()
+
+const coursePackageV3BundleSchema = z.object({
+  manifest: coursePackageManifestV3Schema,
+  files: z.object(coursePackageFilesShape).strict(),
+}).strict()
+
+export const coursePackageBundleSchema = z.union([
+  coursePackageV2BundleSchema,
+  coursePackageV3BundleSchema,
+])
+
+export type CoursePackageManifest = z.infer<typeof coursePackageManifestSchema>

--- a/src/lib/course-blueprint-package.ts
+++ b/src/lib/course-blueprint-package.ts
@@ -14,8 +14,15 @@ import type {
   CourseBlueprintAssessment,
   CourseBlueprintDetail,
   CourseBlueprintLessonTemplate,
-  CoursePackageManifest,
 } from '@/types'
+import {
+  COURSE_BLUEPRINT_PACKAGE_MAX_BYTES,
+  COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES,
+  COURSE_BLUEPRINT_PACKAGE_MAX_FILE_COUNT,
+  COURSE_BLUEPRINT_PACKAGE_VERSION,
+  coursePackageBundleSchema,
+  type CoursePackageManifest,
+} from '@/lib/contracts/course-blueprint-package'
 import {
   DEFAULT_PLANNED_COURSE_SITE_CONFIG,
   normalizePlannedCourseSiteConfig,
@@ -24,7 +31,7 @@ import {
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
-export const COURSE_BLUEPRINT_PACKAGE_VERSION = '3' as const
+export { COURSE_BLUEPRINT_PACKAGE_VERSION } from '@/lib/contracts/course-blueprint-package'
 
 export const COURSE_BLUEPRINT_PACKAGE_FILE_NAMES = [
   'course-overview.md',
@@ -35,6 +42,12 @@ export const COURSE_BLUEPRINT_PACKAGE_FILE_NAMES = [
   'lesson-plans.md',
 ] as const
 
+const COURSE_BLUEPRINT_PACKAGE_ACCEPTED_ARCHIVE_FILE_NAMES = new Set<string>([
+  'manifest.json',
+  ...COURSE_BLUEPRINT_PACKAGE_FILE_NAMES,
+  'quizzes.md',
+])
+
 export type CourseBlueprintPackageFileName =
   (typeof COURSE_BLUEPRINT_PACKAGE_FILE_NAMES)[number]
 
@@ -44,6 +57,7 @@ export type CourseBlueprintPackageBundle = {
 }
 
 export type CourseBlueprintImportResult = {
+  manifest: CoursePackageManifest | null
   blueprint: Pick<
     CourseBlueprint,
     | 'title'
@@ -150,12 +164,17 @@ function isZeroTarBlock(block: Uint8Array): boolean {
 }
 
 export function encodeCourseBlueprintPackageArchive(bundle: CourseBlueprintPackageBundle): Uint8Array {
+  const parsedBundle = coursePackageBundleSchema.parse(bundle)
+  const legacyQuizFile = 'quizzes.md' in parsedBundle.files
+    ? [{ name: 'quizzes.md', content: parsedBundle.files['quizzes.md'] }]
+    : []
   const files: Array<{ name: string; content: string }> = [
-    { name: 'manifest.json', content: JSON.stringify(bundle.manifest, null, 2) },
+    { name: 'manifest.json', content: JSON.stringify(parsedBundle.manifest, null, 2) },
     ...COURSE_BLUEPRINT_PACKAGE_FILE_NAMES.map((fileName) => ({
       name: fileName,
-      content: bundle.files[fileName] ?? '',
+      content: parsedBundle.files[fileName],
     })),
+    ...legacyQuizFile,
   ]
 
   const parts: Uint8Array[] = []
@@ -186,8 +205,11 @@ export function decodeCourseBlueprintPackageArchive(
   input: ArrayBuffer | Uint8Array
 ): CourseBlueprintPackageBundle | null {
   const bytes = input instanceof Uint8Array ? input : new Uint8Array(input)
+  if (bytes.byteLength > COURSE_BLUEPRINT_PACKAGE_MAX_BYTES) return null
+
   const extractedFiles = new Map<string, string>()
   let offset = 0
+  let fileCount = 0
 
   while (offset + 512 <= bytes.length) {
     const header = bytes.slice(offset, offset + 512)
@@ -198,7 +220,18 @@ export function decodeCourseBlueprintPackageArchive(
     const fullName = prefix ? `${prefix}/${name}` : name
     const size = parseTarOctal(header, 124, 12)
 
+    fileCount += 1
+    if (
+      fileCount > COURSE_BLUEPRINT_PACKAGE_MAX_FILE_COUNT ||
+      !COURSE_BLUEPRINT_PACKAGE_ACCEPTED_ARCHIVE_FILE_NAMES.has(fullName) ||
+      extractedFiles.has(fullName) ||
+      size > COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES
+    ) {
+      return null
+    }
+
     offset += 512
+    if (offset + size > bytes.length) return null
     const content = bytes.slice(offset, offset + size)
     extractedFiles.set(fullName, textDecoder.decode(content))
     offset += Math.ceil(size / 512) * 512
@@ -208,12 +241,12 @@ export function decodeCourseBlueprintPackageArchive(
   if (!manifestRaw) return null
 
   try {
-    const manifest = JSON.parse(manifestRaw) as CoursePackageManifest
-    const files = Object.fromEntries(
-      COURSE_BLUEPRINT_PACKAGE_FILE_NAMES.map((fileName) => [fileName, extractedFiles.get(fileName) ?? ''])
-    ) as Record<CourseBlueprintPackageFileName, string>
-
-    return { manifest, files }
+    return normalizeBundle({
+      manifest: JSON.parse(manifestRaw),
+      files: Object.fromEntries(
+        [...extractedFiles.entries()].filter(([fileName]) => fileName !== 'manifest.json')
+      ),
+    })
   } catch {
     return null
   }
@@ -269,11 +302,15 @@ export function buildCourseBlueprintExportBundle(detail: CourseBlueprintDetail):
 }
 
 function normalizeBundle(input: unknown): CourseBlueprintPackageBundle | null {
-  if (typeof input !== 'object' || input === null) return null
-  const record = input as Record<string, unknown>
-  if (typeof record.manifest !== 'object' || record.manifest === null) return null
-  if (typeof record.files !== 'object' || record.files === null) return null
-  return record as CourseBlueprintPackageBundle
+  const parsed = coursePackageBundleSchema.safeParse(input)
+  if (!parsed.success) return null
+
+  return {
+    manifest: parsed.data.manifest,
+    files: Object.fromEntries(
+      COURSE_BLUEPRINT_PACKAGE_FILE_NAMES.map((fileName) => [fileName, parsed.data.files[fileName]])
+    ) as Record<CourseBlueprintPackageFileName, string>,
+  }
 }
 
 export function parseCourseBlueprintImportArchive(
@@ -282,6 +319,7 @@ export function parseCourseBlueprintImportArchive(
   const bundle = decodeCourseBlueprintPackageArchive(input)
   if (!bundle) {
     return {
+      manifest: null,
       blueprint: {
         title: '',
         subject: '',
@@ -309,6 +347,7 @@ export function parseCourseBlueprintImportBundle(input: unknown): CourseBlueprin
   const bundle = normalizeBundle(input)
   if (!bundle) {
     return {
+      manifest: null,
       blueprint: {
         title: '',
         subject: '',
@@ -336,6 +375,7 @@ export function parseCourseBlueprintImportBundle(input: unknown): CourseBlueprin
   const lessonResult = markdownToCourseBlueprintLessonTemplates(files['lesson-plans.md'] ?? '', [])
 
   return {
+    manifest,
     blueprint: {
       title: manifest.title ?? '',
       subject: manifest.subject ?? '',

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -8,7 +8,6 @@ import {
   encodeCourseBlueprintPackageArchive,
   parseCourseBlueprintImportBundle,
   parseCourseBlueprintImportArchive,
-  type CourseBlueprintPackageBundle,
 } from '@/lib/course-blueprint-package'
 import {
   DEFAULT_PLANNED_COURSE_SITE_CONFIG,
@@ -611,11 +610,11 @@ export async function exportCourseBlueprintArchive(teacherId: string, blueprintI
 
 export async function importCourseBlueprintBundle(
   teacherId: string,
-  bundle: CourseBlueprintPackageBundle,
+  bundle: unknown,
   options: BlueprintOperationOptions = {},
 ) {
   const parsed = parseCourseBlueprintImportBundle(bundle)
-  if (parsed.errors.length > 0) {
+  if (parsed.errors.length > 0 || !parsed.manifest) {
     return { ok: false as const, status: 400, error: 'Invalid course package', errors: parsed.errors }
   }
 
@@ -634,8 +633,8 @@ export async function importCourseBlueprintBundle(
       include_in_final: assessment.include_in_final !== false,
     })),
     lessonTemplates: parsed.lesson_templates,
-    manifestVersion: bundle.manifest.version,
-    sourcePackageExportedAt: bundle.manifest.exported_at,
+    manifestVersion: parsed.manifest.version,
+    sourcePackageExportedAt: parsed.manifest.exported_at,
   })
   const operation = await createCourseBlueprintAtomic({
     supabase,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -753,19 +753,6 @@ export interface CourseBlueprintDetail extends CourseBlueprint {
   linked_classrooms: LinkedBlueprintClassroom[]
 }
 
-export interface CoursePackageManifest {
-  version: string
-  exported_at: string
-  title: string
-  subject: string
-  grade_level: string
-  course_code: string
-  term_template: string
-  planned_site_slug?: string | null
-  planned_site_published?: boolean
-  planned_site_config?: PlannedCourseSiteConfig
-}
-
 export interface CreateClassroomFromBlueprintInput {
   blueprintId: string
   title: string

--- a/tests/api/teacher/course-blueprint-import.test.ts
+++ b/tests/api/teacher/course-blueprint-import.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/course-blueprints/import/route'
+import { COURSE_BLUEPRINT_PACKAGE_MAX_BYTES } from '@/lib/contracts/course-blueprint-package'
 
 const operationId = '10000000-0000-4000-8000-000000000030'
 const mockImportBundle = vi.fn()
@@ -85,5 +86,31 @@ describe('POST /api/teacher/course-blueprints/import', () => {
       error_code: 'create_blueprint_assignments_failed',
       retryable: true,
     })
+  })
+
+  it('rejects package bodies over the byte limit before invoking the import service', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/teacher/course-blueprints/import', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(COURSE_BLUEPRINT_PACKAGE_MAX_BYTES + 1),
+      },
+      body: '{}',
+    }))
+
+    expect(response.status).toBe(413)
+    expect(mockImportBundle).not.toHaveBeenCalled()
+    expect(mockImportArchive).not.toHaveBeenCalled()
+  })
+
+  it('maps malformed bounded JSON to a client error', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/teacher/course-blueprints/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    }))
+
+    expect(response.status).toBe(400)
+    expect(mockImportBundle).not.toHaveBeenCalled()
   })
 })

--- a/tests/architecture/api-zod-boundary-baseline.json
+++ b/tests/architecture/api-zod-boundary-baseline.json
@@ -26,7 +26,6 @@
   "src/app/api/teacher/classrooms/[id]/roster/bulk-delete/route.ts",
   "src/app/api/teacher/classrooms/[id]/roster/upload-csv/route.ts",
   "src/app/api/teacher/classrooms/reorder/route.ts",
-  "src/app/api/teacher/course-blueprints/import/route.ts",
   "src/app/api/teacher/surveys/[id]/questions/[qid]/route.ts",
   "src/app/api/teacher/surveys/[id]/questions/route.ts",
   "src/app/api/teacher/surveys/[id]/route.ts",

--- a/tests/fixtures/course-blueprint-package-v2.json
+++ b/tests/fixtures/course-blueprint-package-v2.json
@@ -1,0 +1,31 @@
+{
+  "manifest": {
+    "version": "2",
+    "exported_at": "2026-05-01T12:00:00.000Z",
+    "title": "Legacy Computer Science",
+    "subject": "Computer Science",
+    "grade_level": "Grade 11",
+    "course_code": "ICS3U",
+    "term_template": "Semester 1",
+    "planned_site_slug": "legacy-computer-science",
+    "planned_site_published": false,
+    "planned_site_config": {
+      "overview": true,
+      "outline": true,
+      "resources": true,
+      "assignments": true,
+      "quizzes": true,
+      "tests": true,
+      "lesson_plans": true
+    }
+  },
+  "files": {
+    "course-overview.md": "# Legacy overview",
+    "course-outline.md": "# Legacy outline",
+    "resources.md": "# Legacy resources",
+    "assignments.md": "",
+    "quizzes.md": "Title: Retired quiz\nShow Results: false\n\n## Questions",
+    "tests.md": "",
+    "lesson-plans.md": ""
+  }
+}

--- a/tests/lib/contracts/classroom-artifacts.test.ts
+++ b/tests/lib/contracts/classroom-artifacts.test.ts
@@ -225,6 +225,8 @@ describe('classroom data inventory', () => {
 
 describe('classroom artifact contracts', () => {
   it('keeps reusable blueprints explicitly non-recoverable and student-free', () => {
+    expect(COURSE_BLUEPRINT_TRANSFER_CONTRACT.manifest_version).toBe('3')
+    expect(COURSE_BLUEPRINT_TRANSFER_CONTRACT.supported_import_versions).toEqual(['2', '3'])
     expect(COURSE_BLUEPRINT_TRANSFER_CONTRACT.recoverable_classroom_backup).toBe(false)
     expect(COURSE_BLUEPRINT_TRANSFER_CONTRACT.excluded_data).toContain('student_work')
     expect(COURSE_BLUEPRINT_TRANSFER_CONTRACT.excluded_data).toContain('grades_and_feedback')

--- a/tests/lib/course-blueprint-package.test.ts
+++ b/tests/lib/course-blueprint-package.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   analyzeCourseBlueprintCompleteness,
@@ -7,7 +10,16 @@ import {
   parseCourseBlueprintImportArchive,
   parseCourseBlueprintImportBundle,
 } from '@/lib/course-blueprint-package'
+import {
+  COURSE_BLUEPRINT_PACKAGE_MAX_BYTES,
+  COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES,
+} from '@/lib/contracts/course-blueprint-package'
 import type { CourseBlueprintDetail } from '@/types'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const V2_BUNDLE = JSON.parse(
+  readFileSync(resolve(testDir, '../fixtures/course-blueprint-package-v2.json'), 'utf8')
+)
 
 const DETAIL: CourseBlueprintDetail = {
   id: 'blueprint-1',
@@ -201,6 +213,107 @@ describe('course blueprint package', () => {
     const parsed = parseCourseBlueprintImportArchive(legacyArchive)
 
     expect(parsed.blueprint.planned_site_config.quizzes).toBe(false)
+  })
+
+  it('imports version 2 packages while ignoring retired quiz content', () => {
+    const parsed = parseCourseBlueprintImportBundle(V2_BUNDLE)
+
+    expect(parsed.errors).toEqual([])
+    expect(parsed.blueprint.title).toBe('Legacy Computer Science')
+    expect(parsed.blueprint.planned_site_config.quizzes).toBe(false)
+    expect(parsed.assessments).toEqual([])
+  })
+
+  it('decodes a version 2 tar package while ignoring retired quiz content', () => {
+    const archive = encodeCourseBlueprintPackageArchive(V2_BUNDLE)
+    const decoded = decodeCourseBlueprintPackageArchive(archive)
+    const parsed = parseCourseBlueprintImportArchive(archive)
+
+    expect(decoded?.manifest.version).toBe('2')
+    expect(decoded?.files).not.toHaveProperty('quizzes.md')
+    expect(parsed.errors).toEqual([])
+    expect(parsed.blueprint.title).toBe('Legacy Computer Science')
+    expect(parsed.assessments).toEqual([])
+  })
+
+  it.each(['1', '4'])('rejects unsupported package version %s', (version) => {
+    const parsed = parseCourseBlueprintImportBundle({
+      ...V2_BUNDLE,
+      manifest: { ...V2_BUNDLE.manifest, version },
+    })
+
+    expect(parsed.errors).toEqual(['Invalid course package bundle'])
+  })
+
+  it.each(['quizzes.md', 'notes.md'])('rejects undeclared version 3 file %s', (fileName) => {
+    const bundle = buildCourseBlueprintExportBundle(DETAIL)
+    const parsed = parseCourseBlueprintImportBundle({
+      ...bundle,
+      files: { ...bundle.files, [fileName]: 'Unexpected content' },
+    })
+
+    expect(parsed.errors).toEqual(['Invalid course package bundle'])
+  })
+
+  it('rejects an archive with an unsupported manifest version', () => {
+    const archive = encodeCourseBlueprintPackageArchive(buildCourseBlueprintExportBundle(DETAIL))
+    const versionMarker = new TextEncoder().encode('"version": "3"')
+    const markerOffset = archive.findIndex((byte, index) =>
+      versionMarker.every((markerByte, markerIndex) => archive[index + markerIndex] === markerByte)
+    )
+    expect(markerOffset).toBeGreaterThanOrEqual(0)
+    archive[markerOffset + versionMarker.length - 2] = '4'.charCodeAt(0)
+
+    expect(decodeCourseBlueprintPackageArchive(archive)).toBeNull()
+    expect(parseCourseBlueprintImportArchive(archive).errors).toEqual(['Invalid course package archive'])
+  })
+
+  it('rejects oversized archives and oversized package files', () => {
+    expect(decodeCourseBlueprintPackageArchive(
+      new Uint8Array(COURSE_BLUEPRINT_PACKAGE_MAX_BYTES + 1)
+    )).toBeNull()
+
+    const bundle = buildCourseBlueprintExportBundle(DETAIL)
+    const oversizedBundle = parseCourseBlueprintImportBundle({
+      ...bundle,
+      files: {
+        ...bundle.files,
+        'course-overview.md': 'é'.repeat(Math.floor(COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES / 2) + 1),
+      },
+    })
+    expect(oversizedBundle.errors).toEqual(['Invalid course package bundle'])
+
+    const archive = encodeCourseBlueprintPackageArchive(bundle)
+    const fileName = new TextEncoder().encode('course-overview.md')
+    const headerOffset = archive.findIndex((byte, index) =>
+      fileName.every((fileByte, fileIndex) => archive[index + fileIndex] === fileByte)
+    )
+    expect(headerOffset).toBeGreaterThanOrEqual(0)
+    const oversizedOctal = (COURSE_BLUEPRINT_PACKAGE_MAX_FILE_BYTES + 1).toString(8).padStart(11, '0')
+    archive.set(new TextEncoder().encode(oversizedOctal), headerOffset + 124)
+    archive[headerOffset + 135] = 0
+    expect(decodeCourseBlueprintPackageArchive(archive)).toBeNull()
+  })
+
+  it('rejects unexpected tar entries before decoding their content', () => {
+    const archive = encodeCourseBlueprintPackageArchive(buildCourseBlueprintExportBundle(DETAIL))
+    const fileName = new TextEncoder().encode('tests.md')
+    const fileOffset = archive.findIndex((byte, index) =>
+      fileName.every((fileByte, fileIndex) => archive[index + fileIndex] === fileByte)
+    )
+    expect(fileOffset).toBeGreaterThanOrEqual(0)
+    archive[fileOffset] = 'x'.charCodeAt(0)
+
+    expect(decodeCourseBlueprintPackageArchive(archive)).toBeNull()
+  })
+
+  it('rejects malformed package manifests at the import boundary', () => {
+    const parsed = parseCourseBlueprintImportBundle({
+      ...V2_BUNDLE,
+      manifest: { ...V2_BUNDLE.manifest, exported_at: 'not-a-date' },
+    })
+
+    expect(parsed.errors).toEqual(['Invalid course package bundle'])
   })
 
   it('analyzes missing blueprint areas', () => {

--- a/tests/lib/server/course-blueprints.test.ts
+++ b/tests/lib/server/course-blueprints.test.ts
@@ -536,7 +536,7 @@ describe('course-blueprints server helpers', () => {
 
     const result = await importCourseBlueprintBundle('teacher-1', {
       manifest: {
-        version: '1',
+        version: '2',
         exported_at: '2026-04-20T00:00:00Z',
         title: 'Imported blueprint',
         subject: '',
@@ -549,7 +549,6 @@ describe('course-blueprints server helpers', () => {
         'course-outline.md': '',
         'resources.md': '',
         'assignments.md': '# Assignment 1\n\n## Instructions\n\nBody\n',
-        'quizzes.md': '',
         'tests.md': '',
         'lesson-plans.md': '',
       },
@@ -561,6 +560,10 @@ describe('course-blueprints server helpers', () => {
       expect.objectContaining({
         p_operation_id: operationId,
         p_operation_type: 'import',
+        p_plan: expect.objectContaining({
+          manifest_version: '2',
+          source_package_exported_at: '2026-04-20T00:00:00Z',
+        }),
       }),
     )
     expect(deleteBuilder.delete).not.toHaveBeenCalled()

--- a/tests/unit/course-blueprint-package-docs.test.ts
+++ b/tests/unit/course-blueprint-package-docs.test.ts
@@ -12,6 +12,7 @@ function readRepoFile(relativePath: string) {
 describe('course blueprint package docs', () => {
   it('documents the official portable package contract and round trip', () => {
     const docs = readRepoFile('docs/guidance/course-blueprint-packages.md')
+    const lifecycleDocs = readRepoFile('docs/guidance/classroom-lifecycle-archives.md')
 
     expect(docs).toContain('Course Blueprint')
     expect(docs).toContain('.course-package.tar')
@@ -22,5 +23,11 @@ describe('course blueprint package docs', () => {
     expect(docs).toContain('lesson-plans.md')
     expect(docs).toContain('students, submissions, grades, attendance')
     expect(docs).toContain('Edit the Markdown files in a repo, Codex, or Claude')
+    expect(docs).toContain('canonical export manifest version is `3`')
+    expect(docs).toContain('imports versions `2` and `3`')
+    expect(docs).toContain('ignores that legacy quiz content')
+    expect(lifecycleDocs).toContain('export manifest is version 3')
+    expect(lifecycleDocs).toContain('Import accepts versions 2 and 3')
+    expect(lifecycleDocs).not.toContain('manifest remains version 2')
   })
 })


### PR DESCRIPTION
## Summary
- make course package v3 the canonical export and lifecycle contract while explicitly supporting v2 imports
- validate package manifests/files with a shared version-discriminated Zod contract and consume only validated operation metadata
- bound HTTP/tar import size, file count, and per-file bytes; reject unsupported versions, unknown files, and duplicate archive entries
- preserve v2 packages while intentionally ignoring retired `quizzes.md` content, backed by a checked-in fixture

## Verification
- `pnpm test` (376 files / 3,514 tests)
- focused package, artifact, server, API, docs, and route-standard suites (6 files / 52 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (606 modules / 0 allowances)
- `pnpm build`
- Pika pre-commit audit
- independent Terra/high review loop: findings fixed; final rereview clean
- `git diff --check`

## Risk
- no migration, production data access, or visible UI change
- v3 exports remain unchanged; v2 import compatibility is now explicit
