### PR TITLE
Enforce semantic token contrast contracts

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), the dashboard teacher-entry contract is merged (#894), and blueprint package v3 reconciliation is merged (#895).
-- Phase 2 is active. Its first slice adds enforced semantic-token contrast contracts and corrects inaccessible foreground/fill combinations; the next slice is the shared modal-layer contract.
+- Phase 2 is active. Its first slice adds enforced semantic-token contrast contracts and corrects inaccessible foreground/fill combinations in PR #896; the next slice is the shared modal-layer contract.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,7 +7,8 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- Safety Wave: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), and the dashboard teacher-entry contract is merged (#894). Blueprint package v3 reconciliation is in PR #895 as the final item before Phase 2.
+- The Safety Wave is complete: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), the dashboard teacher-entry contract is merged (#894), and blueprint package v3 reconciliation is merged (#895).
+- Phase 2 is active. Its first slice adds enforced semantic-token contrast contracts and corrects inaccessible foreground/fill combinations; the next slice is the shared modal-layer contract.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -7,8 +7,8 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Core classroom, assignment, test, and auth flows are live.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- The Safety Wave is complete: classroom deletion is retired (#890), assignment integrity is deployed (#891), local seeding supports migration 099 (#893), the dashboard teacher-entry contract is merged (#894), and blueprint package v3 reconciliation is merged (#895).
-- Phase 2 is active. Its first slice adds enforced semantic-token contrast contracts and corrects inaccessible foreground/fill combinations in PR #896; the next slice is the shared modal-layer contract.
+- The Safety Wave is complete through PRs #890, #891, and #893-#895.
+- Phase 2 is active. PR #896 enforces semantic-token contrast; the shared modal-layer contract is next.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13910,3 +13910,21 @@
 - `bash -n scripts/check-classroom-gradex-database.sh`
 - Local executable database contract unavailable because the running Supabase container predates migration 082; migrations were not applied or modified
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:5906846349320a170ff42564401b65db97adf5a3ce418eaf3d35c0066b878a4c -->
+## 2026-07-13 — Verified Gradex retention cleanup runtime
+
+**Completed:**
+- Added a server-only, disabled-by-default cleanup coordinator over migration 084's lease claim, completion, and retry RPCs without adding an HTTP route, cron entry, or automatic caller.
+- Bounded each invocation to 10 claims and strictly validated the private bucket, canonical teacher/classroom/extract path shape, extract id binding, claim uniqueness, attempts, and lease inputs with Zod.
+- Required exact post-delete read-back evidence: only authoritative object-key absence can complete the current lease; missing buckets, present objects, uncertain Storage results, stale leases, and malformed RPC responses fail closed.
+- Added durable per-claim retry recording, stale-lease non-mutation, independent failure containment, privacy-safe aggregate metrics, and idempotent already-absent handling.
+- Updated environment, lifecycle, test, and current-context documentation. No production database, migration, row, storage object, route, schedule, or environment setting was modified.
+
+**Validation:**
+- Full Vitest suite (329 files / 2,915 tests)
+- Focused cleanup/generation/transformer/artifact/migration/startup suites (6 files / 80 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -873,4 +873,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 
 **Remaining:**
-- Review and merge the semantic-token contrast PR. Then implement Phase 2's shared modal-layer contract as a separate slice.
+- Review and merge PR #896. Then implement Phase 2's shared modal-layer contract as a separate slice.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,23 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Verified Gradex retention cleanup runtime
-
-**Completed:**
-- Added a server-only, disabled-by-default cleanup coordinator over migration 084's lease claim, completion, and retry RPCs without adding an HTTP route, cron entry, or automatic caller.
-- Bounded each invocation to 10 claims and strictly validated the private bucket, canonical teacher/classroom/extract path shape, extract id binding, claim uniqueness, attempts, and lease inputs with Zod.
-- Required exact post-delete read-back evidence: only authoritative object-key absence can complete the current lease; missing buckets, present objects, uncertain Storage results, stale leases, and malformed RPC responses fail closed.
-- Added durable per-claim retry recording, stale-lease non-mutation, independent failure containment, privacy-safe aggregate metrics, and idempotent already-absent handling.
-- Updated environment, lifecycle, test, and current-context documentation. No production database, migration, row, storage object, route, schedule, or environment setting was modified.
-
-**Validation:**
-- Full Vitest suite (329 files / 2,915 tests)
-- Focused cleanup/generation/transformer/artifact/migration/startup suites (6 files / 80 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-07-13 — Manual Gradex cleanup canary trigger
 
 **Completed:**
@@ -868,3 +851,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Merge PR #895 after required checks/review. Phase 2 begins after that merge.
+
+## 2026-07-20 — Phase 2 semantic-token contrast contract
+
+**Completed:**
+- Merged PR #895, completing the Product Experience Safety Wave and beginning Phase 2.
+- Added a WCAG AA contract that evaluates semantic foreground/background pairs in both themes, including translucent selected and status surfaces.
+- Split semantic foreground colors from opaque solid action fills, migrated filled controls to the new solid tokens, and corrected failing muted, status, accent, and selected-state combinations.
+- Preserved a persistent selected-row cue in the gradebook after reducing the dark selected-surface opacity.
+- Resolved all findings from two independent reviews, including omitted hover/subtle pairs, solid-fill opacity enforcement, inverse-text bypasses, and missing direct component coverage.
+- Visually verified representative teacher and student routes at desktop/mobile sizes in light/dark themes, plus selected gradebook rows in both themes. No overflow, overlap, console, or page errors were found.
+
+**Validation:**
+- `pnpm test` (378 files / 3,523 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Custom Playwright teacher/student desktop/mobile light/dark matrix and gradebook selected-row checks
+- `git diff --check`
+
+**Remaining:**
+- Review and merge the semantic-token contrast PR. Then implement Phase 2's shared modal-layer contract as a separate slice.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -82,11 +82,14 @@ The `/ui` layer handles dark mode internally via CVA. App code uses semantic cla
 | `border-border` | gray-200 | gray-700 | Default borders |
 | `border-border-strong` | gray-300 | gray-600 | Emphasized borders |
 | `text-text-default` | gray-900 | gray-100 | Primary text |
-| `text-text-muted` | gray-500 | gray-400 | Secondary text |
-| `text-text-inverse` | white | gray-900 | Text on colored backgrounds |
-| `text-primary` | blue-600 | blue-400 | Links, primary actions |
-| `text-danger` | red-600 | red-400 | Error text |
-| `text-success` | green-600 | green-400 | Success text |
+| `text-text-muted` | gray-600 | gray-400 | Secondary text |
+| `text-text-inverse` | white | white | Text on solid semantic fills |
+| `text-primary` | blue-700 | blue-400 | Links and primary accents |
+| `text-danger` | red-800 | red-400 | Error text |
+| `text-success` | green-800 | green-400 | Success text |
+| `bg-primary-solid` | blue-600 | blue-600 | Solid primary fills carrying inverse text |
+| `bg-danger-solid` | red-600 | red-600 | Solid danger fills carrying inverse text |
+| `bg-success-solid` | green-700 | green-700 | Solid success fills carrying inverse text |
 
 ### When to Use `dark:` Classes
 
@@ -107,14 +110,14 @@ Brand asset filters belong in `src/styles/tokens.css` and should be applied thro
 #### Status Colors
 ```css
 /* Attendance status */
---color-success: #22c55e  /* green-500 - Present */
---color-danger: #ef4444   /* red-500 - Absent/Error */
---color-warning: #f59e0b  /* amber-500 */
---color-info: #3b82f6     /* blue-500 */
+--color-success: #4ade80  /* green-400 - Present in dark mode */
+--color-danger: #f87171   /* red-400 - Absent/Error in dark mode */
+--color-warning: #fbbf24  /* amber-400 in dark mode */
+--color-info: #60a5fa     /* blue-400 in dark mode */
 
-/* Action colors */
---color-primary: #3b82f6  /* blue-500 */
---color-primary-hover: #2563eb  /* blue-600 */
+/* Solid fills are separate from foreground/accent colors. */
+--color-primary-solid: #2563eb
+--color-primary-solid-hover: #1d4ed8
 ```
 
 #### Neutral Colors (defined in `/src/styles/tokens.css`)

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1457,7 +1457,7 @@ function ClassroomPageContent({
                 type="button"
                 onClick={calendarSidebarState.onSave}
                 disabled={calendarSidebarState.bulkSaving}
-                className="px-2 py-1 text-xs rounded bg-primary text-text-inverse hover:bg-primary-hover disabled:opacity-50"
+                className="px-2 py-1 text-xs rounded bg-primary-solid text-text-inverse hover:bg-primary-solid-hover disabled:opacity-50"
               >
                 {calendarSidebarState.bulkSaving ? 'Saving...' : 'Save'}
               </button>

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1099,7 +1099,9 @@ function AssessmentMatrixTable({
                   className={[
                     'group transition-colors',
                     isSelectable ? 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary' : '',
-                    isSelected ? 'bg-surface-selected hover:bg-surface-selected' : 'hover:bg-surface-hover',
+                    isSelected
+                      ? 'border-l-2 border-l-primary bg-surface-selected hover:bg-surface-selected'
+                      : 'hover:bg-surface-hover',
                   ].join(' ')}
                   onClick={(event) => {
                     if (!isSelectable) return

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -40,7 +40,7 @@ export default function JoinPage() {
 
           <button
             type="submit"
-            className="w-full px-4 py-2 rounded-md bg-primary text-text-inverse text-sm hover:bg-primary-hover disabled:opacity-50"
+            className="w-full px-4 py-2 rounded-md bg-primary-solid text-text-inverse text-sm hover:bg-primary-solid-hover disabled:opacity-50"
             disabled={!code.trim()}
           >
             Join
@@ -50,4 +50,3 @@ export default function JoinPage() {
     </div>
   )
 }
-

--- a/src/app/snapshots-gallery/SnapshotGallery.tsx
+++ b/src/app/snapshots-gallery/SnapshotGallery.tsx
@@ -174,7 +174,7 @@ export function SnapshotGallery() {
                 onClick={() => setFilter('all')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   filter === 'all'
-                    ? 'bg-primary text-text-inverse'
+                    ? 'bg-primary-solid text-text-inverse'
                     : 'bg-surface text-text-default border border-border hover:bg-surface-accent'
                 }`}
               >
@@ -184,7 +184,7 @@ export function SnapshotGallery() {
                 onClick={() => setFilter('auth')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   filter === 'auth'
-                    ? 'bg-primary text-text-inverse'
+                    ? 'bg-primary-solid text-text-inverse'
                     : 'bg-surface text-text-default border border-border hover:bg-surface-accent'
                 }`}
               >
@@ -194,7 +194,7 @@ export function SnapshotGallery() {
                 onClick={() => setFilter('teacher')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   filter === 'teacher'
-                    ? 'bg-primary text-text-inverse'
+                    ? 'bg-primary-solid text-text-inverse'
                     : 'bg-surface text-text-default border border-border hover:bg-surface-accent'
                 }`}
               >
@@ -204,7 +204,7 @@ export function SnapshotGallery() {
                 onClick={() => setFilter('student')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   filter === 'student'
-                    ? 'bg-primary text-text-inverse'
+                    ? 'bg-primary-solid text-text-inverse'
                     : 'bg-surface text-text-default border border-border hover:bg-surface-accent'
                 }`}
               >

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -672,7 +672,7 @@ export default function TeacherBlueprintsPage() {
                       onClick={() => setActiveTab(tab)}
                       className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
                         activeTab === tab
-                          ? 'bg-primary text-text-inverse'
+                          ? 'bg-primary-solid text-text-inverse'
                           : 'bg-surface-2 text-text-default hover:bg-surface-hover'
                       }`}
                     >

--- a/src/components/AddStudentsModal.tsx
+++ b/src/components/AddStudentsModal.tsx
@@ -245,8 +245,8 @@ Bob Lee bob@example.com 789012 counselor@school.com`}
             type="button"
             onClick={handleSubmit}
             disabled={isSubmitting || !preview || preview.students.length === 0}
-            className="flex-1 px-4 py-2 bg-primary hover:bg-primary-hover
-                       text-white font-medium rounded-md
+            className="flex-1 px-4 py-2 bg-primary-solid hover:bg-primary-solid-hover
+                       text-text-inverse font-medium rounded-md
                        disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {isSubmitting ? 'Adding...' : `Add ${validCount} Student${validCount !== 1 ? 's' : ''}`}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -189,7 +189,7 @@ export function AppHeader({
                 className={[
                   'inline-flex items-center gap-1 rounded-md border px-2 py-1 transition-all duration-300',
                   exitCountPulseActive
-                    ? 'motion-safe:scale-[1.03] border-warning bg-warning font-semibold text-text-inverse shadow-sm ring-2 ring-warning'
+                    ? 'motion-safe:scale-[1.03] border-warning bg-warning-bg font-semibold text-warning shadow-sm ring-2 ring-warning'
                     : 'border-transparent text-text-muted',
                 ].join(' ')}
                 aria-label={`Exits ${examModeHeader.exitsCount}`}

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -364,7 +364,7 @@ export const LessonDayCell = memo(function LessonDayCell({
                   e.stopPropagation()
                   onAssignmentClick?.(assignment)
                 }}
-                className={`w-full min-w-0 rounded bg-primary text-white font-medium hover:bg-primary-hover text-center truncate ${
+                className={`w-full min-w-0 rounded bg-primary-solid text-text-inverse font-medium hover:bg-primary-solid-hover text-center truncate ${
                   compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
                 } ${assignment.is_draft ? 'opacity-50' : ''}`}
               >

--- a/src/components/StudentCountBadge.tsx
+++ b/src/components/StudentCountBadge.tsx
@@ -12,10 +12,10 @@ interface CountBadgeProps {
  */
 export function CountBadge({ count, tooltip, variant = 'primary' }: CountBadgeProps) {
   const bgClass =
-    variant === 'success' ? 'bg-success text-text-inverse' :
-    variant === 'danger' ? 'bg-danger text-text-inverse' :
+    variant === 'success' ? 'bg-success-solid text-text-inverse' :
+    variant === 'danger' ? 'bg-danger-solid text-text-inverse' :
     variant === 'neutral' ? 'bg-surface-2 text-text-muted border border-border' :
-    'bg-primary'
+    'bg-primary-solid'
   const badge = (
     <span className={`inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-badge px-2 text-sm font-semibold ${bgClass} ${variant === 'primary' ? 'text-text-inverse' : ''}`}>
       {count}

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -115,7 +115,7 @@ function ScoreInput({
                 className={[
                   'inline-flex h-6 w-[clamp(0.5rem,calc(100%/11),1.5rem)] flex-none items-center justify-center rounded border px-0 text-[10px] font-semibold leading-none transition-colors',
                   isActive
-                    ? 'border-primary bg-primary text-text-inverse'
+                    ? 'border-primary bg-primary-solid text-text-inverse'
                     : 'border-border bg-surface text-text-default hover:bg-surface-hover',
                 ].join(' ')}
                 aria-label={`Set ${label} score to ${score}`}

--- a/src/components/surveys/SurveyOptionResultBar.tsx
+++ b/src/components/surveys/SurveyOptionResultBar.tsx
@@ -26,7 +26,7 @@ export function SurveyOptionResultBar({
         aria-label={`${option}: ${count} responses, ${roundedPercent}%`}
       >
         <div
-          className="absolute inset-y-0 left-0 rounded-full bg-primary"
+          className="absolute inset-y-0 left-0 rounded-full bg-primary-solid"
           style={{ width: `${percent}%` }}
         >
           {showPercentInFill ? (

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -13,10 +13,10 @@
  * - gray-300: #d1d5db   gray-400: #9ca3af    gray-500: #6b7280
  * - gray-600: #4b5563   gray-700: #374151    gray-800: #1f2937
  * - gray-900: #111827   gray-950: #030712
- * - blue-500: #3b82f6   blue-600: #2563eb    blue-700: #1d4ed8
- * - green-500: #22c55e  green-600: #16a34a   green-700: #15803d
- * - red-500: #ef4444    red-600: #dc2626     red-700: #b91c1c
- * - yellow-400: #facc15 yellow-500: #eab308
+ * - blue-400: #60a5fa   blue-600: #2563eb    blue-700: #1d4ed8
+ * - green-400: #4ade80  green-700: #15803d   green-800: #166534
+ * - red-400: #f87171    red-600: #dc2626     red-800: #991b1b
+ * - amber-400: #fbbf24  amber-700: #b45309   amber-800: #92400e
  */
 
 :root {
@@ -36,29 +36,35 @@
 
   /* Text colors */
   --color-text-default: #111827;
-  --color-text-muted: #6b7280;
+  --color-text-muted: #4b5563;
   --color-text-inverse: #ffffff;
 
   /* Brand assets */
   --pika-logo-filter: none;
 
   /* Primary accent */
-  --color-primary: #2563eb;
-  --color-primary-hover: #1d4ed8;
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-primary-solid: #2563eb;
+  --color-primary-solid-hover: #1d4ed8;
 
   /* Status colors */
-  --color-success: #16a34a;
-  --color-success-hover: #15803d;
+  --color-success: #166534;
+  --color-success-hover: #14532d;
+  --color-success-solid: #15803d;
+  --color-success-solid-hover: #166534;
   --color-success-bg: #dcfce7;
   --color-success-bg-muted: #ecfdf5;
   --color-success-bg-hover: #bbf7d0;
-  --color-danger: #dc2626;
-  --color-danger-hover: #b91c1c;
+  --color-danger: #991b1b;
+  --color-danger-hover: #7f1d1d;
+  --color-danger-solid: #dc2626;
+  --color-danger-solid-hover: #b91c1c;
   --color-danger-bg: #fee2e2;
   --color-danger-bg-hover: #fecaca;
-  --color-warning: #d97706;
+  --color-warning: #92400e;
   --color-warning-bg: #fef3c7;
-  --color-info: #2563eb;
+  --color-info: #1d4ed8;
   --color-info-bg: #dbeafe;
   --color-info-bg-hover: #bfdbfe;
 
@@ -92,7 +98,7 @@
   --color-surface-3: #1f2937;
   --color-surface-panel: #111827;
   --color-surface-accent: #1f2937;
-  --color-surface-selected: rgba(37, 99, 235, 0.58);
+  --color-surface-selected: rgba(37, 99, 235, 0.15);
   --color-surface-hover: #1f2937;
 
   /* Border colors - dark mode */
@@ -108,22 +114,28 @@
   --pika-logo-filter: brightness(0) hue-rotate(15deg) invert(1) saturate(0.3) sepia(1);
 
   /* Primary accent - dark mode */
-  --color-primary: #3b82f6;
-  --color-primary-hover: #2563eb;
+  --color-primary: #60a5fa;
+  --color-primary-hover: #93c5fd;
+  --color-primary-solid: #2563eb;
+  --color-primary-solid-hover: #1d4ed8;
 
   /* Status colors - dark mode */
-  --color-success: #22c55e;
-  --color-success-hover: #16a34a;
+  --color-success: #4ade80;
+  --color-success-hover: #86efac;
+  --color-success-solid: #15803d;
+  --color-success-solid-hover: #166534;
   --color-success-bg: rgba(22, 101, 52, 0.5);
   --color-success-bg-muted: rgba(22, 101, 52, 0.25);
   --color-success-bg-hover: rgba(22, 101, 52, 0.6);
-  --color-danger: #ef4444;
-  --color-danger-hover: #dc2626;
+  --color-danger: #f87171;
+  --color-danger-hover: #fca5a5;
+  --color-danger-solid: #dc2626;
+  --color-danger-solid-hover: #b91c1c;
   --color-danger-bg: rgba(127, 29, 29, 0.3);
   --color-danger-bg-hover: rgba(127, 29, 29, 0.5);
   --color-warning: #fbbf24;
   --color-warning-bg: rgba(120, 53, 15, 0.3);
-  --color-info: #3b82f6;
+  --color-info: #60a5fa;
   --color-info-bg: rgba(30, 58, 138, 0.3);
   --color-info-bg-hover: rgba(30, 58, 138, 0.4);
 

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -9,12 +9,12 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'border-transparent bg-primary text-text-inverse hover:bg-primary-hover',
+        primary: 'border-transparent bg-primary-solid text-text-inverse hover:bg-primary-solid-hover',
         secondary: 'border-border bg-surface-2 hover:bg-surface-hover text-text-default',
         surface: 'border-border bg-surface hover:bg-surface-hover text-text-default',
         subtle: 'border-primary bg-info-bg hover:bg-info-bg-hover text-text-default',
-        danger: 'border-transparent bg-danger hover:bg-danger-hover text-text-inverse',
-        success: 'border-transparent bg-success hover:bg-success-hover text-text-inverse',
+        danger: 'border-transparent bg-danger-solid hover:bg-danger-solid-hover text-text-inverse',
+        success: 'border-transparent bg-success-solid hover:bg-success-solid-hover text-text-inverse',
         ghost: 'border-transparent bg-transparent text-text-muted hover:bg-surface-hover hover:text-text-default',
       },
       size: {

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -227,8 +227,11 @@ const buttonVariants = cva('...', {
 | `border-border` | gray-200 | gray-700 | Default borders |
 | `border-border-strong` | gray-300 | gray-600 | Emphasized borders |
 | `text-text-default` | gray-900 | gray-100 | Primary text |
-| `text-text-muted` | gray-500 | gray-400 | Secondary text |
-| `text-text-inverse` | white | gray-900 | Text on colored backgrounds |
+| `text-text-muted` | gray-600 | gray-400 | Secondary text |
+| `text-text-inverse` | white | white | Text on solid semantic fills |
+| `bg-primary-solid` | blue-600 | blue-600 | Solid primary fills carrying inverse text |
+| `bg-success-solid` | green-700 | green-700 | Solid success fills carrying inverse text |
+| `bg-danger-solid` | red-600 | red-600 | Solid danger fills carrying inverse text |
 
 ### Border Radius
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,10 +63,14 @@ const config: Config = {
         primary: {
           DEFAULT: 'var(--color-primary)',
           hover: 'var(--color-primary-hover)',
+          solid: 'var(--color-primary-solid)',
+          'solid-hover': 'var(--color-primary-solid-hover)',
         },
         success: {
           DEFAULT: 'var(--color-success)',
           hover: 'var(--color-success-hover)',
+          solid: 'var(--color-success-solid)',
+          'solid-hover': 'var(--color-success-solid-hover)',
           bg: {
             DEFAULT: 'var(--color-success-bg)',
             muted: 'var(--color-success-bg-muted)',
@@ -76,6 +80,8 @@ const config: Config = {
         danger: {
           DEFAULT: 'var(--color-danger)',
           hover: 'var(--color-danger-hover)',
+          solid: 'var(--color-danger-solid)',
+          'solid-hover': 'var(--color-danger-solid-hover)',
           bg: {
             DEFAULT: 'var(--color-danger-bg)',
             hover: 'var(--color-danger-bg-hover)',

--- a/tests/components/AppHeader.test.tsx
+++ b/tests/components/AppHeader.test.tsx
@@ -37,7 +37,7 @@ describe('AppHeader exam mode', () => {
 
     rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 2, awayTotalSeconds: 0 }} />)
 
-    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning')
+    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning-bg', 'text-warning')
     expect(screen.getByText('Exit detected')).toHaveClass('sr-only')
 
     rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 1, awayTotalSeconds: 0 }} />)
@@ -47,7 +47,7 @@ describe('AppHeader exam mode', () => {
 
     rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 2, awayTotalSeconds: 0 }} />)
 
-    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning')
+    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning-bg', 'text-warning')
     expect(screen.getByText('Exit detected')).toHaveClass('sr-only')
 
     act(() => {

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -31,9 +31,14 @@ describe('Button component', () => {
     expect(handleClick).not.toHaveBeenCalled()
   })
 
-  it('should apply variant styles', () => {
-    const { container } = render(<Button variant="primary">Primary</Button>)
-    expect(container.querySelector('button')).toHaveClass('bg-primary')
+  it.each([
+    ['primary', 'bg-primary-solid', 'hover:bg-primary-solid-hover'],
+    ['success', 'bg-success-solid', 'hover:bg-success-solid-hover'],
+    ['danger', 'bg-danger-solid', 'hover:bg-danger-solid-hover'],
+  ] as const)('should apply accessible solid fills to the %s variant', (variant, fill, hoverFill) => {
+    render(<Button variant={variant}>{variant}</Button>)
+
+    expect(screen.getByRole('button', { name: variant })).toHaveClass(fill, hoverFill, 'text-text-inverse')
   })
 
   it('should apply size styles', () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -75,7 +75,9 @@ vi.mock('@/components/layout', async () => {
 
   return {
     ThreePanelProvider: ({ children, routeKey }: any) => {
-      const [isRightOpen, setRightOpen] = React.useState(routeKey === 'today' || routeKey === 'assignments-teacher-list')
+      const [isRightOpen, setRightOpen] = React.useState(
+        routeKey === 'today' || routeKey === 'assignments-teacher-list' || routeKey === 'calendar-teacher'
+      )
       const [rightWidth, setRightWidth] = React.useState(320)
       const value = React.useMemo(
         () => ({
@@ -257,10 +259,20 @@ vi.mock('@/app/classrooms/[classroomId]/TeacherSettingsTab', () => ({
     </button>
   ),
 }))
-vi.mock('@/app/classrooms/[classroomId]/TeacherLessonCalendarTab', () => ({
-  TeacherLessonCalendarTab: () => <div />,
-  TeacherLessonCalendarSidebar: () => <div />,
-}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherLessonCalendarTab', async () => {
+  const React = await import('react')
+
+  return {
+    TeacherLessonCalendarTab: ({ onSidebarStateChange }: any) => {
+      React.useEffect(() => {
+        onSidebarStateChange?.({ bulkSaving: false, onSave: vi.fn() })
+      }, [onSidebarStateChange])
+
+      return <div />
+    },
+    TeacherLessonCalendarSidebar: () => <div />,
+  }
+})
 vi.mock('@/app/classrooms/[classroomId]/StudentLessonCalendarTab', () => ({
   StudentLessonCalendarTab: () => <div />,
 }))
@@ -479,6 +491,18 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     renderClient({ initialTab: 'attendance', initialSearchParams: { tab: 'attendance' } })
 
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
+  })
+
+  it('uses the accessible solid fill for the calendar sidebar save action', async () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=calendar')
+
+    renderClient({ initialTab: 'calendar', initialSearchParams: { tab: 'calendar' } })
+
+    expect(await screen.findByRole('button', { name: 'Save' })).toHaveClass(
+      'bg-primary-solid',
+      'hover:bg-primary-solid-hover',
+      'text-text-inverse'
+    )
   })
 
   it('shows today and last class lesson plans in the student today sidebar', async () => {

--- a/tests/components/LessonDayCell.test.tsx
+++ b/tests/components/LessonDayCell.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { useState } from 'react'
 import { applyMarkdownShortcut, LessonDayCell } from '@/components/LessonDayCell'
 import { TooltipProvider } from '@/ui'
-import type { Announcement, LessonPlan, TiptapContent } from '@/types'
+import type { Announcement, Assignment, LessonPlan, TiptapContent } from '@/types'
 
 const content: TiptapContent = {
   type: 'doc',
@@ -182,6 +182,27 @@ describe('LessonDayCell', () => {
     )
 
     expect(screen.getByText('Lesson text').closest('.calendar-day-text')).toBeTruthy()
+  })
+
+  it('uses the accessible solid fill for assignment due dates', () => {
+    renderWithTooltip(
+      <LessonDayCell
+        date="2026-03-13"
+        day={new Date('2026-03-13T12:00:00.000Z')}
+        lessonPlan={lessonPlan}
+        assignments={[{ id: 'assignment-1', title: 'Essay', is_draft: false } as Assignment]}
+        isWeekend={false}
+        isToday={false}
+        editable={false}
+        compact={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Due: Essay' })).toHaveClass(
+      'bg-primary-solid',
+      'hover:bg-primary-solid-hover',
+      'text-text-inverse'
+    )
   })
 
   it('applies bold shortcut to the selected markdown range', () => {

--- a/tests/components/SurveyOptionResultBar.test.tsx
+++ b/tests/components/SurveyOptionResultBar.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SurveyOptionResultBar } from '@/components/surveys/SurveyOptionResultBar'
+
+describe('SurveyOptionResultBar', () => {
+  it('uses the accessible solid fill when percentage text appears inside the bar', () => {
+    render(<SurveyOptionResultBar option="Option A" count={1} totalResponses={2} />)
+
+    expect(screen.getByText('50%').parentElement).toHaveClass('bg-primary-solid')
+    expect(screen.getByText('50%')).toHaveClass('text-text-inverse')
+  })
+})

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -268,7 +268,10 @@ describe('TeacherGradebookTab', () => {
     gradebookMenu = openGradebookActions()
     expect(within(gradebookMenu).getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
 
-    fireEvent.click(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ }))
+    const adaRow = screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ })
+    fireEvent.click(adaRow)
+    expect(adaRow).toHaveAttribute('aria-selected', 'true')
+    expect(adaRow).toHaveClass('border-l-2', 'border-l-primary', 'bg-surface-selected')
     const detailPanel = screen.getByRole('region', { name: 'Ada Lovelace assessment details' })
     expect(within(detailPanel).getByText('1001')).toBeInTheDocument()
     expect(within(detailPanel).getByText('Essay')).toBeInTheDocument()

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -371,6 +371,9 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByRole('button', { name: 'Repo' })).not.toBeInTheDocument()
 
     expect(screen.getByLabelText('Completion score')).toBeInTheDocument()
+    const completionQuickScore = screen.getByRole('button', { name: 'Set Completion score to 6' })
+    fireEvent.click(completionQuickScore)
+    expect(completionQuickScore).toHaveClass('bg-primary-solid', 'text-text-inverse')
     expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()

--- a/tests/components/TestDetailPanel.test.tsx
+++ b/tests/components/TestDetailPanel.test.tsx
@@ -707,7 +707,7 @@ describe('TestDetailPanel', () => {
         expect(within(editorPane).getByRole('button', { name: 'Duplicate question 1' })).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
       })
-      expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toHaveClass('bg-primary')
+      expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toHaveClass('bg-primary-solid')
       expect(within(editorPane).getByRole('button', { name: 'Choose question type' })).toBeInTheDocument()
       expect(within(editorPane).getByLabelText('Question 1 points')).toHaveValue(6)
       expect(within(editorPane).getByLabelText('Question 1 code response')).toBeChecked()

--- a/tests/unit/semantic-token-contrast.test.ts
+++ b/tests/unit/semantic-token-contrast.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+type Rgba = { red: number; green: number; blue: number; alpha: number }
+type Theme = 'light' | 'dark'
+
+const tokensCss = readFileSync(resolve(process.cwd(), 'src/styles/tokens.css'), 'utf8')
+const minimumTextContrast = 4.5
+const backdropTokens = ['color-page', 'color-surface', 'color-surface-2'] as const
+
+const neutralBackgrounds = [
+  'color-page',
+  'color-surface',
+  'color-surface-2',
+  'color-surface-3',
+  'color-surface-panel',
+  'color-surface-accent',
+  'color-surface-selected',
+  'color-surface-hover',
+] as const
+
+const foregroundContracts = [
+  { foreground: 'color-text-default', backgrounds: neutralBackgrounds },
+  { foreground: 'color-text-muted', backgrounds: neutralBackgrounds },
+  { foreground: 'color-primary', backgrounds: neutralBackgrounds },
+  { foreground: 'color-primary-hover', backgrounds: neutralBackgrounds },
+  { foreground: 'color-success', backgrounds: neutralBackgrounds },
+  { foreground: 'color-success-hover', backgrounds: neutralBackgrounds },
+  { foreground: 'color-danger', backgrounds: neutralBackgrounds },
+  { foreground: 'color-danger-hover', backgrounds: neutralBackgrounds },
+  { foreground: 'color-warning', backgrounds: neutralBackgrounds },
+  { foreground: 'color-info', backgrounds: neutralBackgrounds },
+  { foreground: 'color-text-default', backgrounds: ['color-info-bg', 'color-info-bg-hover'] },
+  { foreground: 'color-primary', backgrounds: ['color-info-bg', 'color-info-bg-hover'] },
+  {
+    foreground: 'color-success',
+    backgrounds: ['color-success-bg', 'color-success-bg-muted', 'color-success-bg-hover'],
+  },
+  { foreground: 'color-danger', backgrounds: ['color-danger-bg', 'color-danger-bg-hover'] },
+  { foreground: 'color-warning', backgrounds: ['color-warning-bg'] },
+  { foreground: 'color-info', backgrounds: ['color-info-bg', 'color-info-bg-hover'] },
+] as const
+
+const solidFillContracts = [
+  ['color-text-inverse', 'color-primary-solid'],
+  ['color-text-inverse', 'color-primary-solid-hover'],
+  ['color-text-inverse', 'color-success-solid'],
+  ['color-text-inverse', 'color-success-solid-hover'],
+  ['color-text-inverse', 'color-danger-solid'],
+  ['color-text-inverse', 'color-danger-solid-hover'],
+] as const
+
+function parseThemeTokens(theme: Theme) {
+  const selector = theme === 'light' ? ':root' : '.dark'
+  const escapedSelector = selector.replace('.', '\\.')
+  const body = tokensCss.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`))
+    ?.groups?.body
+
+  expect(body, `Missing ${selector} token block`).toBeDefined()
+
+  return new Map(
+    Array.from(body?.matchAll(/--(?<name>[\w-]+):\s*(?<value>[^;]+);/g) ?? []).map((match) => [
+      match.groups?.name ?? '',
+      match.groups?.value.trim() ?? '',
+    ])
+  )
+}
+
+function parseColor(value: string): Rgba {
+  const hex = value.match(/^#(?<hex>[0-9a-f]{6})$/i)?.groups?.hex
+  if (hex) {
+    return {
+      red: Number.parseInt(hex.slice(0, 2), 16),
+      green: Number.parseInt(hex.slice(2, 4), 16),
+      blue: Number.parseInt(hex.slice(4, 6), 16),
+      alpha: 1,
+    }
+  }
+
+  const rgba = value.match(
+    /^rgba?\(\s*(?<red>\d+)\s*,\s*(?<green>\d+)\s*,\s*(?<blue>\d+)(?:\s*,\s*(?<alpha>[\d.]+))?\s*\)$/
+  )?.groups
+  if (rgba) {
+    return {
+      red: Number(rgba.red),
+      green: Number(rgba.green),
+      blue: Number(rgba.blue),
+      alpha: rgba.alpha === undefined ? 1 : Number(rgba.alpha),
+    }
+  }
+
+  throw new Error(`Unsupported color value: ${value}`)
+}
+
+function composite(foreground: Rgba, background: Rgba): Rgba {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha)
+  const channel = (foregroundChannel: number, backgroundChannel: number) =>
+    (foregroundChannel * foreground.alpha + backgroundChannel * background.alpha * (1 - foreground.alpha)) /
+    alpha
+
+  return {
+    red: channel(foreground.red, background.red),
+    green: channel(foreground.green, background.green),
+    blue: channel(foreground.blue, background.blue),
+    alpha,
+  }
+}
+
+function luminance(color: Rgba) {
+  const linearize = (channel: number) => {
+    const normalized = channel / 255
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4
+  }
+
+  return (
+    linearize(color.red) * 0.2126 +
+    linearize(color.green) * 0.7152 +
+    linearize(color.blue) * 0.0722
+  )
+}
+
+function contrastRatio(foreground: Rgba, background: Rgba) {
+  const lighter = Math.max(luminance(foreground), luminance(background))
+  const darker = Math.min(luminance(foreground), luminance(background))
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function getColor(tokens: Map<string, string>, token: string) {
+  const value = tokens.get(token)
+  expect(value, `Missing --${token}`).toBeDefined()
+  return parseColor(value ?? '')
+}
+
+describe.each<Theme>(['light', 'dark'])('%s semantic token contrast', (theme) => {
+  const tokens = parseThemeTokens(theme)
+
+  it('keeps semantic text readable on its supported backgrounds', () => {
+    for (const contract of foregroundContracts) {
+      for (const backgroundToken of contract.backgrounds) {
+        for (const backdropToken of backdropTokens) {
+          const backdrop = getColor(tokens, backdropToken)
+          const background = composite(getColor(tokens, backgroundToken), backdrop)
+          const foreground = composite(getColor(tokens, contract.foreground), background)
+          const ratio = contrastRatio(foreground, background)
+
+          expect(
+            ratio,
+            `${theme}: --${contract.foreground} on --${backgroundToken} over --${backdropToken} (${ratio.toFixed(2)}:1)`
+          ).toBeGreaterThanOrEqual(minimumTextContrast)
+        }
+      }
+    }
+  })
+
+  it('keeps inverse text readable on solid semantic fills', () => {
+    for (const [foregroundToken, backgroundToken] of solidFillContracts) {
+      const background = getColor(tokens, backgroundToken)
+      expect(background.alpha, `${theme}: --${backgroundToken} must remain opaque`).toBe(1)
+      const foreground = composite(getColor(tokens, foregroundToken), background)
+      const ratio = contrastRatio(foreground, background)
+
+      expect(
+        ratio,
+        `${theme}: --${foregroundToken} on --${backgroundToken} (${ratio.toFixed(2)}:1)`
+      ).toBeGreaterThanOrEqual(minimumTextContrast)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- enforce WCAG AA contrast for canonical semantic foreground/background pairs in light and dark themes
- split semantic foreground colors from opaque solid action fills and migrate affected controls
- preserve clear selected-state treatment and document the governed token contract

## Review
- two independent code reviews completed
- resolved findings covering selected/hover/subtle pairs, opaque solid fills, inverse-text bypasses, selection affordance, and direct component coverage

## Verification
- `pnpm test` (378 files / 3,523 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Playwright matrix: teacher/student, desktop/mobile, light/dark; gradebook selected row in both themes
- `git diff --check`

## UI guidance declaration
- stable design guidance followed: yes
- experimental guidance introduced: no
- human promotion required: no
- composite accessibility review: completed
- semantic regression coverage: added
- full validation: completed

No migration or production data change is included.
