### PR TITLE
Standardize shared control and form semantics

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#897 merged contrast and modal contracts. Shared control targets, focus, and form semantics await PR review; page structure and responsive density follow.
+- Phase 2 is active. PRs #896-#897 merged contrast and modal contracts. PR #898 contains reviewed control targets, focus, and form semantics; page structure and responsive density follow.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PR #896 merged the semantic-token contrast contract. PR #897 adds the reviewed shared modal-layer contract; shared button targets/focus-visible behavior and semantic form fields are next.
+- Phase 2 is active. PRs #896-#897 merged contrast and modal contracts. Shared control targets, focus, and form semantics await PR review; page structure and responsive density follow.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13947,3 +13947,24 @@
 - `pnpm build`
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:7c9e62cadc3acb5e1cea01bc04b4e4de15870aca078b78417dcb0d330c6c3b69 -->
+## 2026-07-13 — Atomic classroom cold-compaction database contract
+
+**Completed:**
+- Added migration 085 with idempotent begin/stage/complete/fail compaction RPCs, exact archive/source/count verification, one child-first deletion transaction, and service-role-only access.
+- Added a durable source-object cleanup ledger whose rows remain ineligible `staged` work until relational deletion and tombstone creation commit atomically, then become retryable `pending` work.
+- Strengthened lifecycle Zod evidence with archive identity, both checksums, fresh read-back proof, and transition-specific compaction cleanup evidence.
+- Added forced rollback, concurrency, idempotency, traversal rejection, security, replay, and real hot-to-cold-to-hot database contracts in ephemeral CI; restore no longer manufactures its tombstone.
+- Kept rollout database-only: no route, runtime caller, UI, schedule, environment gate, production migration application, row, or Storage object was changed.
+
+**Validation:**
+- Full Vitest suite (331 files / 2,931 tests)
+- Focused lifecycle/migration/archive/restore/startup suites (6 files / 45 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash -n` for compaction and restore database contracts
+- Pika pre-commit audit
+- Local migration replay intentionally not run; GitHub's ephemeral Supabase database job is the execution authority
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -882,4 +882,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 
 **Remaining:**
-- Publish and review this Phase 2 PR. Then continue Phase 2 with page structure, typography, spacing, action placement, and responsive density as a separate slice.
+- Merge reviewed PR #898 after required CI. Then continue Phase 2 with page structure, typography, spacing, action placement, and responsive density as a separate slice.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Atomic classroom cold-compaction database contract
-
-**Completed:**
-- Added migration 085 with idempotent begin/stage/complete/fail compaction RPCs, exact archive/source/count verification, one child-first deletion transaction, and service-role-only access.
-- Added a durable source-object cleanup ledger whose rows remain ineligible `staged` work until relational deletion and tombstone creation commit atomically, then become retryable `pending` work.
-- Strengthened lifecycle Zod evidence with archive identity, both checksums, fresh read-back proof, and transition-specific compaction cleanup evidence.
-- Added forced rollback, concurrency, idempotency, traversal rejection, security, replay, and real hot-to-cold-to-hot database contracts in ephemeral CI; restore no longer manufactures its tombstone.
-- Kept rollout database-only: no route, runtime caller, UI, schedule, environment gate, production migration application, row, or Storage object was changed.
-
-**Validation:**
-- Full Vitest suite (331 files / 2,931 tests)
-- Focused lifecycle/migration/archive/restore/startup suites (6 files / 45 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash -n` for compaction and restore database contracts
-- Pika pre-commit audit
-- Local migration replay intentionally not run; GitHub's ephemeral Supabase database job is the execution authority
-- `git diff --check`
-
 ## 2026-07-13 — Gated classroom cold-compaction runtime coordinator
 
 **Completed:**
@@ -878,3 +858,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Review and merge PR #897. Continue Phase 2 with shared button target sizing/focus-visible behavior and semantic form-field propagation.
+
+## 2026-07-21 — Phase 2 shared control and form-field contract
+
+**Completed:**
+- Merged PR #897 and began the next Phase 2 slice from current `main`.
+- Standardized shared button, input, select, segmented-control, split-button, sortable-table, and split-pane interaction targets and focus-visible treatment without changing Pika's information-dense workflows.
+- Made `FormField` the semantic owner for label association, required state, hints, errors, `aria-describedby`, `aria-errormessage`, and `aria-invalid` while preserving child IDs and existing descriptions.
+- Kept hint and error content visible together, prevented custom props from leaking to native controls, and documented the one-control composition contract.
+- Fixed review findings by expanding the split-pane divider target, reconciling the `FormField` docs, reserving the full mobile classroom switcher height, and forwarding generated field naming and validation semantics to the rich-text editor.
+- Visually verified unauthenticated, teacher, and student surfaces across desktop/mobile and light/dark themes, including keyboard focus, form errors, the dense gradebook, and the student Today view. No overflow or layout regression was found.
+
+**Validation:**
+- `pnpm test` (383 files / 3,543 tests)
+- Focused shared-control and integration suites (8 files / 69 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (607 modules / 0 allowances)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/07e8da7d-9a2a-4e74-b516-f5fe2bab1bf8?tab=attendance`
+- Custom Playwright light/dark desktop/mobile focus, error, teacher, and student checks
+- `git diff --check`
+
+**Remaining:**
+- Publish and review this Phase 2 PR. Then continue Phase 2 with page structure, typography, spacing, action placement, and responsive density as a separate slice.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -257,9 +257,10 @@ import { FormField, Input, Select } from '@/ui'
 
 FormField handles:
 - Label rendering with proper `htmlFor` association
-- Error message display with `aria-invalid`
-- Hint text (hidden when error present)
-- Required indicator (*)
+- Error message display with `aria-invalid` and `aria-errormessage`
+- Hint and error description association without discarding caller-provided `aria-describedby`
+- Native and ARIA required state plus a visual required indicator
+- Preservation of a control-provided `id` unless `htmlFor` explicitly overrides it; pass exactly one form control as the child
 
 #### Textarea (native, wrapped by FormField)
 ```tsx
@@ -755,6 +756,7 @@ Use Tailwind's default breakpoints:
 - All interactive elements must be keyboard accessible
 - Logical tab order (follows visual order)
 - Visible focus indicators
+- Shared buttons, segmented controls, sortable table headers, menu items, and form controls use a `focus-visible` ring and maintain a minimum `44x44px` target where they are directly actionable
 - Escape key closes modals/overlays
 - Canonical `@/ui` dialogs and classroom mobile drawers use `ModalLayer`; it owns initial focus, Tab containment, focus return, background inertness, scroll lock, stacking, Escape, and backdrop behavior
 

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -30,6 +30,8 @@ Source grounding:
 - Import primitives from `@/ui`, not from feature-local component paths.
 - Wrap labeled form controls in `FormField`.
 - Reuse `Button`, `Card`, dialogs, and other primitives before inventing feature-local base controls.
+- Preserve the shared 44px target and `focus-visible` treatment instead of shrinking controls with feature-local height classes.
+- Let `FormField` own label, required, hint, error, and description wiring; callers may provide an `id` or existing `aria-describedby`, which the primitive preserves.
 
 Source grounding:
 

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -516,7 +516,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         chrome="none"
         data-testid="classroom-bottom-controls"
       >
-        <div className="relative min-h-9">
+        <div className="relative min-h-[52px]">
           {isEditingClassrooms ? (
             <div className="absolute left-1/2 -translate-x-1/2">
               <SegmentedControl<ViewMode>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -142,7 +142,7 @@ export function SortableHeaderCell({
         onClick={onClick}
         className={[
           densityPadding(density),
-          'w-full flex items-center gap-1',
+          'flex min-h-11 w-full items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
           alignClass,
           'hover:bg-surface-hover transition-colors',
         ].join(' ')}
@@ -284,7 +284,7 @@ export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable
       ref={ref}
       tabIndex={tabIndex ?? 0}
       onKeyDown={handleKeyDown}
-      className={['rounded-card outline-none', className].filter(Boolean).join(' ')}
+      className={['rounded-card outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface', className].filter(Boolean).join(' ')}
     >
       {children}
     </div>

--- a/src/components/WorkspaceSplitPane.tsx
+++ b/src/components/WorkspaceSplitPane.tsx
@@ -69,7 +69,7 @@ export function WorkspaceSplitPane({
             aria-valuenow={divider.ariaValueNow}
             tabIndex={divider.onKeyDown ? 0 : undefined}
             className={cn(
-              'absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent outline-none',
+              'absolute inset-y-0 left-0 z-10 w-11 -translate-x-1/2 cursor-col-resize bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
               divider.className,
             )}
             onPointerDown={divider.onPointerDown}

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -191,6 +191,7 @@ async function handleImageFile(
 }
 
 export interface RichTextEditorProps {
+  id?: string
   content: TiptapContent
   onChange: (content: TiptapContent) => void
   onBlur?: () => void
@@ -205,6 +206,12 @@ export interface RichTextEditorProps {
   enableImageUpload?: boolean
   /** Callback when image upload fails */
   onImageUploadError?: (message: string) => void
+  required?: boolean
+  'aria-required'?: boolean | 'true' | 'false'
+  'aria-invalid'?: boolean | 'true' | 'false' | 'grammar' | 'spelling'
+  'aria-describedby'?: string
+  'aria-errormessage'?: string
+  'aria-labelledby'?: string
 }
 
 const MainToolbarContent = ({
@@ -274,6 +281,7 @@ const MobileToolbarContent = ({
 )
 
 export function RichTextEditor({
+  id,
   content,
   onChange,
   onBlur,
@@ -286,6 +294,12 @@ export function RichTextEditor({
   className = '',
   enableImageUpload = false,
   onImageUploadError,
+  required,
+  'aria-required': ariaRequired,
+  'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedBy,
+  'aria-errormessage': ariaErrorMessage,
+  'aria-labelledby': ariaLabelledBy,
 }: RichTextEditorProps) {
   const canEdit = editable && !disabled
   const isMobile = useIsBreakpoint()
@@ -293,6 +307,28 @@ export function RichTextEditor({
   const [mobileView, setMobileView] = useState<'main' | 'link'>('main')
   const toolbarRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const editorAttributes = useMemo(() => {
+    const attributes: Record<string, string> = {
+      autocomplete: 'off',
+      autocorrect: 'off',
+      autocapitalize: 'off',
+      role: 'textbox',
+      'aria-multiline': 'true',
+      class: 'simple-editor',
+    }
+    const requiredState = ariaRequired ?? required
+
+    if (id) attributes.id = id
+    if (ariaLabelledBy) attributes['aria-labelledby'] = ariaLabelledBy
+    else attributes['aria-label'] = 'Main content area, start typing to enter text.'
+    if (requiredState !== undefined) attributes['aria-required'] = String(requiredState)
+    if (ariaInvalid !== undefined) attributes['aria-invalid'] = String(ariaInvalid)
+    if (ariaDescribedBy) attributes['aria-describedby'] = ariaDescribedBy
+    if (ariaErrorMessage) attributes['aria-errormessage'] = ariaErrorMessage
+
+    return attributes
+  }, [ariaDescribedBy, ariaErrorMessage, ariaInvalid, ariaLabelledBy, ariaRequired, id, required])
 
   // Build extensions array based on props (memoized to avoid recreating on every render)
   const extensions = useMemo(() => [
@@ -356,13 +392,7 @@ export function RichTextEditor({
     immediatelyRender: false,
     editable: canEdit,
     editorProps: {
-      attributes: {
-        autocomplete: 'off',
-        autocorrect: 'off',
-        autocapitalize: 'off',
-        'aria-label': 'Main content area, start typing to enter text.',
-        class: 'simple-editor',
-      },
+      attributes: editorAttributes,
       handleDOMEvents: {
         paste: (_view, event) => {
           // Track text paste for authenticity
@@ -430,6 +460,16 @@ export function RichTextEditor({
       editor.setEditable(canEdit)
     }
   }, [canEdit, editor])
+
+  useEffect(() => {
+    if (!editor) return
+    editor.setOptions({
+      editorProps: {
+        ...editor.options.editorProps,
+        attributes: editorAttributes,
+      },
+    })
+  }, [editor, editorAttributes])
 
   // Reset mobile view when switching to desktop
   useEffect(() => {

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from './utils'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-control border font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+  'inline-flex min-h-11 min-w-11 items-center justify-center gap-2 rounded-control border font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -57,12 +57,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       ref={ref}
       className={cn(buttonVariants({ variant, size, fullWidth }), className)}
       disabled={disabled || loading}
+      aria-busy={loading || undefined}
       {...props}
     >
       {loading ? (
         <>
           <svg
             className="animate-spin -ml-1 mr-2 h-4 w-4"
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/src/ui/FormField.tsx
+++ b/src/ui/FormField.tsx
@@ -1,7 +1,17 @@
 'use client'
 
-import { ReactNode, useId, Children, cloneElement, isValidElement } from 'react'
+import { cloneElement, isValidElement, useId, type ReactElement } from 'react'
 import { cn } from './utils'
+
+type FormControlProps = {
+  id?: string
+  required?: boolean
+  'aria-required'?: boolean | 'true' | 'false'
+  'aria-invalid'?: boolean | 'true' | 'false' | 'grammar' | 'spelling'
+  'aria-describedby'?: string
+  'aria-errormessage'?: string
+  'aria-labelledby'?: string
+}
 
 export interface FormFieldProps {
   /** Label text displayed above the control */
@@ -10,14 +20,14 @@ export interface FormFieldProps {
   htmlFor?: string
   /** Error message displayed below the control */
   error?: string
-  /** Hint text displayed below the control (hidden if error is present) */
+  /** Hint text displayed below the control */
   hint?: string
   /** Show required indicator (*) after label */
   required?: boolean
   /** Keep the label available to assistive tech without showing it visually */
   hideLabel?: boolean
-  /** The form control (Input, Select, Textarea, etc.) */
-  children: ReactNode
+  /** Exactly one form control (Input, Select, Textarea, etc.) */
+  children: ReactElement<FormControlProps>
   /** Additional class names for the wrapper */
   className?: string
 }
@@ -27,6 +37,11 @@ const labelStyles = 'block text-sm font-medium text-text-default mb-1'
 const errorStyles = 'mt-1 text-sm text-danger'
 const hintStyles = 'mt-1 text-sm text-text-muted'
 const requiredMarkerStyles = 'text-danger ml-1'
+
+function mergeIdRefs(...values: Array<string | undefined>): string | undefined {
+  const ids = values.flatMap((value) => value?.split(/\s+/).filter(Boolean) ?? [])
+  return ids.length > 0 ? Array.from(new Set(ids)).join(' ') : undefined
+}
 
 /**
  * FormField wraps form controls with consistent label and error styling.
@@ -53,36 +68,41 @@ export function FormField({
   className,
 }: FormFieldProps) {
   const generatedId = useId()
-  const fieldId = htmlFor || generatedId
+  const child = isValidElement<FormControlProps>(children) ? children : null
+  const fieldId = htmlFor || child?.props.id || generatedId
+  const labelId = `${fieldId}-label`
+  const hintId = hint ? `${fieldId}-hint` : undefined
+  const errorId = error ? `${fieldId}-error` : undefined
+  const describedBy = mergeIdRefs(child?.props['aria-describedby'], hintId, errorId)
+  const labelledBy = mergeIdRefs(labelId, child?.props['aria-labelledby'])
 
-  // Clone child to inject id and hasError props
-  const enhancedChildren = Children.map(children, (child) => {
-    if (isValidElement(child)) {
-      return cloneElement(child, {
+  const enhancedChild = child
+    ? cloneElement(child, {
         id: fieldId,
-        hasError: !!error,
-        'aria-invalid': error ? 'true' : undefined,
-        'aria-describedby': error ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined,
-      } as any)
-    }
-    return child
-  })
+        required: required || child.props.required || undefined,
+        'aria-required': required ? true : child.props['aria-required'],
+        'aria-invalid': error ? true : child.props['aria-invalid'],
+        'aria-describedby': describedBy,
+        'aria-errormessage': errorId ?? child.props['aria-errormessage'],
+        'aria-labelledby': labelledBy,
+      })
+    : children
 
   return (
     <div className={cn('w-full', className)}>
-      <label htmlFor={fieldId} className={cn(labelStyles, hideLabel && 'sr-only')}>
+      <label id={labelId} htmlFor={fieldId} className={cn(labelStyles, hideLabel && 'sr-only')}>
         {label}
-        {required && <span className={requiredMarkerStyles}>*</span>}
+        {required && <span className={requiredMarkerStyles} aria-hidden="true">*</span>}
       </label>
-      {enhancedChildren}
-      {error && (
-        <p id={`${fieldId}-error`} className={errorStyles} role="alert">
-          {error}
+      {enhancedChild}
+      {hint && (
+        <p id={hintId} className={hintStyles}>
+          {hint}
         </p>
       )}
-      {hint && !error && (
-        <p id={`${fieldId}-hint`} className={hintStyles}>
-          {hint}
+      {error && (
+        <p id={errorId} className={errorStyles} role="alert">
+          {error}
         </p>
       )}
     </div>

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -6,10 +6,11 @@ import { cn } from './utils'
 
 const inputVariants = cva(
   [
-    'w-full px-3 py-2 rounded-control',
+    'min-h-11 w-full rounded-control px-3 py-2',
     'bg-surface',
     'text-text-default',
-    'focus:ring-2 focus:ring-primary focus:border-primary',
+    'focus:outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary',
+    'aria-[invalid=true]:border-danger',
     'disabled:bg-surface-2 disabled:cursor-not-allowed',
   ],
   {

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -63,9 +63,11 @@ interface FormFieldProps {
   error?: string
   hint?: string
   required?: boolean
-  children: ReactNode  // Input, Select, Textarea, etc.
+  children: ReactElement  // Exactly one Input, Select, Textarea, etc.
 }
 ```
+
+`FormField` preserves a control-provided `id` unless an explicit `htmlFor` override is supplied, associates the label, propagates native `required` plus ARIA required/invalid state, and merges existing descriptions with hint and error ids. Hints remain available when an error is present. Pass exactly one form control as its child.
 
 ### AlertDialog
 
@@ -185,6 +187,7 @@ These rules ensure consistency across the codebase:
 | **Backgrounds** | Use `bg-page`, `bg-surface`, `bg-surface-2` in app code | Prevents inconsistent dark backgrounds across pages |
 | **Text/borders** | Use `text-text-default`, `text-text-muted`, `border-border` in app code | Consistent semantic naming |
 | **Form labels** | Always via `<FormField>`, never on Input/Select directly | One pattern to learn, one place for label styling |
+| **Targets and focus** | Shared buttons, segmented controls, and form controls provide a 44px minimum target and `focus-visible` ring | Mobile and keyboard access should not depend on feature-local classes |
 | **Token naming** | Intent-based only (`rounded-control`, not `rounded-8px`) | Prevents proliferation of one-off tokens |
 | **Tiptap** | Stays in `/components/tiptap*`, not `/ui` | Editor is a mini-platform; don't mix with app primitives |
 

--- a/src/ui/SegmentedControl.tsx
+++ b/src/ui/SegmentedControl.tsx
@@ -49,8 +49,8 @@ export function SegmentedControl<TValue extends string>({
             key={option.value}
             type="button"
             className={cn(
-              'inline-flex items-center justify-center gap-1.5 rounded-control text-xs font-medium transition-colors',
-              iconOnly ? 'h-8 w-8 px-0' : 'px-3 py-1 sm:text-sm',
+              'inline-flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-control text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
+              iconOnly ? 'h-11 w-11 px-0' : 'px-3 py-1 sm:text-sm',
               capitalizeLabels && !iconOnly ? 'capitalize' : '',
               isActive
                 ? 'bg-info-bg text-primary'

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -6,10 +6,11 @@ import { cn } from './utils'
 
 const selectVariants = cva(
   [
-    'w-full px-3 py-2 rounded-control',
+    'min-h-11 w-full rounded-control px-3 py-2',
     'bg-surface',
     'text-text-default',
-    'focus:ring-2 focus:ring-primary focus:border-primary',
+    'focus:outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary',
+    'aria-[invalid=true]:border-danger',
     'disabled:bg-surface-2 disabled:cursor-not-allowed',
   ],
   {

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -248,7 +248,7 @@ export function SplitButton({
                   handleOptionSelect(option.onSelect)
                 }}
                 className={cn(
-                  'w-full rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50',
+                  'min-h-11 w-full rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50',
                   option.destructive ? 'text-danger hover:bg-danger-bg' : ''
                 )}
               >

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -43,6 +43,25 @@ describe('Button component', () => {
 
   it('should apply size styles', () => {
     const { container } = render(<Button size="lg">Large</Button>)
-    expect(container.querySelector('button')).toHaveClass('px-6')
+    expect(container.querySelector('button')).toHaveClass('min-h-11', 'min-w-11', 'px-6')
+  })
+
+  it('uses a keyboard-only focus treatment', () => {
+    render(<Button>Continue</Button>)
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toHaveClass(
+      'focus:outline-none',
+      'focus-visible:ring-2',
+      'focus-visible:ring-primary',
+    )
+  })
+
+  it('exposes its loading state without announcing the spinner', () => {
+    const { container } = render(<Button loading>Save</Button>)
+    const button = screen.getByRole('button', { name: 'Save' })
+
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
   })
 })

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1,6 +1,12 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
-import { TableCard } from '@/components/DataTable'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DataTable,
+  DataTableHead,
+  KeyboardNavigableTable,
+  SortableHeaderCell,
+  TableCard,
+} from '@/components/DataTable'
 
 describe('TableCard', () => {
   it('renders default chrome for standard tables', () => {
@@ -26,5 +32,50 @@ describe('TableCard', () => {
     expect(container.firstChild).not.toHaveClass('border')
     expect(container.firstChild).not.toHaveClass('bg-surface')
     expect(container.firstChild).toHaveClass('overflow-hidden')
+  })
+
+  it('gives sortable headers a visible focus treatment and accessible target', () => {
+    render(
+      <DataTable>
+        <DataTableHead>
+          <tr>
+            <SortableHeaderCell
+              label="Last name"
+              isActive
+              direction="asc"
+              onClick={vi.fn()}
+            />
+          </tr>
+        </DataTableHead>
+      </DataTable>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Last name' })).toHaveClass(
+      'min-h-11',
+      'focus-visible:ring-2',
+      'focus-visible:ring-inset',
+    )
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending')
+  })
+
+  it('keeps keyboard table navigation focus visible', () => {
+    const onSelectKey = vi.fn()
+    render(
+      <KeyboardNavigableTable
+        rowKeys={['student-1', 'student-2']}
+        selectedKey={null}
+        onSelectKey={onSelectKey}
+        aria-label="Students"
+      >
+        <div>Rows</div>
+      </KeyboardNavigableTable>,
+    )
+
+    const tableNavigation = screen.getByLabelText('Students')
+    expect(tableNavigation).toHaveAttribute('tabindex', '0')
+    expect(tableNavigation).toHaveClass('focus-visible:ring-2', 'focus-visible:ring-primary')
+
+    fireEvent.keyDown(tableNavigation, { key: 'ArrowDown' })
+    expect(onSelectKey).toHaveBeenCalledWith('student-1')
   })
 })

--- a/tests/components/RichTextEditor.test.tsx
+++ b/tests/components/RichTextEditor.test.tsx
@@ -1,9 +1,35 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { RichTextEditor } from '@/components/editor'
+import { FormField } from '@/ui/FormField'
 import type { TiptapContent } from '@/types'
 
 describe('RichTextEditor', () => {
+  it('forwards FormField naming and validation semantics to the editable area', async () => {
+    const onChange = vi.fn()
+    const content: TiptapContent = { type: 'doc', content: [] }
+
+    render(
+      <FormField
+        label="Content"
+        hint="Add links or instructions."
+        error="Content is required."
+        required
+      >
+        <RichTextEditor content={content} onChange={onChange} />
+      </FormField>,
+    )
+
+    const editor = await screen.findByRole('textbox', { name: 'Content' })
+    const describedBy = editor.getAttribute('aria-describedby')?.split(' ') ?? []
+
+    expect(editor.id).not.toBe('')
+    expect(editor).toHaveAttribute('aria-required', 'true')
+    expect(editor).toHaveAttribute('aria-invalid', 'true')
+    expect(editor).toHaveAttribute('aria-errormessage', `${editor.id}-error`)
+    expect(describedBy).toEqual([`${editor.id}-hint`, `${editor.id}-error`])
+  })
+
   it('does not emit duplicate extension warnings', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const onChange = vi.fn()

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -187,7 +187,7 @@ describe('StudentAssignmentsTab', () => {
 
     // Wait for the Instructions button to appear
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Instructions' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Instructions', hidden: true })).toBeInTheDocument()
     })
 
     // Modal can be opened by default; close it first.

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -168,9 +168,11 @@ describe('TeacherClassroomsIndex', () => {
 
     const activeButton = screen.getByRole('button', { name: 'Active' })
     const archivedButton = screen.getByRole('button', { name: 'Archived' })
+    const bottomControls = screen.getByTestId('classroom-bottom-controls')
 
     expect(activeButton).toBeInTheDocument()
     expect(archivedButton).toBeInTheDocument()
+    expect(bottomControls.firstElementChild).toHaveClass('min-h-[52px]')
     expect(activeButton).not.toHaveAttribute('title')
     expect(archivedButton).not.toHaveAttribute('title')
     expect(screen.getByRole('button', { name: 'Drag to reorder Math 101' })).toBeInTheDocument()

--- a/tests/components/WorkspaceSplitPane.test.tsx
+++ b/tests/components/WorkspaceSplitPane.test.tsx
@@ -23,11 +23,35 @@ describe('WorkspaceSplitPane', () => {
     expect(screen.getByText('Right pane')).toBeInTheDocument()
 
     const separator = screen.getByRole('separator', { name: 'Resize panes' })
+    expect(separator).toHaveClass('w-11', 'focus-visible:ring-2', 'focus-visible:ring-primary')
     fireEvent.pointerDown(separator)
     fireEvent.doubleClick(separator)
 
     expect(onPointerDown).toHaveBeenCalledTimes(1)
     expect(onDoubleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('makes a keyboard-controlled divider focusable and reports its value', () => {
+    render(
+      <WorkspaceSplitPane
+        left={<div>Left pane</div>}
+        right={<div>Right pane</div>}
+        divider={{
+          label: 'Resize panes',
+          onPointerDown: vi.fn(),
+          onKeyDown: vi.fn(),
+          ariaValueMin: 20,
+          ariaValueMax: 80,
+          ariaValueNow: 45,
+        }}
+      />,
+    )
+
+    const separator = screen.getByRole('separator', { name: 'Resize panes' })
+    expect(separator).toHaveAttribute('tabindex', '0')
+    expect(separator).toHaveAttribute('aria-valuemin', '20')
+    expect(separator).toHaveAttribute('aria-valuemax', '80')
+    expect(separator).toHaveAttribute('aria-valuenow', '45')
   })
 
   it('omits the right pane when rightVisible is false', () => {

--- a/tests/ui/FormField.test.tsx
+++ b/tests/ui/FormField.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FormField } from '@/ui/FormField'
+import { Input } from '@/ui/Input'
+import { Select } from '@/ui/Select'
+
+describe('form control contract', () => {
+  it('associates the generated label and propagates required semantics', () => {
+    render(
+      <FormField label="School email" required>
+        <Input type="email" />
+      </FormField>,
+    )
+
+    const input = screen.getByRole('textbox', { name: 'School email' })
+    expect(input).toBeRequired()
+    expect(input).toHaveAttribute('aria-required', 'true')
+    expect(input.id).not.toBe('')
+    expect(document.querySelector('label')).toHaveAttribute('for', input.id)
+    expect(document.querySelector('label span')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('preserves a child id and merges existing, hint, and error descriptions', () => {
+    render(
+      <>
+        <span id="format-help">Use your board address.</span>
+        <FormField label="School email" hint="Use your school account." error="Email is invalid.">
+          <Input id="school-email" aria-describedby="format-help" />
+        </FormField>
+      </>,
+    )
+
+    const input = screen.getByRole('textbox', { name: 'School email' })
+    expect(input).toHaveAttribute('id', 'school-email')
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      'format-help school-email-hint school-email-error',
+    )
+    expect(input).toHaveAttribute('aria-errormessage', 'school-email-error')
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('Use your school account.')).toBeVisible()
+    expect(screen.getByRole('alert')).toHaveTextContent('Email is invalid.')
+  })
+
+  it('adds only standard semantic attributes to native controls', () => {
+    render(
+      <FormField label="Reflection" error="Reflection is required.">
+        <textarea />
+      </FormField>,
+    )
+
+    const textarea = screen.getByRole('textbox', { name: 'Reflection' })
+    expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    expect(textarea).not.toHaveAttribute('haserror')
+  })
+
+  it('uses an explicit htmlFor as the control id override', () => {
+    render(
+      <FormField label="Course code" htmlFor="course-code-field">
+        <Input id="caller-id" />
+      </FormField>,
+    )
+
+    expect(screen.getByRole('textbox', { name: 'Course code' })).toHaveAttribute(
+      'id',
+      'course-code-field',
+    )
+  })
+
+  it('gives input and select controls accessible sizing and focus styles', () => {
+    render(
+      <>
+        <Input aria-label="Name" />
+        <Select aria-label="Course" options={[{ value: 'math', label: 'Math' }]} />
+      </>,
+    )
+
+    for (const control of [
+      screen.getByRole('textbox', { name: 'Name' }),
+      screen.getByRole('combobox', { name: 'Course' }),
+    ]) {
+      expect(control).toHaveClass(
+        'min-h-11',
+        'focus:outline-none',
+        'focus-visible:ring-2',
+        'focus-visible:ring-primary',
+      )
+    }
+  })
+})

--- a/tests/ui/SegmentedControl.test.tsx
+++ b/tests/ui/SegmentedControl.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SegmentedControl, TooltipProvider } from '@/ui'
+
+describe('SegmentedControl', () => {
+  it('exposes selection and accessible target/focus treatment', () => {
+    const onChange = vi.fn()
+    render(
+      <SegmentedControl
+        ariaLabel="Editor mode"
+        value="edit"
+        options={[
+          { value: 'edit', label: 'Edit' },
+          { value: 'preview', label: 'Preview' },
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    const group = screen.getByRole('group', { name: 'Editor mode' })
+    const edit = screen.getByRole('button', { name: 'Edit' })
+    const preview = screen.getByRole('button', { name: 'Preview' })
+
+    expect(group).toContainElement(edit)
+    expect(edit).toHaveAttribute('aria-pressed', 'true')
+    expect(preview).toHaveAttribute('aria-pressed', 'false')
+    expect(edit).toHaveClass('min-h-11', 'min-w-11', 'focus-visible:ring-2')
+
+    fireEvent.click(preview)
+    expect(onChange).toHaveBeenCalledWith('preview')
+  })
+
+  it('keeps icon-only options at least 44 by 44 pixels with explicit names', () => {
+    render(
+      <TooltipProvider>
+        <SegmentedControl
+          ariaLabel="View"
+          value="list"
+          iconOnly
+          options={[
+            { value: 'list', label: 'List view', icon: <span>L</span> },
+            { value: 'grid', label: 'Grid view', icon: <span>G</span> },
+          ]}
+          onChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'List view' })).toHaveClass('h-11', 'w-11')
+    expect(screen.getByRole('button', { name: 'Grid view' })).toHaveClass('h-11', 'w-11')
+  })
+})

--- a/tests/ui/SplitButton.test.tsx
+++ b/tests/ui/SplitButton.test.tsx
@@ -48,6 +48,24 @@ describe('SplitButton', () => {
     await waitFor(() => expect(toggle).toHaveFocus())
   })
 
+  it('keeps menu options touch-sized with visible keyboard focus', () => {
+    render(
+      <SplitButton
+        label="Post"
+        onPrimaryClick={vi.fn()}
+        options={[{ id: 'schedule', label: 'Schedule', onSelect: vi.fn() }]}
+        toggleAriaLabel="Choose action"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose action' }))
+    expect(screen.getByRole('menuitem', { name: 'Schedule' })).toHaveClass(
+      'min-h-11',
+      'focus-visible:ring-2',
+      'focus-visible:ring-inset',
+    )
+  })
+
   it('can use the primary button to open the menu', () => {
     const onPrimaryClick = vi.fn()
 


### PR DESCRIPTION
## Summary
- standardize 44px direct interaction targets and focus-visible treatment across shared buttons, fields, segmented controls, split menus, sortable tables, and split panes
- make FormField preserve caller semantics while owning label, required, hint, error, and description wiring
- forward FormField naming and validation state to the rich-text editor contenteditable textbox
- preserve dense layouts by reserving the full classroom mobile switcher height and stabilizing the assignment-instructions modal test

## Review findings resolved
- expand the split-pane divider from a 12px to a 44px transparent pointer target
- reconcile FormField documentation with its one-control composition and hint/error behavior
- reserve the bordered 50px segmented switcher inside a 52px mobile footer slot
- expose RichTextEditor as a labelled multiline textbox and update its ARIA state when FormField props change

## Verification
- `pnpm test` (383 files / 3,543 tests)
- focused shared-control and integration suites (8 files / 69 tests)
- targeted remediation suite (3 files / 39 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (607 modules / 0 allowances)
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- Playwright unauthenticated/teacher/student desktop/mobile light/dark matrix, including focus, errors, gradebook density, mobile switcher geometry, and rich-text accessible naming

## Accessibility checklist
- Checklist reviewed: yes
- Keyboard behavior covered: yes
- Semantic state covered: yes
- Manual follow-up: none

No schema migration or production data change.