### PR TITLE
Standardize page-level data states

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#899 merged shared UI and page-structure contracts. The governed page-state slice is in progress.
+- Phase 2 is active. PRs #896-#899 merged shared UI contracts. PR #900 adds governed page states and route conventions.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#899 merged shared UI contracts. PR #900 adds governed page states and route conventions.
+- Phase 2 is active. PRs #896-#899 merged shared UI contracts. PR #900 adds governed page states and route conventions; independent-review remediation is complete.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#898 merged shared UI contracts. PR #899 adds governed page structure in `@/ui`; final remediation is active.
+- Phase 2 is active. PRs #896-#899 merged shared UI and page-structure contracts. The governed page-state slice is in progress.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -13985,3 +13985,24 @@
 - `pnpm lint`
 - `pnpm build`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:49abe2963750316e82a2571bb76fc55e1accd3cb8e74c914aece3dfda8307822 -->
+## 2026-07-13 — Verified classroom source-object cleanup boundary
+
+**Completed:**
+- Added migration 086 with service-role-only, skip-locked claim/complete/fail RPCs over compaction source objects, explicit processing/failed/deleted states, bounded leases, expired-lease reclaim, exponential retry backoff, and immutable deletion evidence.
+- Restricted claims to completed compact operations with matching cold tombstones; stale, wrong, or expired leases cannot complete or fail work.
+- Added a disabled-by-default server worker that reads each exact key, verifies complete bytes against the archived SHA-256 and byte count before removal, and completes only after authoritative exact-key absence; missing buckets, mismatches, uncertain reads, and unconfirmed deletion fail closed.
+- Added strict Zod validation for RPC claims and runtime bounds, duplicate-object rejection, independent failure containment, and privacy-safe results/metrics with opaque object references.
+- Extended the ephemeral database contract for pre-compaction exclusion, active and expired leases, stale-token rejection, retry backoff, canonical inputs, completion evidence, and role security. No route, UI, schedule, production setting, database, row, or Storage object was changed.
+
+**Validation:**
+- Full Vitest suite (334 files / 2,968 tests)
+- Focused source cleanup runtime/migration suites (2 files / 18 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash -n scripts/check-classroom-archive-compaction-database.sh`
+- Pika pre-commit audit
+- Local migration replay intentionally not run; GitHub's ephemeral Supabase database job is the execution authority
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -888,6 +888,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added cache invalidation before client retries and direct regressions for state semantics, route boundaries, error/empty separation, and retry recovery.
 - Documented the state decision table and App Router conventions in stable guidance.
 - Visually verified teacher/student loading, error, and empty states plus classroom unavailable states at desktop/mobile sizes in light/dark themes. Governed states had no overflow or page errors, and retry/route-away controls measured 44px.
+- Opened PR #900 for independent review; no schema, migration, API contract, or production data change was made.
 
 **Validation:**
 - `pnpm test` (387 files / 3,566 tests)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Verified classroom source-object cleanup boundary
-
-**Completed:**
-- Added migration 086 with service-role-only, skip-locked claim/complete/fail RPCs over compaction source objects, explicit processing/failed/deleted states, bounded leases, expired-lease reclaim, exponential retry backoff, and immutable deletion evidence.
-- Restricted claims to completed compact operations with matching cold tombstones; stale, wrong, or expired leases cannot complete or fail work.
-- Added a disabled-by-default server worker that reads each exact key, verifies complete bytes against the archived SHA-256 and byte count before removal, and completes only after authoritative exact-key absence; missing buckets, mismatches, uncertain reads, and unconfirmed deletion fail closed.
-- Added strict Zod validation for RPC claims and runtime bounds, duplicate-object rejection, independent failure containment, and privacy-safe results/metrics with opaque object references.
-- Extended the ephemeral database contract for pre-compaction exclusion, active and expired leases, stale-token rejection, retry backoff, canonical inputs, completion evidence, and role security. No route, UI, schedule, production setting, database, row, or Storage object was changed.
-
-**Validation:**
-- Full Vitest suite (334 files / 2,968 tests)
-- Focused source cleanup runtime/migration suites (2 files / 18 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash -n scripts/check-classroom-archive-compaction-database.sh`
-- Pika pre-commit audit
-- Local migration replay intentionally not run; GitHub's ephemeral Supabase database job is the execution authority
-- `git diff --check`
-
 ## 2026-07-13 — Manual classroom source cleanup canary
 
 **Completed:**
@@ -897,3 +877,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Complete targeted remediation review and merge PR #899 after required checks. Then continue Phase 2 with page-level loading, error, empty, and forbidden contracts.
+
+## 2026-07-21 — Phase 2 governed page-state contract
+
+**Completed:**
+- Merged PR #899 and started Phase 2 item 5 from current `main` in a dedicated worktree.
+- Added canonical `PageState` loading, error, empty, and forbidden variants with explicit live-region semantics, text-backed icons, optional actions, and compact work-region support.
+- Added classroom route loading, error-boundary retry, and intentionally indistinguishable unavailable/access-denied states while preserving the classroom shell.
+- Migrated teacher dashboard and student history initial loading/empty behavior; failed classroom/history reads now render explicit retryable errors instead of valid-looking empty data.
+- Added cache invalidation before client retries and direct regressions for state semantics, route boundaries, error/empty separation, and retry recovery.
+- Documented the state decision table and App Router conventions in stable guidance.
+- Visually verified teacher/student loading, error, and empty states plus classroom unavailable states at desktop/mobile sizes in light/dark themes. Governed states had no overflow or page errors, and retry/route-away controls measured 44px.
+
+**Validation:**
+- `pnpm test` (387 files / 3,566 tests)
+- Focused page-state, classroom-route, teacher-dashboard, student-history, UI-guidance, and startup-doc suites
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (610 modules / 0 allowances)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Custom Playwright teacher/student desktop/mobile light/dark loading/error/empty/forbidden and keyboard-retry matrix
+- `git diff --check`
+
+**Remaining:**
+- Open, independently review, and merge the page-state PR. Then continue Phase 2 with shared table, menu, tabs, segmented-control, and split-pane contracts.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -883,23 +883,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Merged PR #899 and started Phase 2 item 5 from current `main` in a dedicated worktree.
 - Added canonical `PageState` loading, error, empty, and forbidden variants with explicit live-region semantics, text-backed icons, optional actions, and compact work-region support.
-- Added classroom route loading, error-boundary retry, and intentionally indistinguishable unavailable/access-denied states while preserving the classroom shell.
+- Added classroom route loading, error-boundary retry, and intentionally indistinguishable unavailable/access-denied states while preserving safe layout framing and route-away behavior.
 - Migrated teacher dashboard and student history initial loading/empty behavior; failed classroom/history reads now render explicit retryable errors instead of valid-looking empty data.
 - Added cache invalidation before client retries and direct regressions for state semantics, route boundaries, error/empty separation, and retry recovery.
 - Documented the state decision table and App Router conventions in stable guidance.
 - Visually verified teacher/student loading, error, and empty states plus classroom unavailable states at desktop/mobile sizes in light/dark themes. Governed states had no overflow or page errors, and retry/route-away controls measured 44px.
 - Opened PR #900 for independent review; no schema, migration, API contract, or production data change was made.
+- Fixed independent-review findings by separating attendance read failures from empty rosters, binding data to its owning classroom, routing roster-upload refresh through the same guarded coordinator, and rejecting stale entry-detail responses after class switches.
+- Added deterministic focus recovery and page-level heading semantics, clarified shell behavior when protected identity data is unavailable, and made the teacher dashboard and student history stack cleanly on mobile without changing their table-first desktop workflow.
 
 **Validation:**
-- `pnpm test` (387 files / 3,566 tests)
+- `pnpm test` (387 files / 3,569 tests)
 - Focused page-state, classroom-route, teacher-dashboard, student-history, UI-guidance, and startup-doc suites
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm check:architecture` (610 modules / 0 allowances)
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
-- Custom Playwright teacher/student desktop/mobile light/dark loading/error/empty/forbidden and keyboard-retry matrix
+- Composite-widget checklist reviewed; no composite widget behavior changed in this slice, while retry keyboard/focus behavior is covered directly.
+- Custom Playwright teacher/student desktop/mobile light/dark loading/error/empty/forbidden and keyboard-retry matrix; all remediation cases had no overflow or page errors, 44px retry controls, and stable post-retry focus
 - `git diff --check`
 
 **Remaining:**
-- Open, independently review, and merge the page-state PR. Then continue Phase 2 with shared table, menu, tabs, segmented-control, and split-pane contracts.
+- Merge the independently reviewed page-state PR after required checks. Then continue Phase 2 with shared table, menu, tabs, segmented-control, and split-pane contracts.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/guidance/ui/page-state-conventions.md
+++ b/docs/guidance/ui/page-state-conventions.md
@@ -21,8 +21,9 @@ feedback with their owning feature controls instead.
   retrying a caught client read.
 - Use `not-found.tsx` or generic unavailable copy when distinguishing missing from forbidden would
   disclose protected-resource existence.
-- Preserve the normal app/classroom shell around route states so navigation and page dimensions do
-  not jump.
+- Preserve the normal app/classroom shell when its authenticated identity and navigation data are
+  available. A route boundary without that context must preserve the page geometry and offer a safe
+  route away instead of synthesizing role or classroom navigation from unavailable data.
 - Use `PageState compact` only for a primary region inside an established split workspace. Do not
   put `PageState` inside another card.
 - Keep successful zero-result handling separate from the `catch` path in client coordinators.
@@ -35,6 +36,8 @@ feedback with their owning feature controls instead.
 - Error and forbidden states use assertive alert semantics.
 - The state icon is decorative; the title and description carry the meaning in text.
 - Retry and route-away actions remain normal keyboard-reachable controls with shared 44px targets.
+- When retry replaces the initiating control, move focus to a stable named page or work-region
+  container so the refreshed result has a deterministic focus target.
 
 ## Reference Surfaces
 

--- a/docs/guidance/ui/page-state-conventions.md
+++ b/docs/guidance/ui/page-state-conventions.md
@@ -1,0 +1,43 @@
+# Page-State Conventions
+
+Use `PageState` from `@/ui` when a route or primary work region is loading, failed, empty, or
+unavailable. Keep small field errors, save status, modal progress, table rows, and transient refresh
+feedback with their owning feature controls instead.
+
+## State Decisions
+
+| State | Meaning | Required behavior |
+|---|---|---|
+| `loading` | The initial read has not completed. | Use specific loading copy and `aria-busy`; do not show an empty state while the request is pending. |
+| `error` | A required read failed. | Preserve the surrounding shell, explain that data was not changed, and offer a bounded retry when one is safe. |
+| `empty` | A successful read returned no records. | Describe the first useful action. Never use empty copy as a fallback for a failed request. |
+| `forbidden` | The current identity cannot use the surface. | Do not expose whether a protected resource exists. Provide a safe route away from the state. |
+
+## Route Conventions
+
+- Use App Router `loading.tsx` for route transitions and `error.tsx` for uncaught route failures.
+- Keep `error.tsx` copy generic. Do not render raw exception or database messages.
+- Call the error-boundary `reset()` callback for retry; invalidate an affected client cache before
+  retrying a caught client read.
+- Use `not-found.tsx` or generic unavailable copy when distinguishing missing from forbidden would
+  disclose protected-resource existence.
+- Preserve the normal app/classroom shell around route states so navigation and page dimensions do
+  not jump.
+- Use `PageState compact` only for a primary region inside an established split workspace. Do not
+  put `PageState` inside another card.
+- Keep successful zero-result handling separate from the `catch` path in client coordinators.
+- Use `RefreshingIndicator` or `useOverlayMessage` for non-blocking refreshes after usable data is
+  already visible.
+
+## Accessibility
+
+- Loading and empty states use polite status semantics.
+- Error and forbidden states use assertive alert semantics.
+- The state icon is decorative; the title and description carry the meaning in text.
+- Retry and route-away actions remain normal keyboard-reachable controls with shared 44px targets.
+
+## Reference Surfaces
+
+- Classroom route: `src/app/classrooms/[classroomId]/loading.tsx`, `error.tsx`, and `not-found.tsx`
+- Teacher utility: `src/app/teacher/dashboard/page.tsx`
+- Student utility: `src/app/student/history/page.tsx`

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -69,6 +69,24 @@ Source grounding:
 - [`src/app/classrooms/TeacherClassroomsIndex.tsx`](/src/app/classrooms/TeacherClassroomsIndex.tsx)
 - [`src/app/classrooms/StudentClassroomsIndex.tsx`](/src/app/classrooms/StudentClassroomsIndex.tsx)
 
+### 3b. Page states distinguish pending, failed, empty, and unavailable data
+
+- Use `PageState` from `@/ui` for a route or primary work region.
+- A failed read must render an error state, not empty copy or stale zero counts.
+- Empty means a successful request returned no records.
+- Preserve the surrounding shell and offer a bounded retry when retrying is safe.
+- Keep protected-resource not-found and forbidden copy intentionally indistinguishable when needed
+  to avoid disclosing existence.
+- Use transient overlay loading only when usable content remains visible underneath it.
+
+Source grounding:
+
+- [`docs/guidance/ui/page-state-conventions.md`](/docs/guidance/ui/page-state-conventions.md)
+- [`src/ui/PageState.tsx`](/src/ui/PageState.tsx)
+- [`src/app/classrooms/[classroomId]/error.tsx`](/src/app/classrooms/[classroomId]/error.tsx)
+- [`src/app/teacher/dashboard/page.tsx`](/src/app/teacher/dashboard/page.tsx)
+- [`src/app/student/history/page.tsx`](/src/app/student/history/page.tsx)
+
 ### 4. Attendance stays presence-first and scan-friendly
 
 - Attendance UI is optimized for quick scanning and teacher drill-down, not extra status taxonomy.

--- a/src/app/classrooms/[classroomId]/error.tsx
+++ b/src/app/classrooms/[classroomId]/error.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Link from 'next/link'
+import { AppShell } from '@/components/AppShell'
+import {
+  ACTIONBAR_BUTTON_SECONDARY_CLASSNAME,
+  Button,
+  PageContent,
+  PageLayout,
+  PageState,
+} from '@/ui'
+
+export default function ClassroomError({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <AppShell showHeader={false}>
+      <PageLayout width="reading">
+        <PageContent>
+          <PageState
+            kind="error"
+            headingLevel="h1"
+            title="Could not load this classroom"
+            description="The classroom data could not be retrieved. Your work has not been changed."
+            action={
+              <div className="flex flex-wrap justify-center gap-3">
+                <Button type="button" onClick={reset}>
+                  Try again
+                </Button>
+                <Link href="/classrooms" className={ACTIONBAR_BUTTON_SECONDARY_CLASSNAME}>
+                  Back to classrooms
+                </Link>
+              </div>
+            }
+          />
+        </PageContent>
+      </PageLayout>
+    </AppShell>
+  )
+}

--- a/src/app/classrooms/[classroomId]/loading.tsx
+++ b/src/app/classrooms/[classroomId]/loading.tsx
@@ -21,6 +21,7 @@ export default function ClassroomLoading() {
         <main className="min-w-0">
           <PageState
             kind="loading"
+            headingLevel="h1"
             title="Loading classroom"
             description="Getting the latest classroom information."
             className="min-h-[calc(100vh-3rem)]"

--- a/src/app/classrooms/[classroomId]/loading.tsx
+++ b/src/app/classrooms/[classroomId]/loading.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from '@/components/AppShell'
+import { PageState } from '@/ui'
 
 export default function ClassroomLoading() {
   return (
@@ -17,11 +18,13 @@ export default function ClassroomLoading() {
           </div>
         </aside>
 
-        {/* Main content skeleton */}
-        <main className="p-4 space-y-4">
-          <div className="h-8 w-48 bg-surface-hover rounded animate-pulse" />
-          <div className="h-32 bg-surface-hover rounded animate-pulse" />
-          <div className="h-32 bg-surface-hover rounded animate-pulse" />
+        <main className="min-w-0">
+          <PageState
+            kind="loading"
+            title="Loading classroom"
+            description="Getting the latest classroom information."
+            className="min-h-[calc(100vh-3rem)]"
+          />
         </main>
 
         {/* Right sidebar - empty/collapsed */}

--- a/src/app/classrooms/[classroomId]/not-found.tsx
+++ b/src/app/classrooms/[classroomId]/not-found.tsx
@@ -1,16 +1,31 @@
 import Link from 'next/link'
 import { AppShell } from '@/components/AppShell'
+import {
+  ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
+  PageContent,
+  PageLayout,
+  PageState,
+} from '@/ui'
 
 export default function ClassroomNotFound() {
   return (
     <AppShell showHeader={false}>
-      <div className="max-w-md mx-auto mt-12" data-testid="classroom-not-found">
-        <div className="bg-surface rounded-lg shadow-sm border border-border p-8 text-center">
-          <p className="text-danger mb-4">Classroom not found or you don&apos;t have access.</p>
-          <Link href="/classrooms" className="text-primary hover:text-primary-hover">
-            Back to classrooms
-          </Link>
-        </div>
+      <div data-testid="classroom-not-found">
+        <PageLayout width="reading">
+          <PageContent>
+            <PageState
+              kind="forbidden"
+              headingLevel="h1"
+              title="Classroom unavailable"
+              description="It may not exist, or you may not have access."
+              action={
+                <Link href="/classrooms" className={ACTIONBAR_BUTTON_PRIMARY_CLASSNAME}>
+                  Back to classrooms
+                </Link>
+              }
+            />
+          </PageContent>
+        </PageLayout>
       </div>
     </AppShell>
   )

--- a/src/app/student/history/page.tsx
+++ b/src/app/student/history/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, FormEvent } from 'react'
+import { useState, useEffect, useRef, FormEvent } from 'react'
 import { Button, FormField, Input, PageContent, PageLayout, PageState } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { format, parse } from 'date-fns'
@@ -24,6 +24,7 @@ interface HistoryEntry {
 }
 
 export default function HistoryPage() {
+  const pageRegionRef = useRef<HTMLDivElement>(null)
   const [classrooms, setClassrooms] = useState<Classroom[]>([])
   const [selectedClassroom, setSelectedClassroom] = useState<Classroom | null>(null)
   const [loading, setLoading] = useState(true)
@@ -172,73 +173,101 @@ export default function HistoryPage() {
 
   if (loading) {
     return (
-      <PageLayout density="student" width="reading">
-        <PageContent>
-          <PageState
-            kind="loading"
-            title="Loading history"
-            description="Getting your classrooms and attendance history."
-          />
-        </PageContent>
-      </PageLayout>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Student history"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="student" width="reading">
+          <PageContent>
+            <PageState
+              kind="loading"
+              headingLevel="h1"
+              title="Loading history"
+              description="Getting your classrooms and attendance history."
+            />
+          </PageContent>
+        </PageLayout>
+      </div>
     )
   }
 
   if (loadError) {
     return (
-      <PageLayout density="student" width="reading">
-        <PageContent>
-          <PageState
-            kind="error"
-            title="Could not load your classrooms"
-            description="Your saved history has not been changed, but it could not be retrieved right now."
-            action={
-              <Button
-                type="button"
-                onClick={() => {
-                  invalidateStudentClassrooms()
-                  setLoadAttempt((attempt) => attempt + 1)
-                }}
-              >
-                Try again
-              </Button>
-            }
-          />
-        </PageContent>
-      </PageLayout>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Student history"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="student" width="reading">
+          <PageContent>
+            <PageState
+              kind="error"
+              headingLevel="h1"
+              title="Could not load your classrooms"
+              description="Your saved history has not been changed, but it could not be retrieved right now."
+              action={
+                <Button
+                  type="button"
+                  onClick={() => {
+                    pageRegionRef.current?.focus()
+                    invalidateStudentClassrooms()
+                    setLoadAttempt((attempt) => attempt + 1)
+                  }}
+                >
+                  Try again
+                </Button>
+              }
+            />
+          </PageContent>
+        </PageLayout>
+      </div>
     )
   }
 
   // Empty state - no classrooms
   if (classrooms.length === 0) {
     return (
-      <PageLayout density="student" width="reading">
-        <PageContent>
-          <PageState
-            kind="empty"
-            title="No Classes Yet"
-            description="Join a class to view your history."
-            action={
-              <form onSubmit={handleJoinClassroom} className="w-full space-y-4 text-left">
-                <FormField label="Class Code" error={error} required>
-                  <Input
-                    type="text"
-                    placeholder="Enter class code"
-                    value={joinCode}
-                    onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-                    required
-                    disabled={joining}
-                  />
-                </FormField>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Student history"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="student" width="reading">
+          <PageContent>
+            <PageState
+              kind="empty"
+              headingLevel="h1"
+              title="No Classes Yet"
+              description="Join a class to view your history."
+              action={
+                <form onSubmit={handleJoinClassroom} className="w-full space-y-4 text-left">
+                  <FormField label="Class Code" error={error} required>
+                    <Input
+                      type="text"
+                      placeholder="Enter class code"
+                      value={joinCode}
+                      onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                      required
+                      disabled={joining}
+                    />
+                  </FormField>
 
-                <Button type="submit" disabled={joining || !joinCode} className="w-full">
-                  {joining ? 'Joining...' : 'Join Class'}
-                </Button>
-              </form>
-            }
-          />
-        </PageContent>
-      </PageLayout>
+                  <Button type="submit" disabled={joining || !joinCode} className="w-full">
+                    {joining ? 'Joining...' : 'Join Class'}
+                  </Button>
+                </form>
+              }
+            />
+          </PageContent>
+        </PageLayout>
+      </div>
     )
   }
 
@@ -248,9 +277,15 @@ export default function HistoryPage() {
   }
 
   return (
-    <div className="flex gap-6">
+    <div
+      ref={pageRegionRef}
+      role="region"
+      aria-label="Student history"
+      tabIndex={-1}
+      className="flex flex-col gap-4 focus:outline-none md:flex-row md:gap-6"
+    >
       {/* Classroom List Sidebar */}
-      <div className="w-64 flex-shrink-0">
+      <div className="w-full flex-shrink-0 md:w-64">
         <div className="bg-surface rounded-lg shadow-sm p-4">
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-semibold text-text-default">My Classes</h3>
@@ -304,7 +339,7 @@ export default function HistoryPage() {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         {historyError ? (
           <PageState
             kind="error"
@@ -315,6 +350,7 @@ export default function HistoryPage() {
               <Button
                 type="button"
                 onClick={() => {
+                  pageRegionRef.current?.focus()
                   if (selectedClassroom) {
                     invalidateClassDaysForClassroom(selectedClassroom.id)
                     invalidateStudentEntriesForClassroom(selectedClassroom.id)

--- a/src/app/student/history/page.tsx
+++ b/src/app/student/history/page.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import { useState, useEffect, FormEvent } from 'react'
-import { Button, Input, FormField } from '@/ui'
+import { Button, FormField, Input, PageContent, PageLayout, PageState } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { format, parse } from 'date-fns'
 import type { Entry, ClassDay, AttendanceStatus, Classroom } from '@/types'
 import { entryHasContent, getAttendanceIcon, getAttendanceLabel } from '@/lib/attendance'
-import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
-import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
+import {
+  fetchClassDaysForClassroom,
+  invalidateClassDaysForClassroom,
+} from '@/lib/class-days-client'
+import {
+  fetchStudentEntriesForClassroom,
+  invalidateStudentEntriesForClassroom,
+} from '@/lib/student-entries-client'
 import { fetchStudentClassrooms, invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
 import { getTodayInToronto } from '@/lib/timezone'
 
@@ -21,7 +27,11 @@ export default function HistoryPage() {
   const [classrooms, setClassrooms] = useState<Classroom[]>([])
   const [selectedClassroom, setSelectedClassroom] = useState<Classroom | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+  const [loadAttempt, setLoadAttempt] = useState(0)
   const [loadingHistory, setLoadingHistory] = useState(false)
+  const [historyError, setHistoryError] = useState('')
+  const [historyAttempt, setHistoryAttempt] = useState(0)
   const [history, setHistory] = useState<HistoryEntry[]>([])
   const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null)
   const [error, setError] = useState('')
@@ -33,25 +43,31 @@ export default function HistoryPage() {
 
   // Load classrooms
   useEffect(() => {
+    let cancelled = false
+
     async function loadClassrooms() {
+      setLoading(true)
+      setLoadError('')
       try {
         const nextClassrooms = await fetchStudentClassrooms()
+        if (cancelled) return
 
         setClassrooms(nextClassrooms)
-
-        // Auto-select first classroom
-        if (nextClassrooms.length > 0) {
-          setSelectedClassroom(nextClassrooms[0])
-        }
+        setSelectedClassroom(nextClassrooms[0] ?? null)
       } catch (err) {
         console.error('Error loading classrooms:', err)
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : 'Failed to load classrooms')
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
 
-    loadClassrooms()
-  }, [])
+    void loadClassrooms()
+    return () => {
+      cancelled = true
+    }
+  }, [loadAttempt])
 
   // Load history when classroom selected
   useEffect(() => {
@@ -66,6 +82,7 @@ export default function HistoryPage() {
     async function loadHistory() {
       if (!selectedClassroom) return
       setLoadingHistory(true)
+      setHistoryError('')
       setHistory([])
       try {
         const [classDaysData, entries] = await Promise.all([
@@ -108,6 +125,7 @@ export default function HistoryPage() {
         console.error('Error loading history:', err)
         if (cancelled) return
         setHistory([])
+        setHistoryError(err instanceof Error ? err.message : 'Failed to load history')
       } finally {
         if (cancelled) return
         setLoadingHistory(false)
@@ -119,7 +137,7 @@ export default function HistoryPage() {
     return () => {
       cancelled = true
     }
-  }, [selectedClassroom])
+  }, [historyAttempt, selectedClassroom])
 
   async function handleJoinClassroom(e: FormEvent) {
     e.preventDefault()
@@ -154,38 +172,73 @@ export default function HistoryPage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
+      <PageLayout density="student" width="reading">
+        <PageContent>
+          <PageState
+            kind="loading"
+            title="Loading history"
+            description="Getting your classrooms and attendance history."
+          />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <PageLayout density="student" width="reading">
+        <PageContent>
+          <PageState
+            kind="error"
+            title="Could not load your classrooms"
+            description="Your saved history has not been changed, but it could not be retrieved right now."
+            action={
+              <Button
+                type="button"
+                onClick={() => {
+                  invalidateStudentClassrooms()
+                  setLoadAttempt((attempt) => attempt + 1)
+                }}
+              >
+                Try again
+              </Button>
+            }
+          />
+        </PageContent>
+      </PageLayout>
     )
   }
 
   // Empty state - no classrooms
   if (classrooms.length === 0) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="max-w-md w-full bg-surface rounded-lg shadow-sm p-8 text-center">
-          <h2 className="text-2xl font-bold text-text-default mb-2">No Classes Yet</h2>
-          <p className="text-text-muted mb-6">Join a class to view your history</p>
+      <PageLayout density="student" width="reading">
+        <PageContent>
+          <PageState
+            kind="empty"
+            title="No Classes Yet"
+            description="Join a class to view your history."
+            action={
+              <form onSubmit={handleJoinClassroom} className="w-full space-y-4 text-left">
+                <FormField label="Class Code" error={error} required>
+                  <Input
+                    type="text"
+                    placeholder="Enter class code"
+                    value={joinCode}
+                    onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                    required
+                    disabled={joining}
+                  />
+                </FormField>
 
-          <form onSubmit={handleJoinClassroom} className="space-y-4">
-            <FormField label="Class Code" error={error} required>
-              <Input
-                type="text"
-                placeholder="Enter class code"
-                value={joinCode}
-                onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-                required
-                disabled={joining}
-              />
-            </FormField>
-
-            <Button type="submit" disabled={joining || !joinCode} className="w-full">
-              {joining ? 'Joining...' : 'Join Class'}
-            </Button>
-          </form>
-        </div>
-      </div>
+                <Button type="submit" disabled={joining || !joinCode} className="w-full">
+                  {joining ? 'Joining...' : 'Join Class'}
+                </Button>
+              </form>
+            }
+          />
+        </PageContent>
+      </PageLayout>
     )
   }
 
@@ -252,7 +305,28 @@ export default function HistoryPage() {
 
       {/* Main Content */}
       <div className="flex-1">
-        {selectedClassroom ? (
+        {historyError ? (
+          <PageState
+            kind="error"
+            compact
+            title="Could not load attendance history"
+            description="The selected class history could not be retrieved."
+            action={
+              <Button
+                type="button"
+                onClick={() => {
+                  if (selectedClassroom) {
+                    invalidateClassDaysForClassroom(selectedClassroom.id)
+                    invalidateStudentEntriesForClassroom(selectedClassroom.id)
+                  }
+                  setHistoryAttempt((attempt) => attempt + 1)
+                }}
+              >
+                Try again
+              </Button>
+            }
+          />
+        ) : selectedClassroom ? (
           <div>
             <div className="bg-surface rounded-lg shadow-sm p-6 mb-6">
               <h2 className="text-2xl font-bold text-text-default mb-1">

--- a/src/app/teacher/dashboard/page.tsx
+++ b/src/app/teacher/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button, AlertDialog } from '@/ui'
+import { AlertDialog, Button, PageState } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
@@ -22,6 +22,7 @@ export default function TeacherDashboardPage() {
   const [classrooms, setClassrooms] = useState<Classroom[]>([])
   const [selectedClassroom, setSelectedClassroom] = useState<Classroom | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
   const [attendance, setAttendance] = useState<AttendanceRecord[]>([])
   const [dates, setDates] = useState<string[]>([])
   const [loadingAttendance, setLoadingAttendance] = useState(false)
@@ -35,26 +36,24 @@ export default function TeacherDashboardPage() {
 
   const { alertState, showSuccess, closeAlert } = useAlertDialog()
 
-  // Load classrooms
-  useEffect(() => {
-    async function loadClassrooms() {
-      try {
-        const nextClassrooms = await fetchTeacherClassrooms()
-        setClassrooms(nextClassrooms)
-
-        // Auto-select first classroom
-        if (nextClassrooms.length > 0) {
-          setSelectedClassroom(nextClassrooms[0])
-        }
-      } catch (err) {
-        console.error('Error loading classrooms:', err)
-      } finally {
-        setLoading(false)
-      }
+  const loadClassrooms = useCallback(async () => {
+    setLoading(true)
+    setLoadError('')
+    try {
+      const nextClassrooms = await fetchTeacherClassrooms()
+      setClassrooms(nextClassrooms)
+      setSelectedClassroom(nextClassrooms[0] ?? null)
+    } catch (err) {
+      console.error('Error loading classrooms:', err)
+      setLoadError(err instanceof Error ? err.message : 'Failed to load classrooms')
+    } finally {
+      setLoading(false)
     }
-
-    loadClassrooms()
   }, [])
+
+  useEffect(() => {
+    void loadClassrooms()
+  }, [loadClassrooms])
 
   // Load attendance when classroom selected
   useEffect(() => {
@@ -135,35 +134,71 @@ export default function TeacherDashboardPage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
+      <PageLayout density="teacher" width="reading">
+        <PageContent>
+          <PageState
+            kind="loading"
+            title="Loading classrooms"
+            description="Getting the latest classroom overview."
+          />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <PageLayout density="teacher" width="reading">
+        <PageContent>
+          <PageState
+            kind="error"
+            title="Could not load classrooms"
+            description="The dashboard could not retrieve your classrooms."
+            action={
+              <Button
+                type="button"
+                onClick={() => {
+                  invalidateTeacherClassrooms()
+                  void loadClassrooms()
+                }}
+              >
+                Try again
+              </Button>
+            }
+          />
+        </PageContent>
+      </PageLayout>
     )
   }
 
   // Empty state
   if (classrooms.length === 0) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center">
-          <h2 className="text-2xl font-bold text-text-default mb-2">No Classrooms Yet</h2>
-          <p className="text-text-muted mb-6">Create your first classroom to get started</p>
-          <div className="flex items-center justify-center gap-3">
-            <Button onClick={() => setShowCreateModal(true)}>
-              Create Classroom
-            </Button>
-            <Button variant="secondary" onClick={() => router.push('/teacher/blueprints')}>
-              Course Blueprints
-            </Button>
-          </div>
-        </div>
+      <PageLayout density="teacher" width="reading">
+        <PageContent>
+          <PageState
+            kind="empty"
+            title="No Classrooms Yet"
+            description="Create your first classroom or start from a course blueprint."
+            action={
+              <div className="flex flex-wrap justify-center gap-3">
+                <Button onClick={() => setShowCreateModal(true)}>
+                  Create Classroom
+                </Button>
+                <Button variant="secondary" onClick={() => router.push('/teacher/blueprints')}>
+                  Course Blueprints
+                </Button>
+              </div>
+            }
+          />
+        </PageContent>
 
         <CreateClassroomModal
           isOpen={showCreateModal}
           onClose={() => setShowCreateModal(false)}
           onSuccess={handleClassroomCreated}
         />
-      </div>
+      </PageLayout>
     )
   }
 

--- a/src/app/teacher/dashboard/page.tsx
+++ b/src/app/teacher/dashboard/page.tsx
@@ -25,12 +25,17 @@ export default function TeacherDashboardPage() {
   const [loadError, setLoadError] = useState('')
   const [attendance, setAttendance] = useState<AttendanceRecord[]>([])
   const [dates, setDates] = useState<string[]>([])
+  const [attendanceClassroomId, setAttendanceClassroomId] = useState<string | null>(null)
   const [loadingAttendance, setLoadingAttendance] = useState(false)
+  const [attendanceError, setAttendanceError] = useState('')
+  const [attendanceAttempt, setAttendanceAttempt] = useState(0)
   const [selectedEntry, setSelectedEntry] = useState<Entry & { student_email: string } | null>(null)
   const [loadingEntry, setLoadingEntry] = useState(false)
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [showUploadModal, setShowUploadModal] = useState(false)
   const attendanceRequestIdRef = useRef(0)
+  const entryRequestIdRef = useRef(0)
+  const pageRegionRef = useRef<HTMLDivElement>(null)
   const selectedClassroomIdRef = useRef<string | null>(null)
   selectedClassroomIdRef.current = selectedClassroom?.id ?? null
 
@@ -59,10 +64,19 @@ export default function TeacherDashboardPage() {
   useEffect(() => {
     if (!selectedClassroom) {
       attendanceRequestIdRef.current += 1
+      entryRequestIdRef.current += 1
       setAttendance([])
       setDates([])
+      setAttendanceClassroomId(null)
+      setAttendanceError('')
+      setSelectedEntry(null)
+      setLoadingEntry(false)
       return
     }
+
+    entryRequestIdRef.current += 1
+    setSelectedEntry(null)
+    setLoadingEntry(false)
 
     async function loadAttendance() {
       if (!selectedClassroom) return
@@ -71,15 +85,21 @@ export default function TeacherDashboardPage() {
       attendanceRequestIdRef.current = requestId
 
       setLoadingAttendance(true)
+      setAttendanceError('')
       try {
         const data = await fetchTeacherDashboardAttendance(classroomId)
 
         if (attendanceRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
         setAttendance(data.attendance || [])
         setDates(data.dates || [])
+        setAttendanceClassroomId(classroomId)
       } catch (err) {
         if (attendanceRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
         console.error('Error loading attendance:', err)
+        setAttendance([])
+        setDates([])
+        setAttendanceClassroomId(classroomId)
+        setAttendanceError('The attendance overview could not be retrieved.')
       } finally {
         if (attendanceRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
         setLoadingAttendance(false)
@@ -87,23 +107,35 @@ export default function TeacherDashboardPage() {
     }
 
     loadAttendance()
-  }, [selectedClassroom])
+  }, [attendanceAttempt, selectedClassroom])
 
   async function handleCellClick(studentId: string, studentEmail: string, date: string) {
     if (!selectedClassroom) return
+    const classroomId = selectedClassroom.id
+    const requestId = entryRequestIdRef.current + 1
+    entryRequestIdRef.current = requestId
 
     setLoadingEntry(true)
 
     try {
-      const entry = await fetchTeacherDashboardEntry(selectedClassroom.id, studentId, date)
+      const entry = await fetchTeacherDashboardEntry(classroomId, studentId, date)
 
-      if (entry) {
+      if (
+        entry
+        && entryRequestIdRef.current === requestId
+        && selectedClassroomIdRef.current === classroomId
+      ) {
         setSelectedEntry({ ...entry, student_email: studentEmail })
       }
     } catch (err) {
       console.error('Error loading entry:', err)
     } finally {
-      setLoadingEntry(false)
+      if (
+        entryRequestIdRef.current === requestId
+        && selectedClassroomIdRef.current === classroomId
+      ) {
+        setLoadingEntry(false)
+      }
     }
   }
 
@@ -134,78 +166,112 @@ export default function TeacherDashboardPage() {
 
   if (loading) {
     return (
-      <PageLayout density="teacher" width="reading">
-        <PageContent>
-          <PageState
-            kind="loading"
-            title="Loading classrooms"
-            description="Getting the latest classroom overview."
-          />
-        </PageContent>
-      </PageLayout>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Teacher dashboard"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="teacher" width="reading">
+          <PageContent>
+            <PageState
+              kind="loading"
+              headingLevel="h1"
+              title="Loading classrooms"
+              description="Getting the latest classroom overview."
+            />
+          </PageContent>
+        </PageLayout>
+      </div>
     )
   }
 
   if (loadError) {
     return (
-      <PageLayout density="teacher" width="reading">
-        <PageContent>
-          <PageState
-            kind="error"
-            title="Could not load classrooms"
-            description="The dashboard could not retrieve your classrooms."
-            action={
-              <Button
-                type="button"
-                onClick={() => {
-                  invalidateTeacherClassrooms()
-                  void loadClassrooms()
-                }}
-              >
-                Try again
-              </Button>
-            }
-          />
-        </PageContent>
-      </PageLayout>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Teacher dashboard"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="teacher" width="reading">
+          <PageContent>
+            <PageState
+              kind="error"
+              headingLevel="h1"
+              title="Could not load classrooms"
+              description="The dashboard could not retrieve your classrooms."
+              action={
+                <Button
+                  type="button"
+                  onClick={() => {
+                    pageRegionRef.current?.focus()
+                    invalidateTeacherClassrooms()
+                    void loadClassrooms()
+                  }}
+                >
+                  Try again
+                </Button>
+              }
+            />
+          </PageContent>
+        </PageLayout>
+      </div>
     )
   }
 
   // Empty state
   if (classrooms.length === 0) {
     return (
-      <PageLayout density="teacher" width="reading">
-        <PageContent>
-          <PageState
-            kind="empty"
-            title="No Classrooms Yet"
-            description="Create your first classroom or start from a course blueprint."
-            action={
-              <div className="flex flex-wrap justify-center gap-3">
-                <Button onClick={() => setShowCreateModal(true)}>
-                  Create Classroom
-                </Button>
-                <Button variant="secondary" onClick={() => router.push('/teacher/blueprints')}>
-                  Course Blueprints
-                </Button>
-              </div>
-            }
-          />
-        </PageContent>
+      <div
+        ref={pageRegionRef}
+        role="region"
+        aria-label="Teacher dashboard"
+        tabIndex={-1}
+        className="focus:outline-none"
+      >
+        <PageLayout density="teacher" width="reading">
+          <PageContent>
+            <PageState
+              kind="empty"
+              headingLevel="h1"
+              title="No Classrooms Yet"
+              description="Create your first classroom or start from a course blueprint."
+              action={
+                <div className="flex flex-wrap justify-center gap-3">
+                  <Button onClick={() => setShowCreateModal(true)}>
+                    Create Classroom
+                  </Button>
+                  <Button variant="secondary" onClick={() => router.push('/teacher/blueprints')}>
+                    Course Blueprints
+                  </Button>
+                </div>
+              }
+            />
+          </PageContent>
 
-        <CreateClassroomModal
-          isOpen={showCreateModal}
-          onClose={() => setShowCreateModal(false)}
-          onSuccess={handleClassroomCreated}
-        />
-      </PageLayout>
+          <CreateClassroomModal
+            isOpen={showCreateModal}
+            onClose={() => setShowCreateModal(false)}
+            onSuccess={handleClassroomCreated}
+          />
+        </PageLayout>
+      </div>
     )
   }
 
   return (
-    <div className="flex gap-6">
+    <div
+      ref={pageRegionRef}
+      role="region"
+      aria-label="Teacher dashboard"
+      tabIndex={-1}
+      className="flex flex-col gap-4 focus:outline-none md:flex-row md:gap-6"
+    >
       {/* Classroom List Sidebar */}
-      <div className="w-64 flex-shrink-0">
+      <div className="w-full flex-shrink-0 md:w-64">
         <div className="bg-surface rounded-lg shadow-sm p-4">
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-semibold text-text-default">Classes</h3>
@@ -245,7 +311,7 @@ export default function TeacherDashboardPage() {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         {selectedClassroom ? (
           <PageLayout>
             <PageActionBar
@@ -298,10 +364,30 @@ export default function TeacherDashboardPage() {
 
             <PageContent>
               {/* Attendance Dashboard */}
-              {loadingAttendance ? (
+              {loadingAttendance || attendanceClassroomId !== selectedClassroom.id ? (
                 <div className="flex justify-center py-12">
                   <Spinner size="lg" />
                 </div>
+              ) : attendanceError ? (
+                <PageState
+                  kind="error"
+                  compact
+                  title="Could not load attendance"
+                  description={attendanceError}
+                  action={
+                    <Button
+                      type="button"
+                      onClick={() => {
+                        pageRegionRef.current?.focus()
+                        invalidateTeacherDashboardAttendance(selectedClassroom.id)
+                        setAttendanceClassroomId(null)
+                        setAttendanceAttempt((attempt) => attempt + 1)
+                      }}
+                    >
+                      Try again
+                    </Button>
+                  }
+                />
               ) : attendance.length === 0 ? (
                 <div className="bg-surface rounded-lg shadow-sm p-8 text-center text-text-muted">
                   No students enrolled yet
@@ -444,22 +530,10 @@ export default function TeacherDashboardPage() {
           isOpen={showUploadModal}
           onClose={() => setShowUploadModal(false)}
           classroomId={selectedClassroom.id}
-          onSuccess={async () => {
-            const classroomId = selectedClassroom.id
-            const requestId = attendanceRequestIdRef.current + 1
-            attendanceRequestIdRef.current = requestId
-            invalidateTeacherDashboardAttendance(classroomId)
-            setLoadingAttendance(true)
-            try {
-              const data = await fetchTeacherDashboardAttendance(classroomId)
-              if (attendanceRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
-              setAttendance(data.attendance)
-              setDates(data.dates)
-            } finally {
-              if (attendanceRequestIdRef.current === requestId && selectedClassroomIdRef.current === classroomId) {
-                setLoadingAttendance(false)
-              }
-            }
+          onSuccess={() => {
+            invalidateTeacherDashboardAttendance(selectedClassroom.id)
+            setAttendanceClassroomId(null)
+            setAttendanceAttempt((attempt) => attempt + 1)
           }}
         />
       )}

--- a/src/ui/PageState.tsx
+++ b/src/ui/PageState.tsx
@@ -1,0 +1,63 @@
+import type { ElementType, ReactNode } from 'react'
+import { CircleAlert, Inbox, LoaderCircle, LockKeyhole } from 'lucide-react'
+import { cn } from './utils'
+
+export type PageStateKind = 'loading' | 'error' | 'empty' | 'forbidden'
+
+export interface PageStateProps {
+  kind: PageStateKind
+  title: string
+  description?: ReactNode
+  action?: ReactNode
+  headingLevel?: 'h1' | 'h2' | 'h3'
+  compact?: boolean
+  className?: string
+}
+
+const stateStyles: Record<PageStateKind, { icon: ElementType; iconClassName: string }> = {
+  loading: { icon: LoaderCircle, iconClassName: 'animate-spin text-primary' },
+  error: { icon: CircleAlert, iconClassName: 'text-danger' },
+  empty: { icon: Inbox, iconClassName: 'text-text-muted' },
+  forbidden: { icon: LockKeyhole, iconClassName: 'text-warning' },
+}
+
+export function PageState({
+  kind,
+  title,
+  description,
+  action,
+  headingLevel = 'h2',
+  compact = false,
+  className,
+}: PageStateProps) {
+  const Heading = headingLevel as ElementType
+  const stateStyle = stateStyles[kind]
+  const Icon = stateStyle.icon
+  const isLoading = kind === 'loading'
+  const isAssertive = kind === 'error' || kind === 'forbidden'
+
+  return (
+    <div
+      data-page-state={kind}
+      role={isAssertive ? 'alert' : 'status'}
+      aria-live={isAssertive ? 'assertive' : 'polite'}
+      aria-busy={isLoading || undefined}
+      className={cn(
+        'flex w-full flex-col items-center justify-center px-4 text-center',
+        compact ? 'min-h-40 py-8' : 'min-h-64 py-12',
+        className,
+      )}
+    >
+      <div className="flex h-11 w-11 items-center justify-center rounded-md border border-border bg-surface-2">
+        <Icon className={cn('h-5 w-5', stateStyle.iconClassName)} aria-hidden="true" />
+      </div>
+      <div className="mt-4 max-w-xl">
+        <Heading className="text-lg font-semibold text-text-default">{title}</Heading>
+        {description ? (
+          <div className="mt-1.5 text-sm leading-6 text-text-muted">{description}</div>
+        ) : null}
+      </div>
+      {action ? <div className="mt-5 flex w-full max-w-sm justify-center">{action}</div> : null}
+    </div>
+  )
+}

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -144,6 +144,28 @@ wrappers:
   and uses the keyboard-accessible overflow menu on mobile.
 - Action-bar controls and menu items preserve the shared 44px target and focus-visible treatment.
 
+### Page states
+
+Use `PageState` for the primary `loading`, `error`, `empty`, or `forbidden` state of a route or work
+region. Keep the surrounding app/classroom shell mounted, and never render an empty state from a
+failed request.
+
+```tsx
+<PageState
+  kind="error"
+  title="Could not load classrooms"
+  description="The classroom list could not be retrieved."
+  action={<Button onClick={retry}>Try again</Button>}
+/>
+```
+
+- Initial loading uses `kind="loading"`; non-blocking refreshes use `RefreshingIndicator`.
+- Error and forbidden states use assertive semantics; loading and empty states use polite status
+  semantics.
+- Use `compact` only when the state replaces a primary region in an existing workspace.
+- Route and retry rules live in
+  [`page-state-conventions.md`](/docs/guidance/ui/page-state-conventions.md).
+
 ### EmptyState
 
 ```typescript

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -17,6 +17,7 @@ export { AlertDialog, ConfirmDialog, ContentDialog, DialogPanel, type AlertDialo
 export { ModalLayer, type ModalLayerProps } from './ModalLayer'
 export { Card, type CardProps } from './Card'
 export { EmptyState, type EmptyStateProps } from './EmptyState'
+export { PageState, type PageStateKind, type PageStateProps } from './PageState'
 export { Tooltip, TooltipProvider, type TooltipProps } from './Tooltip'
 export { RefreshingIndicator } from './RefreshingIndicator'
 export { TabContentTransition } from './TabContentTransition'

--- a/tests/components/ClassroomPageStates.test.tsx
+++ b/tests/components/ClassroomPageStates.test.tsx
@@ -14,7 +14,7 @@ describe('classroom route page states', () => {
 
     expect(screen.getByTestId('classroom-skeleton')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveAttribute('data-page-state', 'loading')
-    expect(screen.getByText('Loading classroom')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: 'Loading classroom' })).toBeInTheDocument()
   })
 
   it('keeps missing and unauthorized classrooms intentionally indistinguishable', () => {

--- a/tests/components/ClassroomPageStates.test.tsx
+++ b/tests/components/ClassroomPageStates.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ClassroomError from '@/app/classrooms/[classroomId]/error'
+import ClassroomLoading from '@/app/classrooms/[classroomId]/loading'
+import ClassroomNotFound from '@/app/classrooms/[classroomId]/not-found'
+
+vi.mock('@/components/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe('classroom route page states', () => {
+  it('uses the governed loading state inside the classroom shell skeleton', () => {
+    render(<ClassroomLoading />)
+
+    expect(screen.getByTestId('classroom-skeleton')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute('data-page-state', 'loading')
+    expect(screen.getByText('Loading classroom')).toBeInTheDocument()
+  })
+
+  it('keeps missing and unauthorized classrooms intentionally indistinguishable', () => {
+    render(<ClassroomNotFound />)
+
+    expect(screen.getByTestId('classroom-not-found')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveAttribute('data-page-state', 'forbidden')
+    expect(screen.getByText('It may not exist, or you may not have access.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to classrooms' })).toHaveAttribute(
+      'href',
+      '/classrooms',
+    )
+  })
+
+  it('offers a bounded retry from the route error boundary', () => {
+    const reset = vi.fn()
+    render(<ClassroomError error={new Error('database unavailable')} reset={reset} />)
+
+    expect(screen.queryByText('database unavailable')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/components/StudentHistoryPage.test.tsx
+++ b/tests/components/StudentHistoryPage.test.tsx
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import HistoryPage from '@/app/student/history/page'
-import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
+import { fetchClassDaysForClassroom, invalidateClassDaysForClassroom } from '@/lib/class-days-client'
 import { fetchStudentClassrooms, invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
-import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
+import { fetchStudentEntriesForClassroom, invalidateStudentEntriesForClassroom } from '@/lib/student-entries-client'
 import type { Classroom } from '@/types'
 
 vi.mock('@/components/Spinner', () => ({
@@ -16,6 +16,7 @@ vi.mock('@/lib/timezone', () => ({
 
 vi.mock('@/lib/class-days-client', () => ({
   fetchClassDaysForClassroom: vi.fn(),
+  invalidateClassDaysForClassroom: vi.fn(),
 }))
 
 vi.mock('@/lib/student-classrooms-client', () => ({
@@ -25,6 +26,7 @@ vi.mock('@/lib/student-classrooms-client', () => ({
 
 vi.mock('@/lib/student-entries-client', () => ({
   fetchStudentEntriesForClassroom: vi.fn(),
+  invalidateStudentEntriesForClassroom: vi.fn(),
 }))
 
 const classroom: Classroom = {
@@ -58,6 +60,8 @@ describe('HistoryPage', () => {
     vi.mocked(fetchStudentEntriesForClassroom).mockResolvedValue([])
     vi.mocked(fetchStudentClassrooms).mockResolvedValue([classroom])
     vi.mocked(invalidateStudentClassrooms).mockClear()
+    vi.mocked(invalidateClassDaysForClassroom).mockClear()
+    vi.mocked(invalidateStudentEntriesForClassroom).mockClear()
     vi.stubGlobal('fetch', vi.fn())
   })
 
@@ -79,6 +83,42 @@ describe('HistoryPage', () => {
       expect(fetchClassDaysForClassroom).toHaveBeenCalledWith(classroom.id)
       expect(fetchStudentEntriesForClassroom).toHaveBeenCalledWith(classroom.id)
     })
+  })
+
+  it('separates classroom load failures from empty state and retries', async () => {
+    vi.mocked(fetchStudentClassrooms).mockRejectedValueOnce(new Error('Classrooms unavailable'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<HistoryPage />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load your classrooms')
+    expect(screen.queryByText('No Classes Yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => expect(screen.getAllByText('History Class')).toHaveLength(2))
+    expect(invalidateStudentClassrooms).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('shows an explicit history error with retry instead of an empty list', async () => {
+    vi.mocked(fetchClassDaysForClassroom).mockRejectedValueOnce(new Error('History unavailable'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<HistoryPage />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not load attendance history',
+    )
+    expect(screen.queryByText('No class days yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('Fri May 9')).toBeInTheDocument()
+    expect(screen.queryByText('Could not load attendance history')).not.toBeInTheDocument()
+    expect(invalidateClassDaysForClassroom).toHaveBeenCalledWith(classroom.id)
+    expect(invalidateStudentEntriesForClassroom).toHaveBeenCalledWith(classroom.id)
+    expect(consoleError).toHaveBeenCalled()
   })
 
   it('invalidates cached student classrooms after joining a class from the empty state', async () => {

--- a/tests/components/StudentHistoryPage.test.tsx
+++ b/tests/components/StudentHistoryPage.test.tsx
@@ -92,11 +92,13 @@ describe('HistoryPage', () => {
     render(<HistoryPage />)
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Could not load your classrooms')
+    expect(screen.getByRole('heading', { level: 1, name: 'Could not load your classrooms' })).toBeInTheDocument()
     expect(screen.queryByText('No Classes Yet')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
 
     await waitFor(() => expect(screen.getAllByText('History Class')).toHaveLength(2))
+    expect(screen.getByRole('region', { name: 'Student history' })).toHaveFocus()
     expect(invalidateStudentClassrooms).toHaveBeenCalledOnce()
     expect(consoleError).toHaveBeenCalled()
   })
@@ -116,6 +118,7 @@ describe('HistoryPage', () => {
 
     expect(await screen.findByText('Fri May 9')).toBeInTheDocument()
     expect(screen.queryByText('Could not load attendance history')).not.toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Student history' })).toHaveFocus()
     expect(invalidateClassDaysForClassroom).toHaveBeenCalledWith(classroom.id)
     expect(invalidateStudentEntriesForClassroom).toHaveBeenCalledWith(classroom.id)
     expect(consoleError).toHaveBeenCalled()

--- a/tests/components/TeacherDashboardPage.test.tsx
+++ b/tests/components/TeacherDashboardPage.test.tsx
@@ -123,6 +123,7 @@ function deferred<T>() {
 
 function installFetchMock(options?: {
   classrooms?: Classroom[]
+  classroomFailures?: number
   attendanceByClassroom?: Record<string, AttendanceRecord[] | Promise<{ attendance: AttendanceRecord[]; dates: string[] }>>
   datesByClassroom?: Record<string, string[]>
   entriesByClassroom?: Record<string, Entry[]>
@@ -130,6 +131,7 @@ function installFetchMock(options?: {
   const classrooms = options?.classrooms ?? [
     createMockClassroom({ id: 'c1', title: 'Dashboard Class', class_code: 'DASH1' }),
   ]
+  let classroomFailures = options?.classroomFailures ?? 0
 
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
@@ -142,6 +144,10 @@ function installFetchMock(options?: {
     }
 
     if (url === '/api/teacher/classrooms' && method === 'GET') {
+      if (classroomFailures > 0) {
+        classroomFailures -= 1
+        return Promise.resolve(jsonResponse({ error: 'Classroom service unavailable' }, false))
+      }
       return Promise.resolve(jsonResponse({ classrooms }))
     }
 
@@ -221,6 +227,21 @@ describe('Teacher dashboard page', () => {
       expect.any(Function),
       20_000,
     )
+  })
+
+  it('separates classroom load failures from empty state and retries', async () => {
+    installFetchMock({ classroomFailures: 1 })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    renderDashboard()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load classrooms')
+    expect(screen.queryByText('No Classrooms Yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('student@example.com')).toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalled()
   })
 
   it('does not expose permanent classroom deletion', async () => {

--- a/tests/components/TeacherDashboardPage.test.tsx
+++ b/tests/components/TeacherDashboardPage.test.tsx
@@ -124,6 +124,7 @@ function deferred<T>() {
 function installFetchMock(options?: {
   classrooms?: Classroom[]
   classroomFailures?: number
+  attendanceFailuresByClassroom?: Record<string, number>
   attendanceByClassroom?: Record<string, AttendanceRecord[] | Promise<{ attendance: AttendanceRecord[]; dates: string[] }>>
   datesByClassroom?: Record<string, string[]>
   entriesByClassroom?: Record<string, Entry[]>
@@ -132,6 +133,7 @@ function installFetchMock(options?: {
     createMockClassroom({ id: 'c1', title: 'Dashboard Class', class_code: 'DASH1' }),
   ]
   let classroomFailures = options?.classroomFailures ?? 0
+  const attendanceFailuresByClassroom = { ...options?.attendanceFailuresByClassroom }
 
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
@@ -153,6 +155,10 @@ function installFetchMock(options?: {
 
     if (url.startsWith('/api/teacher/attendance?classroom_id=') && method === 'GET') {
       const classroomId = new URL(url, 'http://localhost').searchParams.get('classroom_id') || ''
+      if ((attendanceFailuresByClassroom[classroomId] ?? 0) > 0) {
+        attendanceFailuresByClassroom[classroomId] -= 1
+        return Promise.resolve(jsonResponse({ error: 'Attendance service unavailable' }, false))
+      }
       const payload = options?.attendanceByClassroom?.[classroomId] ?? [
         attendanceRecord({
           studentId: 's1',
@@ -236,11 +242,30 @@ describe('Teacher dashboard page', () => {
     renderDashboard()
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Could not load classrooms')
+    expect(screen.getByRole('heading', { level: 1, name: 'Could not load classrooms' })).toBeInTheDocument()
     expect(screen.queryByText('No Classrooms Yet')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
 
     expect(await screen.findByText('student@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Teacher dashboard' })).toHaveFocus()
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('separates attendance failures from an empty roster and retries', async () => {
+    installFetchMock({ attendanceFailuresByClassroom: { c1: 1 } })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    renderDashboard()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load attendance')
+    expect(screen.queryByText('No students enrolled yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('student@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Teacher dashboard' })).toHaveFocus()
+    expect(invalidateCachedJSON).toHaveBeenCalledWith('teacher-dashboard:attendance:c1')
     expect(consoleError).toHaveBeenCalled()
   })
 
@@ -288,6 +313,36 @@ describe('Teacher dashboard page', () => {
       expect.any(Function),
       20_000,
     )
+  })
+
+  it('shows a retryable attendance error when the roster-upload refresh fails', async () => {
+    installFetchMock()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let attendanceLoadCount = 0
+    vi.mocked(fetchJSONWithCache).mockImplementation((key, load) => {
+      if (key === 'teacher-dashboard:attendance:c1') {
+        attendanceLoadCount += 1
+        if (attendanceLoadCount === 2) {
+          return Promise.reject(new Error('Attendance refresh unavailable'))
+        }
+      }
+      return load()
+    })
+
+    renderDashboard()
+
+    await screen.findByText('student@example.com')
+    fireEvent.click(screen.getByRole('button', { name: 'Upload roster' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Complete roster upload' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load attendance')
+    expect(screen.queryByText('No students enrolled yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('student@example.com')).toBeInTheDocument()
+    expect(attendanceLoadCount).toBe(3)
+    expect(consoleError).toHaveBeenCalled()
   })
 
   it('keeps roster-upload attendance fresher than older in-flight attendance', async () => {
@@ -390,5 +445,27 @@ describe('Teacher dashboard page', () => {
     expect(within(actionPrimary).getByText('Second Class')).toBeInTheDocument()
     expect(screen.getByText('second@example.com')).toBeInTheDocument()
     expect(screen.queryByText('first@example.com')).not.toBeInTheDocument()
+  })
+
+  it('does not show the prior roster when the newly selected classroom fails', async () => {
+    const firstClassroom = createMockClassroom({ id: 'c1', title: 'First Class', class_code: 'FIRST' })
+    const secondClassroom = createMockClassroom({ id: 'c2', title: 'Second Class', class_code: 'SECOND' })
+    installFetchMock({
+      classrooms: [firstClassroom, secondClassroom],
+      attendanceFailuresByClassroom: { c2: 1 },
+      attendanceByClassroom: {
+        c1: [attendanceRecord({ studentId: 's1', email: 'first@example.com', date: '2026-06-01' })],
+      },
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    renderDashboard()
+
+    expect(await screen.findByText('first@example.com')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Second Class/ }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load attendance')
+    expect(screen.queryByText('first@example.com')).not.toBeInTheDocument()
+    expect(screen.queryByText('No students enrolled yet')).not.toBeInTheDocument()
   })
 })

--- a/tests/ui/PageState.test.tsx
+++ b/tests/ui/PageState.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { PageState } from '@/ui'
+
+describe('PageState', () => {
+  it('announces loading without exposing decorative icon content', () => {
+    render(<PageState kind="loading" title="Loading classroom" />)
+
+    const state = screen.getByRole('status', { name: '' })
+    expect(state).toHaveAttribute('aria-live', 'polite')
+    expect(state).toHaveAttribute('aria-busy', 'true')
+    expect(state).toHaveAttribute('data-page-state', 'loading')
+    expect(screen.getByRole('heading', { level: 2, name: 'Loading classroom' })).toBeInTheDocument()
+  })
+
+  it.each([
+    ['error', 'Could not load classrooms'],
+    ['forbidden', 'Classroom unavailable'],
+  ] as const)('uses assertive semantics for the %s state', (kind, title) => {
+    render(<PageState kind={kind} title={title} description="Try another route." />)
+
+    const state = screen.getByRole('alert')
+    expect(state).toHaveAttribute('aria-live', 'assertive')
+    expect(state).not.toHaveAttribute('aria-busy')
+    expect(state).toHaveTextContent('Try another route.')
+  })
+
+  it('renders an empty state action and supports compact section use', () => {
+    render(
+      <PageState
+        kind="empty"
+        title="No classrooms yet"
+        action={<button type="button">Create classroom</button>}
+        compact
+      />,
+    )
+
+    const state = screen.getByRole('status')
+    expect(state).toHaveClass('min-h-40', 'py-8')
+    expect(screen.getByRole('button', { name: 'Create classroom' })).toBeInTheDocument()
+  })
+
+  it('supports a page-level heading when the state owns the route', () => {
+    render(<PageState kind="error" title="Page failed" headingLevel="h1" />)
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Page failed' })).toBeInTheDocument()
+  })
+})

--- a/tests/unit/ui-guidance-docs.test.ts
+++ b/tests/unit/ui-guidance-docs.test.ts
@@ -79,4 +79,20 @@ describe('ui guidance docs and prompts', () => {
     expect(reviewPrompt).not.toContain('teacher quizzes')
     expect(reviewPrompt).toContain('current implementation of teacher assignments and teacher tests')
   })
+
+  it('defines governed page states without collapsing errors into empty results', () => {
+    const stableGuidance = readRepoFile('docs/guidance/ui/stable.md')
+    const pageStateGuidance = readRepoFile('docs/guidance/ui/page-state-conventions.md')
+    const uiReadme = readRepoFile('src/ui/README.md')
+
+    for (const state of ['loading', 'error', 'empty', 'forbidden']) {
+      expect(pageStateGuidance).toContain(`\`${state}\``)
+    }
+
+    expect(pageStateGuidance).toContain('loading.tsx')
+    expect(pageStateGuidance).toContain('error.tsx')
+    expect(pageStateGuidance).toContain('Never use empty copy as a fallback for a failed request')
+    expect(stableGuidance).toContain('PageState')
+    expect(uiReadme).toContain('page-state-conventions.md')
+  })
 })


### PR DESCRIPTION
## Summary
- add canonical `PageState` loading, error, empty, and forbidden variants with explicit live-region semantics
- add classroom route loading/error/unavailable conventions and migrate teacher dashboard plus student history failures away from valid-looking empty data
- define cache-aware retry and App Router state conventions with focused regressions and stable UI guidance

## UI guidance declaration
- Guidance read: core design, `src/ui/README.md`, stable canon, change brief, UI testing guide, product-experience audit
- Acceptance target: refine existing inline Pika states without changing navigation or feature information architecture
- Stable guidance followed: yes
- Experimental guidance introduced: no
- Human promotion needed: no; this implements the explicitly approved Phase 2 shared-foundation item
- Composite widget accessibility checklist reviewed: yes; no new composite widget, direct live-region and keyboard-action tests added
- Roles: teacher and student
- Viewports: desktop and mobile
- Themes: light and dark
- States: loading, error, empty, forbidden, keyboard retry
- Primary signal: semantic icon/tone, concise title, and shared action controls
- Must not add: decorative cards, new navigation, hidden data, or feature redesign

## Verification
- `pnpm test` (387 files / 3,566 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (610 modules / 0 allowances)
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- focused page-state, classroom-route, dashboard, history, guidance, and startup-doc suites
- custom Playwright teacher/student desktop/mobile light/dark loading/error/empty/forbidden and keyboard-retry matrix
- `git diff --check`

## Risk
- Risk profile: none
- No schema, migration, API contract, or production data changes
- Existing recovered dashboard/history mobile layouts still overflow; this is pre-existing vertical-slice debt and governed state surfaces themselves are overflow-free
