### PR TITLE
Standardize teacher utility navigation

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900 and #902 merged the shared foundation through composite controls. Utility navigation migration now starts with teacher routes.
+- Phase 2 is active. PRs #896-#900 and #902 merged the shared foundation through composite controls. PR #903 starts utility navigation migration with teacher routes.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900 merged shared UI and page-state contracts. PR #902 standardizes composite-control interactions; remediation is complete.
+- Phase 2 is active. PRs #896-#900 and #902 merged the shared foundation through composite controls. Utility navigation migration now starts with teacher routes.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14024,3 +14024,24 @@
 - `pnpm lint`
 - `pnpm build`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:73b44f5f10fa07fef82f1ba10a5db636f43db238e1f7299dc793d74e42b85985 -->
+## 2026-07-13 — Local full-stack classroom archive recovery rehearsal
+
+**Completed:**
+- Added a local-only recovery drill guard requiring an exact destructive-operation acknowledgement, an HTTP loopback Supabase origin, and the Supabase local-demo service-role JWT before client construction.
+- Added a synthetic full-stack rehearsal that invokes the real export, compaction, source-object cleanup, and restore coordinators against local Supabase REST and Storage.
+- The rehearsal verifies representative row equality, restored object bytes, cold tombstone removal, immutable archive retention, idempotent operation replays, and complete synthetic-fixture teardown.
+- Upgraded architecture CI from database-only startup to an ephemeral reduced Supabase stack and added the rehearsal after the existing rollback-only database contracts and ownership audit.
+- Full-stack runs exposed a cleanup boundary mismatch: Node Storage `download()` wraps local missing-key responses in `StorageUnknownError.originalError`; the current SDK/local stack reports status 400, while other deployments can report 404. The worker accepts only that named bounded wrapper and requires a successful exact bucket lookup before treating it as object absence; explicit `NoSuchKey` remains direct evidence, unwrapped generic 400s and missing buckets fail closed.
+- Kept the archive epic unfinished because no production canary or teacher-visible recovery flow has been approved. No production database, migration, row, object, or environment setting was modified.
+
+**Validation:**
+- Recovery target and source-cleanup suites (30 tests)
+- Full Vitest suite
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash -n scripts/check-classroom-archive-recovery-drill.sh`
+- Local full-stack drill intentionally not run because the existing local Supabase instance predates migrations 082-086; migrations were not applied or reset
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -905,6 +905,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added direct navigation, shell-order, and teacher-layout regressions plus stable guidance for incremental utility-family migration.
 - Browser-verified teacher Blueprints and Calendar at desktop/mobile widths in light/dark themes, including active-link focus and navigation-shell overflow isolation. The student mobile shell remained unchanged and overflow-free. Calendar's previously ranked narrow-screen content compression remains assigned to its Phase 3 vertical slice.
 - Opened PR #903 for independent review.
+- Accepted independent-review findings that the first implementation dropped the prior teacher-content gutters and used an outward focus ring that could be clipped by the navigation scroller. Restored the content geometry, moved focus treatment inside each link, and added a durable browser contract for every teacher utility route.
 
 **Validation:**
 - `pnpm test --run` (392 files / 3,584 tests)
@@ -915,6 +916,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - Custom Playwright teacher desktop/mobile light/dark navigation matrix plus unchanged student mobile-dark regression (7 checks including auth setup)
+- Durable Playwright teacher dashboard/Blueprints/Calendar desktop-light and mobile-dark navigation contract
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Local full-stack classroom archive recovery rehearsal
-
-**Completed:**
-- Added a local-only recovery drill guard requiring an exact destructive-operation acknowledgement, an HTTP loopback Supabase origin, and the Supabase local-demo service-role JWT before client construction.
-- Added a synthetic full-stack rehearsal that invokes the real export, compaction, source-object cleanup, and restore coordinators against local Supabase REST and Storage.
-- The rehearsal verifies representative row equality, restored object bytes, cold tombstone removal, immutable archive retention, idempotent operation replays, and complete synthetic-fixture teardown.
-- Upgraded architecture CI from database-only startup to an ephemeral reduced Supabase stack and added the rehearsal after the existing rollback-only database contracts and ownership audit.
-- Full-stack runs exposed a cleanup boundary mismatch: Node Storage `download()` wraps local missing-key responses in `StorageUnknownError.originalError`; the current SDK/local stack reports status 400, while other deployments can report 404. The worker accepts only that named bounded wrapper and requires a successful exact bucket lookup before treating it as object absence; explicit `NoSuchKey` remains direct evidence, unwrapped generic 400s and missing buckets fail closed.
-- Kept the archive epic unfinished because no production canary or teacher-visible recovery flow has been approved. No production database, migration, row, object, or environment setting was modified.
-
-**Validation:**
-- Recovery target and source-cleanup suites (30 tests)
-- Full Vitest suite
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash -n scripts/check-classroom-archive-recovery-drill.sh`
-- Local full-stack drill intentionally not run because the existing local Supabase instance predates migrations 082-086; migrations were not applied or reset
-- `git diff --check`
-
 ## 2026-07-13 — Teacher cold-archive recovery surface
 
 **Completed:**
@@ -914,3 +894,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Merge PR #902 after required CI. Then continue Phase 2 with the next scoped shared-experience slice from the product-experience audit.
+
+## 2026-07-21 — Phase 2 shared application navigation
+
+**Completed:**
+- Merged independently reviewed PR #902 as `14de9893`, fast-forwarded the hub, and started Phase 2 item 7 from current `main` in a dedicated worktree.
+- Added a shared `AppNavigation` route-family mechanism with active-page semantics, stable prefix matching, 44px link targets, visible keyboard focus, and narrow-width horizontal overflow.
+- Added an optional application-navigation region to `AppShell` and migrated the teacher utility layout from its duplicate logo/header/logout implementation to the canonical compact `AppHeader`, `UserMenu`, session watcher, and shared navigation band.
+- Preserved the existing `Classrooms`, `Blueprints`, and `Calendar` destinations without adding a dashboard destination or changing classroom navigation, page content, API contracts, schema, production state, or data.
+- Added direct navigation, shell-order, and teacher-layout regressions plus stable guidance for incremental utility-family migration.
+- Browser-verified teacher Blueprints and Calendar at desktop/mobile widths in light/dark themes, including active-link focus and navigation-shell overflow isolation. The student mobile shell remained unchanged and overflow-free. Calendar's previously ranked narrow-screen content compression remains assigned to its Phase 3 vertical slice.
+
+**Validation:**
+- `pnpm test --run` (392 files / 3,584 tests)
+- Focused application-navigation, app-shell, teacher-layout, and app-header suites (4 files / 12 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Custom Playwright teacher desktop/mobile light/dark navigation matrix plus unchanged student mobile-dark regression (7 checks including auth setup)
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`
+
+**Remaining:**
+- Complete full repository verification, independent review, and merge for the teacher navigation slice. Then migrate the student utility family as a separate Phase 2 item 7 PR.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -904,6 +904,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Preserved the existing `Classrooms`, `Blueprints`, and `Calendar` destinations without adding a dashboard destination or changing classroom navigation, page content, API contracts, schema, production state, or data.
 - Added direct navigation, shell-order, and teacher-layout regressions plus stable guidance for incremental utility-family migration.
 - Browser-verified teacher Blueprints and Calendar at desktop/mobile widths in light/dark themes, including active-link focus and navigation-shell overflow isolation. The student mobile shell remained unchanged and overflow-free. Calendar's previously ranked narrow-screen content compression remains assigned to its Phase 3 vertical slice.
+- Opened PR #903 for independent review.
 
 **Validation:**
 - `pnpm test --run` (392 files / 3,584 tests)

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902", "#903"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -107,6 +107,23 @@ Source grounding:
 - [`src/hooks/use-dropdown-nav.ts`](/src/hooks/use-dropdown-nav.ts)
 - [`src/components/WorkspaceSplitPane.tsx`](/src/components/WorkspaceSplitPane.tsx)
 
+### 3d. Utility routes use the shared application-navigation mechanism
+
+- Keep the compact `AppHeader` and account controls owned by `AppShell`; utility layouts must not
+  recreate their own logo, logout, header, or responsive link wrapper.
+- Use `AppNavigation` for visible route-family links. Preserve the product's existing route labels
+  and information architecture while the utility families migrate incrementally.
+- The current page uses `aria-current="page"`, a semantic accent edge, and the same visible focus
+  and 44px target contracts as other shared controls.
+- Narrow screens scroll the link row horizontally instead of wrapping the app header or hiding
+  destinations in a new menu.
+
+Source grounding:
+
+- [`src/components/AppShell.tsx`](/src/components/AppShell.tsx)
+- [`src/components/AppNavigation.tsx`](/src/components/AppNavigation.tsx)
+- [`src/app/teacher/layout.tsx`](/src/app/teacher/layout.tsx)
+
 ### 4. Attendance stays presence-first and scan-friendly
 
 - Attendance UI is optimized for quick scanning and teacher drill-down, not extra status taxonomy.

--- a/e2e/app-navigation.spec.ts
+++ b/e2e/app-navigation.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from '@playwright/test'
+
+type RouteCase = {
+  path: string
+  currentLabel?: 'Blueprints' | 'Calendar'
+}
+
+const routes: RouteCase[] = [
+  { path: '/teacher/dashboard' },
+  { path: '/teacher/blueprints', currentLabel: 'Blueprints' },
+  { path: '/teacher/calendar', currentLabel: 'Calendar' },
+]
+
+async function setTheme(page: Page, theme: 'light' | 'dark') {
+  await page.addInitScript((nextTheme) => {
+    localStorage.setItem('theme', nextTheme)
+  }, theme)
+}
+
+async function verifyNavigation(page: Page, route: RouteCase) {
+  await page.goto(route.path, { waitUntil: 'networkidle' })
+
+  const navigation = page.getByRole('navigation', { name: 'Teacher tools' })
+  await expect(navigation).toBeVisible()
+  await expect(navigation.getByRole('link')).toHaveCount(3)
+
+  if (route.currentLabel) {
+    await expect(navigation.getByRole('link', { name: route.currentLabel })).toHaveAttribute('aria-current', 'page')
+  } else {
+    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(0)
+  }
+
+  const classrooms = navigation.getByRole('link', { name: 'Classrooms' })
+  const target = await classrooms.boundingBox()
+  expect(target?.height).toBeGreaterThanOrEqual(44)
+
+  await classrooms.focus()
+  await expect(classrooms).toBeFocused()
+  const focusedStyle = await classrooms.evaluate((element) => getComputedStyle(element).boxShadow)
+  expect(focusedStyle).toContain('inset')
+
+  const main = page.getByRole('main')
+  await expect(main).toHaveCSS('padding-left', '16px')
+  await expect(main).toHaveCSS('padding-right', '16px')
+  await expect(main).toHaveCSS('padding-bottom', '32px')
+
+  const shellHasOverflow = await page.evaluate(() => {
+    const mainElement = document.querySelector('main')
+    if (!(mainElement instanceof HTMLElement)) return true
+    const previousDisplay = mainElement.style.display
+    mainElement.style.display = 'none'
+    const hasOverflow = document.documentElement.scrollWidth > document.documentElement.clientWidth
+    mainElement.style.display = previousDisplay
+    return hasOverflow
+  })
+  expect(shellHasOverflow).toBe(false)
+}
+
+test.describe('teacher utility application navigation', () => {
+  test.use({ storageState: '.auth/teacher.json' })
+
+  for (const route of routes) {
+    test(`desktop light ${route.path}`, async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await setTheme(page, 'light')
+      await verifyNavigation(page, route)
+    })
+
+    test(`mobile dark ${route.path}`, async ({ page }) => {
+      await page.setViewportSize({ width: 390, height: 844 })
+      await setTheme(page, 'dark')
+      await verifyNavigation(page, route)
+    })
+  }
+})

--- a/src/app/teacher/layout.tsx
+++ b/src/app/teacher/layout.tsx
@@ -27,7 +27,7 @@ export default async function TeacherLayout({
   return (
     <AppShell
       user={{ email: user.email, role: user.role }}
-      mainClassName="min-h-0 w-full"
+      mainClassName="max-w-7xl mx-auto px-4 pt-0 pb-8"
       navigation={
         <AppNavigation
           label="Teacher tools"

--- a/src/app/teacher/layout.tsx
+++ b/src/app/teacher/layout.tsx
@@ -1,8 +1,13 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
-import Link from 'next/link'
-import { PikaLogo } from '@/components/PikaLogo'
-import { AuthSessionWatcher } from '@/components/AuthSessionWatcher'
+import { AppNavigation, type AppNavigationItem } from '@/components/AppNavigation'
+import { AppShell } from '@/components/AppShell'
+
+const teacherNavigationItems: AppNavigationItem[] = [
+  { href: '/classrooms', label: 'Classrooms' },
+  { href: '/teacher/blueprints', label: 'Blueprints', match: 'prefix' },
+  { href: '/teacher/calendar', label: 'Calendar', match: 'prefix' },
+]
 
 export default async function TeacherLayout({
   children,
@@ -20,49 +25,17 @@ export default async function TeacherLayout({
   }
 
   return (
-    <div className="min-h-screen bg-page">
-      <AuthSessionWatcher expectedRole="teacher" />
-      <nav className="bg-surface shadow-sm border-b border-border">
-        <div className="mx-auto max-w-7xl px-4 py-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-              <Link href="/classrooms" className="flex items-center">
-                <PikaLogo className="h-10 w-10" />
-              </Link>
-              <Link
-                href="/classrooms"
-                className="text-text-muted hover:text-text-default"
-              >
-                Classrooms
-              </Link>
-              <Link
-                href="/teacher/blueprints"
-                className="text-text-muted hover:text-text-default"
-              >
-                Blueprints
-              </Link>
-              <Link
-                href="/teacher/calendar"
-                className="text-text-muted hover:text-text-default"
-              >
-                Calendar
-              </Link>
-            </div>
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
-              <span className="hidden text-sm text-text-muted sm:inline">{user.email}</span>
-              <Link
-                href="/logout"
-                className="text-sm text-danger hover:text-danger-hover"
-              >
-                Logout
-              </Link>
-            </div>
-          </div>
-        </div>
-      </nav>
-      <main className="max-w-7xl mx-auto px-4 pt-0 pb-8">
-        {children}
-      </main>
-    </div>
+    <AppShell
+      user={{ email: user.email, role: user.role }}
+      mainClassName="min-h-0 w-full"
+      navigation={
+        <AppNavigation
+          label="Teacher tools"
+          items={teacherNavigationItems}
+        />
+      }
+    >
+      {children}
+    </AppShell>
   )
 }

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export interface AppNavigationItem {
+  href: string
+  label: string
+  match?: 'exact' | 'prefix'
+}
+
+interface AppNavigationProps {
+  label: string
+  items: AppNavigationItem[]
+  width?: 'reading' | 'standard' | 'wide'
+}
+
+const widthClasses = {
+  reading: 'max-w-4xl',
+  standard: 'max-w-6xl',
+  wide: 'max-w-7xl',
+} as const
+
+function isItemActive(pathname: string, item: AppNavigationItem): boolean {
+  if (item.match !== 'prefix') return pathname === item.href
+  return pathname === item.href || pathname.startsWith(`${item.href}/`)
+}
+
+export function AppNavigation({ label, items, width = 'wide' }: AppNavigationProps) {
+  const pathname = usePathname()
+
+  return (
+    <nav aria-label={label} className="border-b border-border bg-surface">
+      <div className={`mx-auto px-4 ${widthClasses[width]}`}>
+        <div className="flex min-h-11 items-stretch gap-1 overflow-x-auto" data-app-navigation-scroll>
+          {items.map((item) => {
+            const isActive = isItemActive(pathname, item)
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={[
+                  'inline-flex min-h-11 flex-none items-center border-b-2 px-3 text-sm font-medium transition-colors',
+                  'focus:outline-none focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface',
+                  isActive
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-text-muted hover:border-border-strong hover:text-text-default',
+                ].join(' ')}
+              >
+                {item.label}
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -43,7 +43,7 @@ export function AppNavigation({ label, items, width = 'wide' }: AppNavigationPro
                 aria-current={isActive ? 'page' : undefined}
                 className={[
                   'inline-flex min-h-11 flex-none items-center border-b-2 px-3 text-sm font-medium transition-colors',
-                  'focus:outline-none focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
                   isActive
                     ? 'border-primary text-primary'
                     : 'border-transparent text-text-muted hover:border-border-strong hover:text-text-default',

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import type { ClassroomThemeColor } from '@/lib/classroom-theme'
 
 interface AppShellProps {
   children: ReactNode
+  navigation?: ReactNode
   showHeader?: boolean
   user?: {
     email: string
@@ -39,6 +40,7 @@ interface AppShellProps {
  */
 export function AppShell({
   children,
+  navigation,
   showHeader = true,
   user,
   classrooms,
@@ -70,6 +72,7 @@ export function AppShell({
           pageTitle={pageTitle}
         />
       )}
+      {navigation}
       <main
         className={[
           'flex-1 min-h-0 w-full',

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -166,6 +166,16 @@ failed request.
 - Route and retry rules live in
   [`page-state-conventions.md`](/docs/guidance/ui/page-state-conventions.md).
 
+### Application navigation
+
+Authenticated route families use `AppShell` with an `AppNavigation` region instead of defining
+their own logo, account controls, link styling, or responsive navigation wrapper. Navigation items
+keep their existing product labels and route ownership; the shared mechanism supplies active-page
+semantics, keyboard focus treatment, 44px targets, and narrow-width horizontal overflow.
+
+Application navigation is app-specific composition and remains in `src/components/`, while its
+base controls and shell styling follow the `@/ui` contracts.
+
 ### Composite controls
 
 - Use `Tabs` plus `TabPanel` for panel-switching navigation. The tab list owns roving focus,

--- a/tests/components/AppNavigation.test.tsx
+++ b/tests/components/AppNavigation.test.tsx
@@ -48,7 +48,8 @@ describe('AppNavigation', () => {
     const classrooms = screen.getByRole('link', { name: 'Classrooms' })
 
     expect(scrollRegion).toHaveClass('overflow-x-auto', 'min-h-11')
-    expect(classrooms).toHaveClass('min-h-11', 'focus-visible:ring-2')
+    expect(classrooms).toHaveClass('min-h-11', 'focus-visible:ring-2', 'focus-visible:ring-inset')
+    expect(classrooms).not.toHaveClass('focus-visible:ring-offset-2')
 
     classrooms.focus()
     expect(classrooms).toHaveFocus()

--- a/tests/components/AppNavigation.test.tsx
+++ b/tests/components/AppNavigation.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppNavigation } from '@/components/AppNavigation'
+
+let pathname = '/teacher/blueprints'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+}))
+
+const items = [
+  { href: '/classrooms', label: 'Classrooms' },
+  { href: '/teacher/blueprints', label: 'Blueprints', match: 'prefix' as const },
+  { href: '/teacher/calendar', label: 'Calendar', match: 'prefix' as const },
+]
+
+describe('AppNavigation', () => {
+  beforeEach(() => {
+    pathname = '/teacher/blueprints'
+  })
+
+  it('names the route family and marks only the matching destination as current', () => {
+    render(<AppNavigation label="Teacher tools" items={items} />)
+
+    expect(screen.getByRole('navigation', { name: 'Teacher tools' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'Classrooms' })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: 'Calendar' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('keeps nested utility routes active without treating partial sibling names as matches', () => {
+    pathname = '/teacher/blueprints/import'
+    const { rerender } = render(<AppNavigation label="Teacher tools" items={items} />)
+
+    expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('aria-current', 'page')
+
+    pathname = '/teacher/blueprints-old'
+    rerender(<AppNavigation label="Teacher tools" items={items} />)
+
+    expect(screen.queryByRole('link', { current: 'page' })).not.toBeInTheDocument()
+  })
+
+  it('provides stable narrow-width overflow, target sizing, and keyboard focus treatment', () => {
+    render(<AppNavigation label="Teacher tools" items={items} />)
+
+    const scrollRegion = screen.getByRole('navigation', { name: 'Teacher tools' })
+      .querySelector('[data-app-navigation-scroll]')
+    const classrooms = screen.getByRole('link', { name: 'Classrooms' })
+
+    expect(scrollRegion).toHaveClass('overflow-x-auto', 'min-h-11')
+    expect(classrooms).toHaveClass('min-h-11', 'focus-visible:ring-2')
+
+    classrooms.focus()
+    expect(classrooms).toHaveFocus()
+  })
+})

--- a/tests/components/AppShell.test.tsx
+++ b/tests/components/AppShell.test.tsx
@@ -19,4 +19,19 @@ describe('AppShell', () => {
     rerender(<AppShell mainClassName="max-w-none px-0 py-0">Custom content</AppShell>)
     expect(screen.getByRole('main')).toHaveClass('w-full', 'max-w-none', 'px-0', 'py-0')
   })
+
+  it('places optional application navigation between the header and main content', () => {
+    render(
+      <AppShell navigation={<nav aria-label="Teacher tools">Navigation</nav>}>
+        Content
+      </AppShell>,
+    )
+
+    const header = screen.getByRole('banner')
+    const navigation = screen.getByRole('navigation', { name: 'Teacher tools' })
+    const main = screen.getByRole('main')
+
+    expect(header.compareDocumentPosition(navigation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(navigation.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
 })

--- a/tests/components/TeacherLayout.test.tsx
+++ b/tests/components/TeacherLayout.test.tsx
@@ -44,6 +44,7 @@ describe('TeacherLayout', () => {
     expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('href', '/teacher/blueprints')
     expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute('href', '/teacher/calendar')
     expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('main')).toHaveClass('max-w-7xl', 'mx-auto', 'px-4', 'pt-0', 'pb-8')
     expect(screen.getByRole('main')).toHaveTextContent('Teacher content')
   })
 })

--- a/tests/components/TeacherLayout.test.tsx
+++ b/tests/components/TeacherLayout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TeacherLayout from '@/app/teacher/layout'
+import { getCurrentUser } from '@/lib/auth'
+
+let pathname = '/teacher/calendar'
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  usePathname: () => pathname,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock('@/components/AppHeader', () => ({
+  AppHeader: () => <header>Application header</header>,
+}))
+
+vi.mock('@/components/AuthSessionWatcher', () => ({
+  AuthSessionWatcher: ({ expectedRole }: { expectedRole: string }) => (
+    <span data-testid="session-role">{expectedRole}</span>
+  ),
+}))
+
+describe('TeacherLayout', () => {
+  beforeEach(() => {
+    pathname = '/teacher/calendar'
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      id: 'teacher-1',
+      email: 'teacher@example.com',
+      role: 'teacher',
+    })
+  })
+
+  it('uses the canonical app shell and preserves the existing teacher utility destinations', async () => {
+    render(await TeacherLayout({ children: <p>Teacher content</p> }))
+
+    expect(screen.getByRole('banner')).toHaveTextContent('Application header')
+    expect(screen.getByTestId('session-role')).toHaveTextContent('teacher')
+    expect(screen.getByRole('navigation', { name: 'Teacher tools' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Classrooms' })).toHaveAttribute('href', '/classrooms')
+    expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('href', '/teacher/blueprints')
+    expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute('href', '/teacher/calendar')
+    expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('main')).toHaveTextContent('Teacher content')
+  })
+})


### PR DESCRIPTION
## Summary\n- add a shared AppNavigation route-family mechanism with active-page semantics, 44px targets, focus treatment, and narrow-width overflow\n- migrate the teacher utility layout to the canonical AppShell/AppHeader/UserMenu while preserving Classrooms, Blueprints, and Calendar\n- document the incremental navigation contract and add direct component/layout regressions\n\n## Scope\n- teacher utility shell only\n- no route, API, schema, migration, production, or data changes\n- no dashboard destination or classroom-navigation changes\n- student utility migration remains a separate Phase 2 slice\n\n## Verification\n- pnpm test --run (392 files / 3,584 tests)\n- pnpm exec tsc --noEmit\n- pnpm lint\n- pnpm check:architecture (613 modules / 0 allowances)\n- pnpm build\n- Pika audit\n- Playwright teacher desktop/mobile light/dark matrix and unchanged student mobile-dark regression\n- startup-context, UI-guidance, session-log, and diff checks\n\n## Visual note\nThe shared navigation shell is overflow-free. The previously ranked mobile compression inside the top-level Calendar content remains assigned to its Phase 3 vertical slice.