### PR TITLE
Standardize student utility navigation

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900, #902, and #903 merged the shared foundation through teacher utility navigation. The student utility navigation slice is active.
+- Phase 2 is active. PRs #896-#900, #902, and #903 merged the shared foundation through teacher utility navigation. Student utility navigation is in PR #904.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900 and #902 merged the shared foundation through composite controls. PR #903 starts utility navigation migration with teacher routes.
+- Phase 2 is active. PRs #896-#900, #902, and #903 merged the shared foundation through teacher utility navigation. The student utility navigation slice is active.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14045,3 +14045,23 @@
 - `bash -n scripts/check-classroom-archive-recovery-drill.sh`
 - Local full-stack drill intentionally not run because the existing local Supabase instance predates migrations 082-086; migrations were not applied or reset
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:f3792d5bda61ccb13f31db937b092caaf765b0429b69b85227f3e4d888f9f594 -->
+## 2026-07-13 — Teacher cold-archive recovery surface
+
+**Completed:**
+- Extended the teacher Archived API response with teacher-scoped, Zod-validated cold tombstone summaries while preserving the existing response when migration 083 is absent and failing closed on unexpected query or contract errors.
+- Added a distinct Stored archive row to the teacher classroom index; cold submissions, grades, and files remain inaccessible until the existing gated restore operation returns the classroom to `archived_hot`.
+- Reused the existing restore route and required server feature gate, exact teacher allowlist, and database budget before enabling the control. The client keeps one UUID idempotency key through request and list-refresh failures and discards it only after refreshed state is confirmed.
+- Added server, API, client, and component coverage for teacher scoping, rollout fallback, strict response validation, enabled/disabled controls, successful restore, and idempotent retries.
+- Visually verified teacher desktop/mobile in light/dark plus disabled, confirm, processing, error, and restored-hot states; student desktop/mobile remained unchanged. No production database, migration, row, object, environment, or schedule was read or modified.
+
+**Validation:**
+- Full Vitest suite (338 files / 3,009 tests)
+- Focused recovery list/API/client/component suites (5 files / 35 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- Pika pre-commit audit
+- Local-only Playwright matrix with no overflow; intentional restore failure reused the same idempotency key on retry
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -912,6 +912,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Preserved the existing `Classrooms` and `History` destinations plus the original `max-w-4xl px-4 py-8` content geometry. This slice does not redirect, retire, or consolidate `/student/history`, and does not change classroom navigation.
 - Added a direct student-layout regression and expanded the durable application-navigation Playwright contract with student desktop-light and mobile-dark checks for active state, inset focus, rendered target size, spacing, and overflow.
 - Visually inspected populated student History at desktop and mobile widths; the two-column desktop layout and stacked mobile workflow remain intact with the cleaned shared header.
+- Opened PR #904 for independent review.
 
 **Validation:**
 - `pnpm test --run` (393 files / 3,585 tests)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -913,17 +913,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added a direct student-layout regression and expanded the durable application-navigation Playwright contract with student desktop-light and mobile-dark checks for active state, inset focus, rendered target size, spacing, and overflow.
 - Visually inspected populated student History at desktop and mobile widths; the two-column desktop layout and stacked mobile workflow remain intact with the cleaned shared header.
 - Opened PR #904 for independent review.
+- Accepted one independent accessibility finding: the newly activated shared header and account menu exposed sub-44px controls. Enlarged the Home, fullscreen, login, account, sidebar, and menu-item hit areas without changing icon sizes, removed the menu scale animation that temporarily shrank interactive rows, and added unit plus rendered-size keyboard regressions.
 
 **Validation:**
 - `pnpm test --run` (393 files / 3,585 tests)
 - Focused student-layout, application-navigation, app-shell, and student-history suites (4 files / 10 tests)
+- Focused remediation suite for the shared header, account menu, student shell, and navigation (6 files / 20 tests)
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm check:architecture` (613 modules / 0 allowances)
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - Durable Playwright application-navigation suite (10 checks including auth setup)
-- Desktop and mobile student History screenshots
+- Desktop/mobile teacher and student screenshots, including open mobile-dark account menus
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,25 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Teacher cold-archive recovery surface
-
-**Completed:**
-- Extended the teacher Archived API response with teacher-scoped, Zod-validated cold tombstone summaries while preserving the existing response when migration 083 is absent and failing closed on unexpected query or contract errors.
-- Added a distinct Stored archive row to the teacher classroom index; cold submissions, grades, and files remain inaccessible until the existing gated restore operation returns the classroom to `archived_hot`.
-- Reused the existing restore route and required server feature gate, exact teacher allowlist, and database budget before enabling the control. The client keeps one UUID idempotency key through request and list-refresh failures and discards it only after refreshed state is confirmed.
-- Added server, API, client, and component coverage for teacher scoping, rollout fallback, strict response validation, enabled/disabled controls, successful restore, and idempotent retries.
-- Visually verified teacher desktop/mobile in light/dark plus disabled, confirm, processing, error, and restored-hot states; student desktop/mobile remained unchanged. No production database, migration, row, object, environment, or schedule was read or modified.
-
-**Validation:**
-- Full Vitest suite (338 files / 3,009 tests)
-- Focused recovery list/API/client/component suites (5 files / 35 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- Pika pre-commit audit
-- Local-only Playwright matrix with no overflow; intentional restore failure reused the same idempotency key on retry
-- `git diff --check`
-
 ## 2026-07-13 — Archive recovery PR review consistency fix
 
 **Completed:**
@@ -922,3 +903,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Complete full repository verification, independent review, and merge for the teacher navigation slice. Then migrate the student utility family as a separate Phase 2 item 7 PR.
+
+## 2026-07-21 — Phase 2 student utility navigation
+
+**Completed:**
+- Merged independently reviewed PR #903 as `d157d4cf`, fast-forwarded the hub, and started the second Phase 2 item 7 slice from current `main` in a dedicated worktree.
+- Migrated the student utility layout from its duplicate logo/header/logout implementation to the canonical `AppShell`, compact `AppHeader`, account menu, session watcher, and shared application-navigation band.
+- Preserved the existing `Classrooms` and `History` destinations plus the original `max-w-4xl px-4 py-8` content geometry. This slice does not redirect, retire, or consolidate `/student/history`, and does not change classroom navigation.
+- Added a direct student-layout regression and expanded the durable application-navigation Playwright contract with student desktop-light and mobile-dark checks for active state, inset focus, rendered target size, spacing, and overflow.
+- Visually inspected populated student History at desktop and mobile widths; the two-column desktop layout and stacked mobile workflow remain intact with the cleaned shared header.
+
+**Validation:**
+- `pnpm test --run` (393 files / 3,585 tests)
+- Focused student-layout, application-navigation, app-shell, and student-history suites (4 files / 10 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- Durable Playwright application-navigation suite (10 checks including auth setup)
+- Desktop and mobile student History screenshots
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`
+
+**Remaining:**
+- Complete full repository verification, independent review, and merge for the student navigation slice. Then continue Phase 2 with specialized-control policy enforcement.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -156,7 +156,7 @@
       "description": "Six-phase teacher/student product audit, shared experience foundation, vertical workflow improvements, Gradex integration, blueprint/archive productization, and final verification",
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
-      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902", "#903"],
+      "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902", "#903", "#904"],
       "blockedBy": [],
       "addedDate": "2026-07-16"
     }

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -123,6 +123,7 @@ Source grounding:
 - [`src/components/AppShell.tsx`](/src/components/AppShell.tsx)
 - [`src/components/AppNavigation.tsx`](/src/components/AppNavigation.tsx)
 - [`src/app/teacher/layout.tsx`](/src/app/teacher/layout.tsx)
+- [`src/app/student/layout.tsx`](/src/app/student/layout.tsx)
 
 ### 4. Attendance stays presence-first and scan-friendly
 

--- a/e2e/app-navigation.spec.ts
+++ b/e2e/app-navigation.spec.ts
@@ -91,6 +91,31 @@ test.describe('student utility application navigation', () => {
       await expect(navigation.getByRole('link')).toHaveCount(2)
       await expect(navigation.getByRole('link', { name: 'History' })).toHaveAttribute('aria-current', 'page')
 
+      const header = page.getByRole('banner')
+      const home = header.getByRole('link', { name: 'Home' })
+      const fullscreen = header.getByRole('button', { name: /fullscreen/i })
+      const userMenu = header.getByRole('button', { name: 'User menu' })
+
+      for (const control of [home, fullscreen, userMenu]) {
+        const target = await control.boundingBox()
+        expect(target?.height).toBeGreaterThanOrEqual(44)
+        expect(target?.width).toBeGreaterThanOrEqual(44)
+        await control.focus()
+        await expect(control).toBeFocused()
+      }
+
+      await userMenu.press('Enter')
+      const menu = page.getByRole('menu')
+      await expect(menu).toBeVisible()
+      const menuItems = menu.getByRole('menuitem')
+      await expect(menuItems).toHaveCount(3)
+      for (let index = 0; index < 3; index += 1) {
+        expect((await menuItems.nth(index).boundingBox())?.height).toBeGreaterThanOrEqual(44)
+      }
+      await expect(menuItems.first()).toBeFocused()
+      await menuItems.first().press('Escape')
+      await expect(userMenu).toBeFocused()
+
       const classrooms = navigation.getByRole('link', { name: 'Classrooms' })
       expect((await classrooms.boundingBox())?.height).toBeGreaterThanOrEqual(44)
       await classrooms.focus()

--- a/e2e/app-navigation.spec.ts
+++ b/e2e/app-navigation.spec.ts
@@ -73,3 +73,36 @@ test.describe('teacher utility application navigation', () => {
     })
   }
 })
+
+test.describe('student utility application navigation', () => {
+  test.use({ storageState: '.auth/student.json' })
+
+  for (const testCase of [
+    { name: 'desktop light', viewport: { width: 1440, height: 900 }, theme: 'light' as const },
+    { name: 'mobile dark', viewport: { width: 390, height: 844 }, theme: 'dark' as const },
+  ]) {
+    test(`${testCase.name} /student/history`, async ({ page }) => {
+      await page.setViewportSize(testCase.viewport)
+      await setTheme(page, testCase.theme)
+      await page.goto('/student/history', { waitUntil: 'networkidle' })
+
+      const navigation = page.getByRole('navigation', { name: 'Student tools' })
+      await expect(navigation).toBeVisible()
+      await expect(navigation.getByRole('link')).toHaveCount(2)
+      await expect(navigation.getByRole('link', { name: 'History' })).toHaveAttribute('aria-current', 'page')
+
+      const classrooms = navigation.getByRole('link', { name: 'Classrooms' })
+      expect((await classrooms.boundingBox())?.height).toBeGreaterThanOrEqual(44)
+      await classrooms.focus()
+      await expect(classrooms).toBeFocused()
+      expect(await classrooms.evaluate((element) => getComputedStyle(element).boxShadow)).toContain('inset')
+
+      const main = page.getByRole('main')
+      await expect(main).toHaveCSS('padding-left', '16px')
+      await expect(main).toHaveCSS('padding-right', '16px')
+      await expect(main).toHaveCSS('padding-top', '32px')
+      await expect(main).toHaveCSS('padding-bottom', '32px')
+      expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+    })
+  }
+})

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -1,8 +1,12 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
-import Link from 'next/link'
-import { PikaLogo } from '@/components/PikaLogo'
-import { AuthSessionWatcher } from '@/components/AuthSessionWatcher'
+import { AppNavigation, type AppNavigationItem } from '@/components/AppNavigation'
+import { AppShell } from '@/components/AppShell'
+
+const studentNavigationItems: AppNavigationItem[] = [
+  { href: '/classrooms', label: 'Classrooms' },
+  { href: '/student/history', label: 'History', match: 'prefix' },
+]
 
 export default async function StudentLayout({
   children,
@@ -20,43 +24,18 @@ export default async function StudentLayout({
   }
 
   return (
-    <div className="min-h-screen bg-page">
-      <AuthSessionWatcher expectedRole="student" />
-      <nav className="bg-surface shadow-sm border-b border-border">
-        <div className="mx-auto max-w-4xl px-4 py-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-              <Link href="/classrooms" className="flex items-center">
-                <PikaLogo className="h-10 w-10" />
-              </Link>
-              <Link
-                href="/classrooms"
-                className="text-text-muted hover:text-text-default"
-              >
-                Classrooms
-              </Link>
-              <Link
-                href="/student/history"
-                className="text-text-muted hover:text-text-default"
-              >
-                History
-              </Link>
-            </div>
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
-              <span className="hidden text-sm text-text-muted sm:inline">{user.email}</span>
-              <Link
-                href="/logout"
-                className="text-sm text-danger"
-              >
-                Logout
-              </Link>
-            </div>
-          </div>
-        </div>
-      </nav>
-      <main className="max-w-4xl mx-auto px-4 py-8">
-        {children}
-      </main>
-    </div>
+    <AppShell
+      user={{ email: user.email, role: user.role }}
+      mainClassName="max-w-4xl mx-auto px-4 py-8"
+      navigation={
+        <AppNavigation
+          label="Student tools"
+          items={studentNavigationItems}
+          width="reading"
+        />
+      }
+    >
+      {children}
+    </AppShell>
   )
 }

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -142,7 +142,7 @@ export function AppHeader({
             <button
               type="button"
               onClick={onOpenSidebar}
-            className="lg:hidden p-2 -ml-2 rounded-md text-text-muted hover:text-text-default hover:bg-surface-hover transition-colors"
+              className="-ml-2 flex min-h-11 min-w-11 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-hover hover:text-text-default lg:hidden"
               aria-label="Open classroom navigation"
             >
               <Menu className="w-5 h-5" />
@@ -155,7 +155,7 @@ export function AppHeader({
           <Link
             href="/classrooms"
             aria-label="Home"
-            className="flex h-8 w-8 flex-shrink-0 items-center justify-center"
+            className="flex h-11 w-11 flex-shrink-0 items-center justify-center"
             onClick={(event) => {
               const allow = onNavigateHome?.('/classrooms')
               if (allow === false) {
@@ -219,7 +219,7 @@ export function AppHeader({
             <button
               type="button"
               onClick={() => void toggleFullscreen()}
-              className="mr-1 p-2 rounded-md text-text-muted hover:text-text-default hover:bg-surface-hover transition-colors"
+              className="mr-1 flex min-h-11 min-w-11 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-hover hover:text-text-default"
               aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             >
               {isFullscreen ? <Minimize className="w-4 h-4" /> : <Maximize className="w-4 h-4" />}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -99,7 +99,7 @@ export function UserMenu({ user }: UserMenuProps) {
     return (
       <Link
         href="/login"
-        className="text-sm text-text-muted hover:text-text-default font-medium"
+        className="inline-flex min-h-11 min-w-11 items-center justify-center text-sm font-medium text-text-muted hover:text-text-default"
       >
         Login
       </Link>
@@ -120,7 +120,7 @@ export function UserMenu({ user }: UserMenuProps) {
         ref={triggerRef}
         onClick={handleTriggerClick}
         onKeyDown={handleTriggerKeyDown}
-        className="flex items-center justify-center w-8 h-8 rounded-full transition-all hover:ring-2 hover:ring-border-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+        className="flex min-h-11 min-w-11 items-center justify-center rounded-full transition-all hover:ring-2 hover:ring-border-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
         aria-label="User menu"
         aria-expanded={isOpen}
         aria-haspopup="menu"
@@ -138,10 +138,10 @@ export function UserMenu({ user }: UserMenuProps) {
       {/* Dropdown menu with animation */}
       <div
         id={menuId}
-        className={`absolute right-0 mt-2 w-64 bg-surface rounded-lg shadow-lg border border-border py-1 z-50 transition-all duration-200 origin-top-right ${
+        className={`absolute right-0 z-50 mt-2 w-64 rounded-lg border border-border bg-surface py-1 shadow-lg transition-all duration-200 ${
           isOpen
-            ? 'opacity-100 scale-100 translate-y-0'
-            : 'opacity-0 scale-95 -translate-y-1 pointer-events-none'
+            ? 'translate-y-0 opacity-100'
+            : 'pointer-events-none -translate-y-1 opacity-0'
         }`}
         role="menu"
         aria-labelledby={triggerId}
@@ -180,7 +180,7 @@ export function UserMenu({ user }: UserMenuProps) {
           onClick={handleThemeToggle}
           onMouseEnter={() => setFocusedIndex(0)}
           onKeyDown={handleItemKeyDown}
-          className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
+          className={`flex min-h-11 w-full items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
             focusedIndex === 0
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
@@ -201,7 +201,7 @@ export function UserMenu({ user }: UserMenuProps) {
           onClick={() => { setIsOpen(false); setShowFeedback(true) }}
           onMouseEnter={() => setFocusedIndex(1)}
           onKeyDown={handleItemKeyDown}
-          className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
+          className={`flex min-h-11 w-full items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
             focusedIndex === 1
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
@@ -221,7 +221,7 @@ export function UserMenu({ user }: UserMenuProps) {
           onClick={() => setIsOpen(false)}
           onMouseEnter={() => setFocusedIndex(2)}
           onKeyDown={handleItemKeyDown}
-          className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
+          className={`flex min-h-11 w-full items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
             focusedIndex === 2
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'

--- a/tests/components/AppHeader.test.tsx
+++ b/tests/components/AppHeader.test.tsx
@@ -86,6 +86,9 @@ describe('AppHeader classroom theme', () => {
     render(<AppHeader pageTitle="Classrooms" />, { wrapper: Wrapper })
 
     expect(screen.getByAltText('Pika')).toHaveClass('pika-logo')
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveClass('h-11', 'w-11')
+    expect(screen.getByRole('button', { name: 'Enter fullscreen' })).toHaveClass('min-h-11', 'min-w-11')
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveClass('min-h-11', 'min-w-11')
   })
 
   it('themes the brand logo through design tokens instead of component dark utilities', () => {

--- a/tests/components/StudentLayout.test.tsx
+++ b/tests/components/StudentLayout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import StudentLayout from '@/app/student/layout'
+import { getCurrentUser } from '@/lib/auth'
+
+let pathname = '/student/history'
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  usePathname: () => pathname,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock('@/components/AppHeader', () => ({
+  AppHeader: () => <header>Application header</header>,
+}))
+
+vi.mock('@/components/AuthSessionWatcher', () => ({
+  AuthSessionWatcher: ({ expectedRole }: { expectedRole: string }) => (
+    <span data-testid="session-role">{expectedRole}</span>
+  ),
+}))
+
+describe('StudentLayout', () => {
+  beforeEach(() => {
+    pathname = '/student/history'
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      id: 'student-1',
+      email: 'student1@example.com',
+      role: 'student',
+    })
+  })
+
+  it('uses the canonical app shell and preserves the existing student utility destinations', async () => {
+    render(await StudentLayout({ children: <p>Student content</p> }))
+
+    expect(screen.getByRole('banner')).toHaveTextContent('Application header')
+    expect(screen.getByTestId('session-role')).toHaveTextContent('student')
+    expect(screen.getByRole('navigation', { name: 'Student tools' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Classrooms' })).toHaveAttribute('href', '/classrooms')
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute('href', '/student/history')
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('main')).toHaveClass('max-w-4xl', 'mx-auto', 'px-4', 'py-8')
+    expect(screen.getByRole('main')).toHaveTextContent('Student content')
+  })
+})

--- a/tests/components/UserMenu.test.tsx
+++ b/tests/components/UserMenu.test.tsx
@@ -24,12 +24,14 @@ describe('UserMenu', () => {
   it('keeps display preferences out of the account menu', async () => {
     renderUserMenu()
 
-    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+    const trigger = screen.getByRole('button', { name: 'User menu' })
+    expect(trigger).toHaveClass('min-h-11', 'min-w-11')
+    fireEvent.click(trigger)
 
     expect(screen.queryByRole('menuitemcheckbox', { name: 'Show markdown' })).not.toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /dark mode|light mode|toggle theme/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: 'Send Feedback' })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: 'Logout' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /dark mode|light mode|toggle theme/i })).toHaveClass('min-h-11')
+    expect(screen.getByRole('menuitem', { name: 'Send Feedback' })).toHaveClass('min-h-11')
+    expect(screen.getByRole('menuitem', { name: 'Logout' })).toHaveClass('min-h-11')
   })
 
   it('closes with Escape and outside click while restoring focus to the trigger', () => {


### PR DESCRIPTION
## Summary
- migrate the student utility layout to the shared `AppShell` and `AppNavigation`
- preserve existing Classrooms and History destinations and the established student content geometry
- add focused layout coverage plus desktop/mobile application-navigation browser contracts

## Scope
- no API, schema, migration, production, or data changes
- no student-history redirect, retirement, or consolidation
- no classroom navigation changes

## Verification
- `pnpm test --run` (393 files / 3,585 tests)
- focused student layout/navigation/history tests (4 files / 10 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (613 modules / 0 allowances)
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- Playwright application-navigation suite (10 checks)
- desktop/mobile visual inspection
- startup and UI-guidance regressions (2 files / 36 tests)