### PR TITLE
Add browser experience CI matrix

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900 and #902-#904 merged the shared foundation through teacher/student utility navigation. Specialized-control policy enforcement is in PR #905.
+- Phase 2 is active. PRs #896-#900 and #902-#905 merged the shared foundation through specialized-control policy enforcement. The desktop/mobile light/dark Playwright CI matrix is the current final Phase 2 slice.
 
 ## Environment
 

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,28 +1,23 @@
 # Pika Current Context
 
-Read this at session start. `.ai/features.json` is the epic status authority; `.ai/SESSION-LOG.md` holds recent handoff context.
+Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-LOG.md`.
 
 ## Current Focus
 
-- Core classroom, assignment, test, and auth flows are live.
-- Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
-- The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
-- The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active through PR #905. The desktop/mobile light/dark Playwright CI matrix is the final Phase 2 slice.
+- Migrations 001-099 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave complete; browser CI matrix after PR #905 is Phase 2's final slice.
 
 ## Environment
 
-- Hub: `$HOME/Repos/pika`
-- Named worktrees: `$HOME/.codex/worktrees/pika/<branch-name>`
-- App-managed worktrees: `$HOME/.codex/worktrees/<id>/pika`
-- Maintainer env: symlink `.env.local` to `$HOME/Repos/.env/pika/.env.local`
-- Collaborators may copy `.env.example` to a checkout-local `.env.local`
-- Full worktree/env rules: `docs/dev-workflow.md`
+- Hub: `$HOME/Repos/pika`.
+- Worktrees: `$HOME/.codex/worktrees/pika/` (named), `$HOME/.codex/worktrees/<id>/pika` (app-managed).
+- Maintainer env: `$HOME/Repos/.env/pika/.env.local`; collaborators use local `.env.example` copies.
+- Worktree/env rules: `docs/dev-workflow.md`.
 
 ## Invariants And Hazards
 
-- Use `America/Toronto` for deadline/attendance cutoffs; keep business logic in `src/lib/*` or server modules.
-- API routes use `withErrorHandler`; app UI uses semantic tokens and `@/ui`.
-- Migration application needs one-time permission naming target and migration; it never authorizes reset, repair, rollback, seeding, or cleanup.
-- Use a dedicated worktree for non-trivial changes. Keep the session log bounded with `node scripts/trim-session-log.mjs` after appending.
+- Deadlines/attendance use `America/Toronto`; business logic belongs in `src/lib/*` or server modules.
+- API routes use `withErrorHandler`; UI uses semantic tokens and `@/ui`.
+- Migrations need one-time target/migration permission; never infer reset, repair, rollback, seed, or cleanup permission.
+- Use dedicated worktrees. After session-log updates, run `node scripts/trim-session-log.mjs`.
 - `main` accepts linear history; `production` uses the protected PR flow.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -8,7 +8,7 @@ Read this at session start. `.ai/features.json` is the epic status authority; `.
 - Production migrations 001-099 and the named archive round-trip canary are verified. The classroom is hot-restored; source and Gradex cleanup remain disabled.
 - The product-experience program is tracked in `.ai/features.json`; Phase 1 evidence is in `docs/guidance/ui/product-experience-audit-2026-07.md`.
 - The Safety Wave is complete through PRs #890, #891, and #893-#895.
-- Phase 2 is active. PRs #896-#900 and #902-#905 merged the shared foundation through specialized-control policy enforcement. The desktop/mobile light/dark Playwright CI matrix is the current final Phase 2 slice.
+- Phase 2 is active through PR #905. The desktop/mobile light/dark Playwright CI matrix is the final Phase 2 slice.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14084,3 +14084,26 @@
 - Pika pre-commit audit
 - `git diff --check`
 - CI pending after push
+
+<!-- pika-session-log-archive-batch:ed23e12229b47648d8e6694d413fb1faab49160aeaabc196d53dc85ede3f5e0f -->
+## 2026-07-13 — Phase 1 API boundary validation foundation
+
+**Risk profile:** runtime-platform
+
+**Model recommendation:** GPT-5 Codex - cross-cutting API contract and architecture-test work benefits from repository-wide reasoning and strict verification.
+
+**Completed:**
+- Moved course-blueprint request schemas out of the broad teacher validation module into a feature-owned `course-blueprints` contract module, with shared course-publishing primitives isolated separately.
+- Added full nested Zod validation to blueprint assignment, test, and lesson-template bulk mutation routes, reusing canonical test-draft and document validators.
+- Added route tests proving malformed nested payloads return `400` before mutation services run.
+- Added a deletion-only architecture baseline that blocks new body-reading API routes without a named Zod boundary and must shrink as existing routes migrate.
+- Documented boundary parsing, contract ownership, non-JSON decoder expectations, and baseline maintenance.
+- No database migrations, dependencies, UI changes, or production operations.
+
+**Validation:**
+- Focused blueprint and architecture suites: 21 tests passed
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test` (312 files, 2,788 tests passed)
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,28 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Phase 1 API boundary validation foundation
-
-**Risk profile:** runtime-platform
-
-**Model recommendation:** GPT-5 Codex - cross-cutting API contract and architecture-test work benefits from repository-wide reasoning and strict verification.
-
-**Completed:**
-- Moved course-blueprint request schemas out of the broad teacher validation module into a feature-owned `course-blueprints` contract module, with shared course-publishing primitives isolated separately.
-- Added full nested Zod validation to blueprint assignment, test, and lesson-template bulk mutation routes, reusing canonical test-draft and document validators.
-- Added route tests proving malformed nested payloads return `400` before mutation services run.
-- Added a deletion-only architecture baseline that blocks new body-reading API routes without a named Zod boundary and must shrink as existing routes migrate.
-- Documented boundary parsing, contract ownership, non-JSON decoder expectations, and baseline maintenance.
-- No database migrations, dependencies, UI changes, or production operations.
-
-**Validation:**
-- Focused blueprint and architecture suites: 21 tests passed
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test` (312 files, 2,788 tests passed)
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-07-13 — Generated Supabase database contract
 
 **Completed:**
@@ -943,3 +921,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Publish, independently review, remediate, and merge the specialized-control policy PR. Then continue Phase 2 with mobile and light/dark Playwright projects plus representative teacher/student CI coverage.
+
+## 2026-07-21 — Phase 2 browser experience matrix
+
+**Completed:**
+- Merged independently reviewed PR #905 as `126658e0`, fast-forwarded the hub, and started Phase 2 item 9 from current `main` in a dedicated worktree.
+- Added desktop light, desktop dark, mobile light, and mobile dark Chromium projects while preserving the established `chromium-desktop` snapshot identity.
+- Kept the broad feature and manual snapshot suites on the desktop-light project and limited the additional three projects to a focused experience contract, preventing a fourfold expansion of the full E2E suite.
+- Added read-only seeded browser coverage for teacher Daily attendance, student Today, teacher Blueprints navigation, and student History navigation. The contract verifies real role authentication, classroom data, active navigation, mobile drawer behavior, persisted themes, viewport geometry, and horizontal overflow.
+- Added a dedicated GitHub Actions job that starts ephemeral local Supabase, replays migrations, exports local-only credentials, runs `pnpm seed`, installs Chromium, executes the matrix, uploads failure diagnostics, and always tears down the database.
+- Updated testing guidance and Phase 2 audit evidence. No runtime UI, API, schema, migration, production state, or production data changed.
+
+**Validation:**
+- `pnpm e2e:matrix` (18 checks across setup and four projects)
+- `pnpm test` (397 files / 3,603 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+
+**Remaining:**
+- Publish, independently review, remediate, and merge the browser matrix PR. Then confirm Phase 2 exit evidence and begin Phase 3 with the first independently releasable vertical product slice.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,71 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 7
+
+  browser-experience-matrix:
+    name: Browser Experience Matrix
+    runs-on: ubuntu-latest
+    env:
+      E2E_BASE_URL: http://localhost:3000
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      SESSION_SECRET: ci-browser-session-secret-with-at-least-32-characters
+      ENABLE_MOCK_EMAIL: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.103.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.25.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Start ephemeral Supabase and replay migrations
+        run: supabase start -x analytics,edge-runtime,functions,imgproxy,inbucket,meta,realtime,studio,vector
+
+      - name: Export local Supabase environment
+        shell: bash
+        run: |
+          eval "$(supabase status -o env \
+            --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
+            --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            --override-name auth.service_role_key=SUPABASE_SECRET_KEY)"
+          echo "NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL" >> "$GITHUB_ENV"
+          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" >> "$GITHUB_ENV"
+          echo "SUPABASE_SECRET_KEY=$SUPABASE_SECRET_KEY" >> "$GITHUB_ENV"
+
+      - name: Seed browser fixtures
+        run: pnpm seed
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run teacher and student browser matrix
+        run: pnpm e2e:matrix
+
+      - name: Upload browser diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-experience-matrix
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
+      - name: Stop ephemeral database
+        if: always()
+        run: supabase stop --no-backup

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -202,7 +202,14 @@ Focus on **critical user flows**:
    - Create assignment and see student statuses update after submit/unsubmit
    - Export CSV
 
-**Tools**: Consider Playwright for 1-2 E2E tests (optional). Keep Playwright as the canonical E2E tool because tests need to be reproducible locally and in CI.
+**Tools**: Playwright is the canonical E2E tool because tests must be reproducible locally and in CI. The representative experience contract runs read-only teacher and student classroom and utility-shell workflows across desktop/mobile and light/dark Chromium projects. Broader feature E2E and visual snapshots remain on the desktop-light project so CI does not multiply the full suite.
+
+Run the CI browser contract locally against a seeded local Supabase stack:
+
+```bash
+pnpm seed
+pnpm e2e:matrix
+```
 
 ### UI Snapshot Runs (Playwright)
 
@@ -317,6 +324,9 @@ pnpm test:ui
 
 # Coverage report
 pnpm test:coverage
+
+# Representative desktop/mobile and light/dark browser contract
+pnpm e2e:matrix
 ```
 
 ---

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -67,7 +67,7 @@ The classroom shell is the strongest base. Teacher and student utility layouts d
 - Archived classroom discovery is hidden inside Organize mode. Once visible, Restore and Delete are presented as peer actions without recovery context.
 - Resolved in Phase 2 PR #905: the 21-import baseline and unclassified native controls now use the canonical `@/ui` barrel plus an AST-enforced, reasoned registry covering 215 controls across 67 files.
 - `EmptyState`, loading, menus, tabs, and tables have multiple local implementations. Composite ownership is unresolved in `docs/guidance/ui/legacy.md`.
-- Playwright defines one desktop project, CI does not run the browser suite, and existing visual snapshots contain no mobile coverage.
+- Playwright now defines explicit desktop/mobile and light/dark Chromium projects. CI runs a seeded, read-only teacher/student classroom and utility-shell contract across that matrix; the broader feature and manual visual suites remain desktop-light to control runtime. Durable mobile visual baselines remain a Phase 6 deliverable.
 - Student aggregate grades and profile editing are absent. These are product decisions to confirm, not automatic implementation defects.
 - Legacy resource and gradebook helpers remain tested but are not mounted in the current product. Student history is separately mounted under the utility shell and overlaps the classroom Today history model. Retire or consolidate only after caller and compatibility evidence.
 
@@ -164,7 +164,7 @@ Each item is a separate PR unless one shared route contract makes two inseparabl
 6. Establish shared table, menu, tabs, segmented-control, and split-pane contracts with direct keyboard/ARIA tests.
 7. Establish one shared application-navigation mechanism, migrating teacher and student utility routes one at a time.
 8. Strengthen UI policy enforcement with a specialized-control exception registry rather than banning valid native controls.
-9. Add mobile and light/dark Playwright projects plus CI coverage for representative teacher/student workflows.
+9. Completed: add mobile and light/dark Playwright projects plus seeded CI coverage for representative teacher/student classroom and utility workflows.
 
 Exit evidence: canonical primitive tests prove keyboard/focus/ARIA behavior; all semantic foreground/background pairs meet AA; representative classroom, teacher utility, and student utility routes use the governed page-state contracts; desktop/mobile and light/dark browser checks run in CI.
 

--- a/e2e/experience-matrix.spec.ts
+++ b/e2e/experience-matrix.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+const TEACHER_STORAGE = '.auth/teacher.json'
+const STUDENT_STORAGE = '.auth/student.json'
+
+test.setTimeout(90_000)
+
+type ExperienceMetadata = {
+  theme: 'light' | 'dark'
+  viewport: 'desktop' | 'mobile'
+}
+
+function getExperienceMetadata(testInfo: TestInfo): ExperienceMetadata {
+  const { theme, viewport } = testInfo.project.metadata
+
+  if ((theme !== 'light' && theme !== 'dark') || (viewport !== 'desktop' && viewport !== 'mobile')) {
+    throw new Error(`Project ${testInfo.project.name} is missing experience matrix metadata`)
+  }
+
+  return { theme, viewport }
+}
+
+async function applyProjectTheme(page: Page, testInfo: TestInfo) {
+  const { theme } = getExperienceMetadata(testInfo)
+  await page.addInitScript((projectTheme) => {
+    localStorage.setItem('theme', projectTheme)
+  }, theme)
+}
+
+async function verifyProjectContract(page: Page, testInfo: TestInfo) {
+  const { theme, viewport } = getExperienceMetadata(testInfo)
+  const expectedWidth = viewport === 'mobile' ? 390 : 1440
+
+  expect(page.viewportSize()?.width).toBe(expectedWidth)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('theme'))).toBe(theme)
+  await expect(page.locator('html')).toHaveClass(theme === 'dark' ? /\bdark\b/ : /^(?!.*\bdark\b)/)
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+}
+
+async function verifyActiveClassroomTab(page: Page, testInfo: TestInfo, label: 'Daily' | 'Today') {
+  const { viewport } = getExperienceMetadata(testInfo)
+
+  if (viewport === 'mobile') {
+    await page.getByRole('button', { name: 'Open classroom navigation' }).click()
+  }
+
+  await expect(page.getByRole('link', { name: label })).toHaveAttribute('aria-current', 'page')
+
+  if (viewport === 'mobile') {
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('button', { name: 'Open classroom navigation' })).toBeVisible()
+  }
+}
+
+async function enterSeededClassroom(page: Page, role: 'teacher' | 'student') {
+  await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+  const classroom = page.getByRole('button', { name: /Test Classroom/ })
+  await expect(classroom).toHaveCount(1)
+
+  const response = await page.request.get(`/api/${role}/classrooms`)
+  expect(response.ok()).toBe(true)
+  const payload = await response.json() as { classrooms?: Array<{ id: string; title: string }> }
+  const seededClassroom = payload.classrooms?.find((item) => item.title === 'Test Classroom')
+  if (!seededClassroom) {
+    throw new Error(`${role} browser fixture is missing Test Classroom`)
+  }
+
+  const tab = role === 'teacher' ? 'attendance' : 'today'
+  await page.goto(`/classrooms/${seededClassroom.id}?tab=${tab}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  })
+}
+
+test.describe('teacher experience matrix', () => {
+  test.use({ storageState: TEACHER_STORAGE })
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await applyProjectTheme(page, testInfo)
+  })
+
+  test('opens the classroom attendance summary', async ({ page }, testInfo) => {
+    await enterSeededClassroom(page, 'teacher')
+
+    await expect(page.getByRole('table')).toBeVisible()
+    await expect(page.getByRole('row', { name: /Student1 Test/ })).toBeVisible()
+    await verifyActiveClassroomTab(page, testInfo, 'Daily')
+    await verifyProjectContract(page, testInfo)
+  })
+
+  test('opens the shared teacher utility shell', async ({ page }, testInfo) => {
+    await page.goto('/teacher/blueprints', { waitUntil: 'domcontentloaded' })
+
+    const navigation = page.getByRole('navigation', { name: 'Teacher tools' })
+    await expect(navigation.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('aria-current', 'page')
+    await verifyProjectContract(page, testInfo)
+  })
+})
+
+test.describe('student experience matrix', () => {
+  test.use({ storageState: STUDENT_STORAGE })
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await applyProjectTheme(page, testInfo)
+  })
+
+  test('opens the classroom daily workspace', async ({ page }, testInfo) => {
+    await enterSeededClassroom(page, 'student')
+
+    await expect(page.getByRole('heading', { name: 'Past logs' })).toBeVisible()
+    await verifyActiveClassroomTab(page, testInfo, 'Today')
+    await verifyProjectContract(page, testInfo)
+  })
+
+  test('opens the shared student utility shell', async ({ page }, testInfo) => {
+    await page.goto('/student/history', { waitUntil: 'domcontentloaded' })
+
+    const navigation = page.getByRole('navigation', { name: 'Student tools' })
+    await expect(navigation.getByRole('link', { name: 'History' })).toHaveAttribute('aria-current', 'page')
+    await verifyProjectContract(page, testInfo)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docs:sync:test-markdown": "tsx scripts/sync-test-markdown-docs.ts",
     "e2e:install": "playwright install",
     "e2e:auth": "playwright test e2e/auth.setup.ts",
+    "e2e:matrix": "playwright test e2e/experience-matrix.spec.ts",
     "e2e:verify": "tsx e2e/verify/run.ts",
     "e2e:snapshots": "playwright test e2e/ui-snapshots.spec.ts",
     "e2e:snapshots:update": "playwright test e2e/ui-snapshots.spec.ts --update-snapshots",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,20 @@ const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000'
 const resolvedBaseUrl = new URL(baseURL)
 const resolvedPort = resolvedBaseUrl.port || (resolvedBaseUrl.protocol === 'https:' ? '443' : '80')
 const webServerCommand = `pnpm exec next dev --port ${resolvedPort}`
+const experienceMatrixSpec = /experience-matrix\.spec\.ts/
+
+const desktop = {
+  ...devices['Desktop Chrome'],
+  viewport: { width: 1440, height: 900 },
+}
+
+const mobile = {
+  ...devices['Desktop Chrome'],
+  viewport: { width: 390, height: 844 },
+  deviceScaleFactor: 1,
+  hasTouch: true,
+  isMobile: true,
+}
 
 export default defineConfig({
   testDir: './e2e',
@@ -62,12 +76,44 @@ export default defineConfig({
       testMatch: /auth\.setup\.ts/,
     },
 
-    // Desktop viewport - standard testing
+    // Keep the broad suite on one project. The focused experience contract runs
+    // across every project so CI does not multiply expensive feature E2E specs.
     {
       name: 'chromium-desktop',
+      metadata: { theme: 'light', viewport: 'desktop' },
       use: {
-        ...devices['Desktop Chrome'],
-        viewport: { width: 1440, height: 900 },
+        ...desktop,
+        colorScheme: 'light',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'chromium-desktop-dark',
+      testMatch: experienceMatrixSpec,
+      metadata: { theme: 'dark', viewport: 'desktop' },
+      use: {
+        ...desktop,
+        colorScheme: 'dark',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'chromium-mobile-light',
+      testMatch: experienceMatrixSpec,
+      metadata: { theme: 'light', viewport: 'mobile' },
+      use: {
+        ...mobile,
+        colorScheme: 'light',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'chromium-mobile-dark',
+      testMatch: experienceMatrixSpec,
+      metadata: { theme: 'dark', viewport: 'mobile' },
+      use: {
+        ...mobile,
+        colorScheme: 'dark',
       },
       dependencies: ['setup'],
     },


### PR DESCRIPTION
## Summary
- add desktop/mobile and light/dark Chromium projects without multiplying the broad E2E suite
- add seeded, read-only teacher/student classroom and utility-shell browser coverage
- run the representative matrix against ephemeral local Supabase in GitHub Actions

## Validation
- `pnpm e2e:matrix` (18 checks)
- `pnpm test` (397 files / 3,603 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm check:ui-policy`
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`

No runtime UI, API, schema, migration, production state, or production data changes.