### PR TITLE
Phase 3: govern Classwork list states

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,7 +5,7 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 ## Current Focus
 
 - Migrations 001-099 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
-- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave complete; browser CI matrix after PR #905 is Phase 2's final slice.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete; Phase 3 is in progress with the teacher/student Classwork list-state slice.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14107,3 +14107,23 @@
 - `pnpm test` (312 files, 2,788 tests passed)
 - `pnpm build`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:aa6238bd7de766f3572cd84ebba5cc8124d2eb933c63fb23eef64238e8697b9c -->
+## 2026-07-13 — Generated Supabase database contract
+
+**Completed:**
+- Generated and committed the public Supabase schema contract in `src/types/database.generated.ts`; added `src/types/database.ts` for application-owned JSON/status/RPC refinements and typed both central Supabase client factories.
+- Added `db:types:generate` / `db:types:check`, plus a CI `Database Contract` job that starts an ephemeral database, replays migrations, and rejects generated-type drift.
+- Replaced generic persisted payload records exposed by the typed client with `TableRow`, `TableInsert`, and `TableUpdate` contracts; extracted assessment draft contracts into shared domain types.
+- Fixed blueprint instantiation when `points_possible` is null by omitting it so PostgreSQL applies the assignment default; added a regression for null and explicit point values.
+- Added documentation for generated types, custom refinements, compatibility exceptions, and the migration workflow.
+- CI's clean replay exposed migration `080` from another worktree in the shared local stack; aligned the generated file to this branch's `001-079` history and made generation reject mismatched worktree/database migration histories.
+- No production access or local migration-application command was used. Local type generation/checking only read the already-running development stack; CI used its own ephemeral database.
+
+**Validation:**
+- `pnpm test` (311 files, 2785 tests passed)
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm run lint`
+- `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -934,9 +934,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Replaced ambiguous initial loading and failed-read empty states with governed `PageState` loading, error, and successful-empty states for teacher and student Classwork.
 - Added bounded Retry actions that invalidate assignment, material, and survey list caches before reloading; failures never render "No classwork yet," and successful retry restores the normal list.
 - Added focused role regressions and browser-verified loading, error, empty, retry, and restored-list states at desktop/mobile widths in light/dark themes. No API, schema, migration, production state, or production data changed.
+- Independent review found that reactivating Classwork after a failed load used the content-preserving refresh path and could expose the empty state while retrying. Reactivation from an error now uses the blocking load path; both roles prove pending reactivation, repeated failure, and recovery.
 
 **Validation:**
-- Focused Classwork component suites (2 files / 57 tests)
+- Focused Classwork component suites (2 files / 59 tests)
 - `pnpm test --run` (397 files / 3,605 tests)
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -935,9 +935,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added bounded Retry actions that invalidate assignment, material, and survey list caches before reloading; failures never render "No classwork yet," and successful retry restores the normal list.
 - Added focused role regressions and browser-verified loading, error, empty, retry, and restored-list states at desktop/mobile widths in light/dark themes. No API, schema, migration, production state, or production data changed.
 - Independent review found that reactivating Classwork after a failed load used the content-preserving refresh path and could expose the empty state while retrying. Reactivation from an error now uses the blocking load path; both roles prove pending reactivation, repeated failure, and recovery.
+- Final cumulative review found the remaining survey-list exception could still turn survey failures into empty or partial Classwork. Survey reads now participate in the same required failure/retry contract, with teacher and student survey-specific recovery regressions.
 
 **Validation:**
-- Focused Classwork component suites (2 files / 59 tests)
+- Focused Classwork component suites (2 files / 61 tests)
 - `pnpm test --run` (397 files / 3,605 tests)
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,25 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-13 — Generated Supabase database contract
-
-**Completed:**
-- Generated and committed the public Supabase schema contract in `src/types/database.generated.ts`; added `src/types/database.ts` for application-owned JSON/status/RPC refinements and typed both central Supabase client factories.
-- Added `db:types:generate` / `db:types:check`, plus a CI `Database Contract` job that starts an ephemeral database, replays migrations, and rejects generated-type drift.
-- Replaced generic persisted payload records exposed by the typed client with `TableRow`, `TableInsert`, and `TableUpdate` contracts; extracted assessment draft contracts into shared domain types.
-- Fixed blueprint instantiation when `points_possible` is null by omitting it so PostgreSQL applies the assignment default; added a regression for null and explicit point values.
-- Added documentation for generated types, custom refinements, compatibility exceptions, and the migration workflow.
-- CI's clean replay exposed migration `080` from another worktree in the shared local stack; aligned the generated file to this branch's `001-079` history and made generation reject mismatched worktree/database migration histories.
-- No production access or local migration-application command was used. Local type generation/checking only read the already-running development stack; CI used its own ephemeral database.
-
-**Validation:**
-- `pnpm test` (311 files, 2785 tests passed)
-- `pnpm build`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm run lint`
-- `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-07-14 — Atomic test grading contracts
 
 **Completed:**
@@ -945,3 +926,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Publish, independently review, remediate, and merge the browser matrix PR. Then confirm Phase 2 exit evidence and begin Phase 3 with the first independently releasable vertical product slice.
+
+## 2026-07-21 — Phase 3 Classwork list states
+
+**Completed:**
+- Began Phase 3 with a narrow assignment slice that preserves the existing class-wide teacher workflow and student assignment list.
+- Replaced ambiguous initial loading and failed-read empty states with governed `PageState` loading, error, and successful-empty states for teacher and student Classwork.
+- Added bounded Retry actions that invalidate assignment, material, and survey list caches before reloading; failures never render "No classwork yet," and successful retry restores the normal list.
+- Added focused role regressions and browser-verified loading, error, empty, retry, and restored-list states at desktop/mobile widths in light/dark themes. No API, schema, migration, production state, or production data changed.
+
+**Validation:**
+- Focused Classwork component suites (2 files / 57 tests)
+- `pnpm test --run` (397 files / 3,605 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- Playwright forced-state matrix (16 checks across two focused local runs)
+
+**Remaining:**
+- Complete repository gates, independent review, and merge. Then continue the assignment slice with mobile workspace modes, save announcements/dialog semantics, and the Gradex status boundary.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -170,6 +170,12 @@ Exit evidence: canonical primitive tests prove keyboard/focus/ARIA behavior; all
 
 ### Phase 3: Vertical Product Slices
 
+Assignment progress:
+
+- Save/submit integrity was completed in the Safety Wave with atomic persistence and stale-submit regression coverage.
+- The first Phase 3 assignment slice gives teacher and student Classwork lists explicit governed loading, error, and successful-empty states. Retry invalidates the classroom list caches before reloading, and role/viewport/theme browser verification covers failure and recovery without changing the normal class-wide workflow.
+- Remaining assignment work is mobile workspace modes, live save announcements and dialog semantics, and the Gradex status boundary.
+
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: list errors, authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, accessible flags/save status.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Button, Card, ContentDialog, EmptyState, RefreshingIndicator } from '@/ui'
-import { Spinner } from '@/components/Spinner'
+import { Button, Card, ContentDialog, EmptyState, PageState, RefreshingIndicator } from '@/ui'
 import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
 import {
   formatAssignmentTiming,
@@ -21,8 +20,7 @@ import { StudentAssignmentEditor, type StudentAssignmentEditorHandle } from '@/c
 import { RichTextViewer } from '@/components/editor'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { StudentSurveyPanel } from '@/components/surveys/StudentSurveyPanel'
-import { useDelayedBusy } from '@/hooks/useDelayedBusy'
-import { fetchCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { buildOrderedClassworkItems } from '@/lib/classwork-order'
 import { getStudentSurveyStatus, getSurveyStatusBadgeClass, getSurveyStatusLabel } from '@/lib/surveys'
 
@@ -54,6 +52,7 @@ export function StudentAssignmentsTab({
   const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [hasLoaded, setHasLoaded] = useState(false)
+  const [classworkLoadError, setClassworkLoadError] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
   const [editorState, setEditorState] = useState({
@@ -80,10 +79,6 @@ export function StudentAssignmentsTab({
     () => (hasCurrentClassroomData ? surveys : []),
     [hasCurrentClassroomData, surveys],
   )
-  const showBlockingSpinner = useDelayedBusy(
-    loading && currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0
-  )
-
   const loadAssignments = useCallback(
     async (options?: { preserveContent?: boolean }) => {
       const requestId = loadRequestIdRef.current + 1
@@ -94,6 +89,7 @@ export function StudentAssignmentsTab({
       } else {
         setLoading(true)
       }
+      setClassworkLoadError(false)
       try {
         const [assignmentsData, materialsData, surveysData] = await Promise.all([
           fetchCachedJSON<StudentAssignmentsResponse>(
@@ -118,6 +114,7 @@ export function StudentAssignmentsTab({
         setSurveys(surveysData.surveys || [])
         setLoadedClassroomId(classroom.id)
         setHasLoaded(true)
+        setClassworkLoadError(false)
       } catch (err) {
         if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
         setAssignments([])
@@ -125,6 +122,7 @@ export function StudentAssignmentsTab({
         setSurveys([])
         setLoadedClassroomId(classroom.id)
         setHasLoaded(true)
+        setClassworkLoadError(true)
         console.error('Error loading assignments:', err)
       } finally {
         if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
@@ -143,6 +141,7 @@ export function StudentAssignmentsTab({
     setSurveys([])
     setLoadedClassroomId(null)
     setHasLoaded(false)
+    setClassworkLoadError(false)
     setRefreshing(false)
   }, [classroom.id])
 
@@ -157,6 +156,13 @@ export function StudentAssignmentsTab({
     }
     wasActiveRef.current = isActive
   }, [hasLoaded, isActive, loadAssignments])
+
+  const retryLoadAssignments = useCallback(() => {
+    invalidateCachedJSON(`student-assignments:${classroom.id}`)
+    invalidateCachedJSON(`student-materials:${classroom.id}`)
+    invalidateCachedJSON(`student-surveys:${classroom.id}`)
+    void loadAssignments()
+  }, [classroom.id, loadAssignments])
 
   const selectedAssignment = useMemo(() => {
     if (!selectedAssignmentId) return null
@@ -322,15 +328,19 @@ export function StudentAssignmentsTab({
           {refreshing && (
             <RefreshingIndicator className="mb-2 px-0 py-0" />
           )}
-          {showBlockingSpinner ? (
-              <Card tone="panel" padding="lg">
-                <div className="flex justify-center py-8">
-                  <Spinner />
-                </div>
-              </Card>
-            ) : view === 'summary' ? (
+          {!hasLoaded || loading || !hasCurrentClassroomData ? (
+            <PageState kind="loading" title="Loading classwork" />
+          ) : classworkLoadError ? (
+            <PageState
+              kind="error"
+              title="Classwork couldn't load"
+              description="Pika couldn't load this classroom's classwork. Nothing was changed."
+              action={<Button onClick={retryLoadAssignments}>Retry</Button>}
+            />
+          ) : view === 'summary' ? (
               currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0 ? (
-                <EmptyState
+                <PageState
+                  kind="empty"
                   title="No classwork yet"
                   description="When your teacher posts assignments, materials, or surveys, they will show up here."
                 />

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -106,7 +106,7 @@ export function StudentAssignmentsTab({
             `student-surveys:${classroom.id}`,
             `/api/student/surveys?classroom_id=${classroom.id}`,
             { ttlMs: 20_000, errorMessage: 'Failed to load surveys' },
-          ).catch(() => ({ surveys: [] })),
+          ),
         ])
         if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
         setAssignments(assignmentsData.assignments || [])

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -152,10 +152,10 @@ export function StudentAssignmentsTab({
       return
     }
     if (isActive && !wasActiveRef.current && hasLoaded) {
-      loadAssignments({ preserveContent: true })
+      loadAssignments({ preserveContent: !classworkLoadError })
     }
     wasActiveRef.current = isActive
-  }, [hasLoaded, isActive, loadAssignments])
+  }, [classworkLoadError, hasLoaded, isActive, loadAssignments])
 
   const retryLoadAssignments = useCallback(() => {
     invalidateCachedJSON(`student-assignments:${classroom.id}`)

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -747,7 +747,7 @@ export function TeacherClassroomView({
           `teacher-surveys:${classroom.id}`,
           `/api/teacher/surveys?classroom_id=${classroom.id}`,
           { errorMessage: 'Failed to load surveys', ttlMs: 20_000 },
-        ).catch(() => ({ surveys: [] })),
+        ),
         fetchClassDaysForClassroom(classroom.id).catch((err) => {
           console.error('Error loading class days:', err)
           return []

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -38,8 +38,7 @@ import {
   Trash2,
   Unlock,
 } from 'lucide-react'
-import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
-import { useDelayedBusy } from '@/hooks/useDelayedBusy'
+import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, PageState, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
@@ -616,6 +615,7 @@ export function TeacherClassroomView({
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
+  const [classworkLoadError, setClassworkLoadError] = useState(false)
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(false)
   const [isSurveyCreateModalOpen, setIsSurveyCreateModalOpen] = useState(false)
@@ -717,12 +717,6 @@ export function TeacherClassroomView({
     () => (hasCurrentClassroomData ? surveys : []),
     [hasCurrentClassroomData, surveys],
   )
-  const showSummarySpinner = useDelayedBusy(
-    (loading || !hasCurrentClassroomData)
-      && currentAssignments.length === 0
-      && currentMaterials.length === 0
-      && currentSurveys.length === 0
-  )
   const { showMessage } = useAppMessage()
   const {
     layout: assignmentGradingLayout,
@@ -736,6 +730,7 @@ export function TeacherClassroomView({
     if (!preserveContent) {
       setLoading(true)
     }
+    setClassworkLoadError(false)
     try {
       const [assignmentsData, materialsData, surveysData, classDaysData] = await Promise.all([
         fetchCachedJSON<TeacherAssignmentsResponse>(
@@ -765,6 +760,7 @@ export function TeacherClassroomView({
       setClassDays(classDaysData)
       setLoadedClassroomId(classroom.id)
       setHasLoadedOnce(true)
+      setClassworkLoadError(false)
       window.dispatchEvent(
         new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
           detail: { classroomId: classroom.id },
@@ -778,6 +774,7 @@ export function TeacherClassroomView({
       setClassDays([])
       setLoadedClassroomId(classroom.id)
       setHasLoadedOnce(true)
+      setClassworkLoadError(true)
       console.error('Error loading assignments:', err)
     } finally {
       if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
@@ -794,6 +791,7 @@ export function TeacherClassroomView({
     setClassDays([])
     setLoadedClassroomId(null)
     setHasLoadedOnce(false)
+    setClassworkLoadError(false)
     setSelection({ mode: 'summary' })
     setEditAssignment(null)
     setEditMaterial(null)
@@ -809,6 +807,13 @@ export function TeacherClassroomView({
   useEffect(() => {
     loadAssignments()
   }, [loadAssignments])
+
+  const retryLoadAssignments = useCallback(() => {
+    invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+    invalidateCachedJSON(`teacher-materials:${classroom.id}`)
+    invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+    void loadAssignments()
+  }, [classroom.id, loadAssignments])
 
   const handleMaterialSaved = useCallback((material: ClassworkMaterial) => {
     invalidateCachedJSON(`teacher-materials:${classroom.id}`)
@@ -2625,14 +2630,21 @@ export function TeacherClassroomView({
     </>
   )
 
-  const summaryContent = showSummarySpinner ? (
-    <div className="flex justify-center py-8">
-      <Spinner />
-    </div>
+  const summaryContent = loading || !hasLoadedOnce || !hasCurrentClassroomData ? (
+    <PageState kind="loading" title="Loading classwork" />
+  ) : classworkLoadError ? (
+    <PageState
+      kind="error"
+      title="Classwork couldn't load"
+      description="Pika couldn't load this classroom's classwork. Nothing was changed."
+      action={<Button onClick={retryLoadAssignments}>Retry</Button>}
+    />
   ) : currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0 ? (
-    <div className="py-6 text-center text-sm text-text-muted">
-      No classwork yet
-    </div>
+    <PageState
+      kind="empty"
+      title="No classwork yet"
+      description={isReadOnly ? 'This classroom has no classwork.' : 'Create an assignment, material, or survey to get started.'}
+    />
   ) : (
     <TeacherWorkItemList>
       <DndContext

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -954,10 +954,10 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (isActive && !wasActiveRef.current && hasLoadedOnce) {
-      loadAssignments({ preserveContent: true })
+      loadAssignments({ preserveContent: !classworkLoadError })
     }
     wasActiveRef.current = isActive
-  }, [hasLoadedOnce, isActive, loadAssignments])
+  }, [classworkLoadError, hasLoadedOnce, isActive, loadAssignments])
 
   useEffect(() => {
     const node = workspaceContainerRef.current

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { forwardRef, useEffect, useImperativeHandle } from 'react'
 import { StudentAssignmentsTab } from '@/app/classrooms/[classroomId]/StudentAssignmentsTab'
 import { invalidateCachedJSONMatching } from '@/lib/request-cache'
-import type { Classroom, AssignmentWithStatus, ClassworkMaterial } from '@/types'
+import type { Classroom, AssignmentWithStatus, ClassworkMaterial, StudentSurveyView } from '@/types'
 
 // --- Mocks ---
 
@@ -102,6 +102,24 @@ function makeMaterial(overrides: Partial<ClassworkMaterial> = {}): ClassworkMate
   }
 }
 
+function makeSurvey(overrides: Partial<StudentSurveyView> = {}): StudentSurveyView {
+  return {
+    id: 'survey-1',
+    classroom_id: classroom.id,
+    title: 'Class survey',
+    status: 'active',
+    opens_at: null,
+    show_results: true,
+    dynamic_responses: false,
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    student_status: 'not_started',
+    ...overrides,
+  }
+}
+
 function mockFetchClasswork(assignments: AssignmentWithStatus[], materials: ClassworkMaterial[] = []) {
   ;(global.fetch as ReturnType<typeof vi.fn>)
     .mockResolvedValueOnce({
@@ -111,6 +129,10 @@ function mockFetchClasswork(assignments: AssignmentWithStatus[], materials: Clas
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({ materials }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ surveys: [] }),
     })
 }
 
@@ -187,6 +209,44 @@ describe('StudentAssignmentsTab', () => {
     expect(await screen.findByText('Restored assignment')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
+  })
+
+  it('treats a survey list failure as a retryable classwork failure', async () => {
+    const retryClassroom = { ...classroom, id: 'cls-survey-retry' }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let surveysShouldFail = true
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/student/assignments')) return mockJSONResponse({ assignments: [] })
+        if (url.includes('/materials')) return mockJSONResponse({ materials: [] })
+        if (url.includes('/api/student/surveys')) {
+          if (surveysShouldFail) {
+            return {
+              ok: false,
+              json: async () => ({ error: 'Surveys unavailable' }),
+            }
+          }
+          return mockJSONResponse({
+            surveys: [makeSurvey({ classroom_id: retryClassroom.id, title: 'Recovered survey' })],
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      }),
+    )
+
+    render(<StudentAssignmentsTab classroom={retryClassroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+
+    surveysShouldFail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Recovered survey')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('keeps failed classwork in a blocking state while reactivating the tab', async () => {

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -141,6 +141,54 @@ describe('StudentAssignmentsTab', () => {
     vi.restoreAllMocks()
   })
 
+  it('shows a classwork error and restores the list after retry', async () => {
+    const retryClassroom = { ...classroom, id: 'cls-classwork-retry' }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let assignmentsShouldFail = true
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/student/assignments')) {
+          if (assignmentsShouldFail) {
+            return {
+              ok: false,
+              json: async () => ({ error: 'Assignments unavailable' }),
+            }
+          }
+          return mockJSONResponse({
+            assignments: [
+              makeAssignment({
+                classroom_id: retryClassroom.id,
+                title: 'Restored assignment',
+              }),
+            ],
+          })
+        }
+        if (url.includes('/materials')) {
+          return mockJSONResponse({ materials: [] })
+        }
+        if (url.includes('/api/student/surveys')) {
+          return mockJSONResponse({ surveys: [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      }),
+    )
+
+    render(<StudentAssignmentsTab classroom={retryClassroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+
+    assignmentsShouldFail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Restored assignment')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
+  })
+
   it('first-time view: auto-shows instructions modal', async () => {
     const unviewed = makeAssignment({ doc: null })
     searchParamsMap.set('assignmentId', 'asgn-1')

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -189,6 +189,66 @@ describe('StudentAssignmentsTab', () => {
     expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
   })
 
+  it('keeps failed classwork in a blocking state while reactivating the tab', async () => {
+    const retryClassroom = { ...classroom, id: 'cls-classwork-reactivation' }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let assignmentAttempts = 0
+    let resolveReactivation: ((response: ReturnType<typeof mockJSONResponse>) => void) | null = null
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/student/assignments')) {
+          assignmentAttempts += 1
+          if (assignmentAttempts === 1) {
+            return {
+              ok: false,
+              json: async () => ({ error: 'Assignments unavailable' }),
+            }
+          }
+          if (assignmentAttempts === 2) {
+            return await new Promise<ReturnType<typeof mockJSONResponse>>((resolve) => {
+              resolveReactivation = resolve
+            })
+          }
+          return mockJSONResponse({
+            assignments: [
+              makeAssignment({
+                classroom_id: retryClassroom.id,
+                title: 'Recovered after reactivation',
+              }),
+            ],
+          })
+        }
+        if (url.includes('/materials')) return mockJSONResponse({ materials: [] })
+        if (url.includes('/api/student/surveys')) return mockJSONResponse({ surveys: [] })
+        throw new Error(`Unexpected request: ${url}`)
+      }),
+    )
+
+    const view = render(<StudentAssignmentsTab classroom={retryClassroom} isActive />)
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+
+    view.rerender(<StudentAssignmentsTab classroom={retryClassroom} isActive={false} />)
+    view.rerender(<StudentAssignmentsTab classroom={retryClassroom} isActive />)
+
+    expect(await screen.findByRole('heading', { name: 'Loading classwork' })).toBeInTheDocument()
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+    await waitFor(() => expect(resolveReactivation).toEqual(expect.any(Function)))
+
+    await act(async () => {
+      resolveReactivation?.({
+        ok: false,
+        json: async () => ({ error: 'Assignments still unavailable' }),
+      })
+    })
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('Recovered after reactivation')).toBeInTheDocument()
+  })
+
   it('first-time view: auto-shows instructions modal', async () => {
     const unviewed = makeAssignment({ doc: null })
     searchParamsMap.set('assignmentId', 'asgn-1')

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -730,6 +730,55 @@ describe('TeacherClassroomView', () => {
     expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
   })
 
+  it('keeps failed classwork in a blocking state while reactivating the tab', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let assignmentAttempts = 0
+    let rejectReactivation: ((reason: Error) => void) | null = null
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        assignmentAttempts += 1
+        if (assignmentAttempts === 1) {
+          return Promise.reject(new Error('Assignments unavailable'))
+        }
+        if (assignmentAttempts === 2) {
+          return new Promise((_resolve, reject) => {
+            rejectReactivation = reject
+          })
+        }
+        return Promise.resolve({
+          assignments: [makeAssignmentSummary('assignment-recovered', 'Recovered after reactivation')],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) return Promise.resolve({ materials: [] })
+      if (key === `teacher-surveys:${classroom.id}`) return Promise.resolve({ surveys: [] })
+      return fetcher()
+    })
+
+    const view = render(
+      <TeacherClassroomView classroom={classroom} selectedAssignmentId={null} isActive />
+    )
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+
+    view.rerender(
+      <TeacherClassroomView classroom={classroom} selectedAssignmentId={null} isActive={false} />
+    )
+    view.rerender(
+      <TeacherClassroomView classroom={classroom} selectedAssignmentId={null} isActive />
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Loading classwork' })).toBeInTheDocument()
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+    await waitFor(() => expect(rejectReactivation).toEqual(expect.any(Function)))
+
+    await act(async () => {
+      rejectReactivation?.(new Error('Assignments still unavailable'))
+    })
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByRole('button', { name: 'Recovered after reactivation' })).toBeInTheDocument()
+  })
+
   it('does not reopen a stale assignment cookie when URL selection is on summary', async () => {
     document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -693,6 +693,43 @@ describe('TeacherClassroomView', () => {
     clearAssignmentWorkspaceStudentCookie()
   })
 
+  it('shows a classwork error and restores the list after retry', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let assignmentsShouldFail = true
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        if (assignmentsShouldFail) {
+          return Promise.reject(new Error('Assignments unavailable'))
+        }
+        return Promise.resolve({
+          assignments: [makeAssignmentSummary('assignment-restored', 'Restored assignment')],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      return fetcher()
+    })
+
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+
+    assignmentsShouldFail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByRole('button', { name: 'Restored assignment' })).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(mockInvalidateCachedJSON).toHaveBeenCalledWith(`teacher-assignments:${classroom.id}`)
+    expect(mockInvalidateCachedJSON).toHaveBeenCalledWith(`teacher-materials:${classroom.id}`)
+    expect(mockInvalidateCachedJSON).toHaveBeenCalledWith(`teacher-surveys:${classroom.id}`)
+    expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
+  })
+
   it('does not reopen a stale assignment cookie when URL selection is on summary', async () => {
     document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -680,6 +680,9 @@ describe('TeacherClassroomView', () => {
       if (key === `teacher-materials:${classroom.id}`) {
         return Promise.resolve({ materials: [] })
       }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
       return fetcher()
     })
     mockInvalidateCachedJSON.mockReset()
@@ -728,6 +731,33 @@ describe('TeacherClassroomView', () => {
     expect(mockInvalidateCachedJSON).toHaveBeenCalledWith(`teacher-materials:${classroom.id}`)
     expect(mockInvalidateCachedJSON).toHaveBeenCalledWith(`teacher-surveys:${classroom.id}`)
     expect(consoleError).toHaveBeenCalledWith('Error loading assignments:', expect.any(Error))
+  })
+
+  it('treats a survey list failure as a retryable classwork failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let surveysShouldFail = true
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) return Promise.resolve({ assignments: [] })
+      if (key === `teacher-materials:${classroom.id}`) return Promise.resolve({ materials: [] })
+      if (key === `teacher-surveys:${classroom.id}`) {
+        if (surveysShouldFail) return Promise.reject(new Error('Surveys unavailable'))
+        return Promise.resolve({
+          surveys: [makeSurveySummary('survey-restored', 'Recovered survey')],
+        })
+      }
+      return fetcher()
+    })
+
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Classwork couldn't load")
+    expect(screen.queryByText('No classwork yet')).not.toBeInTheDocument()
+
+    surveysShouldFail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByRole('button', { name: 'Recovered survey' })).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('keeps failed classwork in a blocking state while reactivating the tab', async () => {
@@ -1199,6 +1229,9 @@ describe('TeacherClassroomView', () => {
       if (key === `class-days:${classroom.id}`) {
         return Promise.resolve({ class_days: [] })
       }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
       return fetcher()
     })
 
@@ -1570,6 +1603,9 @@ describe('TeacherClassroomView', () => {
       if (key === `teacher-materials:${classroom.id}`) {
         return Promise.resolve({ materials: [] })
       }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
       return fetcher()
     })
     const updateSearchParams = vi.fn()
@@ -1608,6 +1644,9 @@ describe('TeacherClassroomView', () => {
       }
       if (key === `teacher-materials:${classroom.id}`) {
         return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
       }
       return fetcher()
     })
@@ -3467,6 +3506,9 @@ describe('TeacherClassroomView', () => {
       }
       if (key === `teacher-materials:${classroom.id}`) {
         return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
       }
       return fetcher()
     })


### PR DESCRIPTION
## Summary
- distinguish Classwork loading, failed-read, and successful-empty states for teachers and students
- add bounded cache-invalidating Retry actions without changing normal assignment lists or grading workflows
- add role regressions and record desktop/mobile light/dark visual verification

## Risk
Standard application state-transition change. No API, schema, migration, dependency, production state, or production data changes.

## Verification
- `pnpm test --run` (397 files / 3,605 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (613 modules / 0 allowances)
- `pnpm check:ui-policy` (215 controls / 67 files)
- `pnpm build`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- Playwright forced-state matrix: 16 checks covering teacher/student, desktop/mobile, light/dark, loading/error/empty/retry/restored list

## UI brief
This refines the existing Classwork shell; it does not redesign cards, actions, class-wide teacher workflows, assignment selection, or grading. Composite widgets are unchanged.