### PR TITLE
Migrate test grading to the internal core

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14148,3 +14148,21 @@
 - `pnpm vitest run` (359 files, 3,287 tests)
 - `pnpm build`
 - `git diff --check`
+
+## 2026-07-14 — Archive stack review findings fixed
+
+**Completed:**
+- Ran repeated independent SQL, runtime, Gradex, and cross-layer review loops and fixed every actionable finding.
+- Hardened export/restore upload cleanup, exact restore object descriptors, actor-role reconciliation, transactional compaction dry runs, canonical paths, expiry/retry state transitions, and fail-closed source cleanup.
+- Tightened Gradex v2 with strict per-table Zod contracts, required relationships and projected fields, safe analytic enum preservation, Unicode-aware identifier scanning, pseudonymized unknown tokens, exact cleanup canaries, and retention fences.
+- Updated database contract drills, lifecycle guidance, cron integration, and environment documentation. No production database, migration, row, object, environment, deployment, or schedule was read or modified.
+
+**Validation:**
+- Fresh local Supabase reset through migrations 001–086
+- Archive export, restore, compaction, and Gradex database contract scripts
+- Full Vitest suite (339 files / 3,037 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- Pika pre-commit audit
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -688,6 +688,30 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Remaining:**
 - Review and merge PR #897. Continue Phase 2 with shared button target sizing/focus-visible behavior and semantic form-field propagation.
 
+## 2026-07-21 — Internal test grading profile and provenance
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5.4 - this phase crosses provider contracts, privacy boundaries, durable grading concurrency, revision fencing, and rolling database compatibility.
+
+**Completed:**
+- Moved test open-response prompts, strict output schemas, output budgets, and profile versions into the database-independent grading core while preserving Pika's sanitization, reference cache, score buckets, telemetry, and teacher workflows in the compatibility adapter.
+- Routed direct and durable test grading through the shared structured-output provider executor with bounded, pseudonymous per-request provenance and complete retry token accounting.
+- Added signed manual provenance propagation and migration `102` with service-role-only compatibility wrappers that atomically persist provenance without double-incrementing response revisions.
+- Preserved provenance for teacher corrections, cleared stale provenance for legacy AI replacements and grade clears, and kept durable replay idempotent.
+- Kept the remote Gradex worker disabled; no live provider calls, production changes, or local migration application were performed.
+
+**Validation:**
+- Focused grading/persistence suite (10 files / 114 tests)
+- Full Vitest suite (403 files / 3,632 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (620 modules / 0 allowances)
+- `pnpm build`
+- `bash -n scripts/check-atomic-test-grading.sh`
+- `git diff --check`
+- Migration replay, database harness, and generated-type drift check pending ephemeral CI
+
 ## 2026-07-21 — Phase 2 shared control and form-field contract
 
 **Completed:**

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -196,7 +196,8 @@ Before changing remaining `quiz` / `quizzes` names, load
 - **Draft validation**: browser-safe draft contracts live in `@/lib/validations/assessment-drafts`
 - **Draft persistence**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`
 - **Scheduling**: `combineScheduleDateTimeToIso()` / `isScheduleIsoInFuture()` from `@/lib/scheduling`
-- **AI grading** (tests only): `src/lib/ai-test-grading.ts` — reference answer SHA-256 cached per question
+- **AI grading core**: `src/lib/grading/*` owns versioned assignment/test profiles, structured-output execution, provider adapters, and bounded provenance contracts.
+- **Test grading compatibility adapter**: `src/lib/ai-test-grading.ts` owns roster-aware sanitization, reference-answer SHA-256 caching, score buckets, and pseudonymous batch mapping before invoking the internal core.
 
 ### Content Fields
 Assignment docs, test questions, and lesson plans store content as Tiptap JSON.

--- a/docs/guidance/ai-grading-egress.md
+++ b/docs/guidance/ai-grading-egress.md
@@ -34,6 +34,11 @@ that sanitized copy to the provider.
   feedback.
 - Test batch grading sends pseudonymous response refs and maps them back locally
   after the provider response.
+- Assignment and test provider calls run through the database-independent
+  `src/lib/grading/*` core. Pika-specific adapters sanitize first, while
+  versioned profiles own prompt and output contracts.
+- The remote Gradex worker remains disabled during the internal grading pilot;
+  no normal grading path sends classroom data to Gradex.
 
 ## GradeX Adapter Guidance
 

--- a/docs/guidance/atomic-test-grading-rollout.md
+++ b/docs/guidance/atomic-test-grading-rollout.md
@@ -32,3 +32,19 @@ deployment.
 
 Before applying the contract release, verify that every live instance uses the atomic AI run-creation RPC from
 this expand release so no old instance can create a partially initialized run after direct writes are disabled.
+
+## Versioned Provenance Expansion
+
+Migration `102` is a later rolling-safe expansion. Apply it before deploying the
+application version that calls the provenance-aware wrappers. It:
+
+- adds a bounded `test_responses.ai_grading_provenance` contract;
+- leaves every migration `094` RPC signature available to older instances;
+- adds service-role-only manual and durable wrappers that commit the grade and
+  provenance in one transaction without advancing the response revision twice;
+- clears provenance when an older writer replaces or clears AI metadata; and
+- preserves provenance when a teacher edits the final score or feedback while
+  the original AI suggestion metadata remains intact.
+
+Migration `102` does not enable remote Gradex processing and does not change the
+teacher grading workflow.

--- a/docs/guidance/atomic-test-grading-rollout.md
+++ b/docs/guidance/atomic-test-grading-rollout.md
@@ -48,3 +48,8 @@ application version that calls the provenance-aware wrappers. It:
 
 Migration `102` does not enable remote Gradex processing and does not change the
 teacher grading workflow.
+
+Before deployment, require the CI architecture/database-contract job to replay
+migrations `001` through `102`, confirm generated database types have no drift,
+and pass `scripts/check-atomic-test-grading.sh`. A TypeScript-only or mocked RPC
+test is not sufficient evidence for this migration.

--- a/scripts/check-atomic-test-grading.sh
+++ b/scripts/check-atomic-test-grading.sh
@@ -1509,4 +1509,366 @@ if [[ "$AI_FIRST_STATE" != "2:4.00:AI first winner:completed" ]]; then
   exit 1
 fi
 
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+do $provenance_contract$
+declare
+  v_result jsonb;
+  v_provenance_a jsonb := jsonb_build_object(
+    'schemaVersion', 'test-grading-provenance-v1',
+    'gradingRequestId', 'a9000000-0000-4000-8000-000000000601',
+    'provider', 'openai',
+    'model', 'contract-model',
+    'policyVersion', 'pika-test-open-response-policy-v1',
+    'promptVersion', 'pika-test-open-response-manual-prompt-v1',
+    'gradingProfileVersion', 'pika-test-open-response-v1',
+    'rubricVersion', 'pika-test-open-response-rubric-v1',
+    'operation', 'single',
+    'batchSize', 1,
+    'providerRequestCount', 1,
+    'tokenUsage', jsonb_build_object('inputTokens', 100, 'outputTokens', 20, 'totalTokens', 120)
+  );
+  v_provenance_b jsonb := jsonb_build_object(
+    'schemaVersion', 'test-grading-provenance-v1',
+    'gradingRequestId', 'a9000000-0000-4000-8000-000000000602',
+    'provider', 'openai',
+    'model', 'contract-model',
+    'policyVersion', 'pika-test-open-response-policy-v1',
+    'promptVersion', 'pika-test-open-response-bulk-prompt-v1',
+    'gradingProfileVersion', 'pika-test-open-response-v1',
+    'rubricVersion', 'pika-test-open-response-rubric-v1',
+    'operation', 'batch',
+    'batchSize', 2,
+    'providerRequestCount', 1,
+    'tokenUsage', jsonb_build_object('inputTokens', 180, 'outputTokens', 40, 'totalTokens', 220)
+  );
+  v_provenance_c jsonb := jsonb_build_object(
+    'schemaVersion', 'test-grading-provenance-v1',
+    'gradingRequestId', 'a9000000-0000-4000-8000-000000000603',
+    'provider', 'openai',
+    'model', 'contract-model',
+    'policyVersion', 'pika-test-open-response-policy-v1',
+    'promptVersion', 'pika-test-open-response-bulk-prompt-v1',
+    'gradingProfileVersion', 'pika-test-open-response-v1',
+    'rubricVersion', 'pika-test-open-response-rubric-v1',
+    'operation', 'batch',
+    'batchSize', 2,
+    'providerRequestCount', 2,
+    'tokenUsage', jsonb_build_object('inputTokens', 360, 'outputTokens', 80, 'totalTokens', 440)
+  );
+  v_revision bigint;
+  v_request_id text;
+  v_rejected boolean := false;
+begin
+  if has_function_privilege(
+    'anon',
+    'public.save_test_response_grades_with_provenance_atomic(uuid,uuid,uuid,jsonb,timestamp with time zone)',
+    'execute'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.save_test_response_grades_with_provenance_atomic(uuid,uuid,uuid,jsonb,timestamp with time zone)',
+    'execute'
+  ) or not has_function_privilege(
+    'service_role',
+    'public.save_test_response_grades_with_provenance_atomic(uuid,uuid,uuid,jsonb,timestamp with time zone)',
+    'execute'
+  ) then
+    raise exception 'Manual test provenance RPC privileges are invalid';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.finalize_test_ai_grading_item_with_provenance_atomic(uuid,uuid,uuid,numeric,text,text,jsonb,text,jsonb,integer,timestamp with time zone)',
+    'execute'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.finalize_test_ai_grading_item_with_provenance_atomic(uuid,uuid,uuid,numeric,text,text,jsonb,text,jsonb,integer,timestamp with time zone)',
+    'execute'
+  ) or not has_function_privilege(
+    'service_role',
+    'public.finalize_test_ai_grading_item_with_provenance_atomic(uuid,uuid,uuid,numeric,text,text,jsonb,text,jsonb,integer,timestamp with time zone)',
+    'execute'
+  ) then
+    raise exception 'Durable test provenance RPC privileges are invalid';
+  end if;
+
+  insert into public.tests (id, classroom_id, title, status, points_possible, created_by)
+  values (
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000010',
+    'AI provenance contract',
+    'closed',
+    5,
+    'a9000000-0000-4000-8000-000000000001'
+  );
+  insert into public.test_questions (
+    id, test_id, question_type, question_text, options, correct_option, points,
+    response_max_chars, position, answer_key
+  ) values (
+    'a9000000-0000-4000-8000-000000000121',
+    'a9000000-0000-4000-8000-000000000028',
+    'open_response',
+    'Explain the provenance contract.',
+    '[]',
+    null,
+    5,
+    5000,
+    0,
+    'Explain atomic persistence.'
+  );
+  insert into public.test_responses (
+    id, test_id, question_id, student_id, response_text, submitted_at
+  ) values (
+    'a9000000-0000-4000-8000-000000000219',
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000121',
+    'a9000000-0000-4000-8000-000000000002',
+    'The write and audit commit together.',
+    now()
+  );
+
+  v_result := public.save_test_response_grades_with_provenance_atomic(
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000002',
+    'a9000000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'response_id', 'a9000000-0000-4000-8000-000000000219',
+      'question_id', 'a9000000-0000-4000-8000-000000000121',
+      'expected_response_revision', 1,
+      'clear_grade', false,
+      'score', 4,
+      'feedback', 'Manual AI suggestion',
+      'ai_grading_basis', 'teacher_key',
+      'ai_reference_answers', null,
+      'ai_model', 'contract-model',
+      'question_grading_snapshot', jsonb_build_object(
+        'test_title', 'AI provenance contract',
+        'question_text', 'Explain the provenance contract.',
+        'points', 5,
+        'response_monospace', false,
+        'answer_key', 'Explain atomic persistence.',
+        'sample_solution', null
+      ),
+      'ai_suggested_score', 4,
+      'ai_suggested_feedback', 'Manual AI suggestion',
+      'ai_grading_provenance', v_provenance_a
+    )),
+    '2026-07-21T18:00:00Z'
+  );
+  select revision, ai_grading_provenance->>'gradingRequestId'
+  into v_revision, v_request_id
+  from public.test_responses
+  where id = 'a9000000-0000-4000-8000-000000000219';
+  if v_revision <> 2
+    or v_request_id <> 'a9000000-0000-4000-8000-000000000601'
+    or (v_result->'responses'->0->>'revision')::bigint <> 2
+  then
+    raise exception 'Manual test AI provenance did not persist atomically: % / % / %',
+      v_result, v_revision, v_request_id;
+  end if;
+
+  perform public.save_test_response_grades_with_provenance_atomic(
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000002',
+    'a9000000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'response_id', 'a9000000-0000-4000-8000-000000000219',
+      'question_id', 'a9000000-0000-4000-8000-000000000121',
+      'expected_response_revision', 2,
+      'clear_grade', false,
+      'score', 3,
+      'feedback', 'Teacher edited the suggestion'
+    )),
+    '2026-07-21T18:01:00Z'
+  );
+  select revision, ai_grading_provenance->>'gradingRequestId'
+  into v_revision, v_request_id
+  from public.test_responses
+  where id = 'a9000000-0000-4000-8000-000000000219';
+  if v_revision <> 3 or v_request_id <> 'a9000000-0000-4000-8000-000000000601' then
+    raise exception 'Teacher correction erased test AI provenance: % / %', v_revision, v_request_id;
+  end if;
+
+  perform public.save_test_response_grades_atomic(
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000002',
+    'a9000000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'response_id', 'a9000000-0000-4000-8000-000000000219',
+      'question_id', 'a9000000-0000-4000-8000-000000000121',
+      'expected_response_revision', 3,
+      'clear_grade', false,
+      'score', 2,
+      'feedback', 'Legacy replacement',
+      'ai_grading_basis', 'teacher_key',
+      'ai_reference_answers', null,
+      'ai_model', 'legacy-model',
+      'question_grading_snapshot', jsonb_build_object(
+        'test_title', 'AI provenance contract',
+        'question_text', 'Explain the provenance contract.',
+        'points', 5,
+        'response_monospace', false,
+        'answer_key', 'Explain atomic persistence.',
+        'sample_solution', null
+      ),
+      'ai_suggested_score', 2,
+      'ai_suggested_feedback', 'Legacy replacement'
+    )),
+    '2026-07-21T18:02:00Z'
+  );
+  if exists (
+    select 1 from public.test_responses
+    where id = 'a9000000-0000-4000-8000-000000000219'
+      and ai_grading_provenance is not null
+  ) then
+    raise exception 'legacy test grade write left stale AI provenance';
+  end if;
+
+  insert into public.test_ai_grading_runs (
+    id, test_id, status, triggered_by, model, selection_hash, requested_count,
+    eligible_student_count, queued_response_count, lease_token, lease_expires_at, started_at
+  ) values (
+    'a9000000-0000-4000-8000-000000000309',
+    'a9000000-0000-4000-8000-000000000028',
+    'running',
+    'a9000000-0000-4000-8000-000000000001',
+    'contract-model',
+    'provenance',
+    1,
+    1,
+    1,
+    'a9000000-0000-4000-8000-000000000509',
+    now() + interval '10 minutes',
+    now()
+  );
+  insert into public.test_ai_grading_run_items (
+    id, run_id, test_id, student_id, question_id, response_id, queue_position,
+    question_grading_snapshot
+  ) values (
+    'a9000000-0000-4000-8000-000000000408',
+    'a9000000-0000-4000-8000-000000000309',
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000002',
+    'a9000000-0000-4000-8000-000000000121',
+    'a9000000-0000-4000-8000-000000000219',
+    0,
+    jsonb_build_object(
+      'test_title', 'AI provenance contract',
+      'question_text', 'Explain the provenance contract.',
+      'points', 5,
+      'response_monospace', false,
+      'answer_key', 'Explain atomic persistence.',
+      'sample_solution', null
+    )
+  );
+
+  v_result := public.finalize_test_ai_grading_item_with_provenance_atomic(
+    'a9000000-0000-4000-8000-000000000408',
+    'a9000000-0000-4000-8000-000000000001',
+    'a9000000-0000-4000-8000-000000000509',
+    5,
+    'Durable AI grade',
+    'teacher_key',
+    null,
+    'contract-model',
+    v_provenance_b,
+    1,
+    '2026-07-21T18:03:00Z'
+  );
+  select revision, ai_grading_provenance->>'gradingRequestId'
+  into v_revision, v_request_id
+  from public.test_responses
+  where id = 'a9000000-0000-4000-8000-000000000219';
+  if v_result->>'outcome' <> 'saved'
+    or v_revision <> 5
+    or v_request_id <> 'a9000000-0000-4000-8000-000000000602'
+  then
+    raise exception 'Durable test AI provenance did not persist atomically: % / % / %',
+      v_result, v_revision, v_request_id;
+  end if;
+
+  v_result := public.finalize_test_ai_grading_item_with_provenance_atomic(
+    'a9000000-0000-4000-8000-000000000408',
+    'a9000000-0000-4000-8000-000000000001',
+    'a9000000-0000-4000-8000-000000000509',
+    1,
+    'Replay must not replace',
+    'teacher_key',
+    null,
+    'contract-model',
+    v_provenance_c,
+    2,
+    '2026-07-21T18:04:00Z'
+  );
+  select ai_grading_provenance->>'gradingRequestId'
+  into v_request_id
+  from public.test_responses
+  where id = 'a9000000-0000-4000-8000-000000000219';
+  if v_result->>'outcome' <> 'replayed'
+    or v_request_id <> 'a9000000-0000-4000-8000-000000000602'
+  then
+    raise exception 'test AI provenance replay overwrote the original audit: % / %',
+      v_result, v_request_id;
+  end if;
+
+  perform public.clear_test_open_response_grades_atomic(
+    'a9000000-0000-4000-8000-000000000028',
+    'a9000000-0000-4000-8000-000000000001',
+    array['a9000000-0000-4000-8000-000000000002'::uuid],
+    jsonb_build_array(jsonb_build_object(
+      'response_id', 'a9000000-0000-4000-8000-000000000219',
+      'expected_response_revision', 5
+    )),
+    '2026-07-21T18:05:00Z'
+  );
+  if exists (
+    select 1 from public.test_responses
+    where id = 'a9000000-0000-4000-8000-000000000219'
+      and ai_grading_provenance is not null
+  ) then
+    raise exception 'Legacy test grade clear left stale AI provenance';
+  end if;
+
+  begin
+    perform public.save_test_response_grades_with_provenance_atomic(
+      'a9000000-0000-4000-8000-000000000028',
+      'a9000000-0000-4000-8000-000000000002',
+      'a9000000-0000-4000-8000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'response_id', 'a9000000-0000-4000-8000-000000000219',
+        'question_id', 'a9000000-0000-4000-8000-000000000121',
+        'expected_response_revision', 6,
+        'clear_grade', false,
+        'score', 4,
+        'feedback', 'Invalid provenance must roll back',
+        'ai_grading_basis', 'teacher_key',
+        'ai_reference_answers', null,
+        'ai_model', 'contract-model',
+        'question_grading_snapshot', jsonb_build_object(
+          'test_title', 'AI provenance contract',
+          'question_text', 'Explain the provenance contract.',
+          'points', 5,
+          'response_monospace', false,
+          'answer_key', 'Explain atomic persistence.',
+          'sample_solution', null
+        ),
+        'ai_suggested_score', 4,
+        'ai_suggested_feedback', 'Invalid provenance must roll back',
+        'ai_grading_provenance', v_provenance_a - 'provider'
+      )),
+      '2026-07-21T18:06:00Z'
+    );
+  exception when check_violation then
+    v_rejected := true;
+  end;
+  select revision into v_revision
+  from public.test_responses
+  where id = 'a9000000-0000-4000-8000-000000000219';
+  if not v_rejected or v_revision <> 6 then
+    raise exception 'Invalid test AI provenance was not transactionally rejected: % / %',
+      v_rejected, v_revision;
+  end if;
+end;
+$provenance_contract$;
+SQL
+
 echo "Atomic test grading database checks passed."

--- a/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
+++ b/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
@@ -191,6 +191,7 @@ export const POST = withErrorHandler('AiSuggestTeacherTestGrade', async (request
     suggestedScore: suggestion.score,
     suggestedFeedback: suggestion.feedback,
     questionGradingSnapshot,
+    gradingProvenance: suggestion.provenance,
   })
 
   return NextResponse.json({

--- a/src/components/TestIndividualResponses.tsx
+++ b/src/components/TestIndividualResponses.tsx
@@ -6,6 +6,7 @@ import { getTestExitCount } from '@/lib/tests'
 import { Button, Input } from '@/ui'
 import type { TestFocusSummary } from '@/types'
 import type { TestQuestionGradingSnapshot } from '@/lib/test-grading-context'
+import type { TestGradingProvenance } from '@/lib/grading/contracts'
 
 interface QuestionInfo {
   id: string
@@ -53,6 +54,7 @@ interface GradeDraft {
   aiProvenanceToken?: string
   aiSuggestedScore?: number
   aiSuggestedFeedback?: string
+  aiGradingProvenance?: TestGradingProvenance
 }
 
 interface TestStats {
@@ -229,6 +231,7 @@ export function TestIndividualResponses({
         aiProvenanceToken: data.ai_provenance_token,
         aiSuggestedScore: data.suggestion?.score,
         aiSuggestedFeedback: data.suggestion?.feedback,
+        aiGradingProvenance: data.suggestion?.provenance,
       })
       setGradingMessageState({
         scope: operationScope,
@@ -295,6 +298,7 @@ export function TestIndividualResponses({
                 ai_provenance_token: draft.aiProvenanceToken,
                 ai_suggested_score: draft.aiSuggestedScore,
                 ai_suggested_feedback: draft.aiSuggestedFeedback,
+                ai_grading_provenance: draft.aiGradingProvenance,
               }
             : {}),
         }),

--- a/src/lib/ai-test-grading.ts
+++ b/src/lib/ai-test-grading.ts
@@ -1,14 +1,7 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import type { TestAiGradingBasis } from '@/types'
 import {
-  BULK_GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE,
-  BULK_TEST_AI_PROMPT_GUIDELINE,
-  DEFAULT_TEST_AI_PROMPT_GUIDELINE,
-  GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE,
-} from '@/lib/test-ai-prompt-guideline'
-import {
   estimatePromptMetrics,
-  extractOpenAIResponseUsage,
   logAiPromptTelemetry,
   type AiPromptMetrics,
   type OpenAIResponseUsage,
@@ -20,82 +13,44 @@ import {
   sanitizeAiText,
   type AiSanitizationContext,
 } from '@/lib/ai-sanitization'
+import {
+  testGradingProvenanceSchema,
+  type TestGradingProvenance,
+} from '@/lib/grading/contracts'
+import {
+  executeStructuredOutput,
+  GradingOutputError,
+  type GradingExecutionMetadata,
+  type StructuredOutputSpec,
+} from '@/lib/grading/engine'
+import {
+  buildPikaTestBatchSystemPrompt,
+  buildPikaTestBatchUserPrompt,
+  buildPikaTestOpenResponsePrompt,
+  buildPikaTestReferencePrompt,
+  buildPikaTestSingleUserPrompt,
+  getPikaTestPromptVersion,
+  parsePikaTestBatchGradeOutput,
+  parsePikaTestReferenceOutput,
+  parsePikaTestSingleGradeOutput,
+  PIKA_TEST_BATCH_GRADE_OUTPUT,
+  PIKA_TEST_OPEN_RESPONSE_POLICY_VERSION,
+  PIKA_TEST_OPEN_RESPONSE_PROFILE_VERSION,
+  PIKA_TEST_OPEN_RESPONSE_RUBRIC_VERSION,
+  PIKA_TEST_REFERENCE_OUTPUT,
+  PIKA_TEST_SINGLE_GRADE_OUTPUT,
+  resolvePikaTestPromptGuideline,
+} from '@/lib/grading/profiles/pika-test-open-response'
+import { createOpenAiResponsesProvider } from '@/lib/grading/providers/openai-responses'
+import { GradingProviderError } from '@/lib/grading/providers/types'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
 const MAX_REFERENCE_ANSWERS = 3
-const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504])
 const TEST_AI_REASONING_EFFORT = 'minimal'
 const TEST_AI_REQUEST_TIMEOUT_MS = 25_000
-const TEST_AI_REFERENCE_MAX_OUTPUT_TOKENS = 220
-const TEST_AI_REFERENCE_FALLBACK_MAX_OUTPUT_TOKENS = 420
-const TEST_AI_SINGLE_MAX_OUTPUT_TOKENS = 220
-const TEST_AI_SINGLE_FALLBACK_MAX_OUTPUT_TOKENS = 420
-const TEST_AI_BATCH_MAX_OUTPUT_TOKENS = 600
-const TEST_AI_BATCH_FALLBACK_MAX_OUTPUT_TOKENS = 900
 
 export type TestOpenResponsePromptProfile = 'manual' | 'bulk'
 type ReferenceAnswerSource = 'teacher_key' | 'provided' | 'generated'
-
-const TEST_REFERENCE_ANSWERS_JSON_SCHEMA = {
-  type: 'object',
-  properties: {
-    reference_answers: {
-      type: 'array',
-      items: {
-        type: 'string',
-        minLength: 1,
-      },
-      minItems: 1,
-      maxItems: MAX_REFERENCE_ANSWERS,
-    },
-  },
-  required: ['reference_answers'],
-  additionalProperties: false,
-} as const
-
-const TEST_SINGLE_GRADE_JSON_SCHEMA = {
-  type: 'object',
-  properties: {
-    score: {
-      type: 'number',
-    },
-    feedback: {
-      type: 'string',
-      minLength: 1,
-    },
-  },
-  required: ['score', 'feedback'],
-  additionalProperties: false,
-} as const
-
-const TEST_BATCH_GRADE_JSON_SCHEMA = {
-  type: 'object',
-  properties: {
-    results: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          response_id: {
-            type: 'string',
-            minLength: 1,
-          },
-          score: {
-            type: 'number',
-          },
-          feedback: {
-            type: 'string',
-            minLength: 1,
-          },
-        },
-        required: ['response_id', 'score', 'feedback'],
-        additionalProperties: false,
-      },
-    },
-  },
-  required: ['results'],
-  additionalProperties: false,
-} as const
 
 export type TestAiErrorKind =
   | 'config'
@@ -168,6 +123,7 @@ export interface TestOpenResponseSuggestion {
   model: string
   grading_basis: TestAiGradingBasis
   reference_answers: string[]
+  provenance: TestGradingProvenance
 }
 
 export interface TestOpenResponseReferences {
@@ -195,218 +151,26 @@ export function getTestOpenResponseGradingModel(): string {
   return process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
 }
 
-function summarizeResponseBody(bodyText: string): string {
-  const normalized = bodyText.replace(/\s+/g, ' ').trim()
-  if (!normalized) return ''
-  if (normalized.length <= 240) return normalized
-  return `${normalized.slice(0, 237)}...`
-}
-
-function buildInvalidJsonErrorMessage(res: Response, bodyText: string): string {
-  const contentType = res.headers.get('content-type')?.trim() || 'unknown content-type'
-  const summary = summarizeResponseBody(bodyText)
-  return summary
-    ? `OpenAI returned invalid JSON (status ${res.status}, ${contentType}): ${summary}`
-    : `OpenAI returned invalid JSON (status ${res.status}, ${contentType})`
-}
-
-function extractOutputText(payload: any): string | null {
-  if (typeof payload?.output_text === 'string' && payload.output_text.trim()) {
-    return payload.output_text.trim()
-  }
-
-  if (payload?.output_parsed && typeof payload.output_parsed === 'object') {
-    return JSON.stringify(payload.output_parsed)
-  }
-
-  const output = payload?.output
-  if (!Array.isArray(output)) return null
-
-  for (const item of output) {
-    const content = item?.content
-    if (!Array.isArray(content)) continue
-    for (const block of content) {
-      if (block?.type === 'output_text' && typeof block?.text === 'string' && block.text.trim()) {
-        return block.text.trim()
-      }
-      if (block?.parsed && typeof block.parsed === 'object') {
-        return JSON.stringify(block.parsed)
-      }
-      if (block?.json && typeof block.json === 'object') {
-        return JSON.stringify(block.json)
-      }
-    }
-  }
-
-  return null
-}
-
-function parseJsonFromOutputText(outputText: string, parseErrorMessage: string): any {
-  let jsonText = outputText
-  const codeBlockMatch = outputText.match(/```(?:json)?\s*([\s\S]*?)```/)
-  if (codeBlockMatch) {
-    jsonText = codeBlockMatch[1].trim()
-  }
-
-  try {
-    return JSON.parse(jsonText)
-  } catch {
-    throw new Error(parseErrorMessage)
-  }
-}
-
-function extractParsedOutput(payload: any): any | null {
-  if (payload?.output_parsed && typeof payload.output_parsed === 'object') {
-    return payload.output_parsed
-  }
-
-  const output = payload?.output
-  if (!Array.isArray(output)) return null
-
-  for (const item of output) {
-    const content = item?.content
-    if (!Array.isArray(content)) continue
-    for (const block of content) {
-      if (block?.parsed && typeof block.parsed === 'object') {
-        return block.parsed
-      }
-      if (block?.json && typeof block.json === 'object') {
-        return block.json
-      }
-    }
-  }
-
-  return null
-}
-
-function isMaxOutputIncomplete(payload: any): boolean {
-  return (
-    payload?.status === 'incomplete' &&
-    payload?.incomplete_details?.reason === 'max_output_tokens'
-  )
-}
-
-function buildOpenAIJsonBody(opts: {
-  model: string
-  systemPrompt: string
-  userPrompt: string
-  schemaName: string
-  schema: Record<string, unknown>
-  maxOutputTokens: number
-}) {
-  return {
-    model: opts.model,
-    store: false,
-    input: [
-      {
-        role: 'system',
-        content: [{ type: 'input_text', text: opts.systemPrompt }],
-      },
-      {
-        role: 'user',
-        content: [{ type: 'input_text', text: opts.userPrompt }],
-      },
-    ],
-    reasoning: {
-      effort: TEST_AI_REASONING_EFFORT,
-    },
-    max_output_tokens: opts.maxOutputTokens,
-    text: {
-      format: {
-        type: 'json_schema',
-        name: opts.schemaName,
-        strict: true,
-        schema: opts.schema,
-      },
-    },
-  }
-}
-
-async function fetchOpenAIJsonPayload(opts: {
-  apiKey: string
-  model: string
-  systemPrompt: string
-  userPrompt: string
-  schemaName: string
-  schema: Record<string, unknown>
-  maxOutputTokens: number
-  requestTimeoutMs?: number
-}): Promise<any> {
-  let res: Response
-  try {
-    res = await fetch('https://api.openai.com/v1/responses', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${opts.apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(buildOpenAIJsonBody(opts)),
-      signal:
-        opts.requestTimeoutMs && opts.requestTimeoutMs > 0
-          ? AbortSignal.timeout(opts.requestTimeoutMs)
-          : undefined,
-    })
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.name === 'AbortError' || error.name === 'TimeoutError')
-    ) {
-      throw new TestAiGradingError({
-        kind: 'timeout',
-        message: 'OpenAI grading request timed out',
-        retryable: true,
-      })
-    }
-
-    throw new TestAiGradingError({
-      kind: 'network',
-      message: error instanceof Error ? error.message : 'OpenAI request failed',
-      retryable: true,
-    })
-  }
-
-  if (!res.ok) {
-    const bodyText = await res.text().catch(() => '')
-    const statusCode = res.status
-    const retryable = RETRYABLE_STATUS_CODES.has(statusCode)
-    const kind: TestAiErrorKind =
-      statusCode === 429
-        ? 'rate_limit'
-        : retryable
-          ? 'server'
-          : statusCode === 401 || statusCode === 403
-            ? 'config'
-            : 'bad_response'
-
-    throw new TestAiGradingError({
-      kind,
-      message: `OpenAI request failed (${statusCode}): ${bodyText}`,
-      retryable,
-      statusCode,
-    })
-  }
-
-  const fallbackBodyTextPromise =
-    typeof res.clone === 'function'
-      ? res.clone().text().catch(() => '')
-      : Promise.resolve('')
-
-  try {
-    return await res.json()
-  } catch {
-    const bodyText = await fallbackBodyTextPromise
-    throw new TestAiGradingError({
-      kind: 'bad_response',
-      message: buildInvalidJsonErrorMessage(res, bodyText),
-      retryable: false,
-      statusCode: res.status,
-    })
-  }
-}
-
 function toTestAiGradingError(error: unknown): TestAiGradingError {
   if (error instanceof TestAiGradingError) {
     return error
+  }
+
+  if (error instanceof GradingProviderError) {
+    return new TestAiGradingError({
+      kind: error.kind,
+      message: error.message,
+      retryable: error.retryable,
+      statusCode: error.statusCode,
+    })
+  }
+
+  if (error instanceof GradingOutputError) {
+    return new TestAiGradingError({
+      kind: 'invalid_output',
+      message: error.message,
+      retryable: false,
+    })
   }
 
   if (
@@ -440,70 +204,60 @@ async function callOpenAIForJson(opts: {
   model: string
   systemPrompt: string
   userPrompt: string
-  parseErrorMessage: string
-  schemaName: string
-  schema: Record<string, unknown>
-  maxOutputTokens: number
-  fallbackMaxOutputTokens: number
+  output: StructuredOutputSpec
+  parseOutput(outputText: string): unknown
   requestTimeoutMs?: number
-}): Promise<{ parsed: any; usage: OpenAIResponseUsage }> {
+}): Promise<{
+  parsed: any
+  usage: OpenAIResponseUsage
+  execution: GradingExecutionMetadata
+}> {
   try {
-    let payload = await fetchOpenAIJsonPayload({
-      apiKey: opts.apiKey,
-      model: opts.model,
-      systemPrompt: opts.systemPrompt,
-      userPrompt: opts.userPrompt,
-      schemaName: opts.schemaName,
-      schema: opts.schema,
-      maxOutputTokens: opts.maxOutputTokens,
-      requestTimeoutMs: opts.requestTimeoutMs ?? TEST_AI_REQUEST_TIMEOUT_MS,
-    })
-
-    if (isMaxOutputIncomplete(payload)) {
-      payload = await fetchOpenAIJsonPayload({
-        apiKey: opts.apiKey,
+    const result = await executeStructuredOutput({
+      provider: createOpenAiResponsesProvider({ apiKey: opts.apiKey }),
+      policy: {
+        version: PIKA_TEST_OPEN_RESPONSE_POLICY_VERSION,
         model: opts.model,
+        requestTimeoutMs: opts.requestTimeoutMs ?? TEST_AI_REQUEST_TIMEOUT_MS,
+        reasoningEffort: TEST_AI_REASONING_EFFORT,
+      },
+      prompt: {
         systemPrompt: opts.systemPrompt,
         userPrompt: opts.userPrompt,
-        schemaName: opts.schemaName,
-        schema: opts.schema,
-        maxOutputTokens: opts.fallbackMaxOutputTokens,
-        requestTimeoutMs: opts.requestTimeoutMs ?? TEST_AI_REQUEST_TIMEOUT_MS,
-      })
-    }
-
-    if (isMaxOutputIncomplete(payload)) {
-      throw new TestAiGradingError({
-        kind: 'bad_response',
-        message: 'OpenAI response incomplete: max_output_tokens',
-        retryable: false,
-      })
-    }
-
-    const parsedOutput = extractParsedOutput(payload)
-    if (parsedOutput && typeof parsedOutput === 'object') {
-      return {
-        parsed: parsedOutput,
-        usage: extractOpenAIResponseUsage(payload),
-      }
-    }
-
-    const outputText = extractOutputText(payload)
-    if (!outputText) {
-      throw new TestAiGradingError({
-        kind: 'bad_response',
-        message: 'OpenAI response missing structured output',
-        retryable: false,
-      })
-    }
-
+      },
+      output: opts.output,
+      parseOutput: opts.parseOutput,
+    })
     return {
-      parsed: parseJsonFromOutputText(outputText, opts.parseErrorMessage),
-      usage: extractOpenAIResponseUsage(payload),
+      parsed: result.output,
+      usage: result.execution.tokenUsage,
+      execution: result.execution,
     }
   } catch (error) {
     throw toTestAiGradingError(error)
   }
+}
+
+function buildTestGradingProvenance(input: {
+  execution: GradingExecutionMetadata
+  promptProfile: TestOpenResponsePromptProfile
+  operation: 'single' | 'batch'
+  batchSize: number
+}): TestGradingProvenance {
+  return testGradingProvenanceSchema.parse({
+    schemaVersion: 'test-grading-provenance-v1',
+    gradingRequestId: randomUUID(),
+    provider: input.execution.provider,
+    model: input.execution.model,
+    policyVersion: input.execution.policyVersion,
+    promptVersion: getPikaTestPromptVersion(input.promptProfile),
+    gradingProfileVersion: PIKA_TEST_OPEN_RESPONSE_PROFILE_VERSION,
+    rubricVersion: PIKA_TEST_OPEN_RESPONSE_RUBRIC_VERSION,
+    operation: input.operation,
+    batchSize: input.batchSize,
+    providerRequestCount: input.execution.providerRequestCount,
+    tokenUsage: input.execution.tokenUsage,
+  })
 }
 
 function normalizeAnswerKey(raw: string | null | undefined): string | null {
@@ -587,105 +341,6 @@ function scoreToNearestBucket(score: number, buckets: number[]): number {
   }
 
   return nearest
-}
-
-function getCodingReadabilityDeductionCap(maxPoints: number): number {
-  return Math.max(0, Math.floor(maxPoints * 0.2))
-}
-
-function getDefaultPromptGuideline(
-  isCodingQuestion: boolean,
-  promptProfile: TestOpenResponsePromptProfile
-): string {
-  if (isCodingQuestion) {
-    return promptProfile === 'bulk'
-      ? BULK_GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE
-      : GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE
-  }
-
-  return promptProfile === 'bulk'
-    ? BULK_TEST_AI_PROMPT_GUIDELINE
-    : DEFAULT_TEST_AI_PROMPT_GUIDELINE
-}
-
-function sanitizePromptGuidelineForJsonOutput(raw: string): string {
-  const trimmed = raw.trim()
-  if (!trimmed) return ''
-
-  return trimmed.replace(/\n*Output format[\s\S]*$/i, '').trim()
-}
-
-function resolvePromptGuideline(
-  raw: string | null | undefined,
-  isCodingQuestion: boolean,
-  promptProfile: TestOpenResponsePromptProfile
-): string {
-  const baseGuideline = getDefaultPromptGuideline(isCodingQuestion, promptProfile)
-  if (raw == null) return sanitizePromptGuidelineForJsonOutput(baseGuideline)
-
-  const sanitizedExtraGuideline = sanitizePromptGuidelineForJsonOutput(raw)
-  if (!sanitizedExtraGuideline) {
-    return sanitizePromptGuidelineForJsonOutput(baseGuideline)
-  }
-
-  return `${sanitizePromptGuidelineForJsonOutput(baseGuideline)}
-
-Additional teacher instructions:
-${sanitizedExtraGuideline}`
-}
-
-function buildReadabilityDeductionGuidance(
-  maxPoints: number,
-  promptProfile: TestOpenResponsePromptProfile
-): string {
-  const readabilityDeductionCap = getCodingReadabilityDeductionCap(maxPoints)
-
-  if (readabilityDeductionCap <= 0) {
-    return `- Because this question is worth ${maxPoints} point${maxPoints === 1 ? '' : 's'}, do not apply a separate readability/style deduction here; keep grading focused on correctness and required structure.`
-  }
-
-  if (promptProfile === 'bulk') {
-    return `- Apply at most one readability/style deduction, and only when formatting materially hurts readability.
-- Cap any readability/style deduction at ${readabilityDeductionCap} point${readabilityDeductionCap === 1 ? '' : 's'} for this question.
-- Do not deduct for minor style issues when the code is still readable.`
-  }
-
-  return `- You may apply one readability/style deduction only after scoring correctness and required structure first.
-- Forgive one small formatting/style issue.
-- Apply the readability deduction only when formatting materially hurts readability, such as two or more minor formatting issues or one major formatting issue.
-- Minor issues include slightly uneven spacing, one missed indent level, or small brace-placement inconsistencies.
-- Major issues include most code written on one line, indentation missing across nested blocks, or formatting that makes control flow hard to follow.
-- Never stack style deductions per infraction; apply at most one readability deduction total.
-- Cap any readability/style deduction at ${readabilityDeductionCap} point${readabilityDeductionCap === 1 ? '' : 's'} for this question.
-- If readability is still acceptable overall, do not deduct for style.`
-}
-
-function buildCodingRubric(
-  isCodingQuestion: boolean,
-  maxPoints: number,
-  promptProfile: TestOpenResponsePromptProfile
-): string {
-  if (!isCodingQuestion) return ''
-
-  const readabilityGuidance = buildReadabilityDeductionGuidance(maxPoints, promptProfile)
-
-  if (promptProfile === 'bulk') {
-    return `
-- This is a coding response. Prioritize algorithmic correctness and logical reasoning over minor syntax/runtime mistakes.
-- Award strong partial credit when the core approach is correct, even if the implementation is rough.
-- Treat CodeHS Java helpers (for example: ConsoleProgram, readInt/readLine, println, Randomizer) as valid.
-- Accept alternate valid solutions unless the prompt explicitly requires a specific structure.
-${readabilityGuidance}`
-  }
-
-  return `
-- This is a coding response. Prioritize algorithmic correctness and logical reasoning over minor syntax/runtime mistakes.
-- If the approach is logically sound and clearly communicated but has minor implementation issues, award high partial credit (typically 80-95% of max points).
-- Formatting/readability can affect the score only through the capped readability deduction below.
-- For Java/CodeHS classroom contexts, treat platform helper APIs (for example: ConsoleProgram, readInt/readLine, println, Randomizer) as valid and do not penalize solely for using them.
-- If language is unspecified, infer likely language from prompt/context/response. If still ambiguous, evaluate logic language-agnostically and do not penalize language choice alone.
-- Avoid nitpicking minor stylistic preferences when clarity and logic are strong.
-${readabilityGuidance}`
 }
 
 function getCacheStatus(prepared: TestOpenResponsePreparedContext): 'hit' | 'miss' | 'not_applicable' {
@@ -797,26 +452,12 @@ async function generateReferenceAnswers(opts: {
   sanitizationContext?: AiSanitizationContext | null
 }): Promise<string[]> {
   const sanitizeOptions = opts.sanitizationContext ?? undefined
-  const codingGuidance = opts.isCodingQuestion
-    ? `
-- Treat this as a coding question. Provide reference answers as clear code-oriented solution outlines, including algorithm steps and expected structure.
-- For Java/CodeHS contexts, include platform helper APIs when appropriate (for example: ConsoleProgram, readInt/readLine, println, Randomizer).
-- If the language is not explicitly stated, infer likely language from the question/response context; if uncertain, keep references language-agnostic and focus on logic.`
-    : ''
-
-  const systemPrompt = `You generate reference answers for grading open-response test questions.
-Return ONLY valid JSON:
-{"reference_answers":["answer 1","answer 2"]}
-
-Rules:
-- Provide 1-${MAX_REFERENCE_ANSWERS} concise, high-quality reference answers.
-- Each answer should describe acceptable content, not just keywords.
-- Do not include markdown code fences.${codingGuidance}`
-  const userPrompt = `Test: ${sanitizeAiText(opts.testTitle, sanitizeOptions)}
-Question:
-${sanitizeAiText(opts.questionText, sanitizeOptions)}
-
-Max points: ${opts.maxPoints}`
+  const { systemPrompt, userPrompt } = buildPikaTestReferencePrompt({
+    testTitle: sanitizeAiText(opts.testTitle, sanitizeOptions),
+    questionText: sanitizeAiText(opts.questionText, sanitizeOptions),
+    maxPoints: opts.maxPoints,
+    isCodingQuestion: opts.isCodingQuestion,
+  })
 
   const promptMetrics = estimatePromptMetrics(systemPrompt, userPrompt)
   const { parsed, usage } = await callOpenAIForJson({
@@ -824,11 +465,8 @@ Max points: ${opts.maxPoints}`
     model: opts.model,
     systemPrompt,
     userPrompt,
-    parseErrorMessage: 'Failed to parse AI reference answers',
-    schemaName: 'test_reference_answers',
-    schema: TEST_REFERENCE_ANSWERS_JSON_SCHEMA,
-    maxOutputTokens: TEST_AI_REFERENCE_MAX_OUTPUT_TOKENS,
-    fallbackMaxOutputTokens: TEST_AI_REFERENCE_FALLBACK_MAX_OUTPUT_TOKENS,
+    output: PIKA_TEST_REFERENCE_OUTPUT,
+    parseOutput: parsePikaTestReferenceOutput,
     requestTimeoutMs: opts.requestTimeoutMs,
   })
 
@@ -880,13 +518,13 @@ export function buildTestOpenResponsePreparedContext(input: {
   const sanitizeOptions = sanitizationContext ?? undefined
   const testTitle = sanitizeAiText(input.testTitle, sanitizeOptions)
   const questionText = sanitizeAiText(input.questionText, sanitizeOptions)
-  const promptGuideline = resolvePromptGuideline(
-    input.promptGuidelineOverride
+  const promptGuideline = resolvePikaTestPromptGuideline({
+    override: input.promptGuidelineOverride
       ? sanitizeAiText(input.promptGuidelineOverride, sanitizeOptions)
       : input.promptGuidelineOverride,
     isCodingQuestion,
-    promptProfile
-  )
+    promptProfile,
+  })
   const scoreBuckets = normalizeScoreBuckets(input.scoreBuckets, maxPoints)
   const answerKey = normalizeAnswerKey(
     input.answerKey ? sanitizeAiText(input.answerKey, sanitizeOptions) : input.answerKey,
@@ -914,52 +552,20 @@ export function buildTestOpenResponsePreparedContext(input: {
       ? answerKey == null && sampleSolution != null
       : sampleSolution != null
 
-  const promptGuidelineContext = promptGuideline
-    ? `Teacher grading guideline:
-${promptGuideline}`
-    : 'Teacher grading guideline: none provided.'
-
-  const codingRubric = buildCodingRubric(isCodingQuestion, maxPoints, promptProfile)
-  const systemPrompt = `You grade open-response test answers.
-Return ONLY valid JSON with this shape:
-{"score": number, "feedback": "string"}
-
-Rules:
-- score must be between 0 and ${maxPoints}
-- grade for correctness and completeness, not just writing style
-- if the score is less than ${maxPoints}, feedback should include one concrete improvement needed for full marks
-
-${promptGuidelineContext}${codingRubric}`
-
-  const gradingContext =
-    gradingBasis === 'teacher_key'
-      ? `Teacher answer key:
-${answerKey}`
-      : `Reference answers:
-${normalizedReferenceAnswers.map((answer, index) => `${index + 1}. ${answer}`).join('\n')}
-
-Students may use different correct wording. Award credit for equivalent ideas.`
-
-  const sampleSolutionContext = sampleSolutionIncluded
-    ? `
-
-Sample solution (one valid approach, not a required exact match):
-${sampleSolution}`
-    : ''
-
-  const scoreBucketContext = scoreBuckets && scoreBuckets.length > 0
-    ? `Score buckets: ${scoreBuckets.join(', ')}
-Choose the nearest bucket for the score.`
-    : 'No explicit score buckets were provided.'
-
-  const userPromptPrefix = `Test: ${testTitle}
-Question:
-${questionText}
-
-${gradingContext}
-${sampleSolutionContext}
-
-${scoreBucketContext}`
+  const { systemPrompt, userPromptPrefix } = buildPikaTestOpenResponsePrompt({
+    testTitle,
+    questionText,
+    maxPoints,
+    promptGuideline,
+    promptProfile,
+    isCodingQuestion,
+    gradingBasis,
+    answerKey,
+    referenceAnswers: normalizedReferenceAnswers,
+    sampleSolution,
+    sampleSolutionIncluded,
+    scoreBuckets,
+  })
 
   return {
     model,
@@ -984,36 +590,32 @@ export function buildTestOpenResponseSingleUserPrompt(
   prepared: TestOpenResponsePreparedContext,
   responseText: string
 ): string {
-  return `${prepared.userPromptPrefix}
-
-Student response:
-${sanitizeAiText(responseText, prepared.sanitizationContext ?? undefined)}`
+  return buildPikaTestSingleUserPrompt(
+    prepared.userPromptPrefix,
+    sanitizeAiText(responseText, prepared.sanitizationContext ?? undefined),
+  )
 }
 
 export function buildTestOpenResponseBatchSystemPrompt(
   prepared: TestOpenResponsePreparedContext
 ): string {
-  return `${prepared.systemPrompt}
-
-Grade each response independently. Do not compare students against each other.
-Return ONLY valid JSON with this shape:
-{"results":[{"response_id":"string","score":number,"feedback":"string"}]}`
+  return buildPikaTestBatchSystemPrompt(prepared.systemPrompt)
 }
 
 export function buildTestOpenResponseBatchUserPrompt(
   prepared: TestOpenResponsePreparedContext,
   responses: TestOpenResponseBatchRequest[]
 ): string {
-  return `${prepared.userPromptPrefix}
-
-Student responses:
-${responses
-  .map(
-    (response, index) =>
-      `${index + 1}. response_id=${sanitizeAiText(response.responseId)}
-${sanitizeAiText(response.responseText, prepared.sanitizationContext ?? undefined)}`
+  return buildPikaTestBatchUserPrompt(
+    prepared.userPromptPrefix,
+    responses.map((response) => ({
+      responseId: sanitizeAiText(response.responseId),
+      responseText: sanitizeAiText(
+        response.responseText,
+        prepared.sanitizationContext ?? undefined,
+      ),
+    })),
   )
-  .join('\n\n')}`
 }
 
 export async function generateTestOpenResponseReferences(input: {
@@ -1178,16 +780,13 @@ export async function suggestTestOpenResponseGradeWithContext(
 
   const userPrompt = buildTestOpenResponseSingleUserPrompt(prepared, responseText)
   const promptMetrics = estimatePromptMetrics(prepared.systemPrompt, userPrompt)
-  const { parsed, usage } = await callOpenAIForJson({
+  const { parsed, usage, execution } = await callOpenAIForJson({
     apiKey,
     model: prepared.model,
     systemPrompt: prepared.systemPrompt,
     userPrompt,
-    parseErrorMessage: 'Failed to parse AI grade suggestion',
-    schemaName: 'test_single_grade',
-    schema: TEST_SINGLE_GRADE_JSON_SCHEMA,
-    maxOutputTokens: TEST_AI_SINGLE_MAX_OUTPUT_TOKENS,
-    fallbackMaxOutputTokens: TEST_AI_SINGLE_FALLBACK_MAX_OUTPUT_TOKENS,
+    output: PIKA_TEST_SINGLE_GRADE_OUTPUT,
+    parseOutput: parsePikaTestSingleGradeOutput,
     requestTimeoutMs,
   })
 
@@ -1219,6 +818,12 @@ export async function suggestTestOpenResponseGradeWithContext(
     model: prepared.model,
     grading_basis: prepared.grading_basis,
     reference_answers: prepared.reference_answers,
+    provenance: buildTestGradingProvenance({
+      execution,
+      promptProfile: prepared.promptProfile,
+      operation: 'single',
+      batchSize: 1,
+    }),
   }
 }
 
@@ -1251,16 +856,13 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
     })),
   )
   const promptMetrics = estimatePromptMetrics(systemPrompt, userPrompt)
-  const { parsed, usage } = await callOpenAIForJson({
+  const { parsed, usage, execution } = await callOpenAIForJson({
     apiKey,
     model: prepared.model,
     systemPrompt,
     userPrompt,
-    parseErrorMessage: 'Failed to parse AI batch grade suggestions',
-    schemaName: 'test_batch_grade',
-    schema: TEST_BATCH_GRADE_JSON_SCHEMA,
-    maxOutputTokens: TEST_AI_BATCH_MAX_OUTPUT_TOKENS,
-    fallbackMaxOutputTokens: TEST_AI_BATCH_FALLBACK_MAX_OUTPUT_TOKENS,
+    output: PIKA_TEST_BATCH_GRADE_OUTPUT,
+    parseOutput: parsePikaTestBatchGradeOutput,
     requestTimeoutMs,
   })
 
@@ -1293,6 +895,9 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
     if (!localResponseId) {
       throw new Error(`AI batch grade suggestion returned unknown response ${responseId}`)
     }
+    if (resultsById.has(localResponseId)) {
+      throw new Error(`AI batch grade suggestion returned duplicate response ${responseId}`)
+    }
 
     resultsById.set(localResponseId, {
       score: normalizeSuggestedScore(rawScore, prepared.maxPoints, prepared.scoreBuckets),
@@ -1301,6 +906,12 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
   }
 
   const suggestions: TestOpenResponseBatchSuggestion[] = []
+  const provenance = buildTestGradingProvenance({
+    execution,
+    promptProfile: prepared.promptProfile,
+    operation: 'batch',
+    batchSize: responses.length,
+  })
   for (const response of responses) {
     const result = resultsById.get(response.responseId)
     if (!result) {
@@ -1314,6 +925,7 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
       model: prepared.model,
       grading_basis: prepared.grading_basis,
       reference_answers: prepared.reference_answers,
+      provenance,
     })
   }
 

--- a/src/lib/grading/contracts.ts
+++ b/src/lib/grading/contracts.ts
@@ -54,6 +54,23 @@ export const gradingProvenanceSchema = z.object({
   tokenUsage: gradingTokenUsageSchema,
 }).strict()
 
+export const testGradingProvenanceSchema = z.object({
+  schemaVersion: z.literal('test-grading-provenance-v1'),
+  gradingRequestId: z.string().regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  ),
+  provider: z.string().min(1).max(120),
+  model: z.string().min(1).max(200),
+  policyVersion: z.string().min(1).max(120),
+  promptVersion: z.string().min(1).max(120),
+  gradingProfileVersion: z.string().min(1).max(120),
+  rubricVersion: z.string().min(1).max(120),
+  operation: z.enum(['single', 'batch']),
+  batchSize: z.number().int().positive().max(20),
+  providerRequestCount: z.number().int().positive().max(10),
+  tokenUsage: gradingTokenUsageSchema,
+}).strict()
+
 export const gradingCriterionResultSchema = z.object({
   criterionId: z.string().min(1),
   score: z.number().finite(),
@@ -88,6 +105,7 @@ export const gradingResultSchema = z.object({
 export type GradingRubric = z.infer<typeof gradingRubricSchema>
 export type GradingTokenUsage = z.infer<typeof gradingTokenUsageSchema>
 export type GradingProvenance = z.infer<typeof gradingProvenanceSchema>
+export type TestGradingProvenance = z.infer<typeof testGradingProvenanceSchema>
 export type GradingResult = z.infer<typeof gradingResultSchema>
 
 export function toGradingProvenance(result: GradingResult): GradingProvenance {

--- a/src/lib/grading/engine.ts
+++ b/src/lib/grading/engine.ts
@@ -1,6 +1,7 @@
 import {
   gradingResultSchema,
   gradingRubricSchema,
+  type GradingTokenUsage,
   type GradingResult,
 } from '@/lib/grading/contracts'
 import type { GradingProfile } from '@/lib/grading/profiles/types'
@@ -20,6 +21,65 @@ export interface GradingPolicy {
   reasoningEffort: 'minimal' | 'low' | 'medium' | 'high'
 }
 
+export interface StructuredOutputSpec {
+  schemaName: string
+  jsonSchema: Record<string, unknown>
+  initialMaxOutputTokens: number
+  fallbackMaxOutputTokens: number
+}
+
+export interface GradingExecutionMetadata {
+  provider: string
+  model: string
+  policyVersion: string
+  providerRequestCount: number
+  tokenUsage: GradingTokenUsage
+}
+
+export async function executeStructuredOutput<TOutput>(opts: {
+  provider: StructuredOutputProvider
+  policy: GradingPolicy
+  prompt: {
+    systemPrompt: string
+    userPrompt: string
+  }
+  output: StructuredOutputSpec
+  parseOutput(outputText: string): TOutput
+}): Promise<{ output: TOutput; execution: GradingExecutionMetadata }> {
+  const providerResponse = await opts.provider.generate({
+    model: opts.policy.model,
+    systemPrompt: opts.prompt.systemPrompt,
+    userPrompt: opts.prompt.userPrompt,
+    schemaName: opts.output.schemaName,
+    jsonSchema: opts.output.jsonSchema,
+    initialMaxOutputTokens: opts.output.initialMaxOutputTokens,
+    fallbackMaxOutputTokens: opts.output.fallbackMaxOutputTokens,
+    requestTimeoutMs: opts.policy.requestTimeoutMs,
+    reasoningEffort: opts.policy.reasoningEffort,
+  })
+
+  let output: TOutput
+  try {
+    output = opts.parseOutput(providerResponse.outputText)
+  } catch (error) {
+    throw new GradingOutputError(
+      error instanceof Error ? error.message : 'Grading provider returned invalid output',
+      { cause: error },
+    )
+  }
+
+  return {
+    output,
+    execution: {
+      provider: opts.provider.id,
+      model: opts.policy.model,
+      policyVersion: opts.policy.version,
+      providerRequestCount: providerResponse.requestCount,
+      tokenUsage: providerResponse.tokenUsage,
+    },
+  }
+}
+
 export async function executeGrading<TInput, TOutput>(opts: {
   input: TInput
   profile: GradingProfile<TInput, TOutput>
@@ -28,21 +88,17 @@ export async function executeGrading<TInput, TOutput>(opts: {
 }): Promise<GradingResult> {
   const rubric = gradingRubricSchema.parse(opts.profile.rubric)
   const prompt = opts.profile.buildPrompt(opts.input)
-  const providerResponse = await opts.provider.generate({
-    model: opts.policy.model,
-    systemPrompt: prompt.systemPrompt,
-    userPrompt: prompt.userPrompt,
-    schemaName: opts.profile.output.schemaName,
-    jsonSchema: opts.profile.output.jsonSchema,
-    initialMaxOutputTokens: opts.profile.output.initialMaxOutputTokens,
-    fallbackMaxOutputTokens: opts.profile.output.fallbackMaxOutputTokens,
-    requestTimeoutMs: opts.policy.requestTimeoutMs,
-    reasoningEffort: opts.policy.reasoningEffort,
+  const structured = await executeStructuredOutput({
+    provider: opts.provider,
+    policy: opts.policy,
+    prompt,
+    output: opts.profile.output,
+    parseOutput: opts.profile.parseOutput,
   })
 
   let normalized: ReturnType<typeof opts.profile.normalizeOutput>
   try {
-    normalized = opts.profile.normalizeOutput(opts.profile.parseOutput(providerResponse.outputText))
+    normalized = opts.profile.normalizeOutput(structured.output)
   } catch (error) {
     throw new GradingOutputError(
       error instanceof Error ? error.message : 'Grading provider returned invalid output',
@@ -101,14 +157,14 @@ export async function executeGrading<TInput, TOutput>(opts: {
       student: normalized.feedback.student.trim(),
       teacherNotes: normalized.feedback.teacherNotes,
     },
-    provider: opts.provider.id,
-    model: opts.policy.model,
-    policyVersion: opts.policy.version,
+    provider: structured.execution.provider,
+    model: structured.execution.model,
+    policyVersion: structured.execution.policyVersion,
     promptVersion: opts.profile.promptVersion,
     gradingProfileVersion: opts.profile.version,
     rubricVersion: rubric.version,
-    tokenUsage: providerResponse.tokenUsage,
-    providerRequestCount: providerResponse.requestCount,
+    tokenUsage: structured.execution.tokenUsage,
+    providerRequestCount: structured.execution.providerRequestCount,
   })
 }
 

--- a/src/lib/grading/profiles/pika-test-open-response.ts
+++ b/src/lib/grading/profiles/pika-test-open-response.ts
@@ -1,0 +1,320 @@
+import { z } from 'zod'
+import type { StructuredOutputSpec } from '@/lib/grading/engine'
+import {
+  BULK_GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE,
+  BULK_TEST_AI_PROMPT_GUIDELINE,
+  DEFAULT_TEST_AI_PROMPT_GUIDELINE,
+  GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE,
+} from '@/lib/test-ai-prompt-guideline'
+
+export const PIKA_TEST_OPEN_RESPONSE_PROFILE_VERSION = 'pika-test-open-response-v1'
+export const PIKA_TEST_OPEN_RESPONSE_RUBRIC_VERSION = 'pika-test-open-response-rubric-v1'
+export const PIKA_TEST_OPEN_RESPONSE_POLICY_VERSION = 'pika-test-open-response-policy-v1'
+export const PIKA_TEST_OPEN_RESPONSE_MANUAL_PROMPT_VERSION =
+  'pika-test-open-response-manual-prompt-v1'
+export const PIKA_TEST_OPEN_RESPONSE_BULK_PROMPT_VERSION =
+  'pika-test-open-response-bulk-prompt-v1'
+export const PIKA_TEST_REFERENCE_PROFILE_VERSION = 'pika-test-reference-v1'
+export const PIKA_TEST_REFERENCE_PROMPT_VERSION = 'pika-test-reference-prompt-v1'
+
+const referenceOutputSchema = z.object({
+  reference_answers: z.array(z.string().min(1)).min(1).max(3),
+}).strict()
+
+const singleGradeOutputSchema = z.object({
+  score: z.number(),
+  feedback: z.string().min(1),
+}).strict()
+
+const batchGradeOutputSchema = z.object({
+  results: z.array(z.object({
+    response_id: z.string().min(1),
+    score: z.number(),
+    feedback: z.string().min(1),
+  }).strict()),
+}).strict()
+
+export type PikaTestReferenceOutput = z.infer<typeof referenceOutputSchema>
+export type PikaTestSingleGradeOutput = z.infer<typeof singleGradeOutputSchema>
+export type PikaTestBatchGradeOutput = z.infer<typeof batchGradeOutputSchema>
+
+const referenceJsonSchema = {
+  type: 'object',
+  properties: {
+    reference_answers: {
+      type: 'array',
+      items: { type: 'string', minLength: 1 },
+      minItems: 1,
+      maxItems: 3,
+    },
+  },
+  required: ['reference_answers'],
+  additionalProperties: false,
+} as const
+
+const singleGradeJsonSchema = {
+  type: 'object',
+  properties: {
+    score: { type: 'number' },
+    feedback: { type: 'string', minLength: 1 },
+  },
+  required: ['score', 'feedback'],
+  additionalProperties: false,
+} as const
+
+const batchGradeJsonSchema = {
+  type: 'object',
+  properties: {
+    results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          response_id: { type: 'string', minLength: 1 },
+          score: { type: 'number' },
+          feedback: { type: 'string', minLength: 1 },
+        },
+        required: ['response_id', 'score', 'feedback'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['results'],
+  additionalProperties: false,
+} as const
+
+export const PIKA_TEST_REFERENCE_OUTPUT: StructuredOutputSpec = {
+  schemaName: 'test_reference_answers',
+  jsonSchema: referenceJsonSchema,
+  initialMaxOutputTokens: 220,
+  fallbackMaxOutputTokens: 420,
+}
+
+export const PIKA_TEST_SINGLE_GRADE_OUTPUT: StructuredOutputSpec = {
+  schemaName: 'test_single_grade',
+  jsonSchema: singleGradeJsonSchema,
+  initialMaxOutputTokens: 220,
+  fallbackMaxOutputTokens: 420,
+}
+
+export const PIKA_TEST_BATCH_GRADE_OUTPUT: StructuredOutputSpec = {
+  schemaName: 'test_batch_grade',
+  jsonSchema: batchGradeJsonSchema,
+  initialMaxOutputTokens: 600,
+  fallbackMaxOutputTokens: 900,
+}
+
+export function getPikaTestPromptVersion(profile: 'manual' | 'bulk'): string {
+  return profile === 'bulk'
+    ? PIKA_TEST_OPEN_RESPONSE_BULK_PROMPT_VERSION
+    : PIKA_TEST_OPEN_RESPONSE_MANUAL_PROMPT_VERSION
+}
+
+export function resolvePikaTestPromptGuideline(input: {
+  override: string | null | undefined
+  isCodingQuestion: boolean
+  promptProfile: 'manual' | 'bulk'
+}): string {
+  const baseGuideline = input.isCodingQuestion
+    ? input.promptProfile === 'bulk'
+      ? BULK_GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE
+      : GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE
+    : input.promptProfile === 'bulk'
+      ? BULK_TEST_AI_PROMPT_GUIDELINE
+      : DEFAULT_TEST_AI_PROMPT_GUIDELINE
+  const normalizedBase = stripConflictingOutputFormat(baseGuideline)
+  if (input.override == null) return normalizedBase
+
+  const normalizedOverride = stripConflictingOutputFormat(input.override)
+  return normalizedOverride
+    ? `${normalizedBase}\n\nAdditional teacher instructions:\n${normalizedOverride}`
+    : normalizedBase
+}
+
+export function buildPikaTestReferencePrompt(input: {
+  testTitle: string
+  questionText: string
+  maxPoints: number
+  isCodingQuestion: boolean
+}): { systemPrompt: string; userPrompt: string } {
+  const codingGuidance = input.isCodingQuestion
+    ? `
+- Treat this as a coding question. Provide reference answers as clear code-oriented solution outlines, including algorithm steps and expected structure.
+- For Java/CodeHS contexts, include platform helper APIs when appropriate (for example: ConsoleProgram, readInt/readLine, println, Randomizer).
+- If the language is not explicitly stated, infer likely language from the question/response context; if uncertain, keep references language-agnostic and focus on logic.`
+    : ''
+
+  return {
+    systemPrompt: `You generate reference answers for grading open-response test questions.
+Return ONLY valid JSON:
+{"reference_answers":["answer 1","answer 2"]}
+
+Rules:
+- Provide 1-3 concise, high-quality reference answers.
+- Each answer should describe acceptable content, not just keywords.
+- Do not include markdown code fences.${codingGuidance}`,
+    userPrompt: `Test: ${input.testTitle}
+Question:
+${input.questionText}
+
+Max points: ${input.maxPoints}`,
+  }
+}
+
+export function buildPikaTestOpenResponsePrompt(input: {
+  testTitle: string
+  questionText: string
+  maxPoints: number
+  promptGuideline: string
+  promptProfile: 'manual' | 'bulk'
+  isCodingQuestion: boolean
+  gradingBasis: 'teacher_key' | 'generated_reference'
+  answerKey: string | null
+  referenceAnswers: string[]
+  sampleSolution: string | null
+  sampleSolutionIncluded: boolean
+  scoreBuckets: number[] | null
+}): { systemPrompt: string; userPromptPrefix: string } {
+  const promptGuidelineContext = input.promptGuideline
+    ? `Teacher grading guideline:\n${input.promptGuideline}`
+    : 'Teacher grading guideline: none provided.'
+  const codingRubric = buildCodingRubric(
+    input.isCodingQuestion,
+    input.maxPoints,
+    input.promptProfile,
+  )
+  const systemPrompt = `You grade open-response test answers.
+Return ONLY valid JSON with this shape:
+{"score": number, "feedback": "string"}
+
+Rules:
+- score must be between 0 and ${input.maxPoints}
+- grade for correctness and completeness, not just writing style
+- if the score is less than ${input.maxPoints}, feedback should include one concrete improvement needed for full marks
+
+${promptGuidelineContext}${codingRubric}`
+  const gradingContext = input.gradingBasis === 'teacher_key'
+    ? `Teacher answer key:\n${input.answerKey}`
+    : `Reference answers:\n${input.referenceAnswers
+        .map((answer, index) => `${index + 1}. ${answer}`)
+        .join('\n')}
+
+Students may use different correct wording. Award credit for equivalent ideas.`
+  const sampleSolutionContext = input.sampleSolutionIncluded
+    ? `
+
+Sample solution (one valid approach, not a required exact match):
+${input.sampleSolution}`
+    : ''
+  const scoreBucketContext = input.scoreBuckets && input.scoreBuckets.length > 0
+    ? `Score buckets: ${input.scoreBuckets.join(', ')}\nChoose the nearest bucket for the score.`
+    : 'No explicit score buckets were provided.'
+
+  return {
+    systemPrompt,
+    userPromptPrefix: `Test: ${input.testTitle}
+Question:
+${input.questionText}
+
+${gradingContext}
+${sampleSolutionContext}
+
+${scoreBucketContext}`,
+  }
+}
+
+export function buildPikaTestSingleUserPrompt(
+  userPromptPrefix: string,
+  responseText: string,
+): string {
+  return `${userPromptPrefix}\n\nStudent response:\n${responseText}`
+}
+
+export function buildPikaTestBatchSystemPrompt(systemPrompt: string): string {
+  return `${systemPrompt}
+
+Grade each response independently. Do not compare students against each other.
+Return ONLY valid JSON with this shape:
+{"results":[{"response_id":"string","score":number,"feedback":"string"}]}`
+}
+
+export function buildPikaTestBatchUserPrompt(
+  userPromptPrefix: string,
+  responses: Array<{ responseId: string; responseText: string }>,
+): string {
+  return `${userPromptPrefix}
+
+Student responses:
+${responses
+  .map((response, index) => `${index + 1}. response_id=${response.responseId}\n${response.responseText}`)
+  .join('\n\n')}`
+}
+
+export function parsePikaTestReferenceOutput(outputText: string): PikaTestReferenceOutput {
+  return referenceOutputSchema.parse(parseJsonOutput(outputText, 'Failed to parse AI reference answers'))
+}
+
+export function parsePikaTestSingleGradeOutput(outputText: string): PikaTestSingleGradeOutput {
+  return singleGradeOutputSchema.parse(parseJsonOutput(outputText, 'Failed to parse AI grade suggestion'))
+}
+
+export function parsePikaTestBatchGradeOutput(outputText: string): PikaTestBatchGradeOutput {
+  return batchGradeOutputSchema.parse(parseJsonOutput(outputText, 'Failed to parse AI batch grade suggestions'))
+}
+
+function parseJsonOutput(outputText: string, message: string): unknown {
+  const codeBlock = outputText.match(/```(?:json)?\s*([\s\S]*?)```/)
+  const jsonText = codeBlock ? codeBlock[1].trim() : outputText
+  try {
+    return JSON.parse(jsonText)
+  } catch (error) {
+    throw new Error(message, { cause: error })
+  }
+}
+
+function stripConflictingOutputFormat(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  return trimmed.replace(/\n*Output format[\s\S]*$/i, '').trim()
+}
+
+function buildCodingRubric(
+  isCodingQuestion: boolean,
+  maxPoints: number,
+  promptProfile: 'manual' | 'bulk',
+): string {
+  if (!isCodingQuestion) return ''
+  const readabilityDeductionCap = Math.max(0, Math.floor(maxPoints * 0.2))
+  const readabilityGuidance = readabilityDeductionCap <= 0
+    ? `- Because this question is worth ${maxPoints} point${maxPoints === 1 ? '' : 's'}, do not apply a separate readability/style deduction here; keep grading focused on correctness and required structure.`
+    : promptProfile === 'bulk'
+      ? `- Apply at most one readability/style deduction, and only when formatting materially hurts readability.
+- Cap any readability/style deduction at ${readabilityDeductionCap} point${readabilityDeductionCap === 1 ? '' : 's'} for this question.
+- Do not deduct for minor style issues when the code is still readable.`
+      : `- You may apply one readability/style deduction only after scoring correctness and required structure first.
+- Forgive one small formatting/style issue.
+- Apply the readability deduction only when formatting materially hurts readability, such as two or more minor formatting issues or one major formatting issue.
+- Minor issues include slightly uneven spacing, one missed indent level, or small brace-placement inconsistencies.
+- Major issues include most code written on one line, indentation missing across nested blocks, or formatting that makes control flow hard to follow.
+- Never stack style deductions per infraction; apply at most one readability deduction total.
+- Cap any readability/style deduction at ${readabilityDeductionCap} point${readabilityDeductionCap === 1 ? '' : 's'} for this question.
+- If readability is still acceptable overall, do not deduct for style.`
+
+  if (promptProfile === 'bulk') {
+    return `
+- This is a coding response. Prioritize algorithmic correctness and logical reasoning over minor syntax/runtime mistakes.
+- Award strong partial credit when the core approach is correct, even if the implementation is rough.
+- Treat CodeHS Java helpers (for example: ConsoleProgram, readInt/readLine, println, Randomizer) as valid.
+- Accept alternate valid solutions unless the prompt explicitly requires a specific structure.
+${readabilityGuidance}`
+  }
+
+  return `
+- This is a coding response. Prioritize algorithmic correctness and logical reasoning over minor syntax/runtime mistakes.
+- If the approach is logically sound and clearly communicated but has minor implementation issues, award high partial credit (typically 80-95% of max points).
+- Formatting/readability can affect the score only through the capped readability deduction below.
+- For Java/CodeHS classroom contexts, treat platform helper APIs (for example: ConsoleProgram, readInt/readLine, println, Randomizer) as valid and do not penalize solely for using them.
+- If language is unspecified, infer likely language from prompt/context/response. If still ambiguous, evaluate logic language-agnostically and do not penalize language choice alone.
+- Avoid nitpicking minor stylistic preferences when clarity and logic are strong.
+${readabilityGuidance}`
+}

--- a/src/lib/grading/providers/openai-responses.ts
+++ b/src/lib/grading/providers/openai-responses.ts
@@ -120,18 +120,33 @@ async function fetchPayload(
     })
   }
 
+  const fallbackBodyTextPromise = typeof response.clone === 'function'
+    ? response.clone().text().catch(() => '')
+    : Promise.resolve('')
+
   try {
     return await response.json()
   } catch (error) {
     const timedOut = isTimeoutError(error)
+    const bodyText = timedOut ? '' : await fallbackBodyTextPromise
     throw new GradingProviderError({
       kind: timedOut ? 'timeout' : 'bad_response',
       message: timedOut
         ? 'OpenAI grading response timed out'
-        : error instanceof Error ? error.message : 'OpenAI response body could not be parsed',
+        : buildInvalidJsonMessage(response, bodyText),
       retryable: timedOut,
+      statusCode: response.status,
     })
   }
+}
+
+function buildInvalidJsonMessage(response: Response, bodyText: string): string {
+  const contentType = response.headers.get('content-type')?.trim() || 'unknown content-type'
+  const normalized = bodyText.replace(/\s+/g, ' ').trim()
+  const summary = normalized.length > 240 ? `${normalized.slice(0, 237)}...` : normalized
+  return summary
+    ? `OpenAI returned invalid JSON (status ${response.status}, ${contentType}): ${summary}`
+    : `OpenAI returned invalid JSON (status ${response.status}, ${contentType})`
 }
 
 function extractOutputText(payload: unknown): string | null {

--- a/src/lib/server/test-ai-grading-runs.ts
+++ b/src/lib/server/test-ai-grading-runs.ts
@@ -30,6 +30,7 @@ import type {
   TestAiGradingRunSummary,
 } from '@/types'
 import type { Json } from '@/types/database.generated'
+import type { TestGradingProvenance } from '@/lib/grading/contracts'
 import {
   buildTestQuestionGradingSnapshot,
   hasPersistedTestResponseGrade,
@@ -559,6 +560,7 @@ async function persistSuggestionForResponse(opts: {
     model: string
     grading_basis: 'teacher_key' | 'generated_reference'
     reference_answers: string[]
+    provenance: TestGradingProvenance
   }
 }): Promise<void> {
   const result = await finalizeTestAiGradingItem({
@@ -573,6 +575,7 @@ async function persistSuggestionForResponse(opts: {
       opts.suggestion.grading_basis === 'generated_reference'
         ? opts.suggestion.reference_answers
         : null,
+    aiGradingProvenance: opts.suggestion.provenance,
     attemptCount: opts.attemptCount,
   })
   if (result.outcome === 'stale') return

--- a/src/lib/server/test-ai-provenance.ts
+++ b/src/lib/server/test-ai-provenance.ts
@@ -1,10 +1,14 @@
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
 import { z } from 'zod'
+import {
+  testGradingProvenanceSchema,
+  type TestGradingProvenance,
+} from '@/lib/grading/contracts'
 import type { TestQuestionGradingSnapshot } from '@/lib/test-grading-context'
 
 const MANUAL_TEST_AI_PROVENANCE_TTL_MS = 24 * 60 * 60 * 1000
 
-const manualTestAiProvenancePayloadSchema = z.object({
+const manualTestAiProvenancePayloadV1Schema = z.object({
   version: z.literal(1),
   teacher_id: z.string().min(1),
   test_id: z.string().min(1),
@@ -20,6 +24,16 @@ const manualTestAiProvenancePayloadSchema = z.object({
   expires_at_ms: z.number().int().positive(),
 }).strict()
 
+const manualTestAiProvenancePayloadV2Schema = manualTestAiProvenancePayloadV1Schema.extend({
+  version: z.literal(2),
+  grading_provenance_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+}).strict()
+
+const manualTestAiProvenancePayloadSchema = z.discriminatedUnion('version', [
+  manualTestAiProvenancePayloadV1Schema,
+  manualTestAiProvenancePayloadV2Schema,
+])
+
 type ManualTestAiProvenancePayload = z.infer<typeof manualTestAiProvenancePayloadSchema>
 
 export type ManualTestAiProvenanceIdentity = {
@@ -33,6 +47,7 @@ export type ManualTestAiProvenanceIdentity = {
   suggestedScore: number
   suggestedFeedback: string
   questionGradingSnapshot: TestQuestionGradingSnapshot
+  gradingProvenance: TestGradingProvenance | null
 }
 
 function getSigningSecret(): string {
@@ -56,7 +71,7 @@ export function createManualTestAiProvenanceToken(
   nowMs = Date.now(),
 ): string {
   const payload: ManualTestAiProvenancePayload = {
-    version: 1,
+    version: 2,
     teacher_id: input.teacherId,
     test_id: input.testId,
     response_id: input.responseId,
@@ -67,6 +82,9 @@ export function createManualTestAiProvenanceToken(
     suggested_score: input.suggestedScore,
     suggested_feedback_sha256: hashCanonical(input.suggestedFeedback),
     question_grading_snapshot_sha256: hashCanonical(input.questionGradingSnapshot),
+    grading_provenance_sha256: hashCanonical(
+      testGradingProvenanceSchema.parse(input.gradingProvenance),
+    ),
     issued_at_ms: nowMs,
     expires_at_ms: nowMs + MANUAL_TEST_AI_PROVENANCE_TTL_MS,
   }
@@ -103,6 +121,9 @@ export function verifyManualTestAiProvenanceToken(input: {
 
   const nowMs = input.nowMs ?? Date.now()
   const expected = input.expected
+  const expectedProvenance = payload.version === 2
+    ? testGradingProvenanceSchema.safeParse(expected.gradingProvenance)
+    : null
   return payload.issued_at_ms <= nowMs
     && payload.expires_at_ms >= nowMs
     && payload.teacher_id === expected.teacherId
@@ -116,4 +137,8 @@ export function verifyManualTestAiProvenanceToken(input: {
     && payload.suggested_feedback_sha256 === hashCanonical(expected.suggestedFeedback)
     && payload.question_grading_snapshot_sha256
       === hashCanonical(expected.questionGradingSnapshot)
+    && (payload.version === 1
+      ? expected.gradingProvenance === null
+      : expectedProvenance?.success === true
+        && payload.grading_provenance_sha256 === hashCanonical(expectedProvenance.data))
 }

--- a/src/lib/server/test-grades.ts
+++ b/src/lib/server/test-grades.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { ApiError, apiErrors } from '@/lib/api-handler'
 import { getServiceRoleClient } from '@/lib/supabase'
 import type { Json } from '@/types/database.generated'
+import type { TestGradingProvenance } from '@/lib/grading/contracts'
 import { verifyManualTestAiProvenanceToken } from '@/lib/server/test-ai-provenance'
 import type {
   SaveStudentTestGradesInput,
@@ -63,6 +64,7 @@ function toRpcGrade(
         ai_model: grade.ai_model ?? null,
         ai_suggested_score: grade.ai_suggested_score ?? null,
         ai_suggested_feedback: grade.ai_suggested_feedback ?? null,
+        ai_grading_provenance: grade.ai_grading_provenance ?? null,
         question_grading_snapshot: grade.question_grading_snapshot ?? null,
       }
   return {
@@ -106,6 +108,7 @@ function assertManualAiProvenance(input: {
         suggestedScore: grade.ai_suggested_score,
         suggestedFeedback: grade.ai_suggested_feedback,
         questionGradingSnapshot: grade.question_grading_snapshot,
+        gradingProvenance: grade.ai_grading_provenance ?? null,
       },
     })
   ) {
@@ -121,7 +124,7 @@ async function saveGrades(opts: {
   now?: string
 }) {
   const supabase = getServiceRoleClient()
-  const { data, error } = await supabase.rpc('save_test_response_grades_atomic', {
+  const { data, error } = await supabase.rpc('save_test_response_grades_with_provenance_atomic', {
     p_test_id: opts.testId,
     p_student_id: opts.studentId,
     p_teacher_id: opts.teacherId,
@@ -277,11 +280,12 @@ export async function finalizeTestAiGradingItem(input: {
   aiGradingBasis: 'teacher_key' | 'generated_reference'
   aiReferenceAnswers: string[] | null
   aiModel: string
+  aiGradingProvenance: TestGradingProvenance
   attemptCount: number
   now?: string
 }) {
   const supabase = getServiceRoleClient()
-  const { data, error } = await supabase.rpc('finalize_test_ai_grading_item_atomic', {
+  const { data, error } = await supabase.rpc('finalize_test_ai_grading_item_with_provenance_atomic', {
     p_item_id: input.itemId,
     p_teacher_id: input.teacherId,
     p_lease_token: input.leaseToken,
@@ -290,6 +294,7 @@ export async function finalizeTestAiGradingItem(input: {
     p_ai_grading_basis: input.aiGradingBasis,
     p_ai_reference_answers: input.aiReferenceAnswers,
     p_ai_model: input.aiModel,
+    p_ai_grading_provenance: input.aiGradingProvenance,
     p_attempt_count: input.attemptCount,
     p_now: input.now ?? new Date().toISOString(),
   })

--- a/src/lib/validations/test-grading.ts
+++ b/src/lib/validations/test-grading.ts
@@ -3,6 +3,10 @@ import {
   testQuestionGradingSnapshotSchema,
   type TestQuestionGradingSnapshot,
 } from '@/lib/test-grading-context'
+import {
+  testGradingProvenanceSchema,
+  type TestGradingProvenance,
+} from '@/lib/grading/contracts'
 
 type ParsedGrade = {
   score: number | null
@@ -15,6 +19,7 @@ type ParsedGrade = {
   ai_provenance_token: string | null | undefined
   ai_suggested_score: number | null | undefined
   ai_suggested_feedback: string | null | undefined
+  ai_grading_provenance: TestGradingProvenance | null | undefined
 }
 
 function invalidGrade(context: z.RefinementCtx): never {
@@ -45,6 +50,7 @@ function parseGrade(raw: unknown, context: z.RefinementCtx): ParsedGrade | never
       ai_provenance_token: null,
       ai_suggested_score: null,
       ai_suggested_feedback: null,
+      ai_grading_provenance: null,
     }
   }
 
@@ -162,6 +168,17 @@ function parseGrade(raw: unknown, context: z.RefinementCtx): ParsedGrade | never
     }
   }
 
+  let aiGradingProvenance: TestGradingProvenance | null | undefined
+  if (record.ai_grading_provenance !== undefined) {
+    if (record.ai_grading_provenance === null) {
+      aiGradingProvenance = null
+    } else {
+      const parsed = testGradingProvenanceSchema.safeParse(record.ai_grading_provenance)
+      if (!parsed.success) return invalidGrade(context)
+      aiGradingProvenance = parsed.data
+    }
+  }
+
   if (aiGradingBasis === null) {
     aiReferenceAnswers = null
     aiModel = null
@@ -169,6 +186,7 @@ function parseGrade(raw: unknown, context: z.RefinementCtx): ParsedGrade | never
     aiProvenanceToken = null
     aiSuggestedScore = null
     aiSuggestedFeedback = null
+    aiGradingProvenance = null
   } else {
     if (aiGradingBasis === undefined && Array.isArray(aiReferenceAnswers)) {
       aiGradingBasis = 'generated_reference'
@@ -179,6 +197,7 @@ function parseGrade(raw: unknown, context: z.RefinementCtx): ParsedGrade | never
       (aiGradingBasis === undefined && aiProvenanceToken !== undefined) ||
       (aiGradingBasis === undefined && aiSuggestedScore !== undefined) ||
       (aiGradingBasis === undefined && aiSuggestedFeedback !== undefined) ||
+      (aiGradingBasis === undefined && aiGradingProvenance !== undefined) ||
       (aiGradingBasis !== undefined && aiGradingBasis !== null && !aiModel) ||
       (aiGradingBasis !== undefined && aiGradingBasis !== null && !questionGradingSnapshot) ||
       (aiGradingBasis !== undefined && aiGradingBasis !== null && !aiProvenanceToken) ||
@@ -204,6 +223,7 @@ function parseGrade(raw: unknown, context: z.RefinementCtx): ParsedGrade | never
     ai_provenance_token: aiProvenanceToken,
     ai_suggested_score: aiSuggestedScore,
     ai_suggested_feedback: aiSuggestedFeedback,
+    ai_grading_provenance: aiGradingProvenance,
   }
 }
 

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -3640,6 +3640,7 @@ export type Database = {
       test_responses: {
         Row: {
           ai_grading_basis: string | null
+          ai_grading_provenance: Json | null
           ai_model: string | null
           ai_reference_answers: Json | null
           ai_suggested_feedback: string | null
@@ -3659,6 +3660,7 @@ export type Database = {
         }
         Insert: {
           ai_grading_basis?: string | null
+          ai_grading_provenance?: Json | null
           ai_model?: string | null
           ai_reference_answers?: Json | null
           ai_suggested_feedback?: string | null
@@ -3678,6 +3680,7 @@ export type Database = {
         }
         Update: {
           ai_grading_basis?: string | null
+          ai_grading_provenance?: Json | null
           ai_model?: string | null
           ai_reference_answers?: Json | null
           ai_suggested_feedback?: string | null
@@ -4544,6 +4547,22 @@ export type Database = {
         }
         Returns: Json
       }
+      finalize_test_ai_grading_item_with_provenance_atomic: {
+        Args: {
+          p_ai_grading_basis: string
+          p_ai_grading_provenance: Json
+          p_ai_model: string
+          p_ai_reference_answers: Json
+          p_attempt_count: number
+          p_feedback: string
+          p_item_id: string
+          p_lease_token: string
+          p_now: string
+          p_score: number
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
       finalize_test_attempts_for_grading_atomic: {
         Args: {
           p_closed_by: string
@@ -4799,6 +4818,16 @@ export type Database = {
         Returns: Json
       }
       save_test_response_grades_atomic: {
+        Args: {
+          p_grade_rows: Json
+          p_now: string
+          p_student_id: string
+          p_teacher_id: string
+          p_test_id: string
+        }
+        Returns: Json
+      }
+      save_test_response_grades_with_provenance_atomic: {
         Args: {
           p_grade_rows: Json
           p_now: string

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2,7 +2,7 @@ import type {
   AssignmentSubmissionRequirementDraft,
   AssignmentSubmissionValidationPolicyJson,
 } from '@/lib/assignment-submission-requirements'
-import type { GradingProvenance } from '@/lib/grading/contracts'
+import type { GradingProvenance, TestGradingProvenance } from '@/lib/grading/contracts'
 import type { Database as GeneratedDatabase, Json } from '@/types/database.generated'
 import type {
   ActualCourseSiteConfig,
@@ -245,8 +245,14 @@ type TableOverrides = {
   >
   test_responses: TableContract<
     'test_responses',
-    { ai_reference_answers: string[] | null },
-    { ai_reference_answers?: string[] | null }
+    {
+      ai_grading_provenance: TestGradingProvenance | null
+      ai_reference_answers: string[] | null
+    },
+    {
+      ai_grading_provenance?: TestGradingProvenance | null
+      ai_reference_answers?: string[] | null
+    }
   >
   tests: TableContract<
     'tests',
@@ -355,6 +361,14 @@ type FunctionOverrides = {
       p_ai_reference_answers: string[] | null
     }>
   >
+  finalize_test_ai_grading_item_with_provenance_atomic: FunctionContract<
+    'finalize_test_ai_grading_item_with_provenance_atomic',
+    Json,
+    Replace<GeneratedFunctions['finalize_test_ai_grading_item_with_provenance_atomic']['Args'], {
+      p_ai_grading_provenance: TestGradingProvenance
+      p_ai_reference_answers: string[] | null
+    }>
+  >
   create_course_blueprint_atomic: FunctionContract<
     'create_course_blueprint_atomic',
     Json,
@@ -428,6 +442,14 @@ type FunctionOverrides = {
     'save_test_response_grades_atomic',
     Json,
     Replace<GeneratedFunctions['save_test_response_grades_atomic']['Args'], {
+      p_grade_rows: Json
+      p_student_id: string | null
+    }>
+  >
+  save_test_response_grades_with_provenance_atomic: FunctionContract<
+    'save_test_response_grades_with_provenance_atomic',
+    Json,
+    Replace<GeneratedFunctions['save_test_response_grades_with_provenance_atomic']['Args'], {
       p_grade_rows: Json
       p_student_id: string | null
     }>

--- a/supabase/migrations/102_test_ai_grading_provenance.sql
+++ b/supabase/migrations/102_test_ai_grading_provenance.sql
@@ -1,0 +1,298 @@
+-- Persist bounded, versioned test-grading provenance without changing the
+-- signatures used by older application instances.
+
+alter table public.test_responses
+  add column if not exists ai_grading_provenance jsonb;
+
+-- Provenance is part of the same logical grade mutation. The compatibility
+-- wrappers set it after invoking the old RPC, so that metadata-only update must
+-- not advance the optimistic response revision a second time.
+create or replace function public.stamp_test_response_revision()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if current_setting('pika.classroom_archive_restore', true) = 'on'
+    and current_user in ('postgres', 'service_role', 'supabase_admin')
+  then
+    new.revision := coalesce(new.revision, 1);
+    return new;
+  end if;
+  if tg_op = 'INSERT' then
+    new.revision := 1;
+  elsif to_jsonb(new) - 'ai_grading_provenance'
+    = to_jsonb(old) - 'ai_grading_provenance'
+  then
+    new.revision := old.revision;
+    return new;
+  else
+    new.revision := coalesce(old.revision, 0) + 1;
+  end if;
+  if new.ai_grading_basis is null then
+    new.ai_suggested_score := null;
+    new.ai_suggested_feedback := null;
+  end if;
+  return new;
+end;
+$$;
+
+alter table public.test_responses
+  add constraint test_responses_ai_grading_provenance_contract
+  check (
+    ai_grading_provenance is null
+    or (
+      jsonb_typeof(ai_grading_provenance) = 'object'
+      and ai_grading_provenance ?& array[
+        'schemaVersion', 'gradingRequestId', 'provider', 'model', 'policyVersion',
+        'promptVersion', 'gradingProfileVersion', 'rubricVersion', 'operation',
+        'batchSize', 'providerRequestCount', 'tokenUsage'
+      ]
+      and ai_grading_provenance - array[
+        'schemaVersion', 'gradingRequestId', 'provider', 'model', 'policyVersion',
+        'promptVersion', 'gradingProfileVersion', 'rubricVersion', 'operation',
+        'batchSize', 'providerRequestCount', 'tokenUsage'
+      ]::text[] = '{}'::jsonb
+      and jsonb_typeof(ai_grading_provenance->'schemaVersion') = 'string'
+      and ai_grading_provenance->>'schemaVersion' = 'test-grading-provenance-v1'
+      and ai_grading_basis is not null
+      and ai_grading_basis in ('teacher_key', 'generated_reference')
+      and ai_model is not null
+      and ai_model = ai_grading_provenance->>'model'
+      and ai_suggested_score is not null
+      and ai_suggested_feedback is not null
+      and jsonb_typeof(ai_grading_provenance->'gradingRequestId') = 'string'
+      and ai_grading_provenance->>'gradingRequestId'
+        ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      and jsonb_typeof(ai_grading_provenance->'provider') = 'string'
+      and length(ai_grading_provenance->>'provider') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'model') = 'string'
+      and length(ai_grading_provenance->>'model') between 1 and 200
+      and jsonb_typeof(ai_grading_provenance->'policyVersion') = 'string'
+      and length(ai_grading_provenance->>'policyVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'promptVersion') = 'string'
+      and length(ai_grading_provenance->>'promptVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'gradingProfileVersion') = 'string'
+      and length(ai_grading_provenance->>'gradingProfileVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'rubricVersion') = 'string'
+      and length(ai_grading_provenance->>'rubricVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'operation') = 'string'
+      and ai_grading_provenance->>'operation' in ('single', 'batch')
+      and jsonb_typeof(ai_grading_provenance->'batchSize') = 'number'
+      and (ai_grading_provenance->>'batchSize')::integer between 1 and 20
+      and (ai_grading_provenance->>'batchSize')::numeric
+        = trunc((ai_grading_provenance->>'batchSize')::numeric)
+      and jsonb_typeof(ai_grading_provenance->'providerRequestCount') = 'number'
+      and (ai_grading_provenance->>'providerRequestCount')::integer between 1 and 10
+      and (ai_grading_provenance->>'providerRequestCount')::numeric
+        = trunc((ai_grading_provenance->>'providerRequestCount')::numeric)
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage') = 'object'
+      and ai_grading_provenance->'tokenUsage' ?& array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]
+      and (ai_grading_provenance->'tokenUsage') - array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]::text[] = '{}'::jsonb
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'inputTokens') in ('number', 'null')
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'outputTokens') in ('number', 'null')
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'totalTokens') in ('number', 'null')
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'inputTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'outputTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'totalTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric)
+        )
+      )
+      and octet_length(ai_grading_provenance::text) <= 4096
+    )
+  ) not valid;
+
+alter table public.test_responses
+  validate constraint test_responses_ai_grading_provenance_contract;
+
+comment on column public.test_responses.ai_grading_provenance is
+  'Bounded, pseudonymous test-grading provenance; never contains student or roster identifiers.';
+
+create or replace function public.clear_stale_test_ai_grading_provenance()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.ai_grading_provenance is not distinct from old.ai_grading_provenance
+    and (
+      new.ai_grading_basis is distinct from old.ai_grading_basis
+      or new.ai_reference_answers is distinct from old.ai_reference_answers
+      or new.ai_model is distinct from old.ai_model
+      or new.ai_suggested_score is distinct from old.ai_suggested_score
+      or new.ai_suggested_feedback is distinct from old.ai_suggested_feedback
+    )
+  then
+    new.ai_grading_provenance := null;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists clear_stale_test_ai_grading_provenance
+  on public.test_responses;
+create trigger clear_stale_test_ai_grading_provenance
+before update of
+  ai_grading_basis,
+  ai_reference_answers,
+  ai_model,
+  ai_suggested_score,
+  ai_suggested_feedback
+on public.test_responses
+for each row
+execute function public.clear_stale_test_ai_grading_provenance();
+
+create or replace function public.save_test_response_grades_with_provenance_atomic(
+  p_test_id uuid,
+  p_student_id uuid,
+  p_teacher_id uuid,
+  p_grade_rows jsonb,
+  p_now timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_result jsonb;
+  v_grade jsonb;
+  v_response_id uuid;
+begin
+  v_result := public.save_test_response_grades_atomic(
+    p_test_id,
+    p_student_id,
+    p_teacher_id,
+    p_grade_rows,
+    p_now
+  );
+
+  for v_grade in select value from jsonb_array_elements(p_grade_rows)
+  loop
+    if v_grade ? 'ai_grading_provenance' then
+      v_response_id := (v_grade->>'response_id')::uuid;
+      update public.test_responses response
+      set ai_grading_provenance = case
+        when jsonb_typeof(v_grade->'ai_grading_provenance') = 'null' then null
+        else v_grade->'ai_grading_provenance'
+      end
+      where response.id = v_response_id
+        and response.test_id = p_test_id;
+
+      if not found then
+        raise exception 'Test response not found' using errcode = 'P0002';
+      end if;
+    end if;
+  end loop;
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.finalize_test_ai_grading_item_with_provenance_atomic(
+  p_item_id uuid,
+  p_teacher_id uuid,
+  p_lease_token uuid,
+  p_score numeric,
+  p_feedback text,
+  p_ai_grading_basis text,
+  p_ai_reference_answers jsonb,
+  p_ai_model text,
+  p_ai_grading_provenance jsonb,
+  p_attempt_count integer,
+  p_now timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_test_id uuid;
+  v_item_status text;
+  v_result jsonb;
+  v_response_id uuid;
+begin
+  select item.test_id
+  into v_test_id
+  from public.test_ai_grading_run_items item
+  where item.id = p_item_id;
+
+  if not found then
+    raise exception 'Test AI grading item not found' using errcode = 'P0002';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(v_test_id::text, 0));
+
+  select item.status
+  into v_item_status
+  from public.test_ai_grading_run_items item
+  where item.id = p_item_id
+    and item.test_id = v_test_id
+  for update;
+
+  v_result := public.finalize_test_ai_grading_item_atomic(
+    p_item_id,
+    p_teacher_id,
+    p_lease_token,
+    p_score,
+    p_feedback,
+    p_ai_grading_basis,
+    p_ai_reference_answers,
+    p_ai_model,
+    p_attempt_count,
+    p_now
+  );
+
+  if v_item_status <> 'completed' and v_result->>'outcome' = 'saved' then
+    v_response_id := (v_result->'response'->>'id')::uuid;
+    update public.test_responses response
+    set ai_grading_provenance = p_ai_grading_provenance
+    where response.id = v_response_id
+      and response.test_id = v_test_id;
+
+    if not found then
+      raise exception 'Test response not found' using errcode = 'P0002';
+    end if;
+  end if;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.save_test_response_grades_with_provenance_atomic(
+  uuid, uuid, uuid, jsonb, timestamptz
+) from public, anon, authenticated;
+grant execute on function public.save_test_response_grades_with_provenance_atomic(
+  uuid, uuid, uuid, jsonb, timestamptz
+) to service_role;
+
+revoke all on function public.finalize_test_ai_grading_item_with_provenance_atomic(
+  uuid, uuid, uuid, numeric, text, text, jsonb, text, jsonb, integer, timestamptz
+) from public, anon, authenticated;
+grant execute on function public.finalize_test_ai_grading_item_with_provenance_atomic(
+  uuid, uuid, uuid, numeric, text, text, jsonb, text, jsonb, integer, timestamptz
+) to service_role;

--- a/tests/api/teacher/tests-ai-suggest.test.ts
+++ b/tests/api/teacher/tests-ai-suggest.test.ts
@@ -52,6 +52,20 @@ vi.mock('@/lib/ai-test-grading', () => ({
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
+const gradingProvenance = {
+  schemaVersion: 'test-grading-provenance-v1',
+  gradingRequestId: '10000000-0000-4000-8000-000000000001',
+  provider: 'openai',
+  model: 'gpt-5-nano',
+  policyVersion: 'pika-test-open-response-policy-v1',
+  promptVersion: 'pika-test-open-response-manual-prompt-v1',
+  gradingProfileVersion: 'pika-test-open-response-v1',
+  rubricVersion: 'pika-test-open-response-rubric-v1',
+  operation: 'single',
+  batchSize: 1,
+  providerRequestCount: 1,
+  tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+} as const
 
 describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () => {
   beforeEach(() => {
@@ -138,6 +152,7 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
       grading_basis: 'teacher_key',
       reference_answers: [],
       model: 'gpt-5-nano',
+      provenance: gradingProvenance,
     })
 
     setupResponseRow()
@@ -177,6 +192,7 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
       expect.objectContaining({
         grading_basis: 'teacher_key',
         model: 'gpt-5-nano',
+        provenance: gradingProvenance,
       })
     )
     expect(data.question_grading_snapshot).toEqual({
@@ -210,6 +226,7 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
       grading_basis: 'generated_reference',
       reference_answers: ['Generated answer'],
       model: 'gpt-5-nano',
+      provenance: gradingProvenance,
     })
     const { questionUpdate, questionUpdateChain } = setupResponseRow()
 

--- a/tests/components/TestIndividualResponses.test.tsx
+++ b/tests/components/TestIndividualResponses.test.tsx
@@ -193,6 +193,20 @@ describe('TestIndividualResponses', () => {
       answer_key: 'Expected result',
       sample_solution: null,
     }
+    const gradingProvenance = {
+      schemaVersion: 'test-grading-provenance-v1',
+      gradingRequestId: '10000000-0000-4000-8000-000000000001',
+      provider: 'openai',
+      model: 'gpt-5-nano',
+      policyVersion: 'pika-test-open-response-policy-v1',
+      promptVersion: 'pika-test-open-response-manual-prompt-v1',
+      gradingProfileVersion: 'pika-test-open-response-v1',
+      rubricVersion: 'pika-test-open-response-rubric-v1',
+      operation: 'single',
+      batchSize: 1,
+      providerRequestCount: 1,
+      tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+    }
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.endsWith('/api/teacher/tests/test-1/results')) {
@@ -207,6 +221,7 @@ describe('TestIndividualResponses', () => {
             grading_basis: 'teacher_key',
             reference_answers: [],
             model: 'gpt-5-nano',
+            provenance: gradingProvenance,
           },
           question_grading_snapshot: questionGradingSnapshot,
           ai_provenance_token: 'signed-token',
@@ -251,6 +266,7 @@ describe('TestIndividualResponses', () => {
       ai_provenance_token: 'signed-token',
       ai_suggested_score: 4,
       ai_suggested_feedback: 'Clear explanation.',
+      ai_grading_provenance: gradingProvenance,
     })
 
     await user.click(screen.getByRole('button', { name: 'Clear' }))

--- a/tests/lib/grading/engine.test.ts
+++ b/tests/lib/grading/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { executeGrading } from '@/lib/grading/engine'
+import { executeGrading, executeStructuredOutput } from '@/lib/grading/engine'
 import type { GradingProfile } from '@/lib/grading/profiles/types'
 import type { StructuredOutputProvider } from '@/lib/grading/providers/types'
 
@@ -111,5 +111,55 @@ describe('executeGrading', () => {
         reasoningEffort: 'minimal',
       },
     })).rejects.toThrow('Unknown grading criterion: invented')
+  })
+})
+
+describe('executeStructuredOutput', () => {
+  it('returns parsed output with provider execution metadata', async () => {
+    const provider = providerReturning('{"completion":8,"feedback":"Useful feedback."}')
+
+    const result = await executeStructuredOutput({
+      provider,
+      policy: {
+        version: 'policy-v1',
+        model: 'model-v1',
+        requestTimeoutMs: 25_000,
+        reasoningEffort: 'minimal',
+      },
+      prompt: {
+        systemPrompt: 'Grade this response.',
+        userPrompt: 'Student response',
+      },
+      output: profile.output,
+      parseOutput: profile.parseOutput,
+    })
+
+    expect(result).toEqual({
+      output: { completion: 8, feedback: 'Useful feedback.' },
+      execution: {
+        provider: 'fake',
+        model: 'model-v1',
+        policyVersion: 'policy-v1',
+        providerRequestCount: 1,
+        tokenUsage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+      },
+    })
+  })
+
+  it('normalizes parser failures into grading output errors', async () => {
+    await expect(executeStructuredOutput({
+      provider: providerReturning('not-json'),
+      policy: {
+        version: 'policy-v1',
+        model: 'model-v1',
+        reasoningEffort: 'minimal',
+      },
+      prompt: {
+        systemPrompt: 'Grade this response.',
+        userPrompt: 'Student response',
+      },
+      output: profile.output,
+      parseOutput: profile.parseOutput,
+    })).rejects.toMatchObject({ name: 'GradingOutputError' })
   })
 })

--- a/tests/lib/grading/test-open-response-profile.test.ts
+++ b/tests/lib/grading/test-open-response-profile.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { testGradingProvenanceSchema } from '@/lib/grading/contracts'
+import {
+  getPikaTestPromptVersion,
+  parsePikaTestBatchGradeOutput,
+  parsePikaTestSingleGradeOutput,
+  PIKA_TEST_BATCH_GRADE_OUTPUT,
+  PIKA_TEST_OPEN_RESPONSE_BULK_PROMPT_VERSION,
+  PIKA_TEST_OPEN_RESPONSE_MANUAL_PROMPT_VERSION,
+  PIKA_TEST_SINGLE_GRADE_OUTPUT,
+} from '@/lib/grading/profiles/pika-test-open-response'
+
+describe('Pika test open-response profile', () => {
+  it('versions manual and bulk prompts independently', () => {
+    expect(getPikaTestPromptVersion('manual')).toBe(
+      PIKA_TEST_OPEN_RESPONSE_MANUAL_PROMPT_VERSION,
+    )
+    expect(getPikaTestPromptVersion('bulk')).toBe(
+      PIKA_TEST_OPEN_RESPONSE_BULK_PROMPT_VERSION,
+    )
+  })
+
+  it('preserves the existing single and batch output budgets', () => {
+    expect(PIKA_TEST_SINGLE_GRADE_OUTPUT).toMatchObject({
+      initialMaxOutputTokens: 220,
+      fallbackMaxOutputTokens: 420,
+    })
+    expect(PIKA_TEST_BATCH_GRADE_OUTPUT).toMatchObject({
+      initialMaxOutputTokens: 600,
+      fallbackMaxOutputTokens: 900,
+    })
+  })
+
+  it('parses strict single and batch results', () => {
+    expect(parsePikaTestSingleGradeOutput('{"score":4,"feedback":"Clear."}')).toEqual({
+      score: 4,
+      feedback: 'Clear.',
+    })
+    expect(parsePikaTestBatchGradeOutput(
+      '{"results":[{"response_id":"response_1","score":3,"feedback":"Add detail."}]}',
+    )).toEqual({
+      results: [{ response_id: 'response_1', score: 3, feedback: 'Add detail.' }],
+    })
+  })
+
+  it('rejects undeclared output fields', () => {
+    expect(() => parsePikaTestSingleGradeOutput(
+      '{"score":4,"feedback":"Clear.","student_id":"local-id"}',
+    )).toThrow()
+  })
+
+  it('accepts only locally generated UUID v4 grading request ids', () => {
+    const provenance = {
+      schemaVersion: 'test-grading-provenance-v1',
+      gradingRequestId: '10000000-0000-4000-8000-000000000001',
+      provider: 'openai',
+      model: 'gpt-5-nano',
+      policyVersion: 'policy-v1',
+      promptVersion: 'prompt-v1',
+      gradingProfileVersion: 'profile-v1',
+      rubricVersion: 'rubric-v1',
+      operation: 'single',
+      batchSize: 1,
+      providerRequestCount: 1,
+      tokenUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    }
+
+    expect(testGradingProvenanceSchema.safeParse(provenance).success).toBe(true)
+    expect(testGradingProvenanceSchema.safeParse({
+      ...provenance,
+      gradingRequestId: '10000000-0000-7000-8000-000000000001',
+    }).success).toBe(false)
+  })
+})

--- a/tests/lib/server/test-ai-provenance.test.ts
+++ b/tests/lib/server/test-ai-provenance.test.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from 'node:crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   createManualTestAiProvenanceToken,
@@ -22,6 +23,20 @@ const identity = {
     answer_key: null,
     sample_solution: null,
   },
+  gradingProvenance: {
+    schemaVersion: 'test-grading-provenance-v1' as const,
+    gradingRequestId: '10000000-0000-4000-8000-000000000001',
+    provider: 'openai',
+    model: 'gpt-5-nano',
+    policyVersion: 'pika-test-open-response-policy-v1',
+    promptVersion: 'pika-test-open-response-manual-prompt-v1',
+    gradingProfileVersion: 'pika-test-open-response-v1',
+    rubricVersion: 'pika-test-open-response-rubric-v1',
+    operation: 'single' as const,
+    batchSize: 1,
+    providerRequestCount: 1,
+    tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+  },
 }
 
 describe('manual test AI provenance', () => {
@@ -43,6 +58,17 @@ describe('manual test AI provenance', () => {
     })).toBe(false)
     expect(verifyManualTestAiProvenanceToken({
       token,
+      expected: {
+        ...identity,
+        gradingProvenance: {
+          ...identity.gradingProvenance,
+          providerRequestCount: 2,
+        },
+      },
+      nowMs: 2_000,
+    })).toBe(false)
+    expect(verifyManualTestAiProvenanceToken({
+      token,
       expected: { ...identity, model: 'forged-model' },
       nowMs: 2_000,
     })).toBe(false)
@@ -60,8 +86,10 @@ describe('manual test AI provenance', () => {
 
   it('rejects tampered and expired tokens', () => {
     const token = createManualTestAiProvenanceToken(identity, 1_000)
+    const [payload, signature] = token.split('.')
+    const tamperedSignature = `${signature[0] === 'A' ? 'B' : 'A'}${signature.slice(1)}`
     expect(verifyManualTestAiProvenanceToken({
-      token: `${token.slice(0, -1)}x`,
+      token: `${payload}.${tamperedSignature}`,
       expected: identity,
       nowMs: 2_000,
     })).toBe(false)
@@ -92,5 +120,42 @@ describe('manual test AI provenance', () => {
       expected: largeIdentity,
       nowMs: 2_000,
     })).toBe(true)
+  })
+
+  it('accepts rolling-deploy v1 tokens only when no new provenance is supplied', () => {
+    const legacyIdentity = { ...identity, gradingProvenance: null }
+    const hash = (value: unknown) => createHash('sha256')
+      .update(JSON.stringify(value))
+      .digest('hex')
+    const payload = Buffer.from(JSON.stringify({
+      version: 1,
+      teacher_id: legacyIdentity.teacherId,
+      test_id: legacyIdentity.testId,
+      response_id: legacyIdentity.responseId,
+      response_revision: legacyIdentity.responseRevision,
+      grading_basis: legacyIdentity.gradingBasis,
+      reference_answers_sha256: hash(legacyIdentity.referenceAnswers),
+      model: legacyIdentity.model,
+      suggested_score: legacyIdentity.suggestedScore,
+      suggested_feedback_sha256: hash(legacyIdentity.suggestedFeedback),
+      question_grading_snapshot_sha256: hash(legacyIdentity.questionGradingSnapshot),
+      issued_at_ms: 1_000,
+      expires_at_ms: 24 * 60 * 60 * 1000 + 1_000,
+    })).toString('base64url')
+    const signature = createHmac('sha256', process.env.SESSION_SECRET!)
+      .update(payload)
+      .digest('base64url')
+    const token = `${payload}.${signature}`
+
+    expect(verifyManualTestAiProvenanceToken({
+      token,
+      expected: legacyIdentity,
+      nowMs: 2_000,
+    })).toBe(true)
+    expect(verifyManualTestAiProvenanceToken({
+      token,
+      expected: identity,
+      nowMs: 2_000,
+    })).toBe(false)
   })
 })

--- a/tests/lib/server/test-grades.test.ts
+++ b/tests/lib/server/test-grades.test.ts
@@ -20,6 +20,21 @@ const questionGradingSnapshot = {
   sample_solution: null,
 }
 
+const gradingProvenance = {
+  schemaVersion: 'test-grading-provenance-v1' as const,
+  gradingRequestId: '10000000-0000-4000-8000-000000000001',
+  provider: 'openai',
+  model: 'gpt-5-nano',
+  policyVersion: 'pika-test-open-response-policy-v1',
+  promptVersion: 'pika-test-open-response-manual-prompt-v1',
+  gradingProfileVersion: 'pika-test-open-response-v1',
+  rubricVersion: 'pika-test-open-response-rubric-v1',
+  operation: 'single' as const,
+  batchSize: 1,
+  providerRequestCount: 1,
+  tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+}
+
 const { rpc } = vi.hoisted(() => ({ rpc: vi.fn() }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -66,7 +81,7 @@ describe('test grade server workflows', () => {
       responses: [{ id: 'response-1', revision: 3, score: 4, feedback: 'Good work' }],
     })
 
-    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_atomic', {
+    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_with_provenance_atomic', {
       p_grade_rows: [{
         ...grade,
       }],
@@ -103,7 +118,7 @@ describe('test grade server workflows', () => {
       now: '2026-07-14T23:00:00.000Z',
     })).resolves.toEqual({ id: 'response-1', revision: 4, score: null, feedback: null })
 
-    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_atomic', expect.objectContaining({
+    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_with_provenance_atomic', expect.objectContaining({
       p_student_id: null,
       p_grade_rows: [expect.objectContaining({ response_id: 'response-1' })],
     }))
@@ -130,9 +145,11 @@ describe('test grade server workflows', () => {
         suggestedScore: 4,
         suggestedFeedback: 'Original AI feedback',
         questionGradingSnapshot,
+        gradingProvenance,
       }),
       ai_suggested_score: 4,
       ai_suggested_feedback: 'Original AI feedback',
+      ai_grading_provenance: gradingProvenance,
     }
     rpc.mockResolvedValueOnce({
       data: {
@@ -150,12 +167,13 @@ describe('test grade server workflows', () => {
       grade: aiGrade,
     })).resolves.toEqual(expect.objectContaining({ revision: 4 }))
 
-    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_atomic', expect.objectContaining({
+    expect(rpc).toHaveBeenCalledWith('save_test_response_grades_with_provenance_atomic', expect.objectContaining({
       p_grade_rows: [expect.objectContaining({
         score: 3.5,
         feedback: 'Teacher-edited feedback',
         ai_suggested_score: 4,
         ai_suggested_feedback: 'Original AI feedback',
+        ai_grading_provenance: gradingProvenance,
       })],
     }))
 
@@ -163,6 +181,10 @@ describe('test grade server workflows', () => {
       { ...aiGrade, ai_model: 'forged-model' },
       { ...aiGrade, ai_suggested_score: 3 },
       { ...aiGrade, ai_suggested_feedback: 'Forged original feedback' },
+      {
+        ...aiGrade,
+        ai_grading_provenance: { ...gradingProvenance, providerRequestCount: 2 },
+      },
     ]) {
       await expect(saveTestResponseGrade({
         teacherId: 'teacher-1',
@@ -246,12 +268,14 @@ describe('test grade server workflows', () => {
       aiGradingBasis: 'teacher_key',
       aiReferenceAnswers: null,
       aiModel: 'gpt-5-nano',
+      aiGradingProvenance: gradingProvenance,
       attemptCount: 1,
       now: '2026-07-14T23:00:00.000Z',
     })).resolves.toEqual(expect.objectContaining({ outcome: 'saved' }))
 
-    expect(rpc).toHaveBeenCalledWith('finalize_test_ai_grading_item_atomic', {
+    expect(rpc).toHaveBeenCalledWith('finalize_test_ai_grading_item_with_provenance_atomic', {
       p_ai_grading_basis: 'teacher_key',
+      p_ai_grading_provenance: gradingProvenance,
       p_ai_model: 'gpt-5-nano',
       p_ai_reference_answers: null,
       p_attempt_count: 1,
@@ -269,7 +293,7 @@ describe('test grade server workflows', () => {
     await expect(finalizeTestAiGradingItem({
       itemId: 'item-1', teacherId: 'teacher-1', leaseToken: 'lease-1', score: 4,
       feedback: 'Good work', aiGradingBasis: 'teacher_key', aiReferenceAnswers: null,
-      aiModel: 'gpt-5-nano', attemptCount: 1,
+      aiModel: 'gpt-5-nano', aiGradingProvenance: gradingProvenance, attemptCount: 1,
     })).resolves.toEqual({ outcome: 'stale', response: null })
   })
 

--- a/tests/lib/test-ai-grading-runs.test.ts
+++ b/tests/lib/test-ai-grading-runs.test.ts
@@ -43,6 +43,21 @@ vi.mock('@/lib/ai-test-grading', () => ({
 
 import { tickTestAiGradingRun } from '@/lib/server/test-ai-grading-runs'
 
+const gradingProvenance = {
+  schemaVersion: 'test-grading-provenance-v1' as const,
+  gradingRequestId: '10000000-0000-4000-8000-000000000001',
+  provider: 'openai',
+  model: 'gpt-5-nano',
+  policyVersion: 'pika-test-open-response-policy-v1',
+  promptVersion: 'pika-test-open-response-bulk-prompt-v1',
+  gradingProfileVersion: 'pika-test-open-response-v1',
+  rubricVersion: 'pika-test-open-response-rubric-v1',
+  operation: 'batch' as const,
+  batchSize: 2,
+  providerRequestCount: 1,
+  tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+}
+
 function buildPreparedContext() {
   return {
     model: 'gpt-5-nano',
@@ -210,7 +225,7 @@ function buildTickHarness(opts: {
       return { data: true, error: null }
     }
 
-    if (fn === 'finalize_test_ai_grading_item_atomic') {
+    if (fn === 'finalize_test_ai_grading_item_with_provenance_atomic') {
       if (opts.loseLeaseOnFinalize) {
         run.lease_token = 'replacement-lease'
         return { data: null, error: { code: '40001', message: 'Lease changed' } }
@@ -263,6 +278,7 @@ function buildTickHarness(opts: {
         ai_model: args.p_ai_model,
         ai_suggested_score: args.p_score,
         ai_suggested_feedback: args.p_feedback,
+        ai_grading_provenance: args.p_ai_grading_provenance,
         revision: response.revision + 1,
       })
       Object.assign(item, {
@@ -431,6 +447,7 @@ describe('tickTestAiGradingRun', () => {
         model: 'gpt-5-nano',
         grading_basis: 'teacher_key',
         reference_answers: ['Use a hash map.'],
+        provenance: gradingProvenance,
       },
       {
         responseId: 'response-2',
@@ -439,6 +456,7 @@ describe('tickTestAiGradingRun', () => {
         model: 'gpt-5-nano',
         grading_basis: 'teacher_key',
         reference_answers: ['Use a hash map.'],
+        provenance: gradingProvenance,
       },
     ])
 
@@ -468,6 +486,7 @@ describe('tickTestAiGradingRun', () => {
       expect.objectContaining({
         score: 5,
         feedback: 'Correct.',
+        ai_grading_provenance: gradingProvenance,
       }),
     )
     expect(suggestTestOpenResponseGradesBatchWithContext).toHaveBeenCalledTimes(1)
@@ -495,6 +514,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
@@ -528,6 +548,7 @@ describe('tickTestAiGradingRun', () => {
         model: 'gpt-5-nano',
         grading_basis: 'teacher_key',
         reference_answers: ['Use a hash map.'],
+        provenance: gradingProvenance,
       },
     ])
 
@@ -581,6 +602,7 @@ describe('tickTestAiGradingRun', () => {
         model: 'gpt-5-nano',
         grading_basis: 'teacher_key',
         reference_answers: ['Use a hash map.'],
+        provenance: gradingProvenance,
       },
     ])
 
@@ -635,6 +657,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
@@ -685,6 +708,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
@@ -713,6 +737,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
@@ -734,6 +759,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
@@ -766,6 +792,7 @@ describe('tickTestAiGradingRun', () => {
       model: 'gpt-5-nano',
       grading_basis: 'teacher_key',
       reference_answers: ['Use a hash map.'],
+      provenance: gradingProvenance,
     })
 
     const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })

--- a/tests/lib/validations/test-grading.test.ts
+++ b/tests/lib/validations/test-grading.test.ts
@@ -14,6 +14,21 @@ const questionGradingSnapshot = {
   sample_solution: null,
 }
 
+const gradingProvenance = {
+  schemaVersion: 'test-grading-provenance-v1',
+  gradingRequestId: '10000000-0000-4000-8000-000000000001',
+  provider: 'openai',
+  model: 'gpt-5-nano',
+  policyVersion: 'pika-test-open-response-policy-v1',
+  promptVersion: 'pika-test-open-response-manual-prompt-v1',
+  gradingProfileVersion: 'pika-test-open-response-v1',
+  rubricVersion: 'pika-test-open-response-rubric-v1',
+  operation: 'single',
+  batchSize: 1,
+  providerRequestCount: 1,
+  tokenUsage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+}
+
 describe('saveStudentTestGradesSchema', () => {
   it('normalizes grade values, response revisions, and AI audit metadata', () => {
     expect(saveStudentTestGradesSchema.parse({
@@ -31,6 +46,7 @@ describe('saveStudentTestGradesSchema', () => {
           ai_provenance_token: 'signed-token',
           ai_suggested_score: 1.2,
           ai_suggested_feedback: 'Original AI feedback',
+          ai_grading_provenance: gradingProvenance,
         },
       ],
     })).toEqual({
@@ -49,6 +65,7 @@ describe('saveStudentTestGradesSchema', () => {
           ai_provenance_token: 'signed-token',
           ai_suggested_score: 1.2,
           ai_suggested_feedback: 'Original AI feedback',
+          ai_grading_provenance: gradingProvenance,
         },
       ],
     })
@@ -85,6 +102,7 @@ describe('saveStudentTestGradesSchema', () => {
           ai_provenance_token: null,
           ai_suggested_score: null,
           ai_suggested_feedback: null,
+          ai_grading_provenance: null,
         },
       ],
     })

--- a/tests/unit/ai-test-grading.test.ts
+++ b/tests/unit/ai-test-grading.test.ts
@@ -48,7 +48,7 @@ describe('suggestTestOpenResponseGrade', () => {
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(suggestion).toEqual({
+    expect(suggestion).toMatchObject({
       score: 4,
       feedback: 'Good start. Add one more key detail.',
       model: 'gpt-5-nano',
@@ -323,10 +323,11 @@ describe('suggestTestOpenResponseGrade', () => {
       ok: true,
       json: async () => ({
         output_parsed: { score: 4, feedback: 'Clear explanation with one missing detail.' },
+        usage: { input_tokens: 120, output_tokens: 20, total_tokens: 140 },
       }),
     })
 
-    await suggestTestOpenResponseGrade({
+    const suggestion = await suggestTestOpenResponseGrade({
       testTitle: 'Unit 1 Test',
       questionText: 'Explain osmosis.',
       responseText: 'Water moves across the membrane.',
@@ -344,6 +345,20 @@ describe('suggestTestOpenResponseGrade', () => {
       type: 'json_schema',
       name: 'test_single_grade',
       strict: true,
+    })
+    expect(suggestion.provenance).toMatchObject({
+      schemaVersion: 'test-grading-provenance-v1',
+      gradingRequestId: expect.any(String),
+      provider: 'openai',
+      model: 'gpt-5-nano',
+      policyVersion: 'pika-test-open-response-policy-v1',
+      promptVersion: 'pika-test-open-response-manual-prompt-v1',
+      gradingProfileVersion: 'pika-test-open-response-v1',
+      rubricVersion: 'pika-test-open-response-rubric-v1',
+      operation: 'single',
+      batchSize: 1,
+      providerRequestCount: 1,
+      tokenUsage: { inputTokens: 120, outputTokens: 20, totalTokens: 140 },
     })
   })
 
@@ -390,6 +405,7 @@ describe('suggestTestOpenResponseGrade', () => {
         json: async () => ({
           status: 'incomplete',
           incomplete_details: { reason: 'max_output_tokens' },
+          usage: { input_tokens: 100, output_tokens: 30, total_tokens: 130 },
         }),
       })
       .mockResolvedValueOnce({
@@ -404,6 +420,7 @@ describe('suggestTestOpenResponseGrade', () => {
               },
             ],
           },
+          usage: { input_tokens: 110, output_tokens: 40, total_tokens: 150 },
         }),
       })
 
@@ -432,6 +449,12 @@ describe('suggestTestOpenResponseGrade', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? '{}')).max_output_tokens).toBe(600)
     expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? '{}')).max_output_tokens).toBe(900)
+    expect(suggestions[0].provenance).toMatchObject({
+      operation: 'batch',
+      batchSize: 1,
+      providerRequestCount: 2,
+      tokenUsage: { inputTokens: 210, outputTokens: 70, totalTokens: 280 },
+    })
   })
 
   it('returns available batch suggestions when the model omits one requested response', async () => {
@@ -774,6 +797,29 @@ describe('suggestTestOpenResponseGradesBatch', () => {
         ],
       }),
     ).rejects.toThrow('AI batch grade suggestion returned unknown response response_99')
+  })
+
+  it('rejects duplicate provider refs in batch output', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"results":[{"response_id":"response_1","score":5,"feedback":"Excellent."},{"response_id":"response_1","score":3,"feedback":"Add detail."}]}',
+      }),
+    })
+
+    await expect(
+      suggestTestOpenResponseGradesBatch({
+        testTitle: 'Unit 3 Test',
+        questionText: 'Explain what a method does.',
+        maxPoints: 5,
+        answerKey: 'A method groups reusable instructions.',
+        responses: [
+          { responseId: 'response-1', responseText: 'A method is reusable code.' },
+        ],
+      }),
+    ).rejects.toThrow('AI batch grade suggestion returned duplicate response response_1')
   })
 })
 

--- a/tests/unit/test-ai-grading-provenance-migration.test.ts
+++ b/tests/unit/test-ai-grading-provenance-migration.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/102_test_ai_grading_provenance.sql'),
+  'utf8',
+)
+const service = readFileSync(
+  resolve(process.cwd(), 'src/lib/server/test-grades.ts'),
+  'utf8',
+)
+const databaseHarness = readFileSync(
+  resolve(process.cwd(), 'scripts/check-atomic-test-grading.sh'),
+  'utf8',
+)
+
+describe('test AI grading provenance migration', () => {
+  it('adds a bounded provenance contract and rolling-safe atomic wrappers', () => {
+    expect(migration).toContain('add column if not exists ai_grading_provenance jsonb')
+    expect(migration).toContain('test-grading-provenance-v1')
+    expect(migration).toContain("-4[0-9a-f]{3}-[89ab]")
+    expect(migration).toContain("ai_model = ai_grading_provenance->>'model'")
+    expect(migration).toContain('octet_length(ai_grading_provenance::text) <= 4096')
+    expect(migration).toContain('create trigger clear_stale_test_ai_grading_provenance')
+    expect(migration).toContain('new.ai_grading_provenance := null')
+    expect(migration).toContain(
+      'create or replace function public.save_test_response_grades_with_provenance_atomic',
+    )
+    expect(migration).toContain(
+      'create or replace function public.finalize_test_ai_grading_item_with_provenance_atomic',
+    )
+    expect(migration.match(/security definer/g)).toHaveLength(2)
+    expect(migration.match(/set search_path = ''/g)).toHaveLength(4)
+    expect(migration).toContain('from public, anon, authenticated')
+    expect(migration).toContain('to service_role')
+  })
+
+  it('keeps provenance in the same transaction as manual and durable writes', () => {
+    const directStart = migration.indexOf(
+      'create or replace function public.save_test_response_grades_with_provenance_atomic',
+    )
+    const itemStart = migration.indexOf(
+      'create or replace function public.finalize_test_ai_grading_item_with_provenance_atomic',
+    )
+    const direct = migration.slice(directStart, itemStart)
+    const item = migration.slice(itemStart)
+
+    expect(direct).toContain('v_result := public.save_test_response_grades_atomic')
+    expect(direct).toContain('set ai_grading_provenance = case')
+    expect(migration).toContain("to_jsonb(new) - 'ai_grading_provenance'")
+    expect(item).toContain('v_result := public.finalize_test_ai_grading_item_atomic')
+    expect(item).toContain("v_item_status <> 'completed'")
+    expect(item).toContain('set ai_grading_provenance = p_ai_grading_provenance')
+  })
+
+  it('routes manual and durable persistence through provenance-aware RPCs', () => {
+    expect(service).toContain("rpc('save_test_response_grades_with_provenance_atomic'")
+    expect(service).toContain(
+      "rpc('finalize_test_ai_grading_item_with_provenance_atomic'",
+    )
+    expect(service).toContain('ai_grading_provenance: grade.ai_grading_provenance ?? null')
+    expect(service).toContain('p_ai_grading_provenance: input.aiGradingProvenance')
+  })
+
+  it('keeps database-backed persistence, replay, and legacy clearing coverage in CI', () => {
+    expect(databaseHarness).toContain('save_test_response_grades_with_provenance_atomic')
+    expect(databaseHarness).toContain('finalize_test_ai_grading_item_with_provenance_atomic')
+    expect(databaseHarness).toContain("ai_grading_provenance->>'gradingRequestId'")
+    expect(databaseHarness).toContain('test AI provenance replay overwrote the original audit')
+    expect(databaseHarness).toContain('legacy test grade write left stale AI provenance')
+  })
+})


### PR DESCRIPTION
## Summary
- move Pika test open-response prompt/output contracts onto the internal structured grading core while preserving sanitization, caching, score buckets, telemetry, and teacher workflows
- persist bounded versioned test-grading provenance for manual and durable grading, with signed UI propagation and atomic rolling-safe RPC wrappers
- preserve provenance for teacher corrections, clear it for stale legacy AI writes, and keep durable replay idempotent

## Stack
- stacked on #906; merge #906 first
- base branch: `codex/internal-grading-core`
- keeps the remote Gradex worker disabled and makes no deeper cross-service integration

## Database rollout
- migration `102_test_ai_grading_provenance.sql` must be applied before deploying this application version
- legacy migration 094 RPC signatures remain available for older instances
- migration was not applied locally or to production; ephemeral CI is the database authority

## Validation
- focused grading/persistence suite: 10 files, 114 tests
- full Vitest suite: 403 files, 3,632 tests
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (620 modules, 0 allowances)
- `pnpm build`
- `bash -n scripts/check-atomic-test-grading.sh`
- `git diff --check`

## Risk
- async-grading / database migration
- no live provider calls, production changes, or local migration application