### PR TITLE
Migrate repository review grading to internal core

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14166,3 +14166,42 @@
 - `pnpm build`
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:0984d2c766435de4d10db5116a67abeb768de1089c0c5fe7caa0bb5dea2a5d3e -->
+## 2026-07-14 — Archive stack consolidation CI fix
+
+**Completed:**
+- Fast-forward merged reviewed archive PRs 852–866 into the final stack base without changing commit history.
+- Fixed the consolidated recovery drill after CI exposed a stale duplicate of the restore object-path algorithm; the drill now calls the production canonical path helper.
+- Kept PR 851 unmerged from `main` until its refreshed required checks pass. No production state was accessed or modified.
+
+**Validation:**
+- Local full archive recovery drill passed twice, including row equality, object equality, and idempotent replays
+- Focused restore unit suite (1 file / 9 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+
+## 2026-07-14 — Read-only production classroom archive inventory
+
+**Risk profile:** runtime-platform
+
+**Model recommendation:** GPT-5 Codex - production verification crosses Supabase target safety, archive graph consistency, privacy-safe reporting, and fail-closed storage evidence.
+
+**Completed:**
+- Added a target-bound, read-only inventory command that requires the exact hosted Supabase project ref, validates deployed archive and Gradex contract rows, audits exposed PostgREST relationship metadata, and traverses the canonical 42-resource graph with exact-count pagination.
+- Bound the separately required direct PostgreSQL catalog audit to the same expected project ref for direct or Supabase pooler DSNs and required TLS.
+- Hardened the catalog runner against libpq DSN overrides and credential disclosure by allowlisting one TLS parameter, passing validated fields through `PG*` environment variables, sanitizing failures, and requiring either a hosted project ref or explicit loopback-only local mode.
+- Bracketed each hot archived classroom read with archive revisions, resolved managed objects through exact Storage metadata reads, and emitted only aggregate labels, counts, and byte sizes; missing referenced objects fail the command.
+- Ran the inventory against production after migrations 080-086 were applied: three hot archives, 44,813 relational rows, 42.2 MiB canonical relational payload, 165 referenced objects / 25.9 MiB, and zero missing objects or archive/restore/Gradex/cleanup operation rows.
+- Kept the archive epic unfinished. PostgREST metadata cannot prove hidden or stale catalog relationships, so the direct read-only PostgreSQL catalog audit remains required; no export, restore, Gradex, compaction, cleanup, row mutation, or Storage mutation was performed.
+
+**Validation:**
+- Final production read-only inventory passed after all review fixes
+- Full Vitest suite (345 files / 3,080 tests)
+- Focused inventory, catalog-runner, and service-client suites (35 tests)
+- Local read-only PostgreSQL catalog audit (117 foreign-key relationships)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture`
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1056,3 +1056,29 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Complete repository gates, independent review, and merge this evidence slice. Then start Daily/Attendance; assignment mobile UX remains deferred and Gradex remains owned by a separate session.
+## 2026-07-22 — Internal repository-review grading profile and provenance
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5.4 - this slice crosses structured provider contracts, sanitization, deterministic fallback semantics, revision fencing, and transactional database provenance.
+
+**Completed:**
+- Moved ambiguous-change classification and repository-review feedback into versioned, strict, bounded grading-core profiles using the shared OpenAI Responses provider, 25-second timeouts, minimal reasoning, and classification batches capped at 50 changes.
+- Preserved Pika ownership of GitHub access, student identity mapping, sanitization, deterministic metrics, heuristic fallback, teacher workflow, and run orchestration; remote Gradex remains disabled.
+- Added truthful per-result provenance for both model output and local heuristic fallback, with actual model/request/token metadata and zero provider requests for deterministic local grades.
+- Added migration 103 with bounded result provenance, model/provenance linkage, an additive provenance-aware wrapper around the migration-087 completion RPC, completed-run replay preservation, exact student-row matching, and atomic propagation to assignment documents.
+- Extended the database harness for service-role isolation, zero-request heuristic persistence, replay, and rollback on invalid provenance. Updated generated types and rollout/architecture guidance. No migration was applied locally, no live model call was made, and no production state changed.
+
+**Validation:**
+- `pnpm test` (405 files / 3,642 tests)
+- Focused repository-review/core/migration suite (7 files / 30 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (621 modules / 0 allowances)
+- `pnpm build`
+- `bash -n scripts/check-atomic-assignment-feedback-returns.sh`
+- `git diff --check`
+
+**Remaining:**
+- Confirm migration 103 replay, database harness behavior, and generated-type parity in ephemeral PR CI; complete independent review and merge only after the assignment/test stack is approved.
+- Add teacher-correction evaluation capture and offline comparison metrics across assignment, test, and repository-review grading.

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -196,8 +196,9 @@ Before changing remaining `quiz` / `quizzes` names, load
 - **Draft validation**: browser-safe draft contracts live in `@/lib/validations/assessment-drafts`
 - **Draft persistence**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`
 - **Scheduling**: `combineScheduleDateTimeToIso()` / `isScheduleIsoInFuture()` from `@/lib/scheduling`
-- **AI grading core**: `src/lib/grading/*` owns versioned assignment/test profiles, structured-output execution, provider adapters, and bounded provenance contracts.
+- **AI grading core**: `src/lib/grading/*` owns versioned assignment, test, and repository-review profiles, structured-output execution, provider adapters, and bounded provenance contracts.
 - **Test grading compatibility adapter**: `src/lib/ai-test-grading.ts` owns roster-aware sanitization, reference-answer SHA-256 caching, score buckets, and pseudonymous batch mapping before invoking the internal core.
+- **Repository-review compatibility adapter**: `src/lib/repo-review-ai.ts` owns evidence sanitization, pseudonymous change references, deterministic fallback feedback, and Pika result formatting before invoking the internal core. GitHub fetching, identity mapping, metrics, run orchestration, and persistence remain Pika-owned.
 
 ### Content Fields
 Assignment docs, test questions, and lesson plans store content as Tiptap JSON.

--- a/docs/guidance/atomic-assignment-grading-rollout.md
+++ b/docs/guidance/atomic-assignment-grading-rollout.md
@@ -24,3 +24,20 @@ Do not combine the expand and contract migrations into one production migration 
 Rollback of the expand application leaves migration 087 in place because its RPCs and revision column are
 additive. Rollback of the contract release requires restoring the expand application first; do not re-enable
 legacy writers while contract-only application instances are active.
+
+## Grading Provenance Extensions
+
+Migrations `101_assignment_ai_grading_provenance.sql` and
+`103_repo_review_grading_provenance.sql` are additive extensions of the migration-087 contract.
+Apply both migrations before deploying application code that calls their provenance-aware wrappers.
+
+Migration 103 keeps `complete_assignment_repo_review_run_atomic` intact for older application instances and
+adds `complete_assignment_repo_review_run_with_provenance_atomic` for the new repository-review adapter. The
+new wrapper stores each result's grading model and bounded provenance in the same transaction as the draft
+grade and run completion. Deterministic local fallback uses `providerRequestCount: 0`; provider-backed grades
+retain the actual request count and token usage.
+
+Rolling back the application leaves migrations 101 and 103 in place. Older writers remain compatible and
+clear stale assignment-document provenance when they replace AI grading fields without replacement audit
+metadata. Do not deploy the new application before migration 103 because repository-review completion will
+call the new wrapper.

--- a/scripts/check-atomic-assignment-feedback-returns.sh
+++ b/scripts/check-atomic-assignment-feedback-returns.sh
@@ -60,7 +60,9 @@ insert into public.assignments (id, classroom_id, title, due_at, created_by) val
   ('d0000000-0000-4000-8000-000000000018', 'd0000000-0000-4000-8000-000000000010', 'Roster serialization', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001'),
   ('d0000000-0000-4000-8000-000000000019', 'd0000000-0000-4000-8000-000000000010', 'AI item finalization', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001'),
   ('d0000000-0000-4000-8000-000000000020', 'd0000000-0000-4000-8000-000000000010', 'Repo review completion', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001'),
-  ('d0000000-0000-4000-8000-000000000021', 'd0000000-0000-4000-8000-000000000010', 'Repo review rollback', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001');
+  ('d0000000-0000-4000-8000-000000000021', 'd0000000-0000-4000-8000-000000000010', 'Repo review rollback', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001'),
+  ('d0000000-0000-4000-8000-000000000023', 'd0000000-0000-4000-8000-000000000010', 'Repo review provenance', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001'),
+  ('d0000000-0000-4000-8000-000000000024', 'd0000000-0000-4000-8000-000000000010', 'Repo review provenance rollback', now() + interval '1 day', 'd0000000-0000-4000-8000-000000000001');
 
 insert into public.assignment_docs (
   assignment_id,
@@ -85,7 +87,9 @@ insert into public.assignment_docs (
   ('d0000000-0000-4000-8000-000000000019', 'd0000000-0000-4000-8000-000000000002', '{"type":"doc","content":[]}', true, now(), 1, 1, 1, null),
   ('d0000000-0000-4000-8000-000000000020', 'd0000000-0000-4000-8000-000000000003', '{"type":"doc","content":[]}', true, now(), 2, 2, 2, null),
   ('d0000000-0000-4000-8000-000000000021', 'd0000000-0000-4000-8000-000000000004', '{"type":"doc","content":[]}', true, now(), 3, 3, 3, null),
-  ('d0000000-0000-4000-8000-000000000021', 'd0000000-0000-4000-8000-000000000005', '{"type":"doc","content":[]}', true, now(), 4, 4, 4, null);
+  ('d0000000-0000-4000-8000-000000000021', 'd0000000-0000-4000-8000-000000000005', '{"type":"doc","content":[]}', true, now(), 4, 4, 4, null),
+  ('d0000000-0000-4000-8000-000000000023', 'd0000000-0000-4000-8000-000000000006', '{"type":"doc","content":[]}', true, now(), 4, 4, 4, null),
+  ('d0000000-0000-4000-8000-000000000024', 'd0000000-0000-4000-8000-000000000002', '{"type":"doc","content":[]}', true, now(), 5, 5, 5, null);
 
 commit;
 
@@ -605,7 +609,8 @@ fi
 
 docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 -Atc \
   "update public.assignment_docs
-   set ai_grading_provenance = '{\"schemaVersion\":\"assignment-grading-provenance-v1\",\"provider\":\"openai\",\"model\":\"old-model\",\"policyVersion\":\"old-policy\",\"promptVersion\":\"old-prompt\",\"gradingProfileVersion\":\"old-profile\",\"rubricVersion\":\"old-rubric\",\"providerRequestCount\":1,\"tokenUsage\":{\"inputTokens\":10,\"outputTokens\":5,\"totalTokens\":15}}'::jsonb
+   set ai_feedback_model = 'old-model',
+       ai_grading_provenance = '{\"schemaVersion\":\"assignment-grading-provenance-v1\",\"provider\":\"openai\",\"model\":\"old-model\",\"policyVersion\":\"old-policy\",\"promptVersion\":\"old-prompt\",\"gradingProfileVersion\":\"old-profile\",\"rubricVersion\":\"old-rubric\",\"providerRequestCount\":1,\"tokenUsage\":{\"inputTokens\":10,\"outputTokens\":5,\"totalTokens\":15}}'::jsonb
    where assignment_id = 'd0000000-0000-4000-8000-000000000016'
      and student_id = 'd0000000-0000-4000-8000-000000000005';" >/dev/null
 
@@ -823,7 +828,8 @@ begin
   end if;
 
   update public.assignment_docs
-  set ai_grading_provenance = '{"schemaVersion":"assignment-grading-provenance-v1","provider":"openai","model":"old-model","policyVersion":"old-policy","promptVersion":"old-prompt","gradingProfileVersion":"old-profile","rubricVersion":"old-rubric","providerRequestCount":1,"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15}}'::jsonb
+  set ai_feedback_model = 'old-model',
+      ai_grading_provenance = '{"schemaVersion":"assignment-grading-provenance-v1","provider":"openai","model":"old-model","policyVersion":"old-policy","promptVersion":"old-prompt","gradingProfileVersion":"old-profile","rubricVersion":"old-rubric","providerRequestCount":1,"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15}}'::jsonb
   where assignment_id = 'd0000000-0000-4000-8000-000000000017'
     and student_id = 'd0000000-0000-4000-8000-000000000002';
   select updated_at into v_expected
@@ -962,7 +968,8 @@ begin
   end if;
 
   update public.assignment_docs
-  set ai_grading_provenance = '{"schemaVersion":"assignment-grading-provenance-v1","provider":"openai","model":"old-model","policyVersion":"old-policy","promptVersion":"old-prompt","gradingProfileVersion":"old-profile","rubricVersion":"old-rubric","providerRequestCount":1,"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15}}'::jsonb
+  set ai_feedback_model = 'old-model',
+      ai_grading_provenance = '{"schemaVersion":"assignment-grading-provenance-v1","provider":"openai","model":"old-model","policyVersion":"old-policy","promptVersion":"old-prompt","gradingProfileVersion":"old-profile","rubricVersion":"old-rubric","providerRequestCount":1,"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15}}'::jsonb
   where assignment_id = 'd0000000-0000-4000-8000-000000000012'
     and student_id = 'd0000000-0000-4000-8000-000000000003';
   perform public.create_assignment_ai_grading_run_atomic(
@@ -1105,6 +1112,180 @@ begin
     and student_id = 'd0000000-0000-4000-8000-000000000004';
   if v_status <> 'running' or v_result_count <> 0 or v_score <> 3 then
     raise exception 'Repo review conflict partially committed';
+  end if;
+end;
+$contract$;
+SQL
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+do $contract$
+declare
+  v_run_id uuid;
+  v_invalid_run_id uuid;
+  v_expected timestamptz;
+  v_status text;
+  v_result_count integer;
+  v_score integer;
+  v_model text;
+  v_doc_provenance jsonb;
+  v_result_provenance jsonb;
+  v_provenance constant jsonb := '{"schemaVersion":"assignment-grading-provenance-v1","provider":"pika-local","model":"repo-review-heuristic-v1","policyVersion":"pika-repo-review-feedback-policy-v1","promptVersion":"pika-repo-review-feedback-prompt-v1","gradingProfileVersion":"pika-repo-review-feedback-v1","rubricVersion":"pika-repo-review-rubric-v1","providerRequestCount":0,"tokenUsage":{"inputTokens":null,"outputTokens":null,"totalTokens":null}}'::jsonb;
+  v_invalid_provenance constant jsonb := '{"schemaVersion":"assignment-grading-provenance-v1","provider":"pika-local","model":"repo-review-heuristic-v1","policyVersion":"pika-repo-review-feedback-policy-v1","promptVersion":"pika-repo-review-feedback-prompt-v1","gradingProfileVersion":"pika-repo-review-feedback-v1","rubricVersion":"pika-repo-review-rubric-v1","providerRequestCount":11,"tokenUsage":{"inputTokens":null,"outputTokens":null,"totalTokens":null}}'::jsonb;
+begin
+  if has_function_privilege(
+    'anon',
+    'public.complete_assignment_repo_review_run_with_provenance_atomic(uuid,uuid,jsonb,jsonb,text,text,jsonb,timestamp with time zone)',
+    'execute'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.complete_assignment_repo_review_run_with_provenance_atomic(uuid,uuid,jsonb,jsonb,text,text,jsonb,timestamp with time zone)',
+    'execute'
+  ) or not has_function_privilege(
+    'service_role',
+    'public.complete_assignment_repo_review_run_with_provenance_atomic(uuid,uuid,jsonb,jsonb,text,text,jsonb,timestamp with time zone)',
+    'execute'
+  ) then
+    raise exception 'Unexpected repo-review provenance RPC privileges';
+  end if;
+
+  insert into public.assignment_repo_review_runs (
+    assignment_id, status, triggered_by, metrics_version, prompt_version
+  ) values (
+    'd0000000-0000-4000-8000-000000000023', 'running',
+    'd0000000-0000-4000-8000-000000000001', 'metrics-v1', 'prompt-v1'
+  ) returning id into v_run_id;
+
+  select updated_at into v_expected
+  from public.assignment_docs
+  where assignment_id = 'd0000000-0000-4000-8000-000000000023'
+    and student_id = 'd0000000-0000-4000-8000-000000000006';
+
+  perform public.complete_assignment_repo_review_run_with_provenance_atomic(
+    v_run_id,
+    'd0000000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'student_id', 'd0000000-0000-4000-8000-000000000006',
+      'github_login', 'student-5',
+      'commit_count', 3, 'active_days', 2, 'session_count', 2,
+      'burst_ratio', 0.2, 'weighted_contribution', 3.5,
+      'relative_contribution_share', 1, 'spread_score', 0.8,
+      'iteration_score', 0.7, 'semantic_breakdown_json', '{}'::jsonb,
+      'timeline_json', '[]'::jsonb, 'evidence_json', '[]'::jsonb,
+      'draft_score_completion', 8, 'draft_score_thinking', 7,
+      'draft_score_workflow', 9, 'draft_feedback', 'Audited repo feedback',
+      'confidence', 0.9, 'grading_model', 'repo-review-heuristic-v1',
+      'grading_provenance', v_provenance
+    )),
+    jsonb_build_array(jsonb_build_object(
+      'student_id', 'd0000000-0000-4000-8000-000000000006',
+      'expected_doc_updated_at', v_expected,
+      'score_completion', 8, 'score_thinking', 7, 'score_workflow', 9,
+      'feedback', 'Audited repo feedback', 'apply_teacher_feedback_draft', false,
+      'mark_graded', false, 'ai_feedback_suggestion', 'Audited repo feedback',
+      'ai_feedback_model', 'repo-review-heuristic-v1',
+      'ai_grading_provenance', v_provenance
+    )),
+    'main', 'repo-review-heuristic-v1', '[]'::jsonb, now()
+  );
+
+  select run.status, count(result.id), doc.score_completion, doc.ai_feedback_model,
+         doc.ai_grading_provenance, result.grading_provenance
+  into v_status, v_result_count, v_score, v_model, v_doc_provenance, v_result_provenance
+  from public.assignment_repo_review_runs run
+  left join public.assignment_repo_review_results result on result.run_id = run.id
+  join public.assignment_docs doc
+    on doc.assignment_id = run.assignment_id
+   and doc.student_id = 'd0000000-0000-4000-8000-000000000006'
+  where run.id = v_run_id
+  group by run.status, doc.score_completion, doc.ai_feedback_model,
+           doc.ai_grading_provenance, result.grading_provenance;
+
+  if v_status <> 'completed' or v_result_count <> 1 or v_score <> 8
+    or v_model <> 'repo-review-heuristic-v1'
+    or v_doc_provenance is distinct from v_provenance
+    or v_result_provenance is distinct from v_provenance
+  then
+    raise exception 'Repo-review provenance did not commit atomically';
+  end if;
+
+  perform public.complete_assignment_repo_review_run_with_provenance_atomic(
+    v_run_id,
+    'd0000000-0000-4000-8000-000000000001',
+    '[]'::jsonb,
+    '[]'::jsonb,
+    'replay-must-not-overwrite',
+    'replay-must-not-overwrite',
+    '[]'::jsonb,
+    now()
+  );
+
+  select grading_provenance into v_result_provenance
+  from public.assignment_repo_review_results
+  where run_id = v_run_id;
+  if v_result_provenance is distinct from v_provenance then
+    raise exception 'Repo-review replay overwrote provenance';
+  end if;
+
+  insert into public.assignment_repo_review_runs (
+    assignment_id, status, triggered_by, metrics_version, prompt_version
+  ) values (
+    'd0000000-0000-4000-8000-000000000024', 'running',
+    'd0000000-0000-4000-8000-000000000001', 'metrics-v1', 'prompt-v1'
+  ) returning id into v_invalid_run_id;
+
+  select updated_at into v_expected
+  from public.assignment_docs
+  where assignment_id = 'd0000000-0000-4000-8000-000000000024'
+    and student_id = 'd0000000-0000-4000-8000-000000000002';
+
+  begin
+    perform public.complete_assignment_repo_review_run_with_provenance_atomic(
+      v_invalid_run_id,
+      'd0000000-0000-4000-8000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'student_id', 'd0000000-0000-4000-8000-000000000002',
+        'commit_count', 1, 'active_days', 1, 'session_count', 1,
+        'burst_ratio', 0, 'weighted_contribution', 1,
+        'relative_contribution_share', 1, 'spread_score', 0.5,
+        'iteration_score', 0.5, 'semantic_breakdown_json', '{}'::jsonb,
+        'timeline_json', '[]'::jsonb, 'evidence_json', '[]'::jsonb,
+        'draft_score_completion', 9, 'draft_score_thinking', 9,
+        'draft_score_workflow', 9, 'draft_feedback', 'Invalid audit',
+        'confidence', 0.8, 'grading_model', 'repo-review-heuristic-v1',
+        'grading_provenance', v_invalid_provenance
+      )),
+      jsonb_build_array(jsonb_build_object(
+        'student_id', 'd0000000-0000-4000-8000-000000000002',
+        'expected_doc_updated_at', v_expected,
+        'score_completion', 9, 'score_thinking', 9, 'score_workflow', 9,
+        'feedback', 'Invalid audit', 'apply_teacher_feedback_draft', false,
+        'mark_graded', false, 'ai_feedback_suggestion', 'Invalid audit',
+        'ai_feedback_model', 'repo-review-heuristic-v1',
+        'ai_grading_provenance', v_invalid_provenance
+      )),
+      'main', 'repo-review-heuristic-v1', '[]'::jsonb, now()
+    );
+    raise exception 'Repo-review completion accepted invalid provenance';
+  exception
+    when check_violation then null;
+  end;
+
+  select status into v_status
+  from public.assignment_repo_review_runs
+  where id = v_invalid_run_id;
+  select count(*) into v_result_count
+  from public.assignment_repo_review_results
+  where run_id = v_invalid_run_id;
+  select score_completion, ai_feedback_model, ai_grading_provenance
+  into v_score, v_model, v_doc_provenance
+  from public.assignment_docs
+  where assignment_id = 'd0000000-0000-4000-8000-000000000024'
+    and student_id = 'd0000000-0000-4000-8000-000000000002';
+
+  if v_status <> 'running' or v_result_count <> 0 or v_score <> 5
+    or v_model is not null or v_doc_provenance is not null
+  then
+    raise exception 'Invalid repo-review provenance partially committed';
   end if;
 end;
 $contract$;

--- a/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
+++ b/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
@@ -298,18 +298,21 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
             draft_score_workflow: feedback.score_workflow,
             draft_feedback: feedback.feedback,
             confidence: Math.min(1, Math.max(0, (feedback.confidence + analysis.confidence) / 2)),
+            grading_model: feedback.model,
+            grading_provenance: feedback.provenance,
           }
         })
       )
 
       const gradeSavedAt = new Date().toISOString()
+      const gradingModels = [...new Set(results.map((result) => result.grading_model))]
       await completeAssignmentRepoReviewRunAtomic({
         supabase,
         runId: run.id,
         teacherId: user.id,
         results,
         sourceRef: analysis.sourceRef || group.defaultBranch,
-        model: 'repo-review-v2',
+        model: gradingModels.length === 1 ? gradingModels[0] : 'mixed',
         warnings: analysis.warnings,
         now: gradeSavedAt,
         grades: results.map((result) => {
@@ -324,7 +327,8 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
             applyTeacherFeedbackDraft: false,
             markGraded: false,
             aiFeedbackSuggestion: result.draft_feedback,
-            aiFeedbackModel: 'repo-review-v2',
+            aiFeedbackModel: result.grading_model,
+            aiGradingProvenance: result.grading_provenance,
             gradedBy: null,
           }
         }),

--- a/src/lib/grading/contracts.ts
+++ b/src/lib/grading/contracts.ts
@@ -50,7 +50,7 @@ export const gradingProvenanceSchema = z.object({
   promptVersion: z.string().min(1).max(120),
   gradingProfileVersion: z.string().min(1).max(120),
   rubricVersion: z.string().min(1).max(120),
-  providerRequestCount: z.number().int().positive().max(10),
+  providerRequestCount: z.number().int().nonnegative().max(10),
   tokenUsage: gradingTokenUsageSchema,
 }).strict()
 

--- a/src/lib/grading/profiles/pika-repo-review.ts
+++ b/src/lib/grading/profiles/pika-repo-review.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod'
+import type { StructuredOutputSpec } from '@/lib/grading/engine'
+
+export const PIKA_REPO_REVIEW_FEEDBACK_PROFILE_VERSION = 'pika-repo-review-feedback-v1'
+export const PIKA_REPO_REVIEW_FEEDBACK_RUBRIC_VERSION = 'pika-repo-review-rubric-v1'
+export const PIKA_REPO_REVIEW_FEEDBACK_POLICY_VERSION = 'pika-repo-review-feedback-policy-v1'
+export const PIKA_REPO_REVIEW_FEEDBACK_PROMPT_VERSION = 'pika-repo-review-feedback-prompt-v1'
+export const PIKA_REPO_REVIEW_CLASSIFICATION_PROFILE_VERSION = 'pika-repo-review-classification-v1'
+export const PIKA_REPO_REVIEW_CLASSIFICATION_POLICY_VERSION = 'pika-repo-review-classification-policy-v1'
+export const PIKA_REPO_REVIEW_CLASSIFICATION_PROMPT_VERSION = 'pika-repo-review-classification-prompt-v1'
+export const PIKA_REPO_REVIEW_HEURISTIC_MODEL = 'repo-review-heuristic-v1'
+export const PIKA_REPO_REVIEW_LOCAL_PROVIDER = 'pika-local'
+export const PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE = 50
+
+const semanticCategorySchema = z.enum([
+  'feature',
+  'bugfix',
+  'test',
+  'refactor',
+  'docs',
+  'styling',
+  'config',
+  'generated',
+])
+
+const classificationOutputSchema = z.object({
+  items: z.array(z.object({
+    id: z.string().min(1).max(64).regex(/^change_[1-9][0-9]*$/),
+    category: semanticCategorySchema,
+  }).strict()).max(PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE),
+}).strict().superRefine((output, ctx) => {
+  const seen = new Set<string>()
+  for (const [index, item] of output.items.entries()) {
+    if (seen.has(item.id)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Duplicate repository-review classification id: ${item.id}`,
+        path: ['items', index, 'id'],
+      })
+    }
+    seen.add(item.id)
+  }
+})
+
+const feedbackOutputSchema = z.object({
+  score_completion: z.number().int().min(0).max(10),
+  score_thinking: z.number().int().min(0).max(10),
+  score_workflow: z.number().int().min(0).max(10),
+  summary: z.string().min(1).max(1200),
+  strengths: z.array(z.string().min(1).max(500)).max(8),
+  concerns: z.array(z.string().min(1).max(500)).max(8),
+  feedback: z.string().min(1).max(2000),
+  confidence: z.number().min(0).max(1),
+}).strict()
+
+export type PikaRepoReviewClassificationOutput = z.infer<typeof classificationOutputSchema>
+export type PikaRepoReviewFeedbackOutput = z.infer<typeof feedbackOutputSchema>
+
+export const PIKA_REPO_REVIEW_CLASSIFICATION_OUTPUT: StructuredOutputSpec = {
+  schemaName: 'repo_review_change_classification',
+  jsonSchema: {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        maxItems: PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE,
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            category: {
+              type: 'string',
+              enum: semanticCategorySchema.options,
+            },
+          },
+          required: ['id', 'category'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['items'],
+    additionalProperties: false,
+  },
+  initialMaxOutputTokens: 1200,
+  fallbackMaxOutputTokens: 1800,
+}
+
+export const PIKA_REPO_REVIEW_FEEDBACK_OUTPUT: StructuredOutputSpec = {
+  schemaName: 'repo_review_feedback',
+  jsonSchema: {
+    type: 'object',
+    properties: {
+      score_completion: { type: 'integer', minimum: 0, maximum: 10 },
+      score_thinking: { type: 'integer', minimum: 0, maximum: 10 },
+      score_workflow: { type: 'integer', minimum: 0, maximum: 10 },
+      summary: { type: 'string' },
+      strengths: { type: 'array', items: { type: 'string' }, maxItems: 8 },
+      concerns: { type: 'array', items: { type: 'string' }, maxItems: 8 },
+      feedback: { type: 'string' },
+      confidence: { type: 'number', minimum: 0, maximum: 1 },
+    },
+    required: [
+      'score_completion',
+      'score_thinking',
+      'score_workflow',
+      'summary',
+      'strengths',
+      'concerns',
+      'feedback',
+      'confidence',
+    ],
+    additionalProperties: false,
+  },
+  initialMaxOutputTokens: 700,
+  fallbackMaxOutputTokens: 1000,
+}
+
+export function buildPikaRepoReviewClassificationPrompt(
+  items: Array<{ providerRef: string; summary: string }>,
+): { systemPrompt: string; userPrompt: string } {
+  return {
+    systemPrompt: `You classify software change summaries into one category.
+
+Allowed categories:
+- feature
+- bugfix
+- test
+- refactor
+- docs
+- styling
+- config
+- generated
+
+Return one item for every supplied change reference. Use only the supplied summaries.`,
+    userPrompt: items.map((item) => `- ${item.providerRef}: ${item.summary}`).join('\n'),
+  }
+}
+
+export function buildPikaRepoReviewFeedbackPrompt(input: {
+  assignmentTitle: string
+  metrics: Record<string, unknown>
+  evidence: unknown
+  warnings: string[]
+}): { systemPrompt: string; userPrompt: string } {
+  return {
+    systemPrompt: `You are grading repository contribution evidence for a teacher.
+
+Use these rubric definitions:
+- Completion (0-10): meaningful implementation ownership, task coverage, tests/refinement
+- Thinking (0-10): complexity, debugging/refactoring evidence, review/problem-solving quality
+- Workflow (0-10): consistency over time, iteration, commit hygiene, responsiveness to feedback
+
+Rules:
+- Use only the supplied evidence.
+- Do not infer hidden work.
+- Low confidence or incomplete evidence should lower confidence and lead to cautious scoring.
+- Distinguish contribution size from workflow quality.
+- Feedback must be 3-5 sentences total.
+- If workflow is weak, include one sentence starting with "Improve:" and give a concrete workflow improvement.`,
+    userPrompt: JSON.stringify({
+      assignment_title: input.assignmentTitle,
+      repo_ref: 'repo_1',
+      student_ref: 'student_1',
+      metrics: input.metrics,
+      evidence: input.evidence,
+      warnings: input.warnings,
+    }),
+  }
+}
+
+export function parsePikaRepoReviewClassificationOutput(
+  outputText: string,
+): PikaRepoReviewClassificationOutput {
+  return classificationOutputSchema.parse(JSON.parse(outputText))
+}
+
+export function parsePikaRepoReviewFeedbackOutput(outputText: string): PikaRepoReviewFeedbackOutput {
+  return feedbackOutputSchema.parse(JSON.parse(outputText))
+}

--- a/src/lib/repo-review-ai.ts
+++ b/src/lib/repo-review-ai.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
   createProviderRefMap,
   mapProviderRefToLocalId,
@@ -6,54 +5,39 @@ import {
   sanitizeAiText,
   type AiSanitizationContext,
 } from '@/lib/ai-sanitization'
+import {
+  gradingProvenanceSchema,
+  type GradingProvenance,
+} from '@/lib/grading/contracts'
+import { executeStructuredOutput, type GradingExecutionMetadata } from '@/lib/grading/engine'
+import {
+  buildPikaRepoReviewClassificationPrompt,
+  buildPikaRepoReviewFeedbackPrompt,
+  parsePikaRepoReviewClassificationOutput,
+  parsePikaRepoReviewFeedbackOutput,
+  PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE,
+  PIKA_REPO_REVIEW_CLASSIFICATION_OUTPUT,
+  PIKA_REPO_REVIEW_CLASSIFICATION_POLICY_VERSION,
+  PIKA_REPO_REVIEW_FEEDBACK_OUTPUT,
+  PIKA_REPO_REVIEW_FEEDBACK_POLICY_VERSION,
+  PIKA_REPO_REVIEW_FEEDBACK_PROFILE_VERSION,
+  PIKA_REPO_REVIEW_FEEDBACK_PROMPT_VERSION,
+  PIKA_REPO_REVIEW_FEEDBACK_RUBRIC_VERSION,
+  PIKA_REPO_REVIEW_HEURISTIC_MODEL,
+  PIKA_REPO_REVIEW_LOCAL_PROVIDER,
+} from '@/lib/grading/profiles/pika-repo-review'
+import { createOpenAiResponsesProvider } from '@/lib/grading/providers/openai-responses'
 import type { RepoReviewEvidenceItem, RepoReviewSemanticBreakdown } from '@/types'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
+const REPO_REVIEW_REASONING_EFFORT = 'minimal'
+const REPO_REVIEW_REQUEST_TIMEOUT_MS = 25_000
 
 function getOpenAIKey(): string | null {
   const key = process.env.OPENAI_API_KEY
   if (!key) return null
   return key.trim() || null
 }
-
-function extractResponseOutputText(payload: any): string | null {
-  if (typeof payload?.output_text === 'string' && payload.output_text.trim()) {
-    return payload.output_text.trim()
-  }
-
-  const output = payload?.output
-  if (!Array.isArray(output)) return null
-
-  for (const item of output) {
-    const content = item?.content
-    if (!Array.isArray(content)) continue
-    for (const c of content) {
-      if (c?.type === 'output_text' && typeof c?.text === 'string' && c.text.trim()) {
-        return c.text.trim()
-      }
-    }
-  }
-
-  return null
-}
-
-const feedbackSchema = z.object({
-  score_completion: z.number().int().min(0).max(10),
-  score_thinking: z.number().int().min(0).max(10),
-  score_workflow: z.number().int().min(0).max(10),
-  summary: z.string().min(1),
-  strengths: z.array(z.string()).default([]),
-  concerns: z.array(z.string()).default([]),
-  feedback: z.string().min(1),
-  confidence: z.number().min(0).max(1),
-})
-
-const classificationSchema = z.object({
-  items: z.array(z.object({
-    id: z.string(),
-    category: z.enum(['feature', 'bugfix', 'test', 'refactor', 'docs', 'styling', 'config', 'generated']),
-  })),
-})
 
 export interface RepoReviewFeedbackResult {
   score_completion: number
@@ -65,6 +49,7 @@ export interface RepoReviewFeedbackResult {
   feedback: string
   confidence: number
   model: string
+  provenance: GradingProvenance
 }
 
 export interface RepoReviewFeedbackInput {
@@ -97,17 +82,6 @@ type SanitizedRepoReviewValue =
   | SanitizedRepoReviewValue[]
   | { [key: string]: SanitizedRepoReviewValue }
 
-function parseJsonResponse<T>(outputText: string, schema: z.ZodSchema<T>): T {
-  let jsonText = outputText
-  const codeBlockMatch = outputText.match(/```(?:json)?\s*([\s\S]*?)```/)
-  if (codeBlockMatch) {
-    jsonText = codeBlockMatch[1].trim()
-  }
-
-  const parsed = JSON.parse(jsonText)
-  return schema.parse(parsed)
-}
-
 function scoreFromUnit(value: number): number {
   return Math.max(0, Math.min(10, Math.round(value * 10)))
 }
@@ -120,6 +94,34 @@ function formatStrengths(strengths: string[]): string {
 function formatConcerns(concerns: string[]): string {
   if (!concerns.length) return ''
   return `Concerns: ${concerns.join('; ')}`
+}
+
+function buildRepoReviewProvenance(execution: GradingExecutionMetadata): GradingProvenance {
+  return gradingProvenanceSchema.parse({
+    schemaVersion: 'assignment-grading-provenance-v1',
+    provider: execution.provider,
+    model: execution.model,
+    policyVersion: execution.policyVersion,
+    promptVersion: PIKA_REPO_REVIEW_FEEDBACK_PROMPT_VERSION,
+    gradingProfileVersion: PIKA_REPO_REVIEW_FEEDBACK_PROFILE_VERSION,
+    rubricVersion: PIKA_REPO_REVIEW_FEEDBACK_RUBRIC_VERSION,
+    providerRequestCount: execution.providerRequestCount,
+    tokenUsage: execution.tokenUsage,
+  })
+}
+
+function buildHeuristicRepoReviewProvenance(): GradingProvenance {
+  return gradingProvenanceSchema.parse({
+    schemaVersion: 'assignment-grading-provenance-v1',
+    provider: PIKA_REPO_REVIEW_LOCAL_PROVIDER,
+    model: PIKA_REPO_REVIEW_HEURISTIC_MODEL,
+    policyVersion: PIKA_REPO_REVIEW_FEEDBACK_POLICY_VERSION,
+    promptVersion: PIKA_REPO_REVIEW_FEEDBACK_PROMPT_VERSION,
+    gradingProfileVersion: PIKA_REPO_REVIEW_FEEDBACK_PROFILE_VERSION,
+    rubricVersion: PIKA_REPO_REVIEW_FEEDBACK_RUBRIC_VERSION,
+    providerRequestCount: 0,
+    tokenUsage: { inputTokens: null, outputTokens: null, totalTokens: null },
+  })
 }
 
 export function buildHeuristicRepoReviewFeedback(input: RepoReviewFeedbackInput): RepoReviewFeedbackResult {
@@ -182,7 +184,8 @@ export function buildHeuristicRepoReviewFeedback(input: RepoReviewFeedbackInput)
     concerns,
     feedback: parts.join(' '),
     confidence: input.confidence,
-    model: 'heuristic',
+    model: PIKA_REPO_REVIEW_HEURISTIC_MODEL,
+    provenance: buildHeuristicRepoReviewProvenance(),
   }
 }
 
@@ -230,56 +233,31 @@ export async function classifyAmbiguousRepoReviewChanges(
     'change',
   )
   const providerRefToLocalId = mapProviderRefToLocalId(providerItems)
-  const systemPrompt = `You classify software change summaries into one category.
+  const provider = createOpenAiResponsesProvider({ apiKey })
+  const classifications: Array<[string, string]> = []
 
-Allowed categories:
-- feature
-- bugfix
-- test
-- refactor
-- docs
-- styling
-- config
-- generated
+  for (let index = 0; index < providerItems.length; index += PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE) {
+    const batch = providerItems.slice(index, index + PIKA_REPO_REVIEW_CLASSIFICATION_BATCH_SIZE)
+    const result = await executeStructuredOutput({
+      provider,
+      policy: {
+        version: PIKA_REPO_REVIEW_CLASSIFICATION_POLICY_VERSION,
+        model,
+        requestTimeoutMs: REPO_REVIEW_REQUEST_TIMEOUT_MS,
+        reasoningEffort: REPO_REVIEW_REASONING_EFFORT,
+      },
+      prompt: buildPikaRepoReviewClassificationPrompt(batch),
+      output: PIKA_REPO_REVIEW_CLASSIFICATION_OUTPUT,
+      parseOutput: parsePikaRepoReviewClassificationOutput,
+    })
 
-Respond with JSON only:
-{"items":[{"id":"...","category":"feature"}]}`
-
-  const userPrompt = providerItems
-    .map((item) => `- ${item.providerRef}: ${item.summary}`)
-    .join('\n')
-
-  const res = await fetch('https://api.openai.com/v1/responses', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model,
-      store: false,
-      input: [
-        { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
-        { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
-      ],
-    }),
-  })
-
-  if (!res.ok) {
-    return {}
+    for (const item of result.output.items) {
+      const localId = providerRefToLocalId.get(item.id)
+      if (localId) classifications.push([localId, item.category])
+    }
   }
 
-  const payload = await res.json()
-  const outputText = extractResponseOutputText(payload)
-  if (!outputText) return {}
-
-  const parsed = parseJsonResponse(outputText, classificationSchema)
-  return Object.fromEntries(
-    parsed.items.flatMap((item) => {
-      const localId = providerRefToLocalId.get(item.id)
-      return localId ? [[localId, item.category]] : []
-    }),
-  )
+  return Object.fromEntries(classifications)
 }
 
 export async function gradeRepoReviewFeedback(input: RepoReviewFeedbackInput): Promise<RepoReviewFeedbackResult> {
@@ -292,29 +270,9 @@ export async function gradeRepoReviewFeedback(input: RepoReviewFeedbackInput): P
   }
 
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
-  const systemPrompt = `You are grading repository contribution evidence for a teacher.
-
-Use these rubric definitions:
-- Completion (0-10): meaningful implementation ownership, task coverage, tests/refinement
-- Thinking (0-10): complexity, debugging/refactoring evidence, review/problem-solving quality
-- Workflow (0-10): consistency over time, iteration, commit hygiene, responsiveness to feedback
-
-Rules:
-- Use only the supplied evidence.
-- Do not infer hidden work.
-- Low confidence or incomplete evidence should lower confidence and lead to cautious scoring.
-- Distinguish contribution size from workflow quality.
-- Feedback must be 3-5 sentences total.
-- If workflow is weak, include one sentence starting with "Improve:" and give a concrete workflow improvement.
-
-Respond with JSON only:
-{"score_completion":0,"score_thinking":0,"score_workflow":0,"summary":"","strengths":[""],"concerns":[""],"feedback":"","confidence":0.0}`
-
   const sanitizationContext = input.sanitizationContext
-  const userPrompt = JSON.stringify({
-    assignment_title: sanitizeAiText(input.assignmentTitle, sanitizationContext),
-    repo_ref: 'repo_1',
-    student_ref: 'student_1',
+  const prompt = buildPikaRepoReviewFeedbackPrompt({
+    assignmentTitle: sanitizeAiText(input.assignmentTitle, sanitizationContext),
     metrics: {
       commit_count: input.commitCount,
       active_days: input.activeDays,
@@ -334,39 +292,19 @@ Respond with JSON only:
   })
 
   try {
-    const res = await fetch('https://api.openai.com/v1/responses', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+    const result = await executeStructuredOutput({
+      provider: createOpenAiResponsesProvider({ apiKey }),
+      policy: {
+        version: PIKA_REPO_REVIEW_FEEDBACK_POLICY_VERSION,
         model,
-        store: false,
-        input: [
-          { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
-          { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
-        ],
-      }),
+        requestTimeoutMs: REPO_REVIEW_REQUEST_TIMEOUT_MS,
+        reasoningEffort: REPO_REVIEW_REASONING_EFFORT,
+      },
+      prompt,
+      output: PIKA_REPO_REVIEW_FEEDBACK_OUTPUT,
+      parseOutput: parsePikaRepoReviewFeedbackOutput,
     })
-
-    if (!res.ok) {
-      return sanitizeRepoReviewFeedbackResult(
-        buildHeuristicRepoReviewFeedback(input),
-        input.sanitizationContext,
-      )
-    }
-
-    const payload = await res.json()
-    const outputText = extractResponseOutputText(payload)
-    if (!outputText) {
-      return sanitizeRepoReviewFeedbackResult(
-        buildHeuristicRepoReviewFeedback(input),
-        input.sanitizationContext,
-      )
-    }
-
-    const parsed = parseJsonResponse(outputText, feedbackSchema)
+    const parsed = result.output
     const formattedFeedback = [
       parsed.summary,
       formatStrengths(parsed.strengths),
@@ -381,6 +319,7 @@ Respond with JSON only:
       concerns: parsed.concerns.map(sanitizeAiOutputText),
       feedback: sanitizeAiOutputText(formattedFeedback),
       model,
+      provenance: buildRepoReviewProvenance(result.execution),
     }
   } catch {
     return sanitizeRepoReviewFeedbackResult(

--- a/src/lib/repo-review.ts
+++ b/src/lib/repo-review.ts
@@ -1,5 +1,6 @@
 import { formatInTimeZone } from 'date-fns-tz'
 import { classifyAmbiguousRepoReviewChanges } from '@/lib/repo-review-ai'
+import { PIKA_REPO_REVIEW_CLASSIFICATION_PROMPT_VERSION } from '@/lib/grading/profiles/pika-repo-review'
 import { parseGitHubRepoReference } from '@/lib/github-repos'
 import type { AiSanitizationContext } from '@/lib/ai-sanitization'
 import type {
@@ -21,7 +22,7 @@ const MAX_EVIDENCE_ITEMS = 10
 const TORONTO_TIMEZONE = 'America/Toronto'
 
 export const REPO_REVIEW_METRICS_VERSION = 'v1'
-export const REPO_REVIEW_PROMPT_VERSION = 'v1'
+export const REPO_REVIEW_PROMPT_VERSION = PIKA_REPO_REVIEW_CLASSIFICATION_PROMPT_VERSION
 
 export const REPO_REVIEW_SEMANTIC_WEIGHTS: Record<RepoReviewSemanticCategory, number> = {
   feature: 1.0,

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -277,7 +277,7 @@ export async function completeAssignmentRepoReviewRunAtomic(opts: {
   now?: string
 }) {
   const now = opts.now ?? new Date().toISOString()
-  const { data, error } = await opts.supabase.rpc('complete_assignment_repo_review_run_atomic', {
+  const { data, error } = await opts.supabase.rpc('complete_assignment_repo_review_run_with_provenance_atomic', {
     p_run_id: opts.runId,
     p_teacher_id: opts.teacherId,
     p_result_rows: toJson(opts.results),
@@ -292,6 +292,7 @@ export async function completeAssignmentRepoReviewRunAtomic(opts: {
       mark_graded: grade.markGraded ?? true,
       ai_feedback_suggestion: grade.aiFeedbackSuggestion,
       ai_feedback_model: grade.aiFeedbackModel,
+      ai_grading_provenance: grade.aiGradingProvenance ?? null,
       graded_by: grade.gradedBy ?? null,
     })),
     p_source_ref: opts.sourceRef,

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -656,6 +656,8 @@ export type Database = {
           draft_score_workflow: number | null
           evidence_json: Json
           github_login: string | null
+          grading_model: string | null
+          grading_provenance: Json | null
           id: string
           iteration_score: number
           relative_contribution_share: number
@@ -680,6 +682,8 @@ export type Database = {
           draft_score_workflow?: number | null
           evidence_json?: Json
           github_login?: string | null
+          grading_model?: string | null
+          grading_provenance?: Json | null
           id?: string
           iteration_score?: number
           relative_contribution_share?: number
@@ -704,6 +708,8 @@ export type Database = {
           draft_score_workflow?: number | null
           evidence_json?: Json
           github_login?: string | null
+          grading_model?: string | null
+          grading_provenance?: Json | null
           id?: string
           iteration_score?: number
           relative_contribution_share?: number
@@ -4243,6 +4249,19 @@ export type Database = {
         Returns: boolean
       }
       complete_assignment_repo_review_run_atomic: {
+        Args: {
+          p_grade_rows: Json
+          p_model: string
+          p_now: string
+          p_result_rows: Json
+          p_run_id: string
+          p_source_ref: string
+          p_teacher_id: string
+          p_warnings: Json
+        }
+        Returns: Json
+      }
+      complete_assignment_repo_review_run_with_provenance_atomic: {
         Args: {
           p_grade_rows: Json
           p_model: string

--- a/supabase/migrations/103_repo_review_grading_provenance.sql
+++ b/supabase/migrations/103_repo_review_grading_provenance.sql
@@ -1,0 +1,318 @@
+-- Add per-result repository-review provenance and atomically copy it to the
+-- assignment document while preserving the migration-087 completion RPC for
+-- rolling application deploys.
+
+alter table public.assignment_docs
+  drop constraint if exists assignment_docs_ai_grading_provenance_contract;
+
+alter table public.assignment_docs
+  add constraint assignment_docs_ai_grading_provenance_contract
+  check (
+    ai_grading_provenance is null
+    or (
+      jsonb_typeof(ai_grading_provenance) = 'object'
+      and ai_grading_provenance ?& array[
+        'schemaVersion', 'provider', 'model', 'policyVersion', 'promptVersion',
+        'gradingProfileVersion', 'rubricVersion', 'providerRequestCount', 'tokenUsage'
+      ]
+      and ai_grading_provenance - array[
+        'schemaVersion', 'provider', 'model', 'policyVersion', 'promptVersion',
+        'gradingProfileVersion', 'rubricVersion', 'providerRequestCount', 'tokenUsage'
+      ]::text[] = '{}'::jsonb
+      and ai_grading_provenance->>'schemaVersion' = 'assignment-grading-provenance-v1'
+      and jsonb_typeof(ai_grading_provenance->'provider') = 'string'
+      and length(ai_grading_provenance->>'provider') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'model') = 'string'
+      and length(ai_grading_provenance->>'model') between 1 and 200
+      and ai_feedback_model is not null
+      and ai_feedback_model = ai_grading_provenance->>'model'
+      and jsonb_typeof(ai_grading_provenance->'policyVersion') = 'string'
+      and length(ai_grading_provenance->>'policyVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'promptVersion') = 'string'
+      and length(ai_grading_provenance->>'promptVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'gradingProfileVersion') = 'string'
+      and length(ai_grading_provenance->>'gradingProfileVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'rubricVersion') = 'string'
+      and length(ai_grading_provenance->>'rubricVersion') between 1 and 120
+      and jsonb_typeof(ai_grading_provenance->'providerRequestCount') = 'number'
+      and (ai_grading_provenance->>'providerRequestCount')::integer between 0 and 10
+      and (ai_grading_provenance->>'providerRequestCount')::numeric
+        = trunc((ai_grading_provenance->>'providerRequestCount')::numeric)
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage') = 'object'
+      and ai_grading_provenance->'tokenUsage' ?& array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]
+      and (ai_grading_provenance->'tokenUsage') - array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]::text[] = '{}'::jsonb
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'inputTokens') in ('number', 'null')
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'outputTokens') in ('number', 'null')
+      and jsonb_typeof(ai_grading_provenance->'tokenUsage'->'totalTokens') in ('number', 'null')
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'inputTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'inputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'outputTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'outputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(ai_grading_provenance->'tokenUsage'->'totalTokens') = 'null'
+        or (
+          (ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric >= 0
+          and (ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric
+            = trunc((ai_grading_provenance->'tokenUsage'->>'totalTokens')::numeric)
+        )
+      )
+      and octet_length(ai_grading_provenance::text) <= 4096
+    )
+  ) not valid;
+
+alter table public.assignment_docs
+  validate constraint assignment_docs_ai_grading_provenance_contract;
+
+alter table public.assignment_repo_review_results
+  add column if not exists grading_model text,
+  add column if not exists grading_provenance jsonb;
+
+alter table public.assignment_repo_review_results
+  add constraint assignment_repo_review_results_grading_provenance_contract
+  check (
+    (grading_model is null and grading_provenance is null)
+    or (
+      grading_model is not null
+      and length(grading_model) between 1 and 200
+      and grading_provenance is not null
+      and jsonb_typeof(grading_provenance) = 'object'
+      and grading_provenance ?& array[
+        'schemaVersion', 'provider', 'model', 'policyVersion', 'promptVersion',
+        'gradingProfileVersion', 'rubricVersion', 'providerRequestCount', 'tokenUsage'
+      ]
+      and grading_provenance - array[
+        'schemaVersion', 'provider', 'model', 'policyVersion', 'promptVersion',
+        'gradingProfileVersion', 'rubricVersion', 'providerRequestCount', 'tokenUsage'
+      ]::text[] = '{}'::jsonb
+      and grading_provenance->>'schemaVersion' = 'assignment-grading-provenance-v1'
+      and jsonb_typeof(grading_provenance->'provider') = 'string'
+      and length(grading_provenance->>'provider') between 1 and 120
+      and jsonb_typeof(grading_provenance->'model') = 'string'
+      and length(grading_provenance->>'model') between 1 and 200
+      and grading_model = grading_provenance->>'model'
+      and jsonb_typeof(grading_provenance->'policyVersion') = 'string'
+      and length(grading_provenance->>'policyVersion') between 1 and 120
+      and jsonb_typeof(grading_provenance->'promptVersion') = 'string'
+      and length(grading_provenance->>'promptVersion') between 1 and 120
+      and jsonb_typeof(grading_provenance->'gradingProfileVersion') = 'string'
+      and length(grading_provenance->>'gradingProfileVersion') between 1 and 120
+      and jsonb_typeof(grading_provenance->'rubricVersion') = 'string'
+      and length(grading_provenance->>'rubricVersion') between 1 and 120
+      and jsonb_typeof(grading_provenance->'providerRequestCount') = 'number'
+      and (grading_provenance->>'providerRequestCount')::integer between 0 and 10
+      and (grading_provenance->>'providerRequestCount')::numeric
+        = trunc((grading_provenance->>'providerRequestCount')::numeric)
+      and jsonb_typeof(grading_provenance->'tokenUsage') = 'object'
+      and grading_provenance->'tokenUsage' ?& array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]
+      and (grading_provenance->'tokenUsage') - array[
+        'inputTokens', 'outputTokens', 'totalTokens'
+      ]::text[] = '{}'::jsonb
+      and jsonb_typeof(grading_provenance->'tokenUsage'->'inputTokens') in ('number', 'null')
+      and jsonb_typeof(grading_provenance->'tokenUsage'->'outputTokens') in ('number', 'null')
+      and jsonb_typeof(grading_provenance->'tokenUsage'->'totalTokens') in ('number', 'null')
+      and (
+        jsonb_typeof(grading_provenance->'tokenUsage'->'inputTokens') = 'null'
+        or (
+          (grading_provenance->'tokenUsage'->>'inputTokens')::numeric >= 0
+          and (grading_provenance->'tokenUsage'->>'inputTokens')::numeric
+            = trunc((grading_provenance->'tokenUsage'->>'inputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(grading_provenance->'tokenUsage'->'outputTokens') = 'null'
+        or (
+          (grading_provenance->'tokenUsage'->>'outputTokens')::numeric >= 0
+          and (grading_provenance->'tokenUsage'->>'outputTokens')::numeric
+            = trunc((grading_provenance->'tokenUsage'->>'outputTokens')::numeric)
+        )
+      )
+      and (
+        jsonb_typeof(grading_provenance->'tokenUsage'->'totalTokens') = 'null'
+        or (
+          (grading_provenance->'tokenUsage'->>'totalTokens')::numeric >= 0
+          and (grading_provenance->'tokenUsage'->>'totalTokens')::numeric
+            = trunc((grading_provenance->'tokenUsage'->>'totalTokens')::numeric)
+        )
+      )
+      and octet_length(grading_provenance::text) <= 4096
+    )
+  ) not valid;
+
+alter table public.assignment_repo_review_results
+  validate constraint assignment_repo_review_results_grading_provenance_contract;
+
+comment on column public.assignment_repo_review_results.grading_provenance is
+  'Bounded, pseudonymous repository-review grading provenance; never contains student or roster identifiers.';
+
+create or replace function public.complete_assignment_repo_review_run_with_provenance_atomic(
+  p_run_id uuid,
+  p_teacher_id uuid,
+  p_result_rows jsonb,
+  p_grade_rows jsonb,
+  p_source_ref text,
+  p_model text,
+  p_warnings jsonb,
+  p_now timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_assignment_id uuid;
+  v_triggered_by uuid;
+  v_status text;
+  v_result_count integer;
+  v_matched_count integer;
+  v_updated_count integer;
+  v_grade_result jsonb;
+begin
+  select run.assignment_id
+  into v_assignment_id
+  from public.assignment_repo_review_runs run
+  where run.id = p_run_id;
+
+  if not found then
+    raise exception 'Assignment repo review run not found' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(v_assignment_id::text, 0));
+
+  select run.triggered_by, run.status
+  into v_triggered_by, v_status
+  from public.assignment_repo_review_runs run
+  where run.id = p_run_id
+    and run.assignment_id = v_assignment_id
+  for update;
+
+  if not found or v_triggered_by <> p_teacher_id then
+    raise exception 'Assignment repo review mutation is not allowed' using errcode = '42501';
+  end if;
+
+  if v_status <> 'completed' then
+    if jsonb_typeof(p_result_rows) <> 'array'
+      or jsonb_typeof(p_grade_rows) <> 'array'
+      or jsonb_array_length(p_result_rows) = 0
+      or jsonb_array_length(p_result_rows) <> jsonb_array_length(p_grade_rows)
+      or jsonb_array_length(p_result_rows) > 100
+    then
+      raise exception 'Assignment repo review provenance payload is invalid' using errcode = '22023';
+    end if;
+
+    v_result_count := jsonb_array_length(p_result_rows);
+
+    select count(*)
+    into v_matched_count
+    from jsonb_to_recordset(p_result_rows) as result_payload(
+      student_id uuid,
+      grading_model text,
+      grading_provenance jsonb
+    )
+    join jsonb_to_recordset(p_grade_rows) as grade_payload(
+      student_id uuid,
+      ai_feedback_model text,
+      ai_grading_provenance jsonb
+    ) using (student_id)
+    where result_payload.grading_model is not null
+      and result_payload.grading_provenance is not null
+      and result_payload.grading_model = grade_payload.ai_feedback_model
+      and result_payload.grading_provenance = grade_payload.ai_grading_provenance;
+
+    if v_matched_count <> v_result_count
+      or (
+        select count(distinct result_payload.student_id)
+        from jsonb_to_recordset(p_result_rows) as result_payload(student_id uuid)
+      ) <> v_result_count
+      or (
+        select count(distinct grade_payload.student_id)
+        from jsonb_to_recordset(p_grade_rows) as grade_payload(student_id uuid)
+      ) <> v_result_count
+    then
+      raise exception 'Assignment repo review provenance rows do not match' using errcode = '22023';
+    end if;
+  end if;
+
+  v_grade_result := public.complete_assignment_repo_review_run_atomic(
+    p_run_id,
+    p_teacher_id,
+    p_result_rows,
+    p_grade_rows,
+    p_source_ref,
+    p_model,
+    p_warnings,
+    p_now
+  );
+
+  if v_status <> 'completed' then
+    update public.assignment_repo_review_results result
+    set
+      grading_model = payload.grading_model,
+      grading_provenance = payload.grading_provenance
+    from jsonb_to_recordset(p_result_rows) as payload(
+      student_id uuid,
+      grading_model text,
+      grading_provenance jsonb
+    )
+    where result.run_id = p_run_id
+      and result.assignment_id = v_assignment_id
+      and result.student_id = payload.student_id;
+
+    get diagnostics v_updated_count = row_count;
+    if v_updated_count <> v_result_count then
+      raise exception 'Assignment repo review provenance result count mismatch' using errcode = '22023';
+    end if;
+
+    update public.assignment_docs doc
+    set ai_grading_provenance = payload.ai_grading_provenance
+    from jsonb_to_recordset(p_grade_rows) as payload(
+      student_id uuid,
+      ai_grading_provenance jsonb
+    )
+    where doc.assignment_id = v_assignment_id
+      and doc.student_id = payload.student_id;
+
+    get diagnostics v_updated_count = row_count;
+    if v_updated_count <> v_result_count then
+      raise exception 'Assignment repo review provenance grade count mismatch' using errcode = '22023';
+    end if;
+
+    select jsonb_build_object(
+      'docs', coalesce(jsonb_agg(to_jsonb(doc) order by doc.student_id), '[]'::jsonb)
+    )
+    into v_grade_result
+    from public.assignment_docs doc
+    join public.assignment_repo_review_results result
+      on result.assignment_id = doc.assignment_id
+     and result.student_id = doc.student_id
+    where result.run_id = p_run_id;
+  end if;
+
+  return v_grade_result;
+end;
+$$;
+
+revoke all on function public.complete_assignment_repo_review_run_with_provenance_atomic(
+  uuid, uuid, jsonb, jsonb, text, text, jsonb, timestamptz
+) from public, anon, authenticated;
+grant execute on function public.complete_assignment_repo_review_run_with_provenance_atomic(
+  uuid, uuid, jsonb, jsonb, text, text, jsonb, timestamptz
+) to service_role;

--- a/tests/api/teacher/assignments-artifact-repo-run.test.ts
+++ b/tests/api/teacher/assignments-artifact-repo-run.test.ts
@@ -131,7 +131,7 @@ function installRepoRunTables(opts: {
   })
 
   mockSupabaseClient.rpc.mockImplementation(async (fn: string, args: Record<string, unknown>) => {
-    if (fn !== 'complete_assignment_repo_review_run_atomic') {
+    if (fn !== 'complete_assignment_repo_review_run_with_provenance_atomic') {
       throw new Error(`Unexpected RPC: ${fn}`)
     }
     aiGradeCalls.push(args)
@@ -281,6 +281,18 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
       score_workflow: 9,
       feedback: 'Solid repo activity.',
       confidence: 0.8,
+      model: 'gpt-5-nano',
+      provenance: {
+        schemaVersion: 'assignment-grading-provenance-v1',
+        provider: 'openai',
+        model: 'gpt-5-nano',
+        policyVersion: 'pika-repo-review-feedback-policy-v1',
+        promptVersion: 'pika-repo-review-feedback-prompt-v1',
+        gradingProfileVersion: 'pika-repo-review-feedback-v1',
+        rubricVersion: 'pika-repo-review-rubric-v1',
+        providerRequestCount: 1,
+        tokenUsage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      },
     })
     const harness = installRepoRunTables({
       enrollments: [{ student_id: 'b0000000-0000-4000-8000-000000000001', users: { email: 's1@example.com' } }],
@@ -346,6 +358,11 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
         draft_score_thinking: 7,
         draft_score_workflow: 9,
         draft_feedback: 'Solid repo activity.',
+        grading_model: 'gpt-5-nano',
+        grading_provenance: expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-5-nano',
+        }),
       }),
     ])
     expect(harness.aiGradeCalls).toEqual([
@@ -353,7 +370,7 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
         p_run_id: 'run-1',
         p_teacher_id: 'teacher-1',
         p_source_ref: 'main',
-        p_model: 'repo-review-v2',
+        p_model: 'gpt-5-nano',
         p_grade_rows: [expect.objectContaining({
           student_id: 'b0000000-0000-4000-8000-000000000001',
           expected_doc_updated_at: '2026-04-02T12:05:00.000Z',
@@ -363,7 +380,11 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
           apply_teacher_feedback_draft: false,
           mark_graded: false,
           ai_feedback_suggestion: 'Solid repo activity.',
-          ai_feedback_model: 'repo-review-v2',
+          ai_feedback_model: 'gpt-5-nano',
+          ai_grading_provenance: expect.objectContaining({
+            provider: 'openai',
+            model: 'gpt-5-nano',
+          }),
         })],
       }),
     ])

--- a/tests/lib/grading/repo-review-profile.test.ts
+++ b/tests/lib/grading/repo-review-profile.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { gradingProvenanceSchema } from '@/lib/grading/contracts'
+import {
+  parsePikaRepoReviewClassificationOutput,
+  parsePikaRepoReviewFeedbackOutput,
+  PIKA_REPO_REVIEW_CLASSIFICATION_OUTPUT,
+  PIKA_REPO_REVIEW_FEEDBACK_OUTPUT,
+} from '@/lib/grading/profiles/pika-repo-review'
+
+describe('Pika repository-review grading profile', () => {
+  it('uses bounded structured outputs for classification and feedback', () => {
+    expect(PIKA_REPO_REVIEW_CLASSIFICATION_OUTPUT).toMatchObject({
+      schemaName: 'repo_review_change_classification',
+      initialMaxOutputTokens: 1200,
+      fallbackMaxOutputTokens: 1800,
+    })
+    expect(PIKA_REPO_REVIEW_FEEDBACK_OUTPUT).toMatchObject({
+      schemaName: 'repo_review_feedback',
+      initialMaxOutputTokens: 700,
+      fallbackMaxOutputTokens: 1000,
+    })
+  })
+
+  it('parses strict classification and feedback contracts', () => {
+    expect(parsePikaRepoReviewClassificationOutput(
+      '{"items":[{"id":"change_1","category":"bugfix"}]}',
+    )).toEqual({ items: [{ id: 'change_1', category: 'bugfix' }] })
+
+    expect(parsePikaRepoReviewFeedbackOutput(JSON.stringify({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 6,
+      summary: 'Good progress.',
+      strengths: ['Iterated steadily.'],
+      concerns: [],
+      feedback: 'Add another focused test.',
+      confidence: 0.8,
+    }))).toMatchObject({ score_completion: 8, score_thinking: 7, score_workflow: 6 })
+  })
+
+  it('rejects undeclared provider output fields', () => {
+    expect(() => parsePikaRepoReviewFeedbackOutput(JSON.stringify({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 6,
+      summary: 'Good progress.',
+      strengths: [],
+      concerns: [],
+      feedback: 'Add another focused test.',
+      confidence: 0.8,
+      student_id: 'local-id',
+    }))).toThrow()
+  })
+
+  it('represents local heuristic execution without inventing a provider request', () => {
+    expect(gradingProvenanceSchema.parse({
+      schemaVersion: 'assignment-grading-provenance-v1',
+      provider: 'pika-local',
+      model: 'repo-review-heuristic-v1',
+      policyVersion: 'pika-repo-review-feedback-policy-v1',
+      promptVersion: 'pika-repo-review-feedback-prompt-v1',
+      gradingProfileVersion: 'pika-repo-review-feedback-v1',
+      rubricVersion: 'pika-repo-review-rubric-v1',
+      providerRequestCount: 0,
+      tokenUsage: { inputTokens: null, outputTokens: null, totalTokens: null },
+    })).toMatchObject({ provider: 'pika-local', providerRequestCount: 0 })
+  })
+})

--- a/tests/unit/atomic-assignment-feedback-return-migration.test.ts
+++ b/tests/unit/atomic-assignment-feedback-return-migration.test.ts
@@ -124,7 +124,7 @@ describe('atomic assignment feedback return migration', () => {
     expect(gradeService).toContain("rpc('save_assignment_ai_grade_with_provenance_atomic'")
     expect(gradeService).toContain("rpc('save_assignment_ai_grades_atomic'")
     expect(gradeService).toContain("rpc('finalize_assignment_ai_grading_item_with_provenance_atomic'")
-    expect(gradeService).toContain("rpc('complete_assignment_repo_review_run_atomic'")
+    expect(gradeService).toContain("rpc('complete_assignment_repo_review_run_with_provenance_atomic'")
     expect(gradeService).not.toContain("upsert(")
   })
 

--- a/tests/unit/repo-review-ai.test.ts
+++ b/tests/unit/repo-review-ai.test.ts
@@ -42,10 +42,46 @@ describe('repo-review AI egress', () => {
 
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
     expect(body.store).toBe(false)
+    expect(body.reasoning).toEqual({ effort: 'minimal' })
+    expect(body.max_output_tokens).toBe(1200)
+    expect(body.text?.format).toMatchObject({
+      type: 'json_schema',
+      name: 'repo_review_change_classification',
+      strict: true,
+    })
     const userPrompt = body.input[1].content[0].text
     expect(userPrompt).toContain('change_1')
     expect(userPrompt).not.toContain('018f3f57-7b4b-7123-8c04-48ac061c1111')
     expect(userPrompt).toContain('[email redacted]')
+  })
+
+  it('chunks ambiguous classification into bounded provider requests', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body))
+      const userPrompt = String(body.input[1].content[0].text)
+      const ids = [...userPrompt.matchAll(/change_[0-9]+/g)].map((match) => match[0])
+      return new Response(JSON.stringify({
+        output_text: JSON.stringify({
+          items: ids.map((id) => ({ id, category: 'feature' })),
+        }),
+      }), { status: 200 })
+    })
+    global.fetch = fetchMock as typeof fetch
+
+    const result = await classifyAmbiguousRepoReviewChanges(
+      Array.from({ length: 51 }, (_, index) => ({
+        id: `local-${index + 1}`,
+        summary: `Change ${index + 1}`,
+      })),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result['local-1']).toBe('feature')
+    expect(result['local-51']).toBe('feature')
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body))
+    expect(firstBody.input[1].content[0].text.match(/change_[0-9]+/g)).toHaveLength(50)
+    expect(secondBody.input[1].content[0].text.match(/change_[0-9]+/g)).toHaveLength(1)
   })
 
   it('sanitizes repo-review grading prompts and returned feedback', async () => {
@@ -99,6 +135,13 @@ describe('repo-review AI egress', () => {
 
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
     expect(body.store).toBe(false)
+    expect(body.reasoning).toEqual({ effort: 'minimal' })
+    expect(body.max_output_tokens).toBe(700)
+    expect(body.text?.format).toMatchObject({
+      type: 'json_schema',
+      name: 'repo_review_feedback',
+      strict: true,
+    })
     const promptPayload = JSON.parse(body.input[1].content[0].text)
     expect(promptPayload).toMatchObject({
       assignment_title: 'Essay for S.L.',
@@ -113,6 +156,17 @@ describe('repo-review AI egress', () => {
     expect(result.summary).toBe('Email [email redacted] for details.')
     expect(result.concerns[0]).toBe('Call [phone redacted].')
     expect(result.feedback).toContain('[email redacted]')
+    expect(result.model).toBe('gpt-5-nano')
+    expect(result.provenance).toMatchObject({
+      schemaVersion: 'assignment-grading-provenance-v1',
+      provider: 'openai',
+      model: 'gpt-5-nano',
+      policyVersion: 'pika-repo-review-feedback-policy-v1',
+      promptVersion: 'pika-repo-review-feedback-prompt-v1',
+      gradingProfileVersion: 'pika-repo-review-feedback-v1',
+      rubricVersion: 'pika-repo-review-rubric-v1',
+      providerRequestCount: 1,
+    })
   })
 
   it('sanitizes heuristic fallback feedback before persistence', async () => {
@@ -143,12 +197,50 @@ describe('repo-review AI egress', () => {
       sanitizationContext,
     })
 
-    expect(result.model).toBe('heuristic')
+    expect(result.model).toBe('repo-review-heuristic-v1')
+    expect(result.provenance).toMatchObject({
+      provider: 'pika-local',
+      model: 'repo-review-heuristic-v1',
+      providerRequestCount: 0,
+      tokenUsage: { inputTokens: null, outputTokens: null, totalTokens: null },
+    })
     expect(result.summary).toBe('S.L. contributed 100% of mapped weighted work in student-login/private-repo.')
     expect(result.concerns).toContain('S.L. emailed [email redacted].')
     expect(result.feedback).not.toContain('Sam Lee')
     expect(result.feedback).not.toContain('sam@example.com')
     expect(result.feedback).toContain('S.L.')
     expect(result.feedback).toContain('[email redacted]')
+  })
+
+  it('records local provenance when a provider failure triggers heuristic fallback', async () => {
+    global.fetch = vi.fn(async () => new Response('provider unavailable', { status: 503 })) as typeof fetch
+
+    const result = await gradeRepoReviewFeedback({
+      assignmentTitle: 'Repo review',
+      repoName: 'repo_1',
+      studentName: 'Student',
+      githubLogin: null,
+      commitCount: 2,
+      activeDays: 2,
+      sessionCount: 2,
+      burstRatio: 0.2,
+      weightedContribution: 2,
+      relativeContributionShare: 1,
+      spreadScore: 0.8,
+      iterationScore: 0.7,
+      reviewActivityCount: 1,
+      areas: ['src'],
+      semanticBreakdown: { feature: 2 },
+      evidence: [],
+      warnings: [],
+      confidence: 0.8,
+    })
+
+    expect(result.model).toBe('repo-review-heuristic-v1')
+    expect(result.provenance).toMatchObject({
+      provider: 'pika-local',
+      model: 'repo-review-heuristic-v1',
+      providerRequestCount: 0,
+    })
   })
 })

--- a/tests/unit/repo-review-grading-provenance-migration.test.ts
+++ b/tests/unit/repo-review-grading-provenance-migration.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/103_repo_review_grading_provenance.sql'),
+  'utf8',
+).toLowerCase()
+const gradeService = readFileSync(
+  resolve(process.cwd(), 'src/lib/server/assignment-grades.ts'),
+  'utf8',
+)
+
+describe('repository-review grading provenance migration', () => {
+  it('stores bounded model provenance on each repository-review result', () => {
+    expect(migration).toContain('add column if not exists grading_model text')
+    expect(migration).toContain('add column if not exists grading_provenance jsonb')
+    expect(migration).toContain('assignment_repo_review_results_grading_provenance_contract')
+    expect(migration).toContain('assignment-grading-provenance-v1')
+    expect(migration).toContain("grading_model = grading_provenance->>'model'")
+    expect(migration).toContain('octet_length(grading_provenance::text) <= 4096')
+  })
+
+  it('allows truthful zero-request provenance for deterministic local grading', () => {
+    expect(migration).toContain('drop constraint if exists assignment_docs_ai_grading_provenance_contract')
+    expect(migration).toContain("(ai_grading_provenance->>'providerrequestcount')::integer between 0 and 10")
+    expect(migration).toContain("(grading_provenance->>'providerrequestcount')::integer between 0 and 10")
+  })
+
+  it('wraps the old atomic completion contract and preserves completed replay', () => {
+    expect(migration).toContain('create or replace function public.complete_assignment_repo_review_run_with_provenance_atomic')
+    expect(migration).toContain('public.complete_assignment_repo_review_run_atomic(')
+    expect(migration).toContain("if v_status <> 'completed' then")
+    expect(migration).toContain('grading_model = payload.grading_model')
+    expect(migration).toContain('set ai_grading_provenance = payload.ai_grading_provenance')
+    expect(migration).toContain('revoke all on function public.complete_assignment_repo_review_run_with_provenance_atomic')
+    expect(migration).toContain('to service_role')
+  })
+
+  it('routes application completion through the provenance wrapper', () => {
+    expect(gradeService).toContain("rpc('complete_assignment_repo_review_run_with_provenance_atomic'")
+    expect(gradeService).toContain('ai_grading_provenance: grade.aiGradingProvenance ?? null')
+  })
+})


### PR DESCRIPTION
## Summary

- move repository-review classification and feedback generation behind versioned, strict structured-output profiles in the internal grading core
- preserve Pika-owned GitHub access, identity mapping, sanitization, metrics, heuristic fallback, teacher workflow, and run orchestration
- persist the actual per-result grading model and bounded provenance atomically with draft grades and run completion
- represent deterministic heuristic fallback truthfully with `providerRequestCount: 0` and no token usage

## Stack

This PR is stacked on #909 (`codex/internal-test-grading`), which is stacked on #906. Merge the stack in order. Remote Gradex grading remains disabled.

## Database rollout

Migration `103_repo_review_grading_provenance.sql` must be applied before this application version is deployed. It preserves the migration-087 `complete_assignment_repo_review_run_atomic` RPC for older instances and adds the provenance-aware wrapper used here. No migration was applied locally or to production.

The database harness now proves service-role isolation, zero-request heuristic persistence, completed-run replay preservation, exact result/grade row matching, and full rollback when provenance violates the bounded contract. Ephemeral PR CI is the authority for fresh migration replay and generated-type parity.

## Validation

- `pnpm test` (405 files / 3,642 tests)
- focused repository-review/core/migration suite (7 files / 30 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (621 modules / 0 allowances)
- `pnpm build`
- `bash -n scripts/check-atomic-assignment-feedback-returns.sh`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`

No live OpenAI calls, UI changes, production changes, or local migration application were performed.