### PR TITLE
Verify assignment save and restore accessibility

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,7 +5,7 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 ## Current Focus
 
 - Migrations 001-099 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
-- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete; Phase 3 is in progress with the teacher/student Classwork list-state slice.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment desktop/accessibility work is complete; assignment mobile UX is deferred, Gradex is owned by a separate session, and Daily/Attendance is next.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14127,3 +14127,24 @@
 - `pnpm run lint`
 - `pnpm run db:types:check` preflight rejected the intentionally mismatched shared stack (`database=080`, worktree missing `080`)
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+<!-- pika-session-log-archive-batch:a29853a0806d81e629328611af103853e4f80e3af8d3163e610c7318c3f9d7fa -->
+## 2026-07-14 — Atomic test grading contracts
+
+**Completed:**
+- Moved manual, bulk-clear, unanswered, and AI test grading writes behind typed atomic database RPCs with optimistic response/item revisions, exact-cohort validation, deterministic lock ordering, leases, and signed AI provenance.
+- Added shared test-scoped advisory locking and an atomic test-deletion boundary so grading, finalization, and deletion serialize without deadlocks or partial writes.
+- Added bounded client conflict recovery that reloads canonical revisions while preserving the teacher's latest draft, plus Zod validation at changed API/server boundaries.
+- Hardened classroom archive restore context scoping and added database-backed CI coverage for both grading concurrency and archive restore contracts.
+- Added migrations `089` through `095`, generated Supabase types, rollout guidance, focused API/server/component/architecture tests, and multi-session database regression harnesses.
+
+**Validation:**
+- `pnpm exec supabase db reset --local`
+- `pnpm run db:types:check`
+- `bash scripts/check-atomic-test-grading.sh`
+- `bash scripts/check-classroom-archive-restore-database.sh`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm vitest run` (359 files, 3,287 tests)
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-14 — Atomic test grading contracts
-
-**Completed:**
-- Moved manual, bulk-clear, unanswered, and AI test grading writes behind typed atomic database RPCs with optimistic response/item revisions, exact-cohort validation, deterministic lock ordering, leases, and signed AI provenance.
-- Added shared test-scoped advisory locking and an atomic test-deletion boundary so grading, finalization, and deletion serialize without deadlocks or partial writes.
-- Added bounded client conflict recovery that reloads canonical revisions while preserving the teacher's latest draft, plus Zod validation at changed API/server boundaries.
-- Hardened classroom archive restore context scoping and added database-backed CI coverage for both grading concurrency and archive restore contracts.
-- Added migrations `089` through `095`, generated Supabase types, rollout guidance, focused API/server/component/architecture tests, and multi-session database regression harnesses.
-
-**Validation:**
-- `pnpm exec supabase db reset --local`
-- `pnpm run db:types:check`
-- `bash scripts/check-atomic-test-grading.sh`
-- `bash scripts/check-classroom-archive-restore-database.sh`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm vitest run` (359 files, 3,287 tests)
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-07-14 — Archive stack review findings fixed
 
 **Completed:**
@@ -951,3 +931,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Complete repository gates, independent review, and merge. Then continue the assignment slice with mobile workspace modes, save announcements/dialog semantics, and the Gradex status boundary.
+
+## 2026-07-22 — Phase 3 assignment accessibility evidence
+
+**Completed:**
+- Audited the remaining non-mobile assignment backlog against current `main` and confirmed #891 already shipped polite atomic save announcements and the shared restore-confirmation dialog.
+- Replaced the assignment suite's hand-built confirmation stub with the real `ConfirmDialog`, added focused initial-focus coverage, and locked the visible save-status live-region attributes with regression assertions.
+- Updated the product audit and current context to remove completed assignment work from the backlog. No runtime UI, API, schema, migration, production state, or production data changed.
+
+**Validation:**
+- `pnpm test tests/components/StudentAssignmentEditor.save-submit.test.tsx tests/ui/ModalLayer.test.tsx` (2 files / 52 tests)
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`
+
+**Remaining:**
+- Complete repository gates, independent review, and merge this evidence slice. Then start Daily/Attendance; assignment mobile UX remains deferred and Gradex remains owned by a separate session.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -174,7 +174,8 @@ Assignment progress:
 
 - Save/submit integrity was completed in the Safety Wave with atomic persistence and stale-submit regression coverage.
 - The first Phase 3 assignment slice gives teacher and student Classwork lists explicit governed loading, error, and successful-empty states. Retry invalidates the classroom list caches before reloading, and role/viewport/theme browser verification covers failure and recovery without changing the normal class-wide workflow.
-- Remaining assignment work is mobile workspace modes, live save announcements and dialog semantics, and the Gradex status boundary.
+- Accessible assignment save announcements and restore-dialog semantics were completed in #891. The visible save state is a polite atomic live region, and restore confirmation uses the shared modal-layer contract for focus containment, dismissal, background isolation, scroll locking, and focus return.
+- Remaining assignment work is limited to the deferred mobile workspace modes and the separately owned Gradex status boundary.
 
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: list errors, authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, accessible flags/save status.

--- a/tests/components/StudentAssignmentEditor.save-submit.test.tsx
+++ b/tests/components/StudentAssignmentEditor.save-submit.test.tsx
@@ -78,22 +78,6 @@ vi.mock('@/ui', async (importOriginal) => {
   return {
     ...actual,
     Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-    ConfirmDialog: ({
-      isOpen,
-      title,
-      description,
-      confirmLabel,
-      isCancelDisabled,
-      isConfirmDisabled,
-      onCancel,
-      onConfirm,
-    }: any) => isOpen ? (
-      <div role="dialog" aria-modal="true" aria-label={title}>
-        <p>{description}</p>
-        <button type="button" disabled={isCancelDisabled} onClick={onCancel}>Cancel</button>
-        <button type="button" disabled={isConfirmDisabled} onClick={onConfirm}>{confirmLabel}</button>
-      </div>
-    ) : null,
     Tooltip: ({ children }: any) => <>{children}</>,
   }
 })
@@ -216,7 +200,11 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
       expect.anything(),
     )
     expect(screen.getByTestId('editor-content')).toHaveTextContent('Latest unsaved answer')
-    expect(screen.getByTestId('assignment-save-status')).toHaveTextContent('Unsaved')
+    const saveStatus = screen.getByTestId('assignment-save-status')
+    expect(saveStatus).toHaveTextContent('Unsaved')
+    expect(saveStatus).toHaveAttribute('role', 'status')
+    expect(saveStatus).toHaveAttribute('aria-live', 'polite')
+    expect(saveStatus).toHaveAttribute('aria-atomic', 'true')
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent(/not submitted.*try again/i)
     })
@@ -3262,6 +3250,9 @@ describe('StudentAssignmentEditor save-before-submit integrity', () => {
     await user.click(screen.getAllByRole('button', { name: 'Restore' })[0])
     const restoreDialog = screen.getByRole('dialog', { name: 'Restore this version?' })
     expect(restoreDialog).toHaveAttribute('aria-modal', 'true')
+    await waitFor(() => {
+      expect(within(restoreDialog).getByRole('button', { name: 'Cancel' })).toHaveFocus()
+    })
     await user.click(within(restoreDialog).getByRole('button', { name: 'Restore' }))
 
     await waitFor(() => expect(operations).toEqual(['save', 'restore']))


### PR DESCRIPTION
## Summary
- exercise the real shared restore confirmation dialog in assignment regression tests
- lock the assignment save status live-region contract
- record that the non-mobile assignment accessibility backlog was already completed in #891

## Scope
- no runtime UI, API, schema, migration, dependency, production state, or production data changes
- mobile assignment UX remains deferred
- Gradex remains owned by a separate session

## Validation
- `pnpm test tests/components/StudentAssignmentEditor.save-submit.test.tsx tests/ui/ModalLayer.test.tsx` (2 files / 52 tests)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm check:ui-policy`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `node scripts/trim-session-log.mjs --check`
- `git diff --check`