### PR TITLE
Harden Daily and attendance loading states

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,7 +5,7 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 ## Current Focus
 
 - Migrations 001-099 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
-- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment desktop/accessibility work is complete; assignment mobile UX is deferred, Gradex is owned by a separate session, and Daily/Attendance is next.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment and Daily/Attendance desktop/accessibility work is complete; mobile UX is deferred, Gradex is owned by a separate session, and Tests desktop/accessibility is next.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14307,3 +14307,219 @@
 - `pnpm check:architecture` (594 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:20aafc756d9e258a315febc69f7e24a25f988c9585c9da7c5cc8295a3ebcdb5d -->
+## 2026-07-14 — Archive stack review findings fixed
+
+**Completed:**
+- Ran repeated independent SQL, runtime, Gradex, and cross-layer review loops and fixed every actionable finding.
+- Hardened export/restore upload cleanup, exact restore object descriptors, actor-role reconciliation, transactional compaction dry runs, canonical paths, expiry/retry state transitions, and fail-closed source cleanup.
+- Tightened Gradex v2 with strict per-table Zod contracts, required relationships and projected fields, safe analytic enum preservation, Unicode-aware identifier scanning, pseudonymized unknown tokens, exact cleanup canaries, and retention fences.
+- Updated database contract drills, lifecycle guidance, cron integration, and environment documentation. No production database, migration, row, object, environment, deployment, or schedule was read or modified.
+
+**Validation:**
+- Fresh local Supabase reset through migrations 001–086
+- Archive export, restore, compaction, and Gradex database contract scripts
+- Full Vitest suite (339 files / 3,037 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-14 — Archive stack consolidation CI fix
+
+**Completed:**
+- Fast-forward merged reviewed archive PRs 852–866 into the final stack base without changing commit history.
+- Fixed the consolidated recovery drill after CI exposed a stale duplicate of the restore object-path algorithm; the drill now calls the production canonical path helper.
+- Kept PR 851 unmerged from `main` until its refreshed required checks pass. No production state was accessed or modified.
+
+**Validation:**
+- Local full archive recovery drill passed twice, including row equality, object equality, and idempotent replays
+- Focused restore unit suite (1 file / 9 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+
+## 2026-07-14 — Read-only production classroom archive inventory
+
+**Risk profile:** runtime-platform
+
+**Model recommendation:** GPT-5 Codex - production verification crosses Supabase target safety, archive graph consistency, privacy-safe reporting, and fail-closed storage evidence.
+
+**Completed:**
+- Added a target-bound, read-only inventory command that requires the exact hosted Supabase project ref, validates deployed archive and Gradex contract rows, audits exposed PostgREST relationship metadata, and traverses the canonical 42-resource graph with exact-count pagination.
+- Bound the separately required direct PostgreSQL catalog audit to the same expected project ref for direct or Supabase pooler DSNs and required TLS.
+- Hardened the catalog runner against libpq DSN overrides and credential disclosure by allowlisting one TLS parameter, passing validated fields through `PG*` environment variables, sanitizing failures, and requiring either a hosted project ref or explicit loopback-only local mode.
+- Bracketed each hot archived classroom read with archive revisions, resolved managed objects through exact Storage metadata reads, and emitted only aggregate labels, counts, and byte sizes; missing referenced objects fail the command.
+- Ran the inventory against production after migrations 080-086 were applied: three hot archives, 44,813 relational rows, 42.2 MiB canonical relational payload, 165 referenced objects / 25.9 MiB, and zero missing objects or archive/restore/Gradex/cleanup operation rows.
+- Kept the archive epic unfinished. PostgREST metadata cannot prove hidden or stale catalog relationships, so the direct read-only PostgreSQL catalog audit remains required; no export, restore, Gradex, compaction, cleanup, row mutation, or Storage mutation was performed.
+
+**Validation:**
+- Final production read-only inventory passed after all review fixes
+- Full Vitest suite (345 files / 3,080 tests)
+- Focused inventory, catalog-runner, and service-client suites (35 tests)
+- Local read-only PostgreSQL catalog audit (117 foreign-key relationships)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture`
+- `pnpm build`
+- `git diff --check`
+
+## 2026-07-14 — Assessment draft validation boundary
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - cross-module boundary extraction benefits from repository-wide import analysis and behavior-parity verification.
+
+**Completed:**
+- Moved browser-safe assessment draft validation into the feature-owned `@/lib/validations/assessment-drafts` module while keeping persistence and database synchronization in `@/lib/server/assessment-drafts`.
+- Split browser, blueprint, route, and server imports so pure modules no longer reach through the server boundary for validation contracts or draft types.
+- Removed all four remaining deletion-only architecture allowances; the architecture check now covers 588 modules with zero allowances.
+- Removed stale route-test validator stubs so invalid draft payload tests exercise the real validation boundary.
+- Deleted the unused `syncAssessmentMetadataFromDraft` server export after CI coverage exposed that production performs the richer test metadata update directly in the route.
+- No behavior, UI, database schema, dependency, migration, or production changes.
+
+**Validation:**
+- Focused assessment draft, route, and architecture suites (4 files / 34 tests)
+- `pnpm test` (345 files / 3,081 tests)
+- `pnpm vitest run --coverage --maxWorkers=1` (server assessment drafts: 66.67% lines, 95% functions, 65.74% statements)
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture`
+- `node scripts/trim-session-log.mjs --check`
+- `node scripts/features.mjs validate`
+- `git diff --check`
+
+## 2026-07-14 — Assignment grading request boundary
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - feature-boundary extraction requires repository-wide dependency analysis and exact API contract preservation.
+
+**Completed:**
+- Moved single-student and selected-student assignment grading request normalization into the feature-owned `@/lib/validations/assignment-grading` Zod contract.
+- Kept assignment ownership, enrollment checks, and grade persistence in `@/lib/server/assignment-grades`; both routes now consume parsed contract values.
+- Preserved legacy validation messages, ordering, score coercion, draft blanks, selected-ID filtering/deduplication, authentication-before-parse behavior, and the batch-only `apply_target` contract.
+- Removed both grading routes from the deletion-only API Zod baseline, reducing existing migration debt from 62 routes to 60.
+- Completed two independent review/fix rounds with no remaining findings.
+- No UI, database schema, migration, dependency, or production changes.
+
+**Validation:**
+- Focused grading, API handler, and architecture suites (6 files / 33 tests)
+- `pnpm vitest run --coverage --maxWorkers=1` (346 files / 3,098 tests; assignment grading validation: 96.36% lines, 100% functions)
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture` (589 modules / 0 allowances)
+- `git diff --check`
+
+## 2026-07-14 — Atomic assignment grading and feedback expand release
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5 Codex - transactional grading, concurrent roster changes, runtime response contracts, and rolling database deployment require cross-layer invariant analysis.
+
+**Completed:**
+- Added expand-only migration 087 with service-role atomic RPCs for manual and AI grades, AI run/item completion, repository review completion, and single/batch feedback returns.
+- Added optimistic document revisions, assignment/classroom locking, replay-safe terminal operations, final-score validation, and all-or-none grade/result persistence.
+- Routed native AI, Gradex, repository review, and teacher feedback flows through typed server boundaries; feedback returns now submit the browser-observed document revision.
+- Added Zod contracts for assignment identifiers, grading and return payloads, and successful Gradex runtime responses; malformed successful responses fail before grade persistence.
+- Added a live database/concurrency harness, migration contract tests, route/service tests, and completed teacher/student desktop/mobile visual verification.
+- Documented the migration-first expand deployment and the separately numbered contract migration required only after all old application instances are drained.
+- Completed repeated independent database and TypeScript reviews with no remaining findings. No production database or Storage changes were made.
+
+**Validation:**
+- `pnpm test` (350 files / 3,159 tests)
+- Atomic assignment database/concurrency harness
+- `pnpm build`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm db:types:check`
+- `pnpm check:architecture` (592 modules / 0 allowances)
+- Pika pre-commit audit
+- `bash scripts/verify-env.sh`
+- `git diff --check`
+
+## 2026-07-14 — Manual test grading workflow boundary
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5 Codex - grading request compatibility and persistence extraction require exact cross-layer behavior analysis.
+
+**Completed:**
+- Replaced the handwritten manual test-grade decoder with a feature-owned Zod contract while preserving score coercion, rounding, trim behavior, clear semantics, AI audit metadata, and duplicate rejection.
+- Extracted teacher access, enrollment/question validation, existing-response preservation, grade row construction, and the legacy AI-column retry into `@/lib/server/test-grades`.
+- Kept the existing non-transactional persistence sequence unchanged for this behavior-preserving expand slice; atomic test grading remains a separately reviewed follow-up.
+- Made malformed JSON and JSON `null` fail deterministically with 400 responses instead of accidental internal errors.
+- Removed the route from the deletion-only API Zod baseline and added regressions for access arguments, archive protection, query failures, question scope, score caps, clear fields, timestamps, and failed compatibility retries.
+- Completed two independent review/fix rounds with no remaining findings. No UI, database schema, migration, dependency, or production changes.
+
+**Validation:**
+- Focused grading contract, route, and API architecture suites (3 files / 33 tests)
+- `pnpm test` (351 files / 3,186 tests)
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture` (594 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-14 — Atomic student test attempt expand phase
+
+**Risk profile:** async-grading
+
+**Model recommendation:** GPT-5 Codex - student autosave, final submission, lifecycle locks, and rolling database deployment require cross-writer concurrency analysis.
+
+**Completed:**
+- Added expand-only migration 088 with service-role RPCs that atomically save partial attempts and atomically commit final responses with the owning submitted attempt.
+- Serialized submit/save against test close, per-student availability changes, question mutations, classroom archival, enrollment removal, and single/bulk attempt deletion through a consistent parent lock order.
+- Preserved placeholder-response behavior, automatic multiple-choice scoring, open-response grading state, normalized legacy response payloads, and best-effort versioned history after database commit.
+- Routed student autosave and final submit through feature-owned Zod and server boundaries; removed both routes from the API Zod migration baseline.
+- Added forward-compatible 409 handling for the later strict question-immutability contract without enforcing it in migration 088, so old app instances remain compatible during migration-first rollout.
+- Added an ephemeral database harness covering privileges, partial/final saves, validation rollback, forced post-insert rollback, double submit, availability/close/delete/autosave races, cascade deletion, and coherent final state.
+- Completed repeated independent SQL and TypeScript review/fix rounds with no remaining findings. No migration or production state was applied or changed.
+
+**Deployment obligation:**
+- Apply migration 088 before deploying this app version.
+- After deploying and draining all old app instances, add a separately numbered contract migration for semantic question immutability; do not add that enforcement to migration 088.
+
+**Validation:**
+- Focused student attempt/submit, validation, question compatibility, and architecture suites (8 files / 79 tests)
+- `pnpm test`
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (596 modules / 0 allowances)
+- `bash -n` and `shellcheck` for the database harness
+- Pika pre-commit audit
+- `git diff --check`
+
+## 2026-07-15 — Production classroom archive canary runner
+
+**Completed:**
+- Added a production-only prepare/execute/resume CLI bound to one hosted project, teacher,
+  archived-hot classroom, immutable mode-0600 plan, clean deployed commit, exact acknowledgement,
+  and deterministic export/compact/restore operation UUIDs.
+- Added exact pre/archive/restored-projection evidence across all 42 classroom resources and every
+  source object, full manifest and operation metadata auditing, original/restored object byte checks,
+  source-revision equality, pre/post database sizing, and a conservative restore safety margin.
+- Kept every source/Gradex cleanup gate disabled and proved cleanup rows, reservations, restore
+  staging, and upload-cleanup state remain untouched or empty after immediate restore.
+- Added crash recovery for cold state, transient state/archive reads, ambiguous coordinator results,
+  journal failure, and hot state after restore completion. Evidence files reject symlink traversal and
+  unsafe permissions.
+- Updated lifecycle/testing/operator documentation and current context. Production migrations 001-096,
+  read-only inventory, and hosted catalog audit were previously verified; no mutation canary ran in
+  this branch.
+- Completed repeated independent production-safety/data-integrity review and fix rounds.
+
+**Validation:**
+- Production canary contract suite (14 tests)
+- `pnpm vitest run` (363 files / 3,329 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm db:types:check`
+- `pnpm lint`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,221 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-14 — Archive stack review findings fixed
-
-**Completed:**
-- Ran repeated independent SQL, runtime, Gradex, and cross-layer review loops and fixed every actionable finding.
-- Hardened export/restore upload cleanup, exact restore object descriptors, actor-role reconciliation, transactional compaction dry runs, canonical paths, expiry/retry state transitions, and fail-closed source cleanup.
-- Tightened Gradex v2 with strict per-table Zod contracts, required relationships and projected fields, safe analytic enum preservation, Unicode-aware identifier scanning, pseudonymized unknown tokens, exact cleanup canaries, and retention fences.
-- Updated database contract drills, lifecycle guidance, cron integration, and environment documentation. No production database, migration, row, object, environment, deployment, or schedule was read or modified.
-
-**Validation:**
-- Fresh local Supabase reset through migrations 001–086
-- Archive export, restore, compaction, and Gradex database contract scripts
-- Full Vitest suite (339 files / 3,037 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-14 — Archive stack consolidation CI fix
-
-**Completed:**
-- Fast-forward merged reviewed archive PRs 852–866 into the final stack base without changing commit history.
-- Fixed the consolidated recovery drill after CI exposed a stale duplicate of the restore object-path algorithm; the drill now calls the production canonical path helper.
-- Kept PR 851 unmerged from `main` until its refreshed required checks pass. No production state was accessed or modified.
-
-**Validation:**
-- Local full archive recovery drill passed twice, including row equality, object equality, and idempotent replays
-- Focused restore unit suite (1 file / 9 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-
-## 2026-07-14 — Read-only production classroom archive inventory
-
-**Risk profile:** runtime-platform
-
-**Model recommendation:** GPT-5 Codex - production verification crosses Supabase target safety, archive graph consistency, privacy-safe reporting, and fail-closed storage evidence.
-
-**Completed:**
-- Added a target-bound, read-only inventory command that requires the exact hosted Supabase project ref, validates deployed archive and Gradex contract rows, audits exposed PostgREST relationship metadata, and traverses the canonical 42-resource graph with exact-count pagination.
-- Bound the separately required direct PostgreSQL catalog audit to the same expected project ref for direct or Supabase pooler DSNs and required TLS.
-- Hardened the catalog runner against libpq DSN overrides and credential disclosure by allowlisting one TLS parameter, passing validated fields through `PG*` environment variables, sanitizing failures, and requiring either a hosted project ref or explicit loopback-only local mode.
-- Bracketed each hot archived classroom read with archive revisions, resolved managed objects through exact Storage metadata reads, and emitted only aggregate labels, counts, and byte sizes; missing referenced objects fail the command.
-- Ran the inventory against production after migrations 080-086 were applied: three hot archives, 44,813 relational rows, 42.2 MiB canonical relational payload, 165 referenced objects / 25.9 MiB, and zero missing objects or archive/restore/Gradex/cleanup operation rows.
-- Kept the archive epic unfinished. PostgREST metadata cannot prove hidden or stale catalog relationships, so the direct read-only PostgreSQL catalog audit remains required; no export, restore, Gradex, compaction, cleanup, row mutation, or Storage mutation was performed.
-
-**Validation:**
-- Final production read-only inventory passed after all review fixes
-- Full Vitest suite (345 files / 3,080 tests)
-- Focused inventory, catalog-runner, and service-client suites (35 tests)
-- Local read-only PostgreSQL catalog audit (117 foreign-key relationships)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture`
-- `pnpm build`
-- `git diff --check`
-
-## 2026-07-14 — Assessment draft validation boundary
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5 Codex - cross-module boundary extraction benefits from repository-wide import analysis and behavior-parity verification.
-
-**Completed:**
-- Moved browser-safe assessment draft validation into the feature-owned `@/lib/validations/assessment-drafts` module while keeping persistence and database synchronization in `@/lib/server/assessment-drafts`.
-- Split browser, blueprint, route, and server imports so pure modules no longer reach through the server boundary for validation contracts or draft types.
-- Removed all four remaining deletion-only architecture allowances; the architecture check now covers 588 modules with zero allowances.
-- Removed stale route-test validator stubs so invalid draft payload tests exercise the real validation boundary.
-- Deleted the unused `syncAssessmentMetadataFromDraft` server export after CI coverage exposed that production performs the richer test metadata update directly in the route.
-- No behavior, UI, database schema, dependency, migration, or production changes.
-
-**Validation:**
-- Focused assessment draft, route, and architecture suites (4 files / 34 tests)
-- `pnpm test` (345 files / 3,081 tests)
-- `pnpm vitest run --coverage --maxWorkers=1` (server assessment drafts: 66.67% lines, 95% functions, 65.74% statements)
-- `pnpm build`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm check:architecture`
-- `node scripts/trim-session-log.mjs --check`
-- `node scripts/features.mjs validate`
-- `git diff --check`
-
-## 2026-07-14 — Assignment grading request boundary
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5 Codex - feature-boundary extraction requires repository-wide dependency analysis and exact API contract preservation.
-
-**Completed:**
-- Moved single-student and selected-student assignment grading request normalization into the feature-owned `@/lib/validations/assignment-grading` Zod contract.
-- Kept assignment ownership, enrollment checks, and grade persistence in `@/lib/server/assignment-grades`; both routes now consume parsed contract values.
-- Preserved legacy validation messages, ordering, score coercion, draft blanks, selected-ID filtering/deduplication, authentication-before-parse behavior, and the batch-only `apply_target` contract.
-- Removed both grading routes from the deletion-only API Zod baseline, reducing existing migration debt from 62 routes to 60.
-- Completed two independent review/fix rounds with no remaining findings.
-- No UI, database schema, migration, dependency, or production changes.
-
-**Validation:**
-- Focused grading, API handler, and architecture suites (6 files / 33 tests)
-- `pnpm vitest run --coverage --maxWorkers=1` (346 files / 3,098 tests; assignment grading validation: 96.36% lines, 100% functions)
-- `pnpm build`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm check:architecture` (589 modules / 0 allowances)
-- `git diff --check`
-
-## 2026-07-14 — Atomic assignment grading and feedback expand release
-
-**Risk profile:** async-grading
-
-**Model recommendation:** GPT-5 Codex - transactional grading, concurrent roster changes, runtime response contracts, and rolling database deployment require cross-layer invariant analysis.
-
-**Completed:**
-- Added expand-only migration 087 with service-role atomic RPCs for manual and AI grades, AI run/item completion, repository review completion, and single/batch feedback returns.
-- Added optimistic document revisions, assignment/classroom locking, replay-safe terminal operations, final-score validation, and all-or-none grade/result persistence.
-- Routed native AI, Gradex, repository review, and teacher feedback flows through typed server boundaries; feedback returns now submit the browser-observed document revision.
-- Added Zod contracts for assignment identifiers, grading and return payloads, and successful Gradex runtime responses; malformed successful responses fail before grade persistence.
-- Added a live database/concurrency harness, migration contract tests, route/service tests, and completed teacher/student desktop/mobile visual verification.
-- Documented the migration-first expand deployment and the separately numbered contract migration required only after all old application instances are drained.
-- Completed repeated independent database and TypeScript reviews with no remaining findings. No production database or Storage changes were made.
-
-**Validation:**
-- `pnpm test` (350 files / 3,159 tests)
-- Atomic assignment database/concurrency harness
-- `pnpm build`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm db:types:check`
-- `pnpm check:architecture` (592 modules / 0 allowances)
-- Pika pre-commit audit
-- `bash scripts/verify-env.sh`
-- `git diff --check`
-
-## 2026-07-14 — Manual test grading workflow boundary
-
-**Risk profile:** async-grading
-
-**Model recommendation:** GPT-5 Codex - grading request compatibility and persistence extraction require exact cross-layer behavior analysis.
-
-**Completed:**
-- Replaced the handwritten manual test-grade decoder with a feature-owned Zod contract while preserving score coercion, rounding, trim behavior, clear semantics, AI audit metadata, and duplicate rejection.
-- Extracted teacher access, enrollment/question validation, existing-response preservation, grade row construction, and the legacy AI-column retry into `@/lib/server/test-grades`.
-- Kept the existing non-transactional persistence sequence unchanged for this behavior-preserving expand slice; atomic test grading remains a separately reviewed follow-up.
-- Made malformed JSON and JSON `null` fail deterministically with 400 responses instead of accidental internal errors.
-- Removed the route from the deletion-only API Zod baseline and added regressions for access arguments, archive protection, query failures, question scope, score caps, clear fields, timestamps, and failed compatibility retries.
-- Completed two independent review/fix rounds with no remaining findings. No UI, database schema, migration, dependency, or production changes.
-
-**Validation:**
-- Focused grading contract, route, and API architecture suites (3 files / 33 tests)
-- `pnpm test` (351 files / 3,186 tests)
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm check:architecture` (594 modules / 0 allowances)
-- Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-14 — Atomic student test attempt expand phase
-
-**Risk profile:** async-grading
-
-**Model recommendation:** GPT-5 Codex - student autosave, final submission, lifecycle locks, and rolling database deployment require cross-writer concurrency analysis.
-
-**Completed:**
-- Added expand-only migration 088 with service-role RPCs that atomically save partial attempts and atomically commit final responses with the owning submitted attempt.
-- Serialized submit/save against test close, per-student availability changes, question mutations, classroom archival, enrollment removal, and single/bulk attempt deletion through a consistent parent lock order.
-- Preserved placeholder-response behavior, automatic multiple-choice scoring, open-response grading state, normalized legacy response payloads, and best-effort versioned history after database commit.
-- Routed student autosave and final submit through feature-owned Zod and server boundaries; removed both routes from the API Zod migration baseline.
-- Added forward-compatible 409 handling for the later strict question-immutability contract without enforcing it in migration 088, so old app instances remain compatible during migration-first rollout.
-- Added an ephemeral database harness covering privileges, partial/final saves, validation rollback, forced post-insert rollback, double submit, availability/close/delete/autosave races, cascade deletion, and coherent final state.
-- Completed repeated independent SQL and TypeScript review/fix rounds with no remaining findings. No migration or production state was applied or changed.
-
-**Deployment obligation:**
-- Apply migration 088 before deploying this app version.
-- After deploying and draining all old app instances, add a separately numbered contract migration for semantic question immutability; do not add that enforcement to migration 088.
-
-**Validation:**
-- Focused student attempt/submit, validation, question compatibility, and architecture suites (8 files / 79 tests)
-- `pnpm test`
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (596 modules / 0 allowances)
-- `bash -n` and `shellcheck` for the database harness
-- Pika pre-commit audit
-- `git diff --check`
-
-## 2026-07-15 — Production classroom archive canary runner
-
-**Completed:**
-- Added a production-only prepare/execute/resume CLI bound to one hosted project, teacher,
-  archived-hot classroom, immutable mode-0600 plan, clean deployed commit, exact acknowledgement,
-  and deterministic export/compact/restore operation UUIDs.
-- Added exact pre/archive/restored-projection evidence across all 42 classroom resources and every
-  source object, full manifest and operation metadata auditing, original/restored object byte checks,
-  source-revision equality, pre/post database sizing, and a conservative restore safety margin.
-- Kept every source/Gradex cleanup gate disabled and proved cleanup rows, reservations, restore
-  staging, and upload-cleanup state remain untouched or empty after immediate restore.
-- Added crash recovery for cold state, transient state/archive reads, ambiguous coordinator results,
-  journal failure, and hot state after restore completion. Evidence files reject symlink traversal and
-  unsafe permissions.
-- Updated lifecycle/testing/operator documentation and current context. Production migrations 001-096,
-  read-only inventory, and hosted catalog audit were previously verified; no mutation canary ran in
-  this branch.
-- Completed repeated independent production-safety/data-integrity review and fix rounds.
-
-**Validation:**
-- Production canary contract suite (14 tests)
-- `pnpm vitest run` (363 files / 3,329 tests)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm db:types:check`
-- `pnpm lint`
-- `pnpm check:architecture` (600 modules / 0 allowances)
-- Pika pre-commit audit
-- `git diff --check`
-
 ## 2026-07-15 — Gradebook workflow boundary
 
 **Completed:**
@@ -1057,6 +842,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Complete repository gates, independent review, and merge this evidence slice. Then start Daily/Attendance; assignment mobile UX remains deferred and Gradex remains owned by a separate session.
+
 ## 2026-07-22 — Internal repository-review grading profile and provenance
 
 **Risk profile:** async-grading
@@ -1167,3 +953,32 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - After the lower stack lands and PR 911 is retargeted to `main`, require exact-head GitHub Actions and the repository's external approval before merge.
+
+## 2026-07-22 — Hardened Daily and attendance read states
+
+**Risk profile:** workspace-state
+
+**Model recommendation:** GPT-5.6 Terra (high) - this slice crosses shared classroom schedule state, cached student work, teacher history selection, and asynchronous retry boundaries.
+
+**Completed:**
+- Added an explicit class-schedule error and snapshot contract. Cold failures block with retry; failed refreshes retain the last valid teacher/student workspace with a compact retry warning.
+- Added explicit student Daily entry and teacher selected-student history failures, retry behavior, and persistent cached-snapshot recovery without replacing usable data with false empty states.
+- Prevented previous-classroom Daily content from painting during classroom switches and prevented stale load-more responses from appending one student's logs to another student's history.
+- Announced student Daily save status through a polite atomic live region and exposed save failures as alerts.
+- Preserved the existing class-wide teacher table and student journal composition. Mobile workspace redesign and Gradex remained out of scope.
+
+**Validation:**
+- Focused Daily/Attendance and classroom integration suites (5 files / 71 tests)
+- Full exact-head repository suite (407 files / 3,670 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit and composite-widget accessibility checklist
+- Playwright experience matrix (18 cases across both roles, desktop/mobile, light/dark)
+- Exact failure/stale-state screenshots for teacher and student; no horizontal overflow at 390px
+- Two independent review passes; four findings fixed; both remediation re-reviews clean
+
+**Remaining:**
+- Require exact-head PR CI and repository approval before merge.
+- Defer Daily/Attendance mobile history/table modes until the later mobile UX phase; continue Phase 3 with Tests desktop/accessibility while Gradex remains separately owned.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -968,8 +968,8 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Preserved the existing class-wide teacher table and student journal composition. Mobile workspace redesign and Gradex remained out of scope.
 
 **Validation:**
-- Focused Daily/Attendance and classroom integration suites (5 files / 71 tests)
-- Full exact-head repository suite (407 files / 3,670 tests)
+- Focused Daily/Attendance and classroom integration suites (5 files / 72 tests)
+- Full repository suite before the final provider-scope remediation (407 files / 3,670 tests); exact-head PR CI is required
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm check:architecture` (623 modules / 0 allowances)
@@ -977,7 +977,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Pika changed-file audit and composite-widget accessibility checklist
 - Playwright experience matrix (18 cases across both roles, desktop/mobile, light/dark)
 - Exact failure/stale-state screenshots for teacher and student; no horizontal overflow at 390px
-- Two independent review passes; four findings fixed; both remediation re-reviews clean
+- Three independent review passes; five findings fixed in two remediation batches; the first remediation re-reviews are clean and the final provider-scope re-review is pending
 
 **Remaining:**
 - Require exact-head PR CI and repository approval before merge.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -177,6 +177,13 @@ Assignment progress:
 - Accessible assignment save announcements and restore-dialog semantics were completed in #891. The visible save state is a polite atomic live region, and restore confirmation uses the shared modal-layer contract for focus containment, dismissal, background isolation, scroll locking, and focus return.
 - Remaining assignment work is limited to the deferred mobile workspace modes and the separately owned Gradex status boundary.
 
+Daily and attendance progress:
+
+- Cold class-schedule, student-entry, teacher-attendance, and selected-student history reads now render explicit retryable failures instead of false non-class-day or empty states.
+- Failed background schedule and student-entry refreshes preserve the last valid table, editor, and history snapshots with non-blocking retry warnings. Cross-classroom and cross-student stale response guards prevent another classroom's or student's log data from painting in the active workspace.
+- Student Daily save status is a polite atomic live region and save failures are announced. Existing Toronto midnight, DST, quick-jump, stale-mounted-save, and API timing tests remain the timestamp evidence.
+- Remaining Daily/Attendance work is limited to the deferred mobile history/table workspace modes.
+
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: list errors, authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, accessible flags/save status.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useRef, useCallback } from 'react'
-import { Button } from '@/ui'
+import { Button, PageState } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { RichTextEditor } from '@/components/editor'
 import { PageContent, PageLayout, PageStack } from '@/components/PageLayout'
@@ -67,7 +67,13 @@ interface StudentTodayTabProps {
 
 export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }: StudentTodayTabProps) {
   const notifications = useStudentNotifications()
-  const { classDays } = useClassDaysContext()
+  const {
+    classDays,
+    error: classDaysError,
+    hasLoadedSnapshot: hasClassDaysSnapshot,
+    isLoading: classDaysLoading,
+    refresh: refreshClassDays,
+  } = useClassDaysContext()
 
   // Constants
   const historyLimit = 12
@@ -77,6 +83,9 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
   // State
   const [loading, setLoading] = useState(true)
+  const [entriesError, setEntriesError] = useState<string | null>(null)
+  const [entriesRequestVersion, setEntriesRequestVersion] = useState(0)
+  const [entriesSnapshotClassroomId, setEntriesSnapshotClassroomId] = useState<string | null>(null)
   const [today, setToday] = useState('')
   const [content, setContent] = useState<TiptapContent>(EMPTY_DOC)
   const [historyEntries, setHistoryEntries] = useState<Entry[]>([])
@@ -99,6 +108,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   const hasLocalEditSinceLoadRef = useRef(false)
   const loadRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
+  const entriesSnapshotClassroomIdRef = useRef<string | null>(null)
   currentClassroomIdRef.current = classroom.id
 
   useEffect(() => {
@@ -106,12 +116,18 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       const requestId = loadRequestIdRef.current + 1
       loadRequestIdRef.current = requestId
       const requestedClassroomId = classroom.id
+      const hasCurrentSnapshot = entriesSnapshotClassroomIdRef.current === requestedClassroomId
       const isCurrentLoad = () => (
         loadRequestIdRef.current === requestId &&
         currentClassroomIdRef.current === requestedClassroomId
       )
 
-      setLoading(true)
+      setEntriesError(null)
+      if (!hasCurrentSnapshot) {
+        setLoading(true)
+        setHistoryEntries([])
+        setEntriesSnapshotClassroomId(null)
+      }
       try {
         const todayDate = getTodayInToronto()
         todayRef.current = todayDate
@@ -192,12 +208,16 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           setHistoryEntries(cached)
           const todayEntry = cached.find((e: Entry) => e.date === todayDate) || null
           applyEntryState(todayEntry)
+          entriesSnapshotClassroomIdRef.current = requestedClassroomId
+          setEntriesSnapshotClassroomId(requestedClassroomId)
           setLoading(false)
         }
 
         const entriesPromise = fetchStudentEntriesForClassroom(requestedClassroomId, { limit: historyLimit })
           .then(entries => {
             if (!isCurrentLoad()) return
+            entriesSnapshotClassroomIdRef.current = requestedClassroomId
+            setEntriesSnapshotClassroomId(requestedClassroomId)
             if (hasLocalEditSinceLoadRef.current) {
               setHistoryEntries(prev => {
                 if (!isCurrentLoad()) return prev
@@ -218,7 +238,9 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
         await Promise.all([entriesPromise, lessonPlanPromise])
       } catch (err) {
+        if (!isCurrentLoad()) return
         console.error('Error loading today tab:', err)
+        setEntriesError('The daily log could not be loaded.')
       } finally {
         if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === requestedClassroomId) {
           setLoading(false)
@@ -237,7 +259,16 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
         clearTimeout(throttledSaveTimeoutRef.current)
       }
     }
-  }, [classroom.id, historyLimit, onLessonPlanLoad])
+  }, [classroom.id, entriesRequestVersion, historyLimit, onLessonPlanLoad])
+
+  const retryEntries = useCallback(() => {
+    invalidateStudentEntriesForClassroom(classroom.id)
+    setEntriesError(null)
+    if (entriesSnapshotClassroomIdRef.current !== classroom.id) {
+      setLoading(true)
+    }
+    setEntriesRequestVersion((version) => version + 1)
+  }, [classroom.id])
 
   const updateHistoryEntries = useCallback((entry: Entry) => {
     setHistoryEntries(prev => {
@@ -544,12 +575,46 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   }, [conflictEntry, content, saveContent])
 
   const isClassDay = today ? isClassDayOnDate(classDays, today) : true
+  const hasCurrentEntriesSnapshot = entriesSnapshotClassroomId === classroom.id
 
-  if (loading) {
+  const blockingState = classDaysError && !hasClassDaysSnapshot ? (
+    <PageState
+      kind="error"
+      title="Class schedule unavailable"
+      description={classDaysError}
+      compact
+      action={(
+        <Button type="button" onClick={() => void refreshClassDays()}>
+          Try again
+        </Button>
+      )}
+    />
+  ) : entriesError && !hasCurrentEntriesSnapshot ? (
+    <PageState
+      kind="error"
+      title="Daily log unavailable"
+      description={entriesError}
+      compact
+      action={(
+        <Button type="button" onClick={retryEntries}>
+          Try again
+        </Button>
+      )}
+    />
+  ) : loading || classDaysLoading || !hasCurrentEntriesSnapshot ? (
+    <div className="flex justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : null
+
+  if (blockingState) {
+    if (layout === 'pane') {
+      return <div className="h-full min-h-0 overflow-y-auto">{blockingState}</div>
+    }
     return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
+      <PageLayout>
+        <PageContent>{blockingState}</PageContent>
+      </PageLayout>
     )
   }
 
@@ -569,6 +634,22 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
   const todayContent = (
     <PageStack>
+      {classDaysError && hasClassDaysSnapshot && (
+        <div role="alert" className="flex items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-4 py-3">
+          <p className="text-sm text-danger">The latest class schedule could not be loaded.</p>
+          <Button type="button" size="sm" variant="secondary" onClick={() => void refreshClassDays()}>
+            Try again
+          </Button>
+        </div>
+      )}
+      {entriesError && hasCurrentEntriesSnapshot && (
+        <div role="alert" className="flex items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-4 py-3">
+          <p className="text-sm text-danger">The latest daily log could not be loaded.</p>
+          <Button type="button" size="sm" variant="secondary" onClick={retryEntries}>
+            Try again
+          </Button>
+        </div>
+      )}
       <div className="bg-surface rounded-lg border border-border p-6">
         {!isClassDay ? (
           <div className="bg-page border border-border rounded-lg p-4 text-center">
@@ -581,6 +662,9 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
                 What did you do today?
               </label>
               <span
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
                 className={
                   'text-sm ' +
                   (saveStatus === 'saved'
@@ -605,7 +689,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
             {saveError && (
               <div className="space-y-2">
-                <p className="text-sm text-danger">{saveError}</p>
+                <p role="alert" className="text-sm text-danger">{saveError}</p>
                 {conflictEntry && (
                   <div className="flex flex-wrap gap-2">
                     <Button type="button" size="sm" variant="secondary" onClick={resolveConflict}>

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -97,7 +97,13 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   onDateChange,
   isActive = true,
 }: Props, ref) {
-  const { classDays, isLoading: classDaysLoading } = useClassDaysContext()
+  const {
+    classDays,
+    error: classDaysError,
+    hasLoadedSnapshot: hasClassDaysSnapshot,
+    isLoading: classDaysLoading,
+    refresh: refreshClassDays,
+  } = useClassDaysContext()
   const [logs, setLogs] = useState<LogRow[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -159,11 +165,11 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
   // Set initial date once class days are loaded from context
   useEffect(() => {
-    if (classDaysLoading) return
+    if (classDaysLoading || (classDaysError && !hasClassDaysSnapshot)) return
     if (selectedDate) return // Already initialized
     setSelectedDate(lastClassDate || addDaysToDateString(today, -1))
     // Do NOT setLoading(false) here — the logs fetch (Effect 3) handles it
-  }, [classDaysLoading, lastClassDate, selectedDate, today])
+  }, [classDaysError, classDaysLoading, hasClassDaysSnapshot, lastClassDate, selectedDate, today])
 
   useEffect(() => {
     function handleVisibilityChange() {
@@ -749,7 +755,19 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     </div>
   )
 
-  const workspace = loading ? (
+  const workspaceContent = classDaysError && !hasClassDaysSnapshot ? (
+    <PageState
+      kind="error"
+      title="Class schedule unavailable"
+      description={classDaysError}
+      compact
+      action={(
+        <Button type="button" onClick={() => void refreshClassDays()}>
+          Try again
+        </Button>
+      )}
+    />
+  ) : loading ? (
     showBlockingSpinner ? (
       <div className="flex justify-center py-12">
         <Spinner size="lg" />
@@ -880,6 +898,18 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       </div>
     )
   )
+
+  const workspace = classDaysError && hasClassDaysSnapshot ? (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <div role="alert" className="flex items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-4 py-3">
+        <p className="text-sm text-danger">The latest class schedule could not be loaded.</p>
+        <Button type="button" size="sm" variant="secondary" onClick={() => void refreshClassDays()}>
+          Try again
+        </Button>
+      </div>
+      {workspaceContent}
+    </div>
+  ) : workspaceContent
 
   return (
     <TeacherWorkSurfaceShell

--- a/src/components/StudentLogHistory.tsx
+++ b/src/components/StudentLogHistory.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '@/components/Spinner'
 import { entryHasContent } from '@/lib/attendance'
 import { fetchCachedJSON } from '@/lib/request-cache'
 import type { Entry } from '@/types'
+import { Button, PageState } from '@/ui'
 
 interface Props {
   studentId: string
@@ -31,8 +32,14 @@ export function StudentLogHistory({
 }: Props) {
   const [entries, setEntries] = useState<Entry[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const [requestVersion, setRequestVersion] = useState(0)
   const [hasMore, setHasMore] = useState(false)
   const selectedBlockRef = useRef<HTMLDivElement | null>(null)
+  const activeScopeRef = useRef(`${classroomId}:${studentId}`)
+  const loadMoreRequestIdRef = useRef(0)
+  activeScopeRef.current = `${classroomId}:${studentId}`
   const previewEntries = useMemo(
     () => normalizeEntries(initialEntries),
     [initialEntries]
@@ -44,10 +51,13 @@ export function StudentLogHistory({
 
   useEffect(() => {
     let cancelled = false
+    loadMoreRequestIdRef.current += 1
 
     setEntries(previewEntries)
     setHasMore(previewEntries.length === HISTORY_LIMIT)
     setLoading(previewEntries.length === 0)
+    setError(null)
+    setLoadMoreError(null)
 
     const params = new URLSearchParams({
       classroom_id: classroomId,
@@ -68,7 +78,9 @@ export function StudentLogHistory({
         setHasMore(fetched.length === HISTORY_LIMIT)
       })
       .catch(err => {
+        if (cancelled) return
         console.error('Error loading student history:', err)
+        setError('The student\'s log history could not be loaded.')
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -77,12 +89,25 @@ export function StudentLogHistory({
     return () => {
       cancelled = true
     }
-  }, [studentId, classroomId, previewEntries])
+  }, [studentId, classroomId, previewEntries, requestVersion])
+
+  function retryHistory() {
+    setError(null)
+    setLoading(entries.length === 0)
+    setRequestVersion((version) => version + 1)
+  }
 
   function loadMore() {
     if (entries.length === 0) return
+    const requestScope = `${classroomId}:${studentId}`
+    const requestId = loadMoreRequestIdRef.current + 1
+    loadMoreRequestIdRef.current = requestId
+    const isCurrentRequest = () => (
+      activeScopeRef.current === requestScope && loadMoreRequestIdRef.current === requestId
+    )
     const oldestDate = entries[entries.length - 1].date
     setLoading(true)
+    setLoadMoreError(null)
 
     const params = new URLSearchParams({
       classroom_id: classroomId,
@@ -98,14 +123,19 @@ export function StudentLogHistory({
       { errorMessage: 'Failed to load more history', ttlMs: HISTORY_CACHE_TTL_MS },
     )
       .then(data => {
+        if (!isCurrentRequest()) return
         const fetched: Entry[] = data.entries || []
         setEntries(prev => normalizeEntries([...prev, ...fetched]))
         setHasMore(fetched.length === HISTORY_LIMIT)
       })
       .catch(err => {
+        if (!isCurrentRequest()) return
         console.error('Error loading more history:', err)
+        setLoadMoreError('Older history could not be loaded.')
       })
-      .finally(() => setLoading(false))
+      .finally(() => {
+        if (isCurrentRequest()) setLoading(false)
+      })
   }
 
   const historyEntries = useMemo(() => {
@@ -118,7 +148,7 @@ export function StudentLogHistory({
     () => buildDisplayItems(historyEntries, selectedDateToHighlight, !selectedDisplayEntry),
     [historyEntries, selectedDateToHighlight, selectedDisplayEntry]
   )
-  const isEmpty = !selectedDateToHighlight && displayItems.length === 0 && !loading
+  const isEmpty = !selectedDateToHighlight && displayItems.length === 0 && !loading && !error
 
   useEffect(() => {
     if (!selectedDateToHighlight) return
@@ -127,6 +157,20 @@ export function StudentLogHistory({
 
   return (
     <div className="p-4 space-y-3">
+      {error && (
+        <PageState
+          kind="error"
+          title="History unavailable"
+          description={error}
+          compact
+          action={(
+            <Button type="button" size="sm" onClick={retryHistory}>
+              Try again
+            </Button>
+          )}
+        />
+      )}
+
       {isEmpty && (
         <p className="text-sm text-text-muted">No entries.</p>
       )}
@@ -148,7 +192,7 @@ export function StudentLogHistory({
         </div>
       )}
 
-      {hasMore && !loading && (
+      {hasMore && !loading && !loadMoreError && (
         <button
           type="button"
           onClick={loadMore}
@@ -156,6 +200,15 @@ export function StudentLogHistory({
         >
           Load more
         </button>
+      )}
+
+      {loadMoreError && (
+        <div role="alert" className="flex items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2">
+          <p className="text-sm text-danger">{loadMoreError}</p>
+          <Button type="button" size="sm" variant="secondary" onClick={loadMore}>
+            Try again
+          </Button>
+        </div>
       )}
     </div>
   )

--- a/src/contexts/ClassDaysContext.tsx
+++ b/src/contexts/ClassDaysContext.tsx
@@ -28,6 +28,14 @@ interface ClassDaysProviderProps {
  * Centralizes fetching and event listening to avoid multiple listeners.
  */
 export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderProps) {
+  return (
+    <ClassDaysProviderState key={classroomId} classroomId={classroomId}>
+      {children}
+    </ClassDaysProviderState>
+  )
+}
+
+function ClassDaysProviderState({ classroomId, children }: ClassDaysProviderProps) {
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [error, setError] = useState<string | null>(null)
   const [hasLoadedSnapshot, setHasLoadedSnapshot] = useState(false)

--- a/src/contexts/ClassDaysContext.tsx
+++ b/src/contexts/ClassDaysContext.tsx
@@ -10,6 +10,8 @@ import {
 
 interface ClassDaysContextValue {
   classDays: ClassDay[]
+  error: string | null
+  hasLoadedSnapshot: boolean
   isLoading: boolean
   refresh: () => Promise<void>
 }
@@ -27,12 +29,19 @@ interface ClassDaysProviderProps {
  */
 export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderProps) {
   const [classDays, setClassDays] = useState<ClassDay[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [hasLoadedSnapshot, setHasLoadedSnapshot] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const loadSequenceRef = useRef(0)
+  const hasLoadedDataRef = useRef(false)
 
   const loadClassDays = useCallback(async (options?: { force?: boolean }) => {
     const loadSequence = loadSequenceRef.current + 1
     loadSequenceRef.current = loadSequence
+    setError(null)
+    if (!hasLoadedDataRef.current) {
+      setIsLoading(true)
+    }
 
     try {
       if (options?.force) {
@@ -40,11 +49,15 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
       }
       const nextClassDays = await fetchClassDaysForClassroom(classroomId)
       if (loadSequenceRef.current === loadSequence) {
+        hasLoadedDataRef.current = true
+        setHasLoadedSnapshot(true)
         setClassDays(nextClassDays)
+        setError(null)
       }
     } catch (err) {
       if (loadSequenceRef.current === loadSequence) {
         console.error('Error loading class days:', err)
+        setError('The class schedule could not be loaded.')
       }
     } finally {
       if (loadSequenceRef.current === loadSequence) {
@@ -56,7 +69,10 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
   // Initial load
   useEffect(() => {
     loadSequenceRef.current += 1
+    hasLoadedDataRef.current = false
     setClassDays([])
+    setError(null)
+    setHasLoadedSnapshot(false)
     setIsLoading(true)
     loadClassDays()
   }, [loadClassDays])
@@ -76,7 +92,13 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
   }, [classroomId, loadClassDays])
 
   return (
-    <ClassDaysContext.Provider value={{ classDays, isLoading, refresh: () => loadClassDays({ force: true }) }}>
+    <ClassDaysContext.Provider value={{
+      classDays,
+      error,
+      hasLoadedSnapshot,
+      isLoading,
+      refresh: () => loadClassDays({ force: true }),
+    }}>
       {children}
     </ClassDaysContext.Provider>
   )

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -154,6 +154,8 @@ vi.mock('@/hooks/useClassDays', () => ({
   ClassDaysProvider: ({ children }: any) => <>{children}</>,
   useClassDaysContext: () => ({
     classDays: mockClassDays,
+    error: null,
+    hasLoadedSnapshot: true,
     isLoading: false,
     refresh: vi.fn(),
   }),

--- a/tests/components/StudentLogHistory.test.tsx
+++ b/tests/components/StudentLogHistory.test.tsx
@@ -228,6 +228,34 @@ describe('StudentLogHistory', () => {
     expect(screen.queryByText(/Selected date/)).not.toBeInTheDocument()
   })
 
+  it('shows a retryable error instead of an empty history after the read fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const recoveredEntry = entry({
+      id: 'recovered-history-entry',
+      student_id: 'student-retry',
+      classroom_id: 'classroom-retry',
+      text: 'Recovered history.',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(await mockJson({ error: 'History unavailable' }, false))
+      .mockResolvedValueOnce(await mockJson({ entries: [recoveredEntry] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <StudentLogHistory studentId="student-retry" classroomId="classroom-retry" />
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('History unavailable')
+    expect(screen.queryByText('No entries.')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('Recovered history.')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
+
   it('reuses cached exact history when a student is selected again', async () => {
     const exactEntry = entry({
       id: 'cached-entry',
@@ -296,5 +324,63 @@ describe('StudentLogHistory', () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it('ignores an older load-more response after the selected student changes', async () => {
+    const studentALatest = Array.from({ length: 10 }, (_, index) =>
+      entry({
+        id: `student-a-latest-${index}`,
+        student_id: 'student-a',
+        classroom_id: 'classroom-race',
+        date: `2026-03-${String(20 - index).padStart(2, '0')}`,
+        text: `Student A history ${index + 1}.`,
+      })
+    )
+    const studentBOwnEntry = entry({
+      id: 'student-b-entry',
+      student_id: 'student-b',
+      classroom_id: 'classroom-race',
+      text: 'Student B history.',
+    })
+    const studentAOlderEntry = entry({
+      id: 'student-a-older',
+      student_id: 'student-a',
+      classroom_id: 'classroom-race',
+      date: '2026-03-01',
+      text: 'Student A older history must not leak.',
+    })
+    const olderRequest = deferred<any>()
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('student_id=student-a') && url.includes('before_date=')) {
+        return olderRequest.promise
+      }
+      if (url.includes('student_id=student-a')) {
+        return mockJson({ entries: studentALatest })
+      }
+      if (url.includes('student_id=student-b')) {
+        return mockJson({ entries: [studentBOwnEntry] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = render(
+      <StudentLogHistory studentId="student-a" classroomId="classroom-race" />
+    )
+    await screen.findByText('Student A history 10.')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    view.rerender(
+      <StudentLogHistory studentId="student-b" classroomId="classroom-race" />
+    )
+    expect(await screen.findByText('Student B history.')).toBeInTheDocument()
+
+    olderRequest.resolve(await mockJson({ entries: [studentAOlderEntry] }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Student A older history must not leak.')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Student B history.')).toBeInTheDocument()
   })
 })

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -9,6 +9,18 @@ import type { Classroom, Entry } from '@/types'
 const getTodayInTorontoMock = vi.hoisted(() => vi.fn(() => '2025-12-16'))
 const invalidateStudentEntriesForClassroomMock = vi.hoisted(() => vi.fn())
 const redirectToLoginForReauthMock = vi.hoisted(() => vi.fn())
+const classDaysContextMock = vi.hoisted(() => ({
+  classDays: [
+    { id: 'd1', classroom_id: 'c1', date: '2025-12-16', prompt_text: null, is_class_day: true },
+    { id: 'd2', classroom_id: 'c1', date: '2025-05-06', prompt_text: null, is_class_day: true },
+    { id: 'd3', classroom_id: 'c1', date: '2025-05-11', prompt_text: null, is_class_day: true },
+  ],
+  error: null as string | null,
+  hasLoadedSnapshot: true,
+  isLoading: false,
+  refresh: vi.fn(),
+}))
+const defaultClassDays = [...classDaysContextMock.classDays]
 
 vi.mock('@/lib/timezone', () => ({
   getTodayInToronto: getTodayInTorontoMock,
@@ -74,15 +86,7 @@ vi.mock('@/ui', async (importOriginal) => {
 })
 
 vi.mock('@/hooks/useClassDays', () => ({
-  useClassDaysContext: () => ({
-    classDays: [
-      { id: 'd1', classroom_id: 'c1', date: '2025-12-16', prompt_text: null, is_class_day: true },
-      { id: 'd2', classroom_id: 'c1', date: '2025-05-06', prompt_text: null, is_class_day: true },
-      { id: 'd3', classroom_id: 'c1', date: '2025-05-11', prompt_text: null, is_class_day: true },
-    ],
-    isLoading: false,
-    refresh: vi.fn(),
-  }),
+  useClassDaysContext: () => classDaysContextMock,
 }))
 
 const classroom: Classroom = {
@@ -164,6 +168,11 @@ describe('StudentTodayTab history section', () => {
     invalidateCachedJSONMatching('student-entries:')
     invalidateCachedJSONMatching('student-lesson-plans:')
     getTodayInTorontoMock.mockReturnValue('2025-12-16')
+    classDaysContextMock.classDays = defaultClassDays
+    classDaysContextMock.error = null
+    classDaysContextMock.hasLoadedSnapshot = true
+    classDaysContextMock.isLoading = false
+    classDaysContextMock.refresh.mockReset()
     window.sessionStorage.clear()
     document.cookie = 'pika_student_today_history=; Max-Age=0; Path=/'
   })
@@ -236,6 +245,116 @@ describe('StudentTodayTab history section', () => {
 
     expect(await screen.findByText('No past logs yet')).toBeInTheDocument()
     expect(screen.queryByText('Tue Dec 16')).not.toBeInTheDocument()
+  })
+
+  it('shows a retryable entry error instead of an empty saved editor after the initial read fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let entriesRequests = 0
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        entriesRequests += 1
+        return entriesRequests === 1
+          ? mockJson({ error: 'Entries unavailable' }, false)
+          : mockJson({ entries })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lessonPlans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Daily log unavailable')
+    expect(screen.queryByLabelText('Write something...')).not.toBeInTheDocument()
+    expect(screen.queryByText('No past logs yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByDisplayValue(entries[0].text)).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(entriesRequests).toBe(2)
+    consoleError.mockRestore()
+  })
+
+  it('shows a retryable schedule error instead of reporting no class after class-days failure', async () => {
+    classDaysContextMock.classDays = []
+    classDaysContextMock.error = 'The class schedule could not be loaded.'
+    classDaysContextMock.hasLoadedSnapshot = false
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lessonPlans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Class schedule unavailable')
+    expect(screen.queryByText('No class today')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(classDaysContextMock.refresh).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the daily workspace visible when a schedule refresh fails', async () => {
+    classDaysContextMock.error = 'The class schedule could not be loaded.'
+    classDaysContextMock.hasLoadedSnapshot = true
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lessonPlans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The latest class schedule could not be loaded.'
+    )
+    expect(screen.getByDisplayValue(entries[0].text)).toBeInTheDocument()
+    expect(screen.getByText(entries[1].text)).toBeInTheDocument()
+    expect(screen.queryByText('Class schedule unavailable')).not.toBeInTheDocument()
+  })
+
+  it('does not paint the previous classroom log while the next classroom loads', async () => {
+    const secondEntriesRequest = deferred<any>()
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries })
+      }
+      if (url.startsWith(`/api/student/entries?classroom_id=${secondClassroom.id}&limit=12`)) {
+        return secondEntriesRequest.promise
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lessonPlans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = render(<StudentTodayTab classroom={classroom} />)
+    expect(await screen.findByDisplayValue(entries[0].text)).toBeInTheDocument()
+
+    view.rerender(<StudentTodayTab classroom={secondClassroom} />)
+
+    expect(screen.queryByDisplayValue(entries[0].text)).not.toBeInTheDocument()
+
+    secondEntriesRequest.resolve(await mockJson({ entries: [] }))
+    expect(await screen.findByText('No past logs yet')).toBeInTheDocument()
   })
 
   it('ignores stale entry and lesson-plan responses after classroom changes', async () => {
@@ -347,7 +466,10 @@ describe('StudentTodayTab history section', () => {
     render(<StudentTodayTab classroom={classroom} />)
 
     const editor = await screen.findByLabelText('Write something...')
-    expect(screen.getByText('Saved')).toBeInTheDocument()
+    const saveStatus = screen.getByText('Saved')
+    expect(saveStatus).toHaveAttribute('role', 'status')
+    expect(saveStatus).toHaveAttribute('aria-live', 'polite')
+    expect(saveStatus).toHaveAttribute('aria-atomic', 'true')
 
     fireEvent.change(editor, { target: { value: '' } })
 
@@ -397,6 +519,82 @@ describe('StudentTodayTab history section', () => {
 
     expect(await screen.findByText('Refreshed log from the server.')).toBeInTheDocument()
     expect(window.sessionStorage.getItem(cacheKey)).toContain('Refreshed log from the server.')
+  })
+
+  it('keeps cached entries available when a background refresh fails and retries', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
+    window.sessionStorage.setItem(cacheKey, JSON.stringify(entries))
+    let entriesRequests = 0
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?`)) {
+        entriesRequests += 1
+        return entriesRequests === 1
+          ? mockJson({ error: 'Entries unavailable' }, false)
+          : mockJson({ entries })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The latest daily log could not be loaded.'
+    )
+    expect(screen.getByDisplayValue(entries[0].text)).toBeInTheDocument()
+    expect(screen.getByText(entries[1].text)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+    expect(entriesRequests).toBe(2)
+    expect(screen.getByDisplayValue(entries[0].text)).toBeInTheDocument()
+    consoleError.mockRestore()
+  })
+
+  it('retains the session snapshot when a background retry also fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
+    window.sessionStorage.setItem(cacheKey, JSON.stringify(entries))
+    let entriesRequests = 0
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?`)) {
+        entriesRequests += 1
+        return mockJson({ error: 'Entries unavailable' }, false)
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = render(<StudentTodayTab classroom={classroom} />)
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The latest daily log could not be loaded.'
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await waitFor(() => expect(entriesRequests).toBe(2))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The latest daily log could not be loaded.'
+    )
+    expect(window.sessionStorage.getItem(cacheKey)).toContain(entries[0].text)
+
+    view.unmount()
+    render(<StudentTodayTab classroom={classroom} />)
+
+    expect(await screen.findByDisplayValue(entries[0].text)).toBeInTheDocument()
+    expect(window.sessionStorage.getItem(cacheKey)).toContain(entries[0].text)
+    consoleError.mockRestore()
   })
 
   it('does not overwrite local edits when the background refresh completes', async () => {

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -31,13 +31,18 @@ const classDaysMock = vi.hoisted(() => ({
       is_class_day: true,
     },
   ],
+  error: null as string | null,
+  hasLoadedSnapshot: true,
+  isLoading: false,
   refresh: vi.fn(),
 }))
 
 vi.mock('@/hooks/useClassDays', () => ({
   useClassDaysContext: () => ({
     classDays: classDaysMock.classDays,
-    isLoading: false,
+    error: classDaysMock.error,
+    hasLoadedSnapshot: classDaysMock.hasLoadedSnapshot,
+    isLoading: classDaysMock.isLoading,
     refresh: classDaysMock.refresh,
   }),
 }))
@@ -182,6 +187,9 @@ describe('TeacherAttendanceTab', () => {
     cleanup()
     todayMock.today = '2026-05-06'
     classDaysMock.classDays = [...classDaysMock.defaultClassDays]
+    classDaysMock.error = null
+    classDaysMock.hasLoadedSnapshot = true
+    classDaysMock.isLoading = false
     classDaysMock.refresh.mockReset()
     vi.unstubAllGlobals()
   })
@@ -272,6 +280,41 @@ describe('TeacherAttendanceTab', () => {
     expect(await screen.findByText('No students enrolled')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     consoleError.mockRestore()
+  })
+
+  it('shows a retryable schedule error instead of treating failed class days as a non-class day', async () => {
+    classDaysMock.classDays = []
+    classDaysMock.error = 'The class schedule could not be loaded.'
+    classDaysMock.hasLoadedSnapshot = false
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TeacherAttendanceTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Class schedule unavailable')
+    expect(screen.queryByText('Not a class day')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(classDaysMock.refresh).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the attendance table visible when a schedule refresh fails', async () => {
+    const fetchMock = mockLogsFetch()
+    const view = render(<TeacherAttendanceTab classroom={classroom} />)
+
+    expect(await screen.findByText(longLogText)).toBeInTheDocument()
+
+    classDaysMock.error = 'The class schedule could not be loaded.'
+    classDaysMock.hasLoadedSnapshot = true
+    view.rerender(<TeacherAttendanceTab classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The latest class schedule could not be loaded.'
+    )
+    expect(screen.getByText(longLogText)).toBeInTheDocument()
+    expect(screen.queryByText('Class schedule unavailable')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('moves quickly between today and the last class day from the date picker cluster', async () => {

--- a/tests/contexts/ClassDaysContext.test.tsx
+++ b/tests/contexts/ClassDaysContext.test.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from 'react'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -46,6 +47,30 @@ function ContextProbe({ label = 'probe' }: { label?: string }) {
 function ClassDaysProbe({ classroomId }: { classroomId: string }) {
   const classDays = useClassDays(classroomId)
   return <div data-testid="class-days-hook">{classDays.map((day) => day.date).join(',')}</div>
+}
+
+function SnapshotEffectProbe({
+  classroomId,
+  onObservation,
+}: {
+  classroomId: string
+  onObservation: (observation: {
+    classroomId: string
+    dates: string[]
+    hasLoadedSnapshot: boolean
+  }) => void
+}) {
+  const { classDays, hasLoadedSnapshot } = useClassDaysContext()
+
+  useLayoutEffect(() => {
+    onObservation({
+      classroomId,
+      dates: classDays.map((day) => day.date),
+      hasLoadedSnapshot,
+    })
+  }, [classDays, classroomId, hasLoadedSnapshot, onObservation])
+
+  return null
 }
 
 describe('ClassDaysProvider', () => {
@@ -160,6 +185,66 @@ describe('ClassDaysProvider', () => {
     expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-01')
     expect(screen.getByTestId('probe-snapshot')).toHaveTextContent('true')
     expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
+  })
+
+  it('resets the provider subtree before children observe a new classroom', async () => {
+    const classroomTwoLoad = deferred<{ class_days: ClassDay[] }>()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-01')] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => classroomTwoLoad.promise,
+      } as Response)
+    const observations: Array<{
+      classroomId: string
+      dates: string[]
+      hasLoadedSnapshot: boolean
+    }> = []
+    const onObservation = vi.fn((observation) => observations.push(observation))
+
+    const view = render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <SnapshotEffectProbe classroomId="classroom-1" onObservation={onObservation} />
+      </ClassDaysProvider>,
+    )
+
+    await waitFor(() => {
+      expect(observations).toContainEqual({
+        classroomId: 'classroom-1',
+        dates: ['2026-05-01'],
+        hasLoadedSnapshot: true,
+      })
+    })
+
+    view.rerender(
+      <ClassDaysProvider classroomId="classroom-2">
+        <SnapshotEffectProbe classroomId="classroom-2" onObservation={onObservation} />
+      </ClassDaysProvider>,
+    )
+
+    const classroomTwoObservations = observations.filter(
+      (item) => item.classroomId === 'classroom-2',
+    )
+    expect(classroomTwoObservations.length).toBeGreaterThan(0)
+    expect(classroomTwoObservations.every((item) => (
+      item.dates.length === 0 && !item.hasLoadedSnapshot
+    ))).toBe(true)
+
+    await act(async () => {
+      classroomTwoLoad.resolve({ class_days: [classDay('2026-06-02')] })
+    })
+
+    await waitFor(() => {
+      expect(observations).toContainEqual({
+        classroomId: 'classroom-2',
+        dates: ['2026-06-02'],
+        hasLoadedSnapshot: true,
+      })
+    })
   })
 
   it('ignores stale class-days responses that resolve after a forced refresh', async () => {

--- a/tests/contexts/ClassDaysContext.test.tsx
+++ b/tests/contexts/ClassDaysContext.test.tsx
@@ -29,11 +29,13 @@ function deferred<T>() {
 }
 
 function ContextProbe({ label = 'probe' }: { label?: string }) {
-  const { classDays, isLoading, refresh } = useClassDaysContext()
+  const { classDays, error, hasLoadedSnapshot, isLoading, refresh } = useClassDaysContext()
   return (
     <div>
       <div data-testid={`${label}-loading`}>{String(isLoading)}</div>
       <div data-testid={`${label}-dates`}>{classDays.map((day) => day.date).join(',')}</div>
+      <div data-testid={`${label}-error`}>{error ?? ''}</div>
+      <div data-testid={`${label}-snapshot`}>{String(hasLoadedSnapshot)}</div>
       <button type="button" onClick={() => void refresh()}>
         Refresh {label}
       </button>
@@ -122,6 +124,42 @@ describe('ClassDaysProvider', () => {
 
     await screen.findByText('2026-05-02')
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retains the last successful snapshot when a refresh fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-01')] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Class days unavailable' }),
+      } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    await screen.findByText('2026-05-01')
+    expect(screen.getByTestId('probe-snapshot')).toHaveTextContent('true')
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Refresh probe' }).click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-error')).toHaveTextContent(
+        'The class schedule could not be loaded.',
+      )
+    })
+    expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-01')
+    expect(screen.getByTestId('probe-snapshot')).toHaveTextContent('true')
+    expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
   })
 
   it('ignores stale class-days responses that resolve after a forced refresh', async () => {
@@ -247,12 +285,17 @@ describe('ClassDaysProvider', () => {
       expect(screen.getByTestId('probe-loading')).toHaveTextContent('false')
     })
     expect(screen.getByTestId('probe-dates')).toHaveTextContent('')
+    expect(screen.getByTestId('probe-snapshot')).toHaveTextContent('false')
+    expect(screen.getByTestId('probe-error')).toHaveTextContent(
+      'The class schedule could not be loaded.',
+    )
 
     await act(async () => {
       screen.getByRole('button', { name: 'Refresh probe' }).click()
     })
 
     await screen.findByText('2026-05-04')
+    expect(screen.getByTestId('probe-error')).toHaveTextContent('')
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
   })


### PR DESCRIPTION
## Summary
- distinguish cold class-schedule failures from valid empty/non-class-day states
- preserve cached teacher and student workspaces across failed background refreshes
- add retryable student entry/history failures, async scope guards, and Daily save announcements
- record Daily/Attendance desktop completion while leaving mobile workspace redesign and Gradex out of scope

## Verification
- `pnpm test` (407 files / 3,670 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (623 modules / 0 allowances)
- `pnpm build`
- Pika audit
- Playwright experience matrix (18 cases)
- exact error/stale-state screenshots at desktop and 390px, light/dark, teacher/student
- composite-widget checklist reviewed: yes; keyboard behavior covered: unchanged and existing tests pass; semantic state covered by tests: yes; remaining manual follow-up: none

## Review
- two independent initial reviewers found four stale-data/race issues
- all findings fixed in one remediation batch with regression coverage
- both targeted remediation re-reviews returned no actionable findings