### PR TITLE
Scope Daily history across student switches

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14523,3 +14523,23 @@
 - `pnpm check:architecture` (600 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:fb0c304e9220cbe355e0d542e1835591247d38684c85d746ec014e9e0c43e289 -->
+## 2026-07-15 — Gradebook workflow boundary
+
+**Completed:**
+- Reduced the gradebook API route from 1,127 lines to a transport-only handler backed by a feature-owned server workflow and Zod request contracts.
+- Preserved roster paging, 50-ID chunking, 1,000-row pagination, legacy-column fallbacks, assessment ordering, status calculation, summaries, and response shape while reusing the shared query-chunks infrastructure.
+- Moved `ApiError` into a framework-neutral module so server workflows do not depend on Next transport types; `api-handler` re-exports the same class for compatibility.
+- Tightened assessment weight input to string IDs and integer/decimal-digit weights, retained the intentional legacy-category `410`, and removed the route from the API Zod baseline.
+- Narrowed missing-table detection so partial migrations fail visibly instead of silently hiding tests; added route, validation, migration-compatibility, and architecture regressions.
+- Completed independent behavior/authorization and API/Zod review-fix rounds with no remaining findings. No UI, migration, dependency, or production changes.
+
+**Validation:**
+- Focused gradebook/API/error/architecture suites (5 files / 75 tests)
+- `pnpm check:architecture` (602 modules / 0 allowances)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm vitest run` (361 files / 3,322 tests)
+- `pnpm build`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,25 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-15 — Gradebook workflow boundary
-
-**Completed:**
-- Reduced the gradebook API route from 1,127 lines to a transport-only handler backed by a feature-owned server workflow and Zod request contracts.
-- Preserved roster paging, 50-ID chunking, 1,000-row pagination, legacy-column fallbacks, assessment ordering, status calculation, summaries, and response shape while reusing the shared query-chunks infrastructure.
-- Moved `ApiError` into a framework-neutral module so server workflows do not depend on Next transport types; `api-handler` re-exports the same class for compatibility.
-- Tightened assessment weight input to string IDs and integer/decimal-digit weights, retained the intentional legacy-category `410`, and removed the route from the API Zod baseline.
-- Narrowed missing-table detection so partial migrations fail visibly instead of silently hiding tests; added route, validation, migration-compatibility, and architecture regressions.
-- Completed independent behavior/authorization and API/Zod review-fix rounds with no remaining findings. No UI, migration, dependency, or production changes.
-
-**Validation:**
-- Focused gradebook/API/error/architecture suites (5 files / 75 tests)
-- `pnpm check:architecture` (602 modules / 0 allowances)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm vitest run` (361 files / 3,322 tests)
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-07-15 — Legacy quiz gradebook and archive compatibility decision
 
 **Completed:**
@@ -982,3 +963,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Remaining:**
 - Require exact-head PR CI and repository approval before merge.
 - Defer Daily/Attendance mobile history/table modes until the later mobile UX phase; continue Phase 3 with Tests desktop/accessibility while Gradex remains separately owned.
+
+## 2026-07-22 — Scoped Daily history across student switches
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5.6 Terra (high) - the fix is narrow, but correctness depends on React commit and effect ordering across student identity changes.
+
+**Completed:**
+- Remounted only the selected-student history state when the classroom/student scope changes, preventing the prior student's entries from committing beneath the next student's inspector heading.
+- Initialized each scoped history view from that student's preview so the privacy fix does not introduce a false empty-state flash.
+- Added a layout-effect regression test that observes the transition commit before passive effects run.
+- Preserved the existing teacher Daily table and inspector UI; no student, mobile, schema, migration, or production behavior changed.
+
+**Validation:**
+- `pnpm test` (407 files / 3,672 tests)
+- Focused Daily history and attendance suites (2 files / 25 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- Pika changed-file audit
+- Teacher Daily desktop screenshots after sequential student selection in light and dark themes; no horizontal overflow
+
+**Remaining:**
+- Require independent rereview and exact-head PR CI before merge.

--- a/src/components/StudentLogHistory.tsx
+++ b/src/components/StudentLogHistory.tsx
@@ -23,27 +23,33 @@ const HISTORY_LIMIT = 10
 const HISTORY_CACHE_TTL_MS = 60_000
 const EMPTY_ENTRIES: Entry[] = []
 
-export function StudentLogHistory({
+export function StudentLogHistory(props: Props) {
+  const scope = `${props.classroomId}:${props.studentId}`
+
+  return <StudentLogHistoryState key={scope} {...props} />
+}
+
+function StudentLogHistoryState({
   studentId,
   classroomId,
   selectedDate = null,
   selectedEntry = null,
   initialEntries = EMPTY_ENTRIES,
 }: Props) {
-  const [entries, setEntries] = useState<Entry[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
-  const [requestVersion, setRequestVersion] = useState(0)
-  const [hasMore, setHasMore] = useState(false)
-  const selectedBlockRef = useRef<HTMLDivElement | null>(null)
-  const activeScopeRef = useRef(`${classroomId}:${studentId}`)
-  const loadMoreRequestIdRef = useRef(0)
-  activeScopeRef.current = `${classroomId}:${studentId}`
   const previewEntries = useMemo(
     () => normalizeEntries(initialEntries),
     [initialEntries]
   )
+  const [entries, setEntries] = useState<Entry[]>(previewEntries)
+  const [loading, setLoading] = useState(previewEntries.length === 0)
+  const [error, setError] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const [requestVersion, setRequestVersion] = useState(0)
+  const [hasMore, setHasMore] = useState(previewEntries.length === HISTORY_LIMIT)
+  const selectedBlockRef = useRef<HTMLDivElement | null>(null)
+  const activeScopeRef = useRef(`${classroomId}:${studentId}`)
+  const loadMoreRequestIdRef = useRef(0)
+  activeScopeRef.current = `${classroomId}:${studentId}`
   const selectedDisplayEntry = selectedEntry && entryHasContent(selectedEntry)
     ? selectedEntry
     : null

--- a/tests/components/StudentLogHistory.test.tsx
+++ b/tests/components/StudentLogHistory.test.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
@@ -33,6 +34,40 @@ function deferred<T>() {
     reject = promiseReject
   })
   return { promise, resolve, reject }
+}
+
+function StudentHistoryCommitProbe({
+  studentId,
+  classroomId,
+  initialEntries,
+  selectedEntry,
+  onCommit,
+}: {
+  studentId: string
+  classroomId: string
+  initialEntries: Entry[]
+  selectedEntry: Entry
+  onCommit: (observation: { studentId: string; text: string }) => void
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    onCommit({
+      studentId,
+      text: containerRef.current?.textContent ?? '',
+    })
+  }, [onCommit, studentId])
+
+  return (
+    <div ref={containerRef}>
+      <StudentLogHistory
+        studentId={studentId}
+        classroomId={classroomId}
+        initialEntries={initialEntries}
+        selectedEntry={selectedEntry}
+      />
+    </div>
+  )
 }
 
 describe('StudentLogHistory', () => {
@@ -382,5 +417,55 @@ describe('StudentLogHistory', () => {
       expect(screen.queryByText('Student A older history must not leak.')).not.toBeInTheDocument()
     })
     expect(screen.getByText('Student B history.')).toBeInTheDocument()
+  })
+
+  it('never commits the previous student history under the next student scope', () => {
+    const studentAEntry = entry({
+      id: 'student-a-commit-entry',
+      student_id: 'student-a',
+      classroom_id: 'classroom-commit',
+      text: 'Student A private history.',
+    })
+    const studentBEntry = entry({
+      id: 'student-b-commit-entry',
+      student_id: 'student-b',
+      classroom_id: 'classroom-commit',
+      text: 'Student B current history.',
+    })
+    const requests = new Map<string, ReturnType<typeof deferred<any>>>()
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const studentId = new URL(String(input), 'http://localhost').searchParams.get('student_id') ?? ''
+      const request = deferred<any>()
+      requests.set(studentId, request)
+      return request.promise
+    }))
+    const observations: Array<{ studentId: string; text: string }> = []
+    const onCommit = vi.fn((observation) => observations.push(observation))
+
+    const view = render(
+      <StudentHistoryCommitProbe
+        studentId="student-a"
+        classroomId="classroom-commit"
+        initialEntries={[studentAEntry]}
+        selectedEntry={studentAEntry}
+        onCommit={onCommit}
+      />
+    )
+
+    view.rerender(
+      <StudentHistoryCommitProbe
+        studentId="student-b"
+        classroomId="classroom-commit"
+        initialEntries={[studentBEntry]}
+        selectedEntry={studentBEntry}
+        onCommit={onCommit}
+      />
+    )
+
+    const studentBCommit = observations.find((observation) => observation.studentId === 'student-b')
+    expect(studentBCommit?.text).toContain('Student B current history.')
+    expect(studentBCommit?.text).not.toContain('Student A private history.')
+    expect(requests.has('student-a')).toBe(true)
+    expect(requests.has('student-b')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- remount selected-student history state when classroom/student identity changes
- initialize the new scope from its own history preview
- add a commit-phase regression test that rejects cross-student stale content

## Verification
- pnpm test (407 files / 3,672 tests)
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm check:architecture
- pnpm build
- Pika changed-file audit
- teacher Daily desktop visual verification in light and dark themes