### PR TITLE
Harden Tests list loading states

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,7 +5,7 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 ## Current Focus
 
 - Migrations 001-099 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
-- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment and Daily/Attendance desktop/accessibility work is complete; mobile UX is deferred, Gradex is owned by a separate session, and Tests desktop/accessibility is next.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment, Daily/Attendance desktop/accessibility, and Tests list reliability work is complete; mobile UX is deferred, Gradex is owned by a separate session, and Tests authoring/grading separation is next.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14566,3 +14566,23 @@
 - `pnpm check:architecture` (602 modules / 0 allowances)
 - `bash -n scripts/check-classroom-archive-restore-database.sh`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:99346d1f3e24951e57877768ad838147f0e9fceb6ba95bd19413d23321e783f9 -->
+## 2026-07-15 — Legacy quiz alias retirement
+
+**Completed:**
+- Removed unused quiz server access/re-export modules, quiz-named assessment helper aliases, zero-caller `Quiz*` domain/draft/markdown type aliases, and obsolete test factories.
+- Preserved persisted quiz tables/discriminants, archive resources, draft synchronization, markdown behavior, API payload aliases, gradebook tombstones, URLs, and UI compatibility props.
+- Added a TypeScript module-resolution/export-graph regression that prevents retired modules or public aliases from returning through direct exports, re-exports, or replacement index modules.
+- Removed stale Vitest coverage thresholds for deleted quiz modules and API routes, and corrected architecture/cleanup documentation.
+- Completed independent behavior and architecture/config review-fix loops; six findings were fixed and final rereviews returned no findings. No UI, migration, dependency, or production changes.
+
+**Validation:**
+- Focused assessment/access/architecture suites (4 files / 90 tests)
+- `pnpm vitest run` (361 files / 3,308 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (599 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,25 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-15 — Legacy quiz alias retirement
-
-**Completed:**
-- Removed unused quiz server access/re-export modules, quiz-named assessment helper aliases, zero-caller `Quiz*` domain/draft/markdown type aliases, and obsolete test factories.
-- Preserved persisted quiz tables/discriminants, archive resources, draft synchronization, markdown behavior, API payload aliases, gradebook tombstones, URLs, and UI compatibility props.
-- Added a TypeScript module-resolution/export-graph regression that prevents retired modules or public aliases from returning through direct exports, re-exports, or replacement index modules.
-- Removed stale Vitest coverage thresholds for deleted quiz modules and API routes, and corrected architecture/cleanup documentation.
-- Completed independent behavior and architecture/config review-fix loops; six findings were fixed and final rereviews returned no findings. No UI, migration, dependency, or production changes.
-
-**Validation:**
-- Focused assessment/access/architecture suites (4 files / 90 tests)
-- `pnpm vitest run` (361 files / 3,308 tests)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (599 modules / 0 allowances)
-- Pika pre-commit audit
-- `git diff --check`
-
 ## 2026-07-15 — Legacy quiz draft alias retirement
 
 **Completed:**
@@ -985,3 +966,31 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Require exact-head PR CI and normal protected merge into `main`.
+
+## 2026-07-22 — Hardened Tests list read states
+
+**Risk profile:** workspace-state
+
+**Model recommendation:** GPT-5.6 Terra (high) - the slice crosses cached teacher/student lists, controlled workspace URLs, classroom transitions, and asynchronous retry boundaries.
+
+**Completed:**
+- Added explicit teacher and student Tests list loading, cold-error, successful-empty, and failed-refresh contracts with retry controls.
+- Preserved the last valid list when refresh fails, rejected non-successful student list responses, and replaced one-off refresh cache keys with canonical invalidation.
+- Scoped rendered list snapshots and errors to the active classroom so another classroom's tests cannot paint during navigation.
+- Kept controlled teacher test URLs intact until a successful list snapshot proves the selected test is invalid.
+- Preserved the existing desktop list-first composition. Mobile UX, Gradex, schema, migrations, and production state were unchanged.
+
+**Validation:**
+- Focused teacher/student Tests list suites (3 files / 110 tests)
+- Full repository suite (407 files / 3,680 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit and composite-widget accessibility checklist
+- Playwright desktop matrix for both roles in light/dark across normal, cold-error, and preserved-refresh-error states (12 captures; no horizontal overflow)
+- `git diff --check`
+
+**Remaining:**
+- Require independent review and exact-head PR CI before merge.
+- Continue Tests with authoring/grading mode separation; defer mobile navigation and Gradex to their separately owned phases.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -978,19 +978,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Preserved the last valid list when refresh fails, rejected non-successful student list responses, and replaced one-off refresh cache keys with canonical invalidation.
 - Scoped rendered list snapshots and errors to the active classroom so another classroom's tests cannot paint during navigation.
 - Kept controlled teacher test URLs intact until a successful list snapshot proves the selected test is invalid.
+- Resolved independent review feedback by moving focus from a replaced Retry button to a stable named Tests region for both failed and successful retries.
 - Preserved the existing desktop list-first composition. Mobile UX, Gradex, schema, migrations, and production state were unchanged.
 
 **Validation:**
 - Focused teacher/student Tests list suites (3 files / 110 tests)
-- Full repository suite (407 files / 3,680 tests)
+- Full repository suite before the focus-only remediation (407 files / 3,680 tests); exact-head PR CI is required
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm check:architecture` (623 modules / 0 allowances)
 - `pnpm build`
 - Pika changed-file audit and composite-widget accessibility checklist
 - Playwright desktop matrix for both roles in light/dark across normal, cold-error, and preserved-refresh-error states (12 captures; no horizontal overflow)
+- Post-remediation teacher/student desktop light/dark captures (4 captures; no layout change or horizontal overflow)
 - `git diff --check`
 
 **Remaining:**
-- Require independent review and exact-head PR CI before merge.
+- Require targeted remediation review and exact-head PR CI before merge.
 - Continue Tests with authoring/grading mode separation; defer mobile navigation and Gradex to their separately owned phases.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -184,8 +184,15 @@ Daily and attendance progress:
 - Student Daily save status is a polite atomic live region and save failures are announced. Existing Toronto midnight, DST, quick-jump, stale-mounted-save, and API timing tests remain the timestamp evidence.
 - Remaining Daily/Attendance work is limited to the deferred mobile history/table workspace modes.
 
+Tests progress:
+
+- Teacher and student Tests lists now distinguish loading, cold failure, successful empty, and failed refresh states. Cold failures offer an explicit retry instead of claiming that no tests exist.
+- Failed refreshes retain the last valid list with a compact retry warning, while classroom-scoped snapshots and request guards prevent another classroom's tests from painting in the active view.
+- Teacher controlled test URLs remain intact until a successful list snapshot proves that the selected test is invalid. Existing list-first teacher and student compositions are unchanged.
+- Remaining Tests work is authoring/grading mode separation, standalone preview authorization and framing, accessible flag/save announcements, and the deferred mobile navigation treatment.
+
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
-2. Tests: list errors, authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, accessible flags/save status.
+2. Tests: completed list errors; remaining authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, and accessible flags/save status.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.
 4. Dashboard: teacher-owned entry detail, responsive summary-first attendance, and removal of invalid classroom commands.
 5. Roster: mobile row detail, keyboard table behavior, bulk-action recovery, and counselor-field access.

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -11,10 +11,10 @@ import {
   getTestStatusBadgeClass,
   TEST_EXIT_BURST_WINDOW_MS,
 } from '@/lib/tests'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { StudentTestForm } from '@/components/StudentTestForm'
 import { StudentTestResults } from '@/components/StudentTestResults'
-import { Button, ConfirmDialog, EmptyState } from '@/ui'
+import { Button, ConfirmDialog, EmptyState, PageState } from '@/ui'
 import { readTestFromPayload, readTestsFromPayload } from '@/lib/test-api-contract'
 import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
@@ -251,6 +251,8 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const notifications = useStudentNotifications()
   const [tests, setTests] = useState<StudentTestView[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadedTestsScope, setLoadedTestsScope] = useState<string | null>(null)
+  const [listErrorState, setListErrorState] = useState<{ scope: string; message: string } | null>(null)
   const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
   const [focusSummary, setFocusSummary] = useState<TestFocusSummary | null>(null)
   const [selectedTest, setSelectedTest] = useState<{
@@ -288,6 +290,10 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const currentScopeRef = useRef({ classroomId: classroom.id, assessmentType })
   const isTestsView = true
   const apiBasePath = '/api/student/tests'
+  const currentTestsScope = `${assessmentType}:${classroom.id}`
+  const hasCurrentTestsSnapshot = loadedTestsScope === currentTestsScope
+  const visibleTests = hasCurrentTestsSnapshot ? tests : []
+  const listError = listErrorState?.scope === currentTestsScope ? listErrorState.message : null
   currentScopeRef.current = { classroomId: classroom.id, assessmentType }
   const focusEnabled = useMemo(() => {
     if (!selectedTest) return false
@@ -369,19 +375,26 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
     const classroomId = classroom.id
     const viewAssessmentType = assessmentType
     const basePath = apiBasePath
+    const requestScope = `${viewAssessmentType}:${classroomId}`
+    const cacheKey = `student-assessments:${viewAssessmentType}:${classroomId}`
     const requestId = listRequestIdRef.current + 1
     listRequestIdRef.current = requestId
+    if (options.forceRefresh) {
+      invalidateCachedJSON(cacheKey)
+    }
     setLoading(true)
+    setListErrorState((current) => current?.scope === requestScope ? null : current)
     try {
       const query = new URLSearchParams({ classroom_id: classroomId })
       const data = await fetchJSONWithCache<StudentTestListResponse>(
-        options.forceRefresh
-          ? `student-assessments:${viewAssessmentType}:${classroomId}:refresh:${requestId}`
-          : `student-assessments:${viewAssessmentType}:${classroomId}`,
+        cacheKey,
         async () => {
-          // fetchJSONWithCache wraps this repeated GET; force refreshes use one-off keys.
           const res = await fetch(`${basePath}?${query.toString()}`)
-          return res.json()
+          const payload = await res.json().catch(() => null) as StudentTestListResponse & { error?: string } | null
+          if (!res.ok) {
+            throw new Error(payload?.error || 'Failed to load tests')
+          }
+          return payload ?? {}
         },
         0,
       )
@@ -393,6 +406,8 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
         return
       }
       setTests(readTestsFromPayload(data))
+      setLoadedTestsScope(requestScope)
+      setListErrorState(null)
     } catch (err) {
       if (
         listRequestIdRef.current === requestId &&
@@ -400,6 +415,10 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
         currentScopeRef.current.assessmentType === viewAssessmentType
       ) {
         console.error('Error loading tests:', err)
+        setListErrorState({
+          scope: requestScope,
+          message: err instanceof Error ? err.message : 'Failed to load tests',
+        })
       }
     } finally {
       if (
@@ -411,6 +430,10 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
       }
     }
   }, [apiBasePath, assessmentType, classroom.id])
+
+  const retryTests = useCallback(() => {
+    void loadTests({ forceRefresh: true })
+  }, [loadTests])
 
   useEffect(() => {
     loadTests()
@@ -1164,16 +1187,8 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
     }
   }, [logRouteExitAttempt])
 
-  if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
-    )
-  }
-
   const renderAssessmentList = (showSelectionState: boolean) => {
-    if (tests.length === 0) {
+    if (visibleTests.length === 0) {
       return (
         <p className="text-text-muted text-center py-8">
           No tests available.
@@ -1183,7 +1198,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
 
     return (
       <PageStack>
-        {tests.map((test) => {
+        {visibleTests.map((test) => {
           const isSelected = selectedTestId === test.id
 
           return (
@@ -1332,6 +1347,9 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
         )}
 
         <PageContent className={showSplitExamShell ? 'flex-1 min-h-0 px-0 pt-1' : 'flex-1 min-h-0'}>
+          {hasCurrentTestsSnapshot && loading ? (
+            <span role="status" className="sr-only">Refreshing tests</span>
+          ) : null}
           <div
             aria-hidden={showNotMaximizedWarning}
             className={`mx-auto h-full w-full ${
@@ -1613,14 +1631,40 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                   </section>
                 </div>
             ) : !hasSelectedTest ? (
-                tests.length === 0 ? (
-                  <EmptyState
-                    title="No tests available."
-                    description="When your teacher publishes a test, it will show up here."
-                  />
+                !hasCurrentTestsSnapshot ? (
+                  listError ? (
+                    <PageState
+                      kind="error"
+                      title="Tests unavailable"
+                      description="Pika couldn't load this classroom's tests. Nothing was changed."
+                      action={<Button type="button" onClick={retryTests}>Retry</Button>}
+                    />
+                  ) : (
+                    <PageState kind="loading" title="Loading tests" />
+                  )
                 ) : (
-                  <div className="min-w-0 h-full flex flex-col max-w-none">
-                    {renderAssessmentList(false)}
+                  <div className="space-y-3">
+                    {listError ? (
+                      <div
+                        role="alert"
+                        className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger"
+                      >
+                        <span>Tests could not be refreshed. Showing the last loaded list.</span>
+                        <Button type="button" variant="secondary" size="sm" onClick={retryTests}>
+                          Retry
+                        </Button>
+                      </div>
+                    ) : null}
+                    {visibleTests.length === 0 ? (
+                      <EmptyState
+                        title="No tests available."
+                        description="When your teacher publishes a test, it will show up here."
+                      />
+                    ) : (
+                      <div className="min-w-0 h-full flex flex-col max-w-none">
+                        {renderAssessmentList(false)}
+                      </div>
+                    )}
                   </div>
                 )
             ) : selectedTestId && loadingTest ? (

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -286,6 +286,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const sessionStatusInFlightRef = useRef(false)
   const listRequestIdRef = useRef(0)
   const detailRequestIdRef = useRef(0)
+  const testsRegionRef = useRef<HTMLDivElement>(null)
   const assessmentType: TestAssessmentType = 'test'
   const currentScopeRef = useRef({ classroomId: classroom.id, assessmentType })
   const isTestsView = true
@@ -432,6 +433,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   }, [apiBasePath, assessmentType, classroom.id])
 
   const retryTests = useCallback(() => {
+    testsRegionRef.current?.focus()
     void loadTests({ forceRefresh: true })
   }, [loadTests])
 
@@ -1351,8 +1353,12 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
             <span role="status" className="sr-only">Refreshing tests</span>
           ) : null}
           <div
+            ref={testsRegionRef}
+            role="region"
+            aria-label="Tests"
+            tabIndex={-1}
             aria-hidden={showNotMaximizedWarning}
-            className={`mx-auto h-full w-full ${
+            className={`mx-auto h-full w-full focus:outline-none ${
               showSplitExamShell || !hasSelectedTest ? 'max-w-none' : 'max-w-3xl'
             }`}
             style={showNotMaximizedWarning ? { visibility: 'hidden' } : undefined}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -296,6 +296,7 @@ export function TeacherTestsTab({
   })
   const latestCreateTestRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
+  const testsRegionRef = useRef<HTMLDivElement>(null)
   const previousClassroomIdRef = useRef(classroom.id)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
 
@@ -365,6 +366,10 @@ export function TeacherTestsTab({
     selectedTestDraftSummary,
     apiBasePath,
   })
+  const handleRetryTests = useCallback(() => {
+    testsRegionRef.current?.focus()
+    void retryTests()
+  }, [retryTests])
   const [gradingInfo, setGradingInfo] = useState('')
   const [gradingWarning, setGradingWarning] = useState('')
   const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
@@ -2547,7 +2552,7 @@ export function TeacherTestsTab({
         title="Tests unavailable"
         description="Pika couldn't load this classroom's tests. Nothing was changed."
         compact
-        action={<Button type="button" onClick={() => void retryTests()}>Retry</Button>}
+        action={<Button type="button" onClick={handleRetryTests}>Retry</Button>}
       />
     ) : (
       <PageState kind="loading" title="Loading tests" compact />
@@ -2561,7 +2566,7 @@ export function TeacherTestsTab({
           className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger"
         >
           <span>Tests could not be refreshed. Showing the last loaded list.</span>
-          <Button type="button" variant="secondary" size="sm" onClick={() => void retryTests()}>
+          <Button type="button" variant="secondary" size="sm" onClick={handleRetryTests}>
             Retry
           </Button>
         </div>
@@ -2596,7 +2601,7 @@ export function TeacherTestsTab({
         title="Tests unavailable"
         description="Pika couldn't load this classroom's tests. Nothing was changed."
         compact
-        action={<Button type="button" onClick={() => void retryTests()}>Retry</Button>}
+        action={<Button type="button" onClick={handleRetryTests}>Retry</Button>}
       />
     ) : (
       <PageState kind="loading" title="Loading tests" compact />
@@ -2637,15 +2642,23 @@ export function TeacherTestsTab({
 
   return (
     <>
-      <TeacherWorkSurfaceShell
-        state={workspaceState === 'selected' ? 'workspace' : 'summary'}
-        primary={primaryContent}
-        feedback={feedback}
-        summary={summaryContent}
-        workspace={workspaceContent}
-        workspaceFrame="standalone"
-        workspaceFrameClassName="min-h-[360px] border-0 bg-page"
-      />
+      <div
+        ref={testsRegionRef}
+        role="region"
+        aria-label="Tests"
+        tabIndex={-1}
+        className="h-full min-h-0 focus:outline-none"
+      >
+        <TeacherWorkSurfaceShell
+          state={workspaceState === 'selected' ? 'workspace' : 'summary'}
+          primary={primaryContent}
+          feedback={feedback}
+          summary={summaryContent}
+          workspace={workspaceContent}
+          workspaceFrame="standalone"
+          workspaceFrameClassName="min-h-[360px] border-0 bg-page"
+        />
+      </div>
 
       <DialogPanel
         isOpen={isTestEditorOpen}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -73,6 +73,7 @@ import {
   DialogPanel,
   EmptyState,
   KeyboardNavigableTable,
+  PageState,
   RefreshingIndicator,
   Select,
   SplitButton,
@@ -354,7 +355,10 @@ export function TeacherTestsTab({
     setTests,
     visibleTests,
     loading,
+    error: testsLoadError,
+    hasLoadedSnapshot: hasTestsSnapshot,
     loadTests,
+    retryTests,
   } = useTeacherTestList({
     classroomId: classroom.id,
     selectedTestId,
@@ -814,12 +818,12 @@ export function TeacherTestsTab({
   }, [selectedTestId, selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
-    if (!selectedTestId || loading) return
+    if (!selectedTestId || !hasTestsSnapshot) return
     if (visibleTests.some((test) => test.id === selectedTestId)) return
 
     clearTestWorkspace({ replace: true })
     clearBatchSelection()
-  }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, visibleTests])
+  }, [clearBatchSelection, clearTestWorkspace, hasTestsSnapshot, selectedTestId, visibleTests])
 
   useEffect(() => {
     setSelectedTestDraftSummary(null)
@@ -2501,11 +2505,7 @@ export function TeacherTestsTab({
     </>
   )
 
-  const summaryContent = loading ? (
-    <div className="flex justify-center py-12">
-      <Spinner size="lg" />
-    </div>
-  ) : visibleTests.length === 0 ? (
+  const testListContent = visibleTests.length === 0 ? (
     <EmptyState
       title="No tests yet"
       description="Create a test to get started."
@@ -2540,6 +2540,36 @@ export function TeacherTestsTab({
     </DndContext>
   )
 
+  const summaryContent = !hasTestsSnapshot ? (
+    testsLoadError ? (
+      <PageState
+        kind="error"
+        title="Tests unavailable"
+        description="Pika couldn't load this classroom's tests. Nothing was changed."
+        compact
+        action={<Button type="button" onClick={() => void retryTests()}>Retry</Button>}
+      />
+    ) : (
+      <PageState kind="loading" title="Loading tests" compact />
+    )
+  ) : (
+    <div className="space-y-3">
+      {loading ? <RefreshingIndicator label="Refreshing tests" /> : null}
+      {testsLoadError ? (
+        <div
+          role="alert"
+          className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger"
+        >
+          <span>Tests could not be refreshed. Showing the last loaded list.</span>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void retryTests()}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+      {testListContent}
+    </div>
+  )
+
   const gradingInspector = selectedTest && selectedStudentId ? (
     <TestStudentGradingPanel
       testId={selectedTest.id}
@@ -2559,7 +2589,19 @@ export function TeacherTestsTab({
     }
   }, [navigateTestWorkspace, selectedTestId, selectedWorkspaceTab])
 
-  const workspaceContent = !selectedTest ? (
+  const workspaceContent = !hasTestsSnapshot ? (
+    testsLoadError ? (
+      <PageState
+        kind="error"
+        title="Tests unavailable"
+        description="Pika couldn't load this classroom's tests. Nothing was changed."
+        compact
+        action={<Button type="button" onClick={() => void retryTests()}>Retry</Button>}
+      />
+    ) : (
+      <PageState kind="loading" title="Loading tests" compact />
+    )
+  ) : !selectedTest ? (
     <div className="flex flex-1 justify-center py-12">
       <Spinner size="lg" />
     </div>

--- a/src/hooks/useTeacherTestList.ts
+++ b/src/hooks/useTeacherTestList.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
-import { fetchCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { readTestsFromPayload } from '@/lib/test-api-contract'
 import { applyTestSummaryPatchToTest } from '@/lib/test-summary-patch'
 import type { AssessmentEditorSummaryUpdate, TestAssessmentWithStats } from '@/types'
@@ -23,7 +23,10 @@ export type UseTeacherTestListResult = {
   setTests: Dispatch<SetStateAction<TestAssessmentWithStats[]>>
   visibleTests: TestAssessmentWithStats[]
   loading: boolean
+  error: string | null
+  hasLoadedSnapshot: boolean
   loadTests: () => Promise<void>
+  retryTests: () => Promise<void>
 }
 
 export function useTeacherTestList({
@@ -40,10 +43,12 @@ export function useTeacherTestList({
   const [tests, setTests] = useState<TestAssessmentWithStats[]>([])
   const [loadedTestsClassroomId, setLoadedTestsClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [errorState, setErrorState] = useState<{ classroomId: string; message: string } | null>(null)
 
   currentClassroomIdRef.current = classroomId
 
   const hasCurrentTests = loadedTestsClassroomId === classroomId
+  const error = errorState?.classroomId === classroomId ? errorState.message : null
   const visibleTests = useMemo(
     () => (hasCurrentTests ? tests : []),
     [hasCurrentTests, tests],
@@ -59,6 +64,7 @@ export function useTeacherTestList({
     )
 
     setLoading(true)
+    setErrorState((current) => current?.classroomId === requestedClassroomId ? null : current)
     try {
       const query = new URLSearchParams({ classroom_id: requestedClassroomId })
       const data = await fetchCachedJSON<TeacherTestListResponse>(
@@ -81,17 +87,25 @@ export function useTeacherTestList({
           : loadedTests,
       )
       setLoadedTestsClassroomId(requestedClassroomId)
+      setErrorState(null)
     } catch (error) {
       if (!isCurrentRequest()) return
       console.error('Error loading tests:', error)
-      setTests([])
-      setLoadedTestsClassroomId(requestedClassroomId)
+      setErrorState({
+        classroomId: requestedClassroomId,
+        message: error instanceof Error ? error.message : 'Failed to load tests',
+      })
     } finally {
       if (isCurrentRequest()) {
         setLoading(false)
       }
     }
   }, [apiBasePath, classroomId])
+
+  const retryTests = useCallback(async () => {
+    invalidateCachedJSON(`teacher-tests:${classroomId}`)
+    await loadTests()
+  }, [classroomId, loadTests])
 
   useEffect(() => {
     selectedTestIdRef.current = selectedTestId
@@ -121,6 +135,9 @@ export function useTeacherTestList({
     setTests,
     visibleTests,
     loading,
+    error,
+    hasLoadedSnapshot: hasCurrentTests,
     loadTests,
+    retryTests,
   }
 }

--- a/tests/components/StudentTestsTab.test.tsx
+++ b/tests/components/StudentTestsTab.test.tsx
@@ -55,8 +55,8 @@ describe('StudentTestsTab exam mode', () => {
     return { promise, resolve, reject }
   }
 
-  function jsonResponse(body: unknown): Response {
-    return { ok: true, json: async () => body } as Response
+  function jsonResponse(body: unknown, ok = true): Response {
+    return { ok, json: async () => body } as Response
   }
 
   function queueTestList() {
@@ -154,6 +154,93 @@ describe('StudentTestsTab exam mode', () => {
     fireEvent.click(screen.getByText('Legacy-Keyed Test'))
 
     expect(await screen.findByText('1 question · 1 pt total')).toBeInTheDocument()
+  })
+
+  it('shows a retryable error instead of an empty state when the tests list fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Database unavailable' }, false))
+      .mockResolvedValueOnce(jsonResponse({
+        tests: [{
+          id: 'test-recovered',
+          title: 'Recovered Test',
+          assessment_type: 'test',
+          status: 'active',
+          show_results: false,
+          position: 0,
+          student_status: 'not_started',
+        }],
+      }))
+
+    render(<StudentTestsTab classroom={classroom} assessmentType="test" />)
+
+    expect(await screen.findByText('Tests unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('No tests available.')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Recovered Test')).toBeInTheDocument()
+    expect(screen.queryByText('Tests unavailable')).not.toBeInTheDocument()
+  })
+
+  it('keeps the current list visible when a background refresh fails', async () => {
+    queueTestList()
+    queueTestDetail()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'Refresh failed' }, false))
+
+    render(<StudentTestsTab classroom={classroom} assessmentType="test" />)
+
+    fireEvent.click(await screen.findByText('Midterm Test'))
+    expect(await screen.findByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to tests' }))
+
+    expect(await screen.findByText('Midterm Test')).toBeInTheDocument()
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Tests could not be refreshed. Showing the last loaded list.',
+    )
+    expect(screen.queryByText('No tests available.')).not.toBeInTheDocument()
+  })
+
+  it('does not paint the previous classroom list while the next classroom loads', async () => {
+    const firstClassroom = createMockClassroom({ id: 'classroom-a', title: 'Classroom A' })
+    const secondClassroom = createMockClassroom({ id: 'classroom-b', title: 'Classroom B' })
+    const secondList = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=classroom-a')) {
+        return Promise.resolve(jsonResponse({
+          tests: [{
+            id: 'test-old',
+            title: 'Previous Classroom Test',
+            assessment_type: 'test',
+            status: 'active',
+            show_results: false,
+            position: 0,
+            student_status: 'not_started',
+          }],
+        }))
+      }
+      if (url.includes('/api/student/tests?classroom_id=classroom-b')) return secondList.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const { rerender } = render(
+      <StudentTestsTab classroom={firstClassroom} assessmentType="test" />
+    )
+
+    expect(await screen.findByText('Previous Classroom Test')).toBeInTheDocument()
+
+    rerender(<StudentTestsTab classroom={secondClassroom} assessmentType="test" />)
+
+    expect(screen.queryByText('Previous Classroom Test')).not.toBeInTheDocument()
+    expect(screen.getByText('Loading tests')).toBeInTheDocument()
+
+    await act(async () => {
+      secondList.resolve(jsonResponse({ tests: [] }))
+      await secondList.promise
+    })
+
+    expect(await screen.findByText('No tests available.')).toBeInTheDocument()
   })
 
   it('ignores stale assessment list responses after classroom changes', async () => {

--- a/tests/components/StudentTestsTab.test.tsx
+++ b/tests/components/StudentTestsTab.test.tsx
@@ -159,6 +159,7 @@ describe('StudentTestsTab exam mode', () => {
   it('shows a retryable error instead of an empty state when the tests list fails', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ error: 'Database unavailable' }, false))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Still unavailable' }, false))
       .mockResolvedValueOnce(jsonResponse({
         tests: [{
           id: 'test-recovered',
@@ -178,7 +179,13 @@ describe('StudentTestsTab exam mode', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
 
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('region', { name: 'Tests' })).toHaveFocus()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
     expect(await screen.findByText('Recovered Test')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Tests' })).toHaveFocus()
     expect(screen.queryByText('Tests unavailable')).not.toBeInTheDocument()
   })
 

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -300,6 +300,10 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ error: 'Database unavailable' }),
       })
       .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Still unavailable' }),
+      })
+      .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Recovered Test' })] }),
       })
@@ -311,7 +315,13 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
 
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('region', { name: 'Tests' })).toHaveFocus()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
     expect(await screen.findByText('Recovered Test')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Tests' })).toHaveFocus()
     expect(screen.queryByText('Tests unavailable')).not.toBeInTheDocument()
   })
 

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -293,6 +293,56 @@ describe('TeacherTestsTab', () => {
     })
   }
 
+  it('shows a retryable error instead of an empty state when the tests list fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Database unavailable' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Recovered Test' })] }),
+      })
+
+    renderTab()
+
+    expect(await screen.findByText('Tests unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('No tests yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Recovered Test')).toBeInTheDocument()
+    expect(screen.queryByText('Tests unavailable')).not.toBeInTheDocument()
+  })
+
+  it('keeps the current list visible when a background refresh fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Current Test' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Refresh failed' }),
+      })
+
+    renderTab()
+
+    expect(await screen.findByText('Current Test')).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, { detail: { classroomId: classroom.id } }),
+      )
+    })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Tests could not be refreshed. Showing the last loaded list.',
+    )
+    expect(screen.getByText('Current Test')).toBeInTheDocument()
+    expect(screen.queryByText('No tests yet')).not.toBeInTheDocument()
+  })
+
   function renderTab(options?: {
     classroom?: Classroom
     testsTabClickToken?: number
@@ -1695,6 +1745,23 @@ describe('TeacherTestsTab', () => {
 
     expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(0)
+    expect(updateSearchParams).not.toHaveBeenCalled()
+  })
+
+  it('keeps controlled test params intact when the tests list fails', async () => {
+    const updateSearchParams = vi.fn()
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Database unavailable' }),
+    })
+
+    renderTab({
+      selectedTestId: 'test-1',
+      selectedTestMode: 'authoring',
+      updateSearchParams,
+    })
+
+    expect(await screen.findByText('Tests unavailable')).toBeInTheDocument()
     expect(updateSearchParams).not.toHaveBeenCalled()
   })
 

--- a/tests/hooks/useTeacherTestList.test.ts
+++ b/tests/hooks/useTeacherTestList.test.ts
@@ -65,6 +65,71 @@ describe('useTeacherTestList', () => {
     expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Unit Test'])
   })
 
+  it('reports a cold load failure without treating it as an empty snapshot', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Database unavailable' }),
+    })
+
+    const { result } = renderHook(() =>
+      useTeacherTestList({
+        classroomId: 'classroom-1',
+        selectedTestId: null,
+        selectedTestDraftSummary: null,
+      }),
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBe('Database unavailable')
+    expect(result.current.hasLoadedSnapshot).toBe(false)
+    expect(result.current.visibleTests).toEqual([])
+  })
+
+  it('preserves a valid snapshot when refresh fails and retries explicitly', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Current Test' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Refresh failed' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-2', title: 'Recovered Test' })] }),
+      })
+
+    const { result } = renderHook(() =>
+      useTeacherTestList({
+        classroomId: 'classroom-1',
+        selectedTestId: null,
+        selectedTestDraftSummary: null,
+      }),
+    )
+
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Current Test']))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, { detail: { classroomId: 'classroom-1' } }),
+      )
+    })
+
+    await waitFor(() => expect(result.current.error).toBe('Refresh failed'))
+    expect(result.current.hasLoadedSnapshot).toBe(true)
+    expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Current Test'])
+
+    await act(async () => {
+      await result.current.retryTests()
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Recovered Test'])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
   it('hides prior classroom tests while the next classroom is loading', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary
- distinguish loading, cold failure, successful empty, and failed refresh states in teacher and student Tests lists
- preserve classroom-scoped snapshots during refresh failures and keep controlled teacher test URLs until a successful snapshot proves them invalid
- add explicit cache-invalidating retries and regression coverage for HTTP errors, stale classrooms, and retained lists

## Verification
- `pnpm test` (407 files / 3,680 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture` (623 modules / 0 allowances)
- `pnpm build`
- Pika changed-file audit
- Playwright desktop matrix: teacher/student, light/dark, normal/cold-error/refresh-error (12 captures, no horizontal overflow)

## Scope
- no migration, schema, dependency, Gradex, production, or mobile UX changes
- composite-widget checklist reviewed: yes; keyboard behavior changed: no; semantic error state covered by role-based tests: yes; remaining manual follow-up: none