### PR TITLE
Clarify Tests authoring workflow

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -5,7 +5,7 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 ## Current Focus
 
 - Migrations 001-104 and the archive canary are verified; classroom hot-restored; source/Gradex cleanup disabled.
-- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment, Daily/Attendance desktop/accessibility, and Tests list reliability work is complete; mobile UX is deferred, Gradex is owned by a separate session, and Tests authoring/grading separation is next.
+- Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment, Daily/Attendance desktop/accessibility, and Tests list reliability plus authoring/grading separation are complete; mobile UX is deferred, Gradex is owned by a separate session, and standalone test preview hardening is next.
 
 ## Environment
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14605,3 +14605,31 @@
 - `pnpm check:architecture` (599 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:f00a1076562bba010bb5ab76936668500ccf32287de5b65aa8af7fd02063eb70 -->
+## 2026-07-15 — Classroom archive source ownership fence
+
+**Completed:**
+- Added migration 096 to make assignment-artifact source deletion require a bounded, transactional ownership verification and a permanent SHA-256 path reservation.
+- Serialized verification against artifact references, Storage writes, cleanup-ledger staging, and stale-worker deletion; reset pre-fence leases and rejected unreconciled historical deletions.
+- Restricted cleanup claims, lease transitions, and exact Storage presence checks to service-owned database contracts with explicit privilege tests.
+- Kept source cleanup manual, default-off, unscheduled, operation-scoped, and limited to one object per invocation; submission images and test documents remain preserved until they have authoritative relational registries.
+- Expanded the database harness with live multi-session races and the recovery drill with exact export, cleanup, byte-identical restore, replay, and deidentified-fence retention checks.
+- Completed repeated runtime and database review/fix rounds. No production state was read or modified by this phase.
+
+**Deployment obligation:**
+- Apply migration 096 before deploying this app version.
+- Run hosted catalog audit and named canaries read-only before enabling any source cleanup; keep cleanup disabled unless both explicit gates and an exact completed operation ID are supplied.
+
+**Validation:**
+- Classroom archive source-cleanup route/server/migration suites (33 tests)
+- `pnpm vitest run` (362 files / 3,317 tests)
+- Classroom archive compaction database contract harness, including concurrent verifier/reference/Storage/staging races
+- Classroom archive full recovery drill (42 resource tables; exact restore and replay)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm db:types:check`
+- `pnpm lint`
+- `pnpm check:architecture` (599 modules / 0 allowances)
+- Pika pre-commit audit
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -994,8 +994,11 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - Pika changed-file audit
 - Composite-widget accessibility checklist: reviewed; keyboard focus return and dialog semantics covered by tests; no remaining manual accessibility follow-up
+- In-app browser visual matrix: teacher Tests grading table plus `Edit Test` and `New Test` dialog states at desktop and mobile breakpoints in light and dark themes; no viewport overflow, clipped controls, or grading-workspace regression observed
+- Keyboard verification: tab focus showed the browser focus outline on `Edit test title`, and closing the dialog returned focus to `Edit Test`
+- The in-app browser capture compositor tiled each screenshot; the repeated rendered tiles and measured DOM bounds agreed, with dialog and document widths contained in every tested viewport
 - `git diff --check`
 
 **Remaining:**
-- Complete independent review and exact-head PR CI. Local screenshot verification was blocked by the in-app browser URL policy after the local server restarted, so no visual-pass claim is recorded.
+- Complete targeted independent rereview and exact-head PR CI.
 - Continue Tests with standalone preview authorization/framing, then student flag/save accessibility; keep mobile and Gradex deferred.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,33 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-15 — Classroom archive source ownership fence
-
-**Completed:**
-- Added migration 096 to make assignment-artifact source deletion require a bounded, transactional ownership verification and a permanent SHA-256 path reservation.
-- Serialized verification against artifact references, Storage writes, cleanup-ledger staging, and stale-worker deletion; reset pre-fence leases and rejected unreconciled historical deletions.
-- Restricted cleanup claims, lease transitions, and exact Storage presence checks to service-owned database contracts with explicit privilege tests.
-- Kept source cleanup manual, default-off, unscheduled, operation-scoped, and limited to one object per invocation; submission images and test documents remain preserved until they have authoritative relational registries.
-- Expanded the database harness with live multi-session races and the recovery drill with exact export, cleanup, byte-identical restore, replay, and deidentified-fence retention checks.
-- Completed repeated runtime and database review/fix rounds. No production state was read or modified by this phase.
-
-**Deployment obligation:**
-- Apply migration 096 before deploying this app version.
-- Run hosted catalog audit and named canaries read-only before enabling any source cleanup; keep cleanup disabled unless both explicit gates and an exact completed operation ID are supplied.
-
-**Validation:**
-- Classroom archive source-cleanup route/server/migration suites (33 tests)
-- `pnpm vitest run` (362 files / 3,317 tests)
-- Classroom archive compaction database contract harness, including concurrent verifier/reference/Storage/staging races
-- Classroom archive full recovery drill (42 resource tables; exact restore and replay)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm db:types:check`
-- `pnpm lint`
-- `pnpm check:architecture` (599 modules / 0 allowances)
-- Pika pre-commit audit
-- `git diff --check`
-
 ## 2026-07-15 — Production archive canary retry and recovery hardening
 
 **Completed:**
@@ -998,3 +971,31 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Remaining:**
 - Require exact-head PR CI and normal protected merge into `main`.
+
+## 2026-07-23 — Separated Tests authoring from grading
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5.6 Terra (high) - the slice crosses route-backed workspace mode, dialog accessibility, and a large teacher Tests coordinator while preserving existing grading behavior.
+
+**Completed:**
+- Preserved the grading-first, class-wide Tests table and prior decision not to restore large Authoring/Grading tabs.
+- Replaced the icon-only pencil with a visible `Edit Test` command so teachers can distinguish test construction from student-work review without leaving the selected test.
+- Gave the editor dialog an explicit accessible `Edit test` name and visible mode label.
+- Extracted authoring-only dialog, markdown-view, and title-portal composition into `TeacherTestAuthoringDialog`, reducing state and presentation ownership in `TeacherTestsTab`.
+- Left APIs, grading behavior, schema, migrations, Gradex, production state, student UI, and deferred mobile UX unchanged.
+
+**Validation:**
+- Focused teacher Tests authoring/workspace suites (2 files / 67 tests)
+- Full repository suite (407 files / 3,680 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (624 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit
+- Composite-widget accessibility checklist: reviewed; keyboard focus return and dialog semantics covered by tests; no remaining manual accessibility follow-up
+- `git diff --check`
+
+**Remaining:**
+- Complete independent review and exact-head PR CI. Local screenshot verification was blocked by the in-app browser URL policy after the local server restarted, so no visual-pass claim is recorded.
+- Continue Tests with standalone preview authorization/framing, then student flag/save accessibility; keep mobile and Gradex deferred.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -189,10 +189,11 @@ Tests progress:
 - Teacher and student Tests lists now distinguish loading, cold failure, successful empty, and failed refresh states. Cold failures offer an explicit retry instead of claiming that no tests exist.
 - Failed refreshes retain the last valid list with a compact retry warning, while classroom-scoped snapshots and request guards prevent another classroom's tests from painting in the active view.
 - Teacher controlled test URLs remain intact until a successful list snapshot proves that the selected test is invalid. Existing list-first teacher and student compositions are unchanged.
-- Remaining Tests work is authoring/grading mode separation, standalone preview authorization and framing, accessible flag/save announcements, and the deferred mobile navigation treatment.
+- The selected Tests workspace remains grading-first and preserves the class-wide student table. Test authoring is now an explicit visible `Edit Test` command with a named editor dialog, and authoring-only dialog/view composition lives in `TeacherTestAuthoringDialog` instead of expanding the grading coordinator.
+- Remaining Tests work is standalone preview authorization and framing, accessible flag/save announcements, and the deferred mobile navigation treatment.
 
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
-2. Tests: completed list errors; remaining authoring/grading mode separation, standalone preview authorization/framing, mobile navigation, and accessible flags/save status.
+2. Tests: completed list errors and authoring/grading separation; remaining standalone preview authorization/framing, mobile navigation, and accessible flags/save status.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.
 4. Dashboard: teacher-owned entry detail, responsive summary-first attendance, and removal of invalid classroom commands.
 5. Roster: mobile row detail, keyboard table behavior, bulk-action recovery, and counselor-field access.

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -16,15 +16,15 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Check, ClockAlert, Code, ExternalLink, Lock, LogOut, Pencil, RotateCcw, Send, Trash2, Unlock, X } from 'lucide-react'
+import { Check, ClockAlert, Lock, LogOut, Pencil, RotateCcw, Send, Trash2, Unlock, X } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
-import { TestDetailPanel } from '@/components/TestDetailPanel'
 import { TeacherTestCard } from '@/components/TeacherTestCard'
 import {
   AssessmentStatusIndicator,
   getTestGradingWorkStatusDisplay,
 } from '@/components/AssessmentStatusIndicator'
 import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
+import { TeacherTestAuthoringDialog } from '@/components/test-workspace/TeacherTestAuthoringDialog'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import {
   TeacherWorkSurfaceActionCluster,
@@ -38,7 +38,6 @@ import {
   TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
   type TeacherTestGradingRowUpdatedEventDetail,
 } from '@/lib/events'
-import { getDisplayAssessmentTitle } from '@/lib/assessment-titles'
 import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { getTestExitCount } from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
@@ -112,8 +111,6 @@ interface Props {
   onRequestDelete?: () => void
 }
 
-type TestEditModalView = 'edit' | 'markdown'
-type TestEditSaveStatus = 'saved' | 'saving' | 'unsaved'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
 const GRADING_POLL_INTERVAL_MS = 15_000
@@ -307,9 +304,6 @@ export function TeacherTestsTab({
   const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [isCreatingTest, setIsCreatingTest] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
-  const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
-  const [testEditTitlePortalTarget, setTestEditTitlePortalTarget] = useState<HTMLDivElement | null>(null)
-  const [, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
   const [pendingDeleteTest, setPendingDeleteTest] = useState<TestAssessmentWithStats | null>(null)
   const [isDeletingTest, setIsDeletingTest] = useState(false)
 
@@ -396,7 +390,6 @@ export function TeacherTestsTab({
 
     if (selectedTestMode !== undefined && previousMode === 'authoring' && selectedTestMode !== 'authoring') {
       setShowEditModal(false)
-      setTestEditModalView('edit')
       setHasPendingMarkdownImport(false)
     }
   }, [selectedTestMode])
@@ -529,8 +522,6 @@ export function TeacherTestsTab({
     setIsReorderingTests(false)
     setIsCreatingTest(false)
     setShowEditModal(false)
-    setTestEditModalView('edit')
-    setTestEditSaveStatus('saved')
     setHasPendingMarkdownImport(false)
     setPendingDeleteTest(null)
     setIsDeletingTest(false)
@@ -1213,16 +1204,6 @@ export function TeacherTestsTab({
     clearBatchSelection()
   }
 
-  function handleEditTest(test: TestAssessmentWithStats) {
-    navigateTestWorkspace({ testId: test.id, mode: 'authoring', studentId: null })
-    setGradingError('')
-    setGradingWarning('')
-    setGradingInfo('')
-    clearBatchSelection()
-    setTestEditModalView('edit')
-    setShowEditModal(true)
-  }
-
   function handleOpenSavedTestPreview(preview: { testId: string; title: string }) {
     if (onRequestTestPreview) {
       onRequestTestPreview(preview)
@@ -1235,10 +1216,6 @@ export function TeacherTestsTab({
     )
     previewWindow?.focus()
   }
-
-  useEffect(() => {
-    setTestEditSaveStatus('saved')
-  }, [selectedTestId])
 
   async function handleNewTest() {
     if (isCreatingTest || isReadOnly || loading) return
@@ -1289,7 +1266,6 @@ export function TeacherTestsTab({
       return [createdTest, ...next]
     })
     navigateTestWorkspace({ testId: createdTest.id, mode: 'authoring', studentId: null }, { replace: true })
-    setTestEditModalView('edit')
     setShowEditModal(true)
     window.dispatchEvent(
       new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
@@ -2235,7 +2211,6 @@ export function TeacherTestsTab({
   const openSelectedTestEditor = () => {
     if (!selectedTestWorkspace) return
     navigateTestWorkspace({ testId: selectedTestWorkspace.id, mode: 'authoring', studentId: null })
-    setTestEditModalView('edit')
     setHasPendingMarkdownImport(false)
     setShowEditModal(true)
   }
@@ -2394,13 +2369,17 @@ export function TeacherTestsTab({
     >
       <TeacherWorkSurfaceActionCluster>
         <SplitButton {...selectedTestAction} />
-        <TeacherWorkSurfaceIconButton
-          ariaLabel="Edit Test"
-          icon={<Pencil className="h-4 w-4" aria-hidden="true" />}
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
           onClick={openSelectedTestEditor}
           disabled={isReadOnly}
-          tooltip="Edit Test"
-        />
+          className="gap-1.5"
+        >
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+          Edit Test
+        </Button>
       </TeacherWorkSurfaceActionCluster>
       {workspaceModeStatus}
     </div>
@@ -2587,7 +2566,6 @@ export function TeacherTestsTab({
   const isTestEditorOpen = !!selectedTestWorkspace && (showEditModal || selectedWorkspaceTab === 'authoring')
   const handleCloseTestEditor = useCallback(() => {
     setShowEditModal(false)
-    setTestEditModalView('edit')
     setHasPendingMarkdownImport(false)
     if (selectedTestId && selectedWorkspaceTab === 'authoring') {
       navigateTestWorkspace({ testId: selectedTestId, mode: 'grading', studentId: null }, { replace: true })
@@ -2660,91 +2638,24 @@ export function TeacherTestsTab({
         />
       </div>
 
-      <DialogPanel
+      <TeacherTestAuthoringDialog
         isOpen={isTestEditorOpen}
+        test={selectedTestWorkspace}
+        classroomId={classroom.id}
+        apiBasePath={apiBasePath}
+        hasPendingMarkdownImport={hasPendingMarkdownImport}
         onClose={handleCloseTestEditor}
-        ariaLabelledBy="test-edit-title"
-        maxWidth="max-w-6xl"
-        className="h-[85vh] overflow-hidden p-0"
-      >
-        <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3">
-          <div
-            id="test-edit-title"
-            ref={setTestEditTitlePortalTarget}
-            className="min-w-0 basis-full text-base font-semibold text-text-default sm:basis-auto sm:flex-1"
-          >
-            {!testEditTitlePortalTarget && selectedTestWorkspace
-              ? getDisplayAssessmentTitle(selectedTestWorkspace.title, 'Untitled Test')
-              : null}
-          </div>
-          <Tooltip content="Markdown view">
-            <Button
-              type="button"
-              variant={testEditModalView === 'markdown' ? 'subtle' : 'secondary'}
-              size="sm"
-              aria-pressed={testEditModalView === 'markdown'}
-              className="gap-1.5"
-              onClick={() => {
-                setTestEditModalView((current) => (current === 'markdown' ? 'edit' : 'markdown'))
-              }}
-            >
-              <Code className="h-4 w-4" aria-hidden="true" />
-              <span>Code</span>
-            </Button>
-          </Tooltip>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              if (!selectedTestWorkspace) return
-              handleOpenSavedTestPreview({
-                testId: selectedTestWorkspace.id,
-                title: selectedTestWorkspace.title,
-              })
-            }}
-            disabled={hasPendingMarkdownImport || !selectedTestWorkspace}
-            className="gap-1.5"
-          >
-            <ExternalLink className="h-4 w-4" aria-hidden="true" />
-            Preview
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={handleCloseTestEditor}
-          >
-            Close
-          </Button>
-        </div>
-        <div className="min-h-0 flex-1 overflow-hidden">
-          {selectedTestWorkspace ? (
-            <TestDetailPanel
-              test={selectedTestWorkspace}
-              classroomId={classroom.id}
-              apiBasePath={apiBasePath}
-              onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
-              onTestUpdate={(update) => {
-                if (update) {
-                  applySelectedTestDraftSummary(update)
-                  return
-                }
-                void loadTests()
-              }}
-              onPendingMarkdownImportChange={setHasPendingMarkdownImport}
-              onSaveStatusChange={setTestEditSaveStatus}
-              onRequestTestPreview={handleOpenSavedTestPreview}
-              showInlineDeleteAction={false}
-              testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
-              showPreviewButton={false}
-              showResultsTab={false}
-              titlePortalTarget={testEditTitlePortalTarget}
-              generatedTitleLabel="Untitled Test"
-            />
-          ) : null}
-        </div>
-      </DialogPanel>
+        onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
+        onTestUpdate={(update) => {
+          if (update) {
+            applySelectedTestDraftSummary(update)
+            return
+          }
+          void loadTests()
+        }}
+        onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+        onRequestPreview={handleOpenSavedTestPreview}
+      />
 
       <DialogPanel
         isOpen={showBatchGradeModal}

--- a/src/components/test-workspace/TeacherTestAuthoringDialog.tsx
+++ b/src/components/test-workspace/TeacherTestAuthoringDialog.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Code, ExternalLink } from 'lucide-react'
+import { TestDetailPanel } from '@/components/TestDetailPanel'
+import { getDisplayAssessmentTitle } from '@/lib/assessment-titles'
+import { Button, DialogPanel, Tooltip } from '@/ui'
+import type {
+  AssessmentEditorSummaryUpdate,
+  TestAssessmentWithStats,
+} from '@/types'
+
+type AuthoringView = 'edit' | 'markdown'
+
+interface TeacherTestAuthoringDialogProps {
+  isOpen: boolean
+  test: TestAssessmentWithStats | null
+  classroomId: string
+  apiBasePath: string
+  hasPendingMarkdownImport: boolean
+  onClose: () => void
+  onDraftSummaryChange: (update: AssessmentEditorSummaryUpdate) => void
+  onTestUpdate: (update?: AssessmentEditorSummaryUpdate) => void
+  onPendingMarkdownImportChange: (pending: boolean) => void
+  onRequestPreview: (preview: { testId: string; title: string }) => void
+}
+
+export function TeacherTestAuthoringDialog({
+  isOpen,
+  test,
+  classroomId,
+  apiBasePath,
+  hasPendingMarkdownImport,
+  onClose,
+  onDraftSummaryChange,
+  onTestUpdate,
+  onPendingMarkdownImportChange,
+  onRequestPreview,
+}: TeacherTestAuthoringDialogProps) {
+  const [authoringView, setAuthoringView] = useState<AuthoringView>('edit')
+  const [titlePortalTarget, setTitlePortalTarget] = useState<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setAuthoringView('edit')
+    }
+  }, [isOpen, test?.id])
+
+  const handleClose = () => {
+    setAuthoringView('edit')
+    onClose()
+  }
+
+  return (
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={handleClose}
+      ariaLabelledBy="test-authoring-dialog-title"
+      maxWidth="max-w-6xl"
+      className="h-[85vh] overflow-hidden p-0"
+    >
+      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0 basis-full sm:basis-auto sm:flex-1">
+          <h2
+            id="test-authoring-dialog-title"
+            className="text-xs font-medium text-text-muted"
+          >
+            Edit test
+          </h2>
+          <div
+            ref={setTitlePortalTarget}
+            className="mt-0.5 min-w-0 text-base font-semibold text-text-default"
+          >
+            {!titlePortalTarget && test
+              ? getDisplayAssessmentTitle(test.title, 'Untitled Test')
+              : null}
+          </div>
+        </div>
+        <Tooltip content="Markdown view">
+          <Button
+            type="button"
+            variant={authoringView === 'markdown' ? 'subtle' : 'secondary'}
+            size="sm"
+            aria-pressed={authoringView === 'markdown'}
+            className="gap-1.5"
+            onClick={() => {
+              setAuthoringView((current) => (current === 'markdown' ? 'edit' : 'markdown'))
+            }}
+          >
+            <Code className="h-4 w-4" aria-hidden="true" />
+            <span>Code</span>
+          </Button>
+        </Tooltip>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            if (!test) return
+            onRequestPreview({ testId: test.id, title: test.title })
+          }}
+          disabled={hasPendingMarkdownImport || !test}
+          className="gap-1.5"
+        >
+          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          Preview
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleClose}
+        >
+          Close
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {test ? (
+          <TestDetailPanel
+            test={test}
+            classroomId={classroomId}
+            apiBasePath={apiBasePath}
+            onDraftSummaryChange={onDraftSummaryChange}
+            onTestUpdate={onTestUpdate}
+            onPendingMarkdownImportChange={onPendingMarkdownImportChange}
+            onRequestTestPreview={onRequestPreview}
+            showInlineDeleteAction={false}
+            testQuestionLayout={authoringView === 'markdown' ? 'markdown-only' : 'editor-only'}
+            showPreviewButton={false}
+            showResultsTab={false}
+            titlePortalTarget={titlePortalTarget}
+            generatedTitleLabel="Untitled Test"
+          />
+        ) : null}
+      </div>
+    </DialogPanel>
+  )
+}

--- a/tests/components/TeacherTestAuthoringDialog.test.tsx
+++ b/tests/components/TeacherTestAuthoringDialog.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TeacherTestAuthoringDialog } from '@/components/test-workspace/TeacherTestAuthoringDialog'
+import { TooltipProvider } from '@/ui'
+import { createMockTest } from '../helpers/mocks'
+import type { TestAssessmentWithStats } from '@/types'
+
+vi.mock('@/components/TestDetailPanel', () => ({
+  TestDetailPanel: ({ testQuestionLayout }: { testQuestionLayout?: string }) => (
+    <div data-testid="test-authoring-detail" data-question-layout={testQuestionLayout} />
+  ),
+}))
+
+const test = {
+  ...createMockTest({
+    id: 'test-1',
+    title: 'Unit Test',
+    assessment_type: 'test',
+  }),
+  assessment_type: 'test',
+  stats: {
+    total_students: 10,
+    responded: 5,
+    submitted: 3,
+    open_access: 2,
+    closed_access: 8,
+    questions_count: 4,
+  },
+} as TestAssessmentWithStats
+
+function renderDialog({
+  hasPendingMarkdownImport = false,
+  onRequestPreview = vi.fn(),
+}: {
+  hasPendingMarkdownImport?: boolean
+  onRequestPreview?: (preview: { testId: string; title: string }) => void
+} = {}) {
+  render(
+    <TooltipProvider>
+      <TeacherTestAuthoringDialog
+        isOpen
+        test={test}
+        classroomId="classroom-1"
+        apiBasePath="/api/teacher/tests"
+        hasPendingMarkdownImport={hasPendingMarkdownImport}
+        onClose={vi.fn()}
+        onDraftSummaryChange={vi.fn()}
+        onTestUpdate={vi.fn()}
+        onPendingMarkdownImportChange={vi.fn()}
+        onRequestPreview={onRequestPreview}
+      />
+    </TooltipProvider>,
+  )
+
+  return { onRequestPreview }
+}
+
+describe('TeacherTestAuthoringDialog', () => {
+  it('names the authoring surface and exposes visual and markdown editor modes', () => {
+    const { onRequestPreview } = renderDialog()
+    const dialog = screen.getByRole('dialog', { name: 'Edit test' })
+    const codeButton = within(dialog).getByRole('button', { name: 'Code' })
+
+    expect(within(dialog).getByText('Edit test')).toBeVisible()
+    expect(screen.getByTestId('test-authoring-detail')).toHaveAttribute(
+      'data-question-layout',
+      'editor-only',
+    )
+    expect(codeButton).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(codeButton)
+
+    expect(screen.getByTestId('test-authoring-detail')).toHaveAttribute(
+      'data-question-layout',
+      'markdown-only',
+    )
+    expect(codeButton).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Preview' }))
+    expect(onRequestPreview).toHaveBeenCalledWith({
+      testId: 'test-1',
+      title: 'Unit Test',
+    })
+  })
+
+  it('locks preview while markdown changes are pending', () => {
+    renderDialog({ hasPendingMarkdownImport: true })
+
+    expect(
+      within(screen.getByRole('dialog', { name: 'Edit test' })).getByRole('button', {
+        name: 'Preview',
+      }),
+    ).toBeDisabled()
+  })
+})

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -718,7 +718,9 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByText('Unit Test'))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit Test' })).toBeEnabled()
+    const editTestButton = screen.getByRole('button', { name: 'Edit Test' })
+    expect(editTestButton).toBeEnabled()
+    expect(within(editTestButton).getByText('Edit Test')).toBeVisible()
 
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
     expect(screen.queryByRole('menuitem', { name: 'Manage Attempts' })).not.toBeInTheDocument()
@@ -727,9 +729,12 @@ describe('TeacherTestsTab', () => {
     expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
     fireEvent.keyDown(window, { key: 'Escape' })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Test' }))
+    editTestButton.focus()
+    fireEvent.click(editTestButton)
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByRole('dialog', { name: 'Edit test' })).toBeInTheDocument()
+    expect(within(screen.getByRole('dialog')).getByText('Edit test')).toBeVisible()
     expect(updateSearchParams).toHaveBeenCalledTimes(2)
     const params = new URLSearchParams('tab=tests&testId=test-1&testMode=grading&testStudentId=student-1')
     updateSearchParams.mock.calls[1][0](params)
@@ -742,6 +747,11 @@ describe('TeacherTestsTab', () => {
       'aria-pressed',
       'false'
     )
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
+    await waitFor(() => {
+      expect(editTestButton).toHaveFocus()
+    })
   })
 
   it('closes the edit modal when controlled params return from authoring to grading', async () => {


### PR DESCRIPTION
## Summary
- preserve the grading-first, class-wide Tests workspace while making the authoring entry point explicit with a visible **Edit Test** action
- extract the authoring dialog and its visual/markdown state from the large teacher Tests container
- add direct dialog and workspace regression coverage, including focus return and semantic state

## Scope
- no API, domain, database, migration, production, Gradex, student, or mobile behavior changes
- continues the existing list-first teacher UX rather than restoring the retired Authoring/Grading mode tabs

## Verification
- focused: 2 files, 67 tests passed
- full suite: 407 files, 3,680 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm build`
- changed-file Pika audit passed
- composite-widget accessibility checklist reviewed; keyboard focus return and semantic dialog/toggle state covered by tests

## Visual verification
- teacher Tests grading table plus `Edit Test` and `New Test` dialog states checked at desktop and mobile breakpoints in light and dark themes
- no viewport overflow, clipped controls, or grading-workspace regression observed
- tab focus showed the browser focus outline; closing returned focus to `Edit Test`
- the in-app browser compositor tiled the captures, but repeated rendered tiles and measured DOM bounds agreed in every tested viewport