### PR TITLE
Retire legacy Quiz API response aliases

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14633,3 +14633,29 @@
 - `pnpm check:architecture` (599 modules / 0 allowances)
 - Pika pre-commit audit
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:5aeafb31c6794336988914c338c319e2b6ec8d389fbf075c33a722655707b7e6 -->
+## 2026-07-15 — Production archive canary retry and recovery hardening
+
+**Completed:**
+- Hardened restore storage read-back, unexpected transport failures, durable failure recording, and terminal best-effort cleanup so retries retain the fixed operation ID without deleting reused objects.
+- Added an independent archive-to-restored evidence oracle covering all resource rows, nested storage references, canonical public URLs, object identity, byte size, and SHA-256 bindings; the production canary no longer verifies restore output from its own restore plan.
+- Made the canary reconcile thrown restore calls against durable hot/cold state and retry the fixed operation ID up to three times.
+- Added migration 097 to preserve concurrent retryable restore failures and safely rearm exact expired requests. Expiry recovery now fences active cleanup leases, rolls back transient rearm state when delegated begin fails, and recovers a naturally expired snapshot in one call.
+- Expanded the database contract drill for same-ID finalization races, active cleanup leases, delegated-failure rollback, and expiry recovery. Completed repeated independent review/fix loops covering restore safety, equality evidence, SQL concurrency, privilege boundaries, and cleanup ownership.
+- No production canary, source cleanup, Gradex cleanup, or migration application was performed.
+
+**Deployment obligation:**
+- Apply migration 097 before deploying or running the production canary.
+- Keep source cleanup and Gradex cleanup disabled. Prepare a fresh named canary plan after production is on the reviewed commit; do not reuse the obsolete local plan.
+
+**Validation:**
+- Focused archive restore/canary/migration suites (4 files / 37 tests)
+- `pnpm vitest run` (364 files / 3,345 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- Bash syntax validation for the restore database contract drill
+- Pika pre-commit audit
+- `git diff --check`
+- `pnpm db:types:check` intentionally blocked because local database history remains at 096 and AI did not apply migration 097

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,31 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-15 — Production archive canary retry and recovery hardening
-
-**Completed:**
-- Hardened restore storage read-back, unexpected transport failures, durable failure recording, and terminal best-effort cleanup so retries retain the fixed operation ID without deleting reused objects.
-- Added an independent archive-to-restored evidence oracle covering all resource rows, nested storage references, canonical public URLs, object identity, byte size, and SHA-256 bindings; the production canary no longer verifies restore output from its own restore plan.
-- Made the canary reconcile thrown restore calls against durable hot/cold state and retry the fixed operation ID up to three times.
-- Added migration 097 to preserve concurrent retryable restore failures and safely rearm exact expired requests. Expiry recovery now fences active cleanup leases, rolls back transient rearm state when delegated begin fails, and recovers a naturally expired snapshot in one call.
-- Expanded the database contract drill for same-ID finalization races, active cleanup leases, delegated-failure rollback, and expiry recovery. Completed repeated independent review/fix loops covering restore safety, equality evidence, SQL concurrency, privilege boundaries, and cleanup ownership.
-- No production canary, source cleanup, Gradex cleanup, or migration application was performed.
-
-**Deployment obligation:**
-- Apply migration 097 before deploying or running the production canary.
-- Keep source cleanup and Gradex cleanup disabled. Prepare a fresh named canary plan after production is on the reviewed commit; do not reuse the obsolete local plan.
-
-**Validation:**
-- Focused archive restore/canary/migration suites (4 files / 37 tests)
-- `pnpm vitest run` (364 files / 3,345 tests)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm check:architecture` (600 modules / 0 allowances)
-- Bash syntax validation for the restore database contract drill
-- Pika pre-commit audit
-- `git diff --check`
-- `pnpm db:types:check` intentionally blocked because local database history remains at 096 and AI did not apply migration 097
-
 ## 2026-07-15 — Production archive canary timeout hardening
 
 **Completed:**
@@ -1002,3 +977,30 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Remaining:**
 - Complete targeted independent rereview and exact-head PR CI.
 - Continue Tests with standalone preview authorization/framing, then student flag/save accessibility; keep mobile and Gradex deferred.
+
+## 2026-07-23 — Retired legacy Quiz API response aliases
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - the pass crosses student and teacher API producers, client normalizers, component consumers, and contract documentation.
+
+**Completed:**
+- Closed the internal Tests API compatibility window and removed legacy `quiz` / `quizzes` response aliases from active student and teacher Tests routes.
+- Removed quiz-key fallback reads and compatibility fixtures while preserving current `test` / `tests` handling for optional and error payloads.
+- Added route assertions and an architecture ratchet preventing the retired response helpers from returning.
+- Documented the cutoff, older-client risk, code-only rollback, and remaining database, archive, gradebook, package, component, URL, and automation compatibility boundaries.
+- Left schema, migrations, persisted `quiz_id` fields, archive v1 resources, gradebook tombstones, and course package compatibility unchanged.
+
+**Validation:**
+- Focused Tests API/client/component suites (12 files / 208 tests)
+- Full repository suite (408 files / 3,674 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (624 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit
+- `git diff --check`
+
+**Remaining:**
+- Require independent PR review and exact-head CI before merge.
+- Next retire unused component prop wrappers and the legacy test automation id; preserve database-shaped fields and the old `tab=quizzes` URL tombstone.

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -188,7 +188,8 @@ Use raw `fetch()` only for one-off mutations (POST/PATCH/DELETE) or when freshne
 
 ### Assessments Pattern
 Pika exposes **tests** as the active assessment surface. Quiz product routes and tabs have been removed.
-Some database history and compatibility response keys still retain legacy quiz naming during the contract transition.
+Some database history, archive resources, and portable-package fields still retain legacy quiz naming
+during the data-contract transition. Active Tests APIs emit only `test` / `tests` response keys.
 Before changing remaining `quiz` / `quizzes` names, load
 [`docs/guidance/legacy-quiz-contract-cleanup.md`](../guidance/legacy-quiz-contract-cleanup.md).
 

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -7,8 +7,9 @@ The current product contract is:
 
 - User-facing navigation, labels, and active routes should say **Tests**.
 - Legacy quiz routes/tabs are removed from the product surface.
-- Some database tables, payload aliases, TypeScript aliases, package fields, and
-  tests intentionally still use `quiz` names while compatibility is maintained.
+- Some database tables, persisted discriminants, package fields, component
+  wrappers, and tests intentionally still use `quiz` names while compatibility
+  is maintained.
 - AI agents may create migration files after approval. Application follows the
   one-time authorization contract in the schema rollout checklist.
 
@@ -35,19 +36,22 @@ explicit approval.
 
 ### API Routes And Payload Contracts
 
-Retain during the compatibility window:
+The legacy response-key compatibility window is closed:
 
-- Active Tests APIs emit both current and legacy response keys through
-  `src/lib/test-api-contract.ts`: `{ tests, quizzes }` for lists and
-  `{ test, quiz }` for details.
-- Student and teacher Tests UI reads current keys first and falls back to
-  legacy keys.
-- Tests that assert `data.tests === data.quizzes` or `data.test === data.quiz`
-  protect this compatibility contract.
+- Active `/api/student/tests/**` and `/api/teacher/tests/**` routes emit only
+  `{ tests }` for lists and `{ test }` for details.
+- In-repo Tests consumers read only current keys. Tests reject the retired
+  `quiz` / `quizzes` aliases on representative list and detail routes.
+- `src/lib/test-api-contract.ts` remains a current-contract normalizer for
+  optional or error payloads; it no longer accepts legacy response keys.
 
-Next compatibility decision: choose the deprecation point for legacy response
-keys, then remove fallback readers in the same or next release after clients
-have moved to `test` / `tests`.
+Deprecation decision: the first release containing this contract retirement is
+the cutoff. Pika has no active quiz routes or in-repo quiz-key consumers, and
+the active endpoints are product-internal rather than a separately versioned
+public API. An older independently deployed client that still reads only
+`quiz` / `quizzes` will stop receiving assessment data and must upgrade with
+the server. Rollback is code-only: restore the response helpers and fallback
+readers; no stored data changes are involved.
 
 ### TypeScript Domain Types
 
@@ -75,9 +79,9 @@ Retain for compatibility or schema-backed behavior:
   must never read quiz tables or include quiz rows in calculations.
 
 The active Tests, gradebook, and student-notification workflows do not query
-legacy quiz tables. The unused quiz server access module, re-export shims, and
-quiz-named helper/type aliases have been removed and are protected by an
-architecture regression.
+legacy quiz tables. The unused quiz server access module, re-export shims,
+quiz-named helper/type aliases, and API response aliases have been removed.
+Architecture and route regressions protect those boundaries.
 
 ### UI Compatibility Wrappers
 
@@ -90,14 +94,14 @@ Retain until their callers are removed:
 - Legacy `tab=quizzes` route fallback tests, which prove old URLs fall back to
   the supported tab instead of exposing a removed product surface.
 
-Safe cleanup: rename current-path fixtures and test descriptions from quiz to
-test when they are not exercising a compatibility fallback.
+The UI no longer accepts quiz-keyed API response payloads. Remaining wrappers
+are component/URL/automation contracts and should be retired independently.
 
 ### Tests
 
 Remaining quiz references usually fall into one of these groups:
 
-- Compatibility regressions for legacy response keys, props, or route params.
+- Compatibility regressions for legacy props, route params, or persisted data.
 - Database-shaped mocks that must still use `quiz_id` or legacy table names.
 - Gradebook tests that prove legacy quiz response fields remain inert and the
   active server never queries quiz tables.
@@ -138,7 +142,6 @@ Requires a follow-up design and approval:
 
 - Renaming database tables, columns, functions, indexes, policies, or migration
   history from quiz to test.
-- Removing `quiz` / `quizzes` API response keys.
 - Removing a TypeScript compatibility alias that still has application callers.
 - Changing gradebook quiz category fields, weights, override routes, or report
   payloads.
@@ -167,12 +170,11 @@ Requires a follow-up design and approval:
      `pnpm test`.
 
 3. **Payload deprecation**
-   - Pick a release where active Tests APIs stop emitting legacy `quiz` keys.
-   - First add telemetry or targeted tests that prove all in-repo readers use
-     `test` / `tests`.
-   - Remove `withLegacyQuizKey`, `withLegacyQuizListKey`, and fallback reads in
-     one coordinated PR.
-   - Rollback: restore the helpers and response aliases without data changes.
+   - Completed: active Tests APIs emit only `test` / `tests`.
+   - Completed: removed `withLegacyQuizKey`, `withLegacyQuizListKey`, and
+     quiz-key fallback readers in one coordinated pass.
+   - Route tests prove representative current payloads omit legacy aliases.
+   - Rollback remains code-only; no data rollback is required.
 
 4. **Type and wrapper retirement**
    - Completed: removed unused `Quiz*` types, quiz-named assessment helper
@@ -240,18 +242,17 @@ For each implementation pass:
 
 ## Next Implementation Pass
 
-The gradebook/course-package decision and dead draft alias retirement are
-complete. The next safe pass should decide whether the test-only markdown
-aliases have completed their compatibility window or continue fixture-only
-cleanup where no persisted/API/UI compatibility contract depends on the name.
-Start with:
+The API response-key window, gradebook/course-package decisions, and dead draft
+alias retirement are complete. The next safe pass is UI compatibility-wrapper
+retirement:
 
-- `tests/lib/quiz-markdown.test.ts` only if the test is rewritten to clearly say
-  it covers legacy quiz markdown compatibility.
-- Gradebook tests may remove dead quiz-table mocks, but must retain assertions
-  for null/empty compatibility response fields.
-- Course blueprint tests must retain the version 3 `quizzes: false` package
-  contract.
+- remove `quiz`, `quizId`, `quizTitle`, and `onQuizUpdate` props when their
+  current callers and explicit compatibility tests are gone;
+- rename `student-quiz-action-footer` after checking external automation;
+- retain `tab=quizzes` as a URL tombstone until the old-link window is closed;
+- keep database-shaped `quiz_id` fields wherever persistence still requires
+  them.
 
-Payload and schema removal remain blocked until the deprecation window and
-production verification prove the compatibility aliases are no longer needed.
+Schema removal remains blocked on archive-format support and production
+verification. Gradebook tombstones and course package compatibility fields
+remain until their separately documented versioned migrations.

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -13,7 +13,6 @@ import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 import type { TestAssessmentQuestion, TestAssessmentResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -402,7 +401,7 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
     results: aggregated,
     my_responses: myResponses,
     question_results: questionResults,

--- a/src/app/api/student/tests/[id]/route.ts
+++ b/src/app/api/student/tests/[id]/route.ts
@@ -13,7 +13,6 @@ import { normalizeTestResponses, type TestResponses } from '@/lib/test-attempts'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -191,7 +190,7 @@ export const GET = withErrorHandler('GetStudentTest', async (request, context) =
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
     questions: questions || [],
     student_status: studentStatus,
     student_responses: studentResponses,

--- a/src/app/api/student/tests/[id]/session-status/route.ts
+++ b/src/app/api/student/tests/[id]/session-status/route.ts
@@ -11,7 +11,6 @@ import {
 } from '@/lib/server/tests'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -146,7 +145,7 @@ export const GET = withErrorHandler('GetStudentTestSessionStatus', async (_reque
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
     student_status: studentStatus,
     returned_at: attempt?.returned_at || null,
     can_continue: canContinue,

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -12,7 +12,6 @@ import { getStudentTestStatus } from '@/lib/tests'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizListKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -48,7 +47,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
 
   if (activeError) {
     if (activeError.code === 'PGRST205') {
-      return NextResponse.json({ ...withLegacyQuizListKey([]), migration_required: true })
+      return NextResponse.json({ tests: [], migration_required: true })
     }
     console.error('Error fetching active tests:', activeError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -246,5 +245,5 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
     }
   })
 
-  return NextResponse.json(withLegacyQuizListKey(testsWithStatus))
+  return NextResponse.json({ tests: testsWithStatus })
 })

--- a/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
@@ -5,7 +5,6 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
 import { clearTestDocumentSnapshot, normalizeTestDocuments } from '@/lib/test-documents'
 import { findTestDocument, syncExternalLinkTestDocument } from '@/lib/server/test-document-snapshots'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 
@@ -62,6 +61,6 @@ export const POST = withErrorHandler('SyncTeacherTestDocument', async (_request,
 
   return NextResponse.json({
     doc: syncedDoc,
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
   })
 })

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -20,7 +20,6 @@ import type {
   TestStudentAvailabilityState,
 } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -655,7 +654,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
     questions: (questions || []).map((q) => ({
       id: q.id,
       question_type: q.question_type === 'open_response' ? 'open_response' : 'multiple_choice',

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -14,7 +14,6 @@ import {
 } from '@/lib/server/assessment-drafts'
 import { validateTestDraftContent } from '@/lib/validations/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
-import { withLegacyQuizKey } from '@/lib/test-api-contract'
 import type { TableRow } from '@/types/database'
 import type { TestDraftContent } from '@/types'
 
@@ -132,7 +131,7 @@ export const GET = withErrorHandler('GetTestById', async (_request, context) => 
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
     questions: responseQuestions,
     classroom: test.classrooms,
   })
@@ -356,7 +355,7 @@ export const PATCH = withErrorHandler('PatchUpdateTest', async (request, context
   }
 
   return NextResponse.json({
-    ...withLegacyQuizKey(responseTest),
+    test: responseTest,
   })
 })
 

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -22,7 +22,6 @@ import { withErrorHandler } from '@/lib/api-handler'
 import { getFallbackAssessmentTitle } from '@/lib/assessment-titles'
 import type { TestDraftContent, TestStudentAvailabilityState } from '@/types'
 import { chunkValues, loadChunkedRows } from '@/lib/server/query-chunks'
-import { withLegacyQuizKey, withLegacyQuizListKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -135,7 +134,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
   if (testsError) {
     if (testsError.code === 'PGRST205') {
-      return NextResponse.json({ ...withLegacyQuizListKey([]), migration_required: true })
+      return NextResponse.json({ tests: [], migration_required: true })
     }
     console.error('Error fetching tests:', testsError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -315,7 +314,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
     }
   })
 
-  return NextResponse.json(withLegacyQuizListKey(testsWithStats))
+  return NextResponse.json({ tests: testsWithStats })
 })
 
 // POST /api/teacher/tests - Create a new test
@@ -416,7 +415,7 @@ export const POST = withErrorHandler('CreateTeacherTest', async (request) => {
 
   return NextResponse.json(
     {
-      ...withLegacyQuizKey(responseTest),
+      test: responseTest,
     },
     { status: 201 }
   )

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -67,7 +67,6 @@ interface StudentTestSessionStatusSummary {
 
 interface StudentTestSessionStatusResponse {
   test?: StudentTestSessionStatusSummary
-  quiz?: StudentTestSessionStatusSummary
   student_status: StudentTestStatus
   returned_at: string | null
   can_continue: boolean
@@ -76,14 +75,10 @@ interface StudentTestSessionStatusResponse {
 
 interface StudentTestListResponse {
   tests?: StudentTestView[]
-  /** Legacy compatibility key emitted during the Tests contract transition. */
-  quizzes?: StudentTestView[]
 }
 
 interface StudentTestDetailResponse {
   test?: StudentTestView
-  /** Legacy compatibility key emitted during the Tests contract transition. */
-  quiz?: StudentTestView
   questions?: TestAssessmentQuestion[]
   student_responses?: Record<string, number | TestResponseDraftValue>
   student_status?: StudentTestStatus

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -66,7 +66,6 @@ interface TestResultsPayload {
 
 type TestResultsResponsePayload = Omit<TestResultsPayload, 'test'> & {
   test?: TestResultSummary | null
-  quiz?: TestResultSummary | null
 }
 
 interface GradeDraft {

--- a/src/hooks/useTeacherTestList.ts
+++ b/src/hooks/useTeacherTestList.ts
@@ -7,8 +7,6 @@ import type { AssessmentEditorSummaryUpdate, TestAssessmentWithStats } from '@/t
 
 type TeacherTestListResponse = {
   tests?: TestAssessmentWithStats[]
-  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
-  quizzes?: TestAssessmentWithStats[]
 }
 
 type UseTeacherTestListOptions = {

--- a/src/lib/test-api-contract.ts
+++ b/src/lib/test-api-contract.ts
@@ -4,40 +4,20 @@ import type {
   TestFocusSummary,
 } from '@/types'
 
-/**
- * Tests are the active product surface, but these routes still emit legacy
- * quiz-shaped keys for older clients during the contract transition.
- */
-export function withLegacyQuizListKey<T>(tests: T[]): { tests: T[]; quizzes: T[] } {
-  return {
-    tests,
-    quizzes: tests,
-  }
-}
-
-export function withLegacyQuizKey<T>(test: T): { test: T; quiz: T } {
-  return {
-    test,
-    quiz: test,
-  }
-}
-
 type TestApiListPayload<T> = {
   tests?: T[] | null
-  quizzes?: T[] | null
 }
 
 type TestApiDetailPayload<T> = {
   test?: T | null
-  quiz?: T | null
 }
 
 export function readTestsFromPayload<T>(payload: TestApiListPayload<T> | null | undefined): T[] {
-  return payload?.tests ?? payload?.quizzes ?? []
+  return payload?.tests ?? []
 }
 
 export function readTestFromPayload<T>(payload: TestApiDetailPayload<T> | null | undefined): T | undefined {
-  return payload?.test ?? payload?.quiz ?? undefined
+  return payload?.test ?? undefined
 }
 
 export interface TeacherTestGradingStudentRow {

--- a/tests/api/student/tests-id.test.ts
+++ b/tests/api/student/tests-id.test.ts
@@ -226,7 +226,7 @@ describe('GET /api/student/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.test).toEqual(data.quiz)
+    expect(data).not.toHaveProperty('quiz')
     expect(data.test.id).toBe('test-1')
     expect(data.test.returned_at).toBeNull()
     expect(questionSelectColumns).not.toContain('correct_option')

--- a/tests/api/student/tests-results.test.ts
+++ b/tests/api/student/tests-results.test.ts
@@ -434,7 +434,7 @@ describe('GET /api/student/tests/[id]/results', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.test).toEqual(data.quiz)
+    expect(data).not.toHaveProperty('quiz')
     expect(data.test.id).toBe('test-1')
     expect(data.test.returned_at).toBe('2026-03-05T11:00:00.000Z')
     expect(data.summary.earned_points).toBe(4)

--- a/tests/api/student/tests-route.test.ts
+++ b/tests/api/student/tests-route.test.ts
@@ -170,7 +170,7 @@ describe('GET /api/student/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.tests).toEqual(data.quizzes)
+    expect(data).not.toHaveProperty('quizzes')
     expect(data.tests).toHaveLength(1)
     expect(data.tests[0].id).toBe('test-1')
   })

--- a/tests/api/student/tests-session-status.test.ts
+++ b/tests/api/student/tests-session-status.test.ts
@@ -291,7 +291,7 @@ describe('GET /api/student/tests/[id]/session-status', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.test).toEqual(data.quiz)
+    expect(data).not.toHaveProperty('quiz')
     expect(data.can_continue).toBe(false)
     expect(data.effective_access ?? data.test.effective_access).toBe('closed')
     expect(data.message).toContain('saved draft is preserved')

--- a/tests/api/teacher/tests-id-route.test.ts
+++ b/tests/api/teacher/tests-id-route.test.ts
@@ -157,7 +157,7 @@ describe('PATCH /api/teacher/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.test).toEqual(data.quiz)
+    expect(data).not.toHaveProperty('quiz')
     expect(data.test.title).toBe('Closed Test')
     expect(data.test.show_results).toBe(false)
     expect(data.questions[0].question_text).toBe('Canonical question text')

--- a/tests/api/teacher/tests-route.test.ts
+++ b/tests/api/teacher/tests-route.test.ts
@@ -185,7 +185,7 @@ describe('GET /api/teacher/tests', () => {
       { column: 'position', ascending: false },
       { column: 'created_at', ascending: false },
     ])
-    expect(data.tests).toEqual(data.quizzes)
+    expect(data).not.toHaveProperty('quizzes')
     expect((data.tests as Array<{ id: string }>).map((test) => test.id)).toEqual(['test-2', 'test-1'])
   })
 
@@ -752,7 +752,7 @@ describe('POST /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(201)
-    expect(data.test).toEqual(data.quiz)
+    expect(data).not.toHaveProperty('quiz')
     expect(data.test.position).toBe(3)
     expect(data.test.title).toBe('New Test')
     expect(assessmentDraftInsertSpy).toHaveBeenCalledWith(

--- a/tests/architecture/legacy-quiz-alias-retirement.test.ts
+++ b/tests/architecture/legacy-quiz-alias-retirement.test.ts
@@ -80,6 +80,8 @@ describe('legacy quiz alias retirement', () => {
       'getQuizExitCount',
       'emptyQuizFocusSummary',
       'summarizeQuizFocusEvents',
+      'withLegacyQuizKey',
+      'withLegacyQuizListKey',
     ]
     const retiredDraftAliases = [
       'buildQuizDraftContentFromRows',

--- a/tests/components/StudentTestsTab.test.tsx
+++ b/tests/components/StudentTestsTab.test.tsx
@@ -108,54 +108,6 @@ describe('StudentTestsTab exam mode', () => {
     })
   }
 
-  it('reads legacy quiz-keyed test payloads as a compatibility fallback', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      quizzes: [{
-        id: 'legacy-test-1',
-        title: 'Legacy-Keyed Test',
-        assessment_type: 'test',
-        status: 'active',
-        show_results: false,
-        position: 0,
-        student_status: 'not_started',
-      }],
-    }))
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      quiz: {
-        id: 'legacy-test-1',
-        title: 'Legacy-Keyed Test',
-        assessment_type: 'test',
-        status: 'active',
-        show_results: false,
-        position: 0,
-        student_status: 'not_started',
-      },
-      student_status: 'not_started',
-      questions: [
-        {
-          id: 'legacy-question-1',
-          quiz_id: 'legacy-test-1',
-          question_text: 'Legacy-keyed detail question',
-          options: ['A', 'B'],
-          question_type: 'multiple_choice',
-          points: 1,
-          response_max_chars: 5000,
-          position: 0,
-        },
-      ],
-      student_responses: {},
-      focus_summary: null,
-    }))
-
-    render(<StudentTestsTab classroom={classroom} assessmentType="test" />)
-
-    expect(await screen.findByText('Legacy-Keyed Test')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByText('Legacy-Keyed Test'))
-
-    expect(await screen.findByText('1 question · 1 pt total')).toBeInTheDocument()
-  })
-
   it('shows a retryable error instead of an empty state when the tests list fails', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ error: 'Database unavailable' }, false))

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -235,7 +235,6 @@ function makeResultsResponse(overrides?: {
   questions?: Array<Record<string, unknown>>
   testStatus?: TestAssessmentWithStats['status']
   activeRun?: Record<string, unknown> | null
-  legacyQuizKey?: boolean
 }) {
   const testSummary = {
     id: overrides?.testId ?? 'test-1',
@@ -247,7 +246,7 @@ function makeResultsResponse(overrides?: {
   return {
     ok: true,
     json: async () => ({
-      [overrides?.legacyQuizKey ? 'quiz' : 'test']: testSummary,
+      test: testSummary,
       questions:
         overrides?.questions ?? [
           {
@@ -690,19 +689,6 @@ describe('TeacherTestsTab', () => {
     expect(onSelectTest).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'test-1', title: 'Unit Test' })
     )
-  })
-
-  it('reads legacy quiz-keyed test results payloads as a compatibility fallback', async () => {
-    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ legacyQuizKey: true }))
-    renderTab()
-
-    fireEvent.click(await screen.findByText('Unit Test'))
-
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
-    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
-    expect(screen.queryByText('Failed to load test results')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Close All' })).toBeInTheDocument()
   })
 
   it('opens the edit modal from the selected test edit button', async () => {

--- a/tests/components/TestDetailPanel.test.tsx
+++ b/tests/components/TestDetailPanel.test.tsx
@@ -135,50 +135,6 @@ describe('TestDetailPanel', () => {
     })
   })
 
-  it('reads legacy quiz-keyed test detail payloads as a compatibility fallback', async () => {
-    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((url: string) => {
-      if (url.endsWith('/api/teacher/tests/legacy-test/draft')) {
-        return Promise.resolve(jsonResponse({
-          draft: {
-            version: 1,
-            content: {
-              questions: [],
-            },
-          },
-        }))
-      }
-      if (url.endsWith('/api/teacher/tests/legacy-test')) {
-        return Promise.resolve(jsonResponse({
-          quiz: {
-            documents: [
-              { id: 'legacy-doc', title: 'Legacy Reference', source: 'text', content: 'Legacy detail' },
-            ],
-          },
-        }))
-      }
-      throw new Error(`Unexpected fetch: ${url}`)
-    })
-
-    render(
-      <TestDetailPanel
-        test={makeTestWithStats({ id: 'legacy-test', title: 'Legacy-Keyed Detail' })}
-        classroomId="classroom-1"
-        apiBasePath="/api/teacher/tests"
-        onTestUpdate={vi.fn()}
-      />,
-      { wrapper: Wrapper }
-    )
-
-    await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Documents (1)' })).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole('tab', { name: 'Documents (1)' }))
-
-    expect(screen.getByText('Legacy Reference')).toBeInTheDocument()
-  })
-
   it('ignores stale draft responses after selected assessment changes', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     const staleDraft = createDeferred<Response>()

--- a/tests/components/TestStudentGradingPanel.test.tsx
+++ b/tests/components/TestStudentGradingPanel.test.tsx
@@ -286,30 +286,6 @@ describe('TestStudentGradingPanel save-all grading', () => {
     })
   })
 
-  it('accepts legacy quiz result payloads as a compatibility fallback', async () => {
-    const legacyPayload = makeResultsPayload(3, 'Legacy feedback') as ReturnType<typeof makeResultsPayload> & {
-      quiz?: { id: string; title: string }
-      test?: { id: string; title: string }
-    }
-    legacyPayload.quiz = legacyPayload.test
-    delete legacyPayload.test
-
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => legacyPayload,
-    })
-
-    render(
-      <TestStudentGradingPanel
-        testId="test-1"
-        selectedStudentId="student-1"
-      />
-    )
-
-    await screen.findByDisplayValue('3')
-    expect(screen.getByDisplayValue('Legacy feedback')).toBeInTheDocument()
-  })
-
   it('renders score inputs for MC and open questions and saves MC overrides', async () => {
     let persistedMcScore = 2
     let persistedOpenScore: number | null = 3

--- a/tests/lib/test-api-contract.test.ts
+++ b/tests/lib/test-api-contract.test.ts
@@ -3,60 +3,25 @@ import {
   readTeacherTestResultsFromPayload,
   readTestFromPayload,
   readTestsFromPayload,
-  withLegacyQuizKey,
-  withLegacyQuizListKey,
 } from '@/lib/test-api-contract'
 
-describe('test API compatibility contract', () => {
-  it('mirrors the current tests list under the legacy quizzes key', () => {
+describe('test API contract', () => {
+  it('reads the tests list and defaults missing lists to empty', () => {
     const tests = [{ id: 'test-1' }, { id: 'test-2' }]
 
-    const payload = withLegacyQuizListKey(tests)
-
-    expect(payload).toEqual({ tests, quizzes: tests })
-    expect(payload.quizzes).toBe(payload.tests)
-  })
-
-  it('mirrors the current test detail under the legacy quiz key', () => {
-    const test = { id: 'test-1' }
-
-    const payload = withLegacyQuizKey(test)
-
-    expect(payload).toEqual({ test, quiz: test })
-    expect(payload.quiz).toBe(payload.test)
-  })
-
-  it('reads the current tests list before the legacy quizzes key', () => {
-    const currentTests = [{ id: 'test-current' }]
-    const legacyTests = [{ id: 'test-legacy' }]
-
-    expect(readTestsFromPayload({ tests: currentTests, quizzes: legacyTests })).toBe(currentTests)
-  })
-
-  it('falls back to the legacy quizzes key for older list payloads', () => {
-    const legacyTests = [{ id: 'test-legacy' }]
-
-    expect(readTestsFromPayload({ quizzes: legacyTests })).toBe(legacyTests)
+    expect(readTestsFromPayload({ tests })).toBe(tests)
     expect(readTestsFromPayload(null)).toEqual([])
   })
 
-  it('reads the current test detail before the legacy quiz key', () => {
-    const currentTest = { id: 'test-current' }
-    const legacyTest = { id: 'test-legacy' }
+  it('reads the test detail and defaults missing details to undefined', () => {
+    const test = { id: 'test-1' }
 
-    expect(readTestFromPayload({ test: currentTest, quiz: legacyTest })).toBe(currentTest)
-  })
-
-  it('falls back to the legacy quiz key for older detail payloads', () => {
-    const legacyTest = { id: 'test-legacy' }
-
-    expect(readTestFromPayload({ quiz: legacyTest })).toBe(legacyTest)
+    expect(readTestFromPayload({ test })).toBe(test)
     expect(readTestFromPayload(undefined)).toBeUndefined()
   })
 
-  it('normalizes teacher test results from the current test key first', () => {
+  it('normalizes teacher test results from the test key', () => {
     const currentTest = { id: 'test-current', status: 'active' } as any
-    const legacyTest = { id: 'test-legacy', status: 'closed' } as any
     const students = [
       {
         student_id: 'student-1',
@@ -79,7 +44,6 @@ describe('test API compatibility contract', () => {
 
     const result = readTeacherTestResultsFromPayload({
       test: currentTest,
-      quiz: legacyTest,
       students,
       questions: [
         { id: 'q-open', question_type: 'open_response', response_monospace: true },
@@ -98,16 +62,11 @@ describe('test API compatibility contract', () => {
     expect(result.activeAiGradingRun).toBe(activeRun)
   })
 
-  it('normalizes teacher test results from the legacy quiz fallback', () => {
-    const legacyTest = { id: 'test-legacy', status: 'closed' } as any
+  it('normalizes a missing teacher test result', () => {
+    const result = readTeacherTestResultsFromPayload({ error: 'No results' })
 
-    const result = readTeacherTestResultsFromPayload({
-      quiz: legacyTest,
-      error: 'No results',
-    })
-
-    expect(result.test).toBe(legacyTest)
-    expect(result.testStatus).toBe('closed')
+    expect(result.test).toBeUndefined()
+    expect(result.testStatus).toBeNull()
     expect(result.students).toEqual([])
     expect(result.questions).toEqual([])
     expect(result.activeAiGradingRun).toBeNull()


### PR DESCRIPTION
## Summary
- stop active student and teacher Tests APIs from emitting legacy `quiz` / `quizzes` response keys
- remove in-repo fallback readers and compatibility fixtures while retaining current optional/error normalization
- document the deprecation cutoff, rollback, and remaining persisted/archive/package/UI boundaries
- extend the architecture ratchet so the retired helpers cannot return

## Compatibility and rollback
- older independently deployed clients that read only `quiz` / `quizzes` must upgrade with the server
- rollback is code-only by restoring response aliases and readers
- no schema, migration, persisted data, archive v1, gradebook tombstone, or course-package compatibility changes

## Validation
- focused Tests API/client/component suites: 12 files / 208 tests
- `pnpm test`: 408 files / 3,674 tests
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm build`
- Pika changed-file audit
- `git diff --check`