### PR TITLE
Retire legacy Quiz UI wrappers

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14659,3 +14659,29 @@
 - Pika pre-commit audit
 - `git diff --check`
 - `pnpm db:types:check` intentionally blocked because local database history remains at 096 and AI did not apply migration 097
+
+<!-- pika-session-log-archive-batch:a818e3b99d20d74a9e930edb6f2d5991665662c919943c82a4e28e73ff5387e1 -->
+## 2026-07-15 — Production archive canary timeout hardening
+
+**Completed:**
+- Verified production migrations 001-097, released the reviewed archive recovery changes, and prepared a fresh named canary against the exact production deployment.
+- Completed the approved production export for one archived-hot classroom: 42 relational resources and 20 source objects were captured in a 2,489,962-byte compressed archive with independent evidence.
+- Kept the classroom hot after two same-operation compaction attempts rolled back atomically. No source or Gradex cleanup ran; all 20 source cleanup rows remain staged and no ownership verification or deletion attempt was recorded.
+- Correlated both failures with PostgreSQL SQLSTATE `57014` in hosted logs: `complete_classroom_archive_compaction` exceeded the default statement timeout while finalizing the transition.
+- Added migration 098 to set `statement_timeout = '60s'` only on the service-only compaction finalizer. Added source and replayed-database assertions that reject role- or database-wide timeout changes.
+- Left migration application and the existing canary resume to a human. Independent subagent review was unavailable due to the account usage limit; local SQL review found no additional issue.
+
+**Deployment obligation:**
+- Apply migration 098 before resuming the existing fixed canary operation from its approved runner commit.
+- Keep source cleanup and Gradex cleanup disabled. Resume the same plan; do not prepare a replacement operation or release a different runner before the round trip completes.
+
+**Validation:**
+- Focused archive timeout/compaction/migration suites (3 files / 11 tests)
+- `pnpm vitest run` (365 files / 3,346 tests)
+- `pnpm build`
+- `pnpm exec tsc --noEmit`
+- `pnpm check:architecture` (600 modules / 0 allowances)
+- Bash syntax validation for the compaction database contract harness
+- Pika pre-commit audit (no TypeScript files changed)
+- `git diff --check`
+- Database replay deferred to PR CI because local database history remains at 097 and AI did not apply migration 098

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,31 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-15 — Production archive canary timeout hardening
-
-**Completed:**
-- Verified production migrations 001-097, released the reviewed archive recovery changes, and prepared a fresh named canary against the exact production deployment.
-- Completed the approved production export for one archived-hot classroom: 42 relational resources and 20 source objects were captured in a 2,489,962-byte compressed archive with independent evidence.
-- Kept the classroom hot after two same-operation compaction attempts rolled back atomically. No source or Gradex cleanup ran; all 20 source cleanup rows remain staged and no ownership verification or deletion attempt was recorded.
-- Correlated both failures with PostgreSQL SQLSTATE `57014` in hosted logs: `complete_classroom_archive_compaction` exceeded the default statement timeout while finalizing the transition.
-- Added migration 098 to set `statement_timeout = '60s'` only on the service-only compaction finalizer. Added source and replayed-database assertions that reject role- or database-wide timeout changes.
-- Left migration application and the existing canary resume to a human. Independent subagent review was unavailable due to the account usage limit; local SQL review found no additional issue.
-
-**Deployment obligation:**
-- Apply migration 098 before resuming the existing fixed canary operation from its approved runner commit.
-- Keep source cleanup and Gradex cleanup disabled. Resume the same plan; do not prepare a replacement operation or release a different runner before the round trip completes.
-
-**Validation:**
-- Focused archive timeout/compaction/migration suites (3 files / 11 tests)
-- `pnpm vitest run` (365 files / 3,346 tests)
-- `pnpm build`
-- `pnpm exec tsc --noEmit`
-- `pnpm check:architecture` (600 modules / 0 allowances)
-- Bash syntax validation for the compaction database contract harness
-- Pika pre-commit audit (no TypeScript files changed)
-- `git diff --check`
-- Database replay deferred to PR CI because local database history remains at 097 and AI did not apply migration 098
-
 ## 2026-07-15 — Explicit AI migration authorization policy
 
 **Completed:**
@@ -1004,3 +979,33 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Remaining:**
 - Require independent PR review and exact-head CI before merge.
 - Next retire unused component prop wrappers and the legacy test automation id; preserve database-shaped fields and the old `tab=quizzes` URL tombstone.
+
+## 2026-07-23 — Retired legacy Quiz UI wrappers
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - the pass crosses shared Test component contracts, draft identity, exam-mode E2E setup, and the legacy retirement ratchet without changing rendered behavior.
+
+**Completed:**
+- Removed unused `quiz`, `quizId`, `quizTitle`, and `onQuizUpdate` component and hook aliases after confirming no production callers remained.
+- Made current Test identity and update props explicit and required.
+- Renamed the internal student action-footer automation id from `student-quiz-action-footer` to `student-test-action-footer`.
+- Updated student and teacher exam-mode E2E setup to decode the current `test` API response key.
+- Removed the final quiz-keyed Tests list payload type from assessment URL-state E2E setup after independent review.
+- Added an architecture ratchet preventing retired UI aliases and the old automation id from returning.
+- Preserved the `tab=quizzes&quizId=...` old-link tombstone, persisted `quiz_id` fields, schema, archives, gradebook tombstones, and course package compatibility.
+
+**Validation:**
+- Focused wrapper and component suites (7 files / 115 tests)
+- Full repository suite (408 files / 3,670 tests)
+- Exam-mode Playwright discovery (10 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (624 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit
+- `git diff --check`
+
+**Remaining:**
+- Require independent PR review and exact-head CI before merge.
+- Next prove and remove unreachable quiz-mode rendering and legacy quiz markdown code while preserving URL and data contracts.

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -85,23 +85,23 @@ Architecture and route regressions protect those boundaries.
 
 ### UI Compatibility Wrappers
 
-Retain until their callers are removed:
+Component and automation aliases are retired:
 
-- Component props such as `quiz`, `quizId`, `quizTitle`, and `onQuizUpdate`
-  when paired with explicit compatibility tests.
-- `student-quiz-action-footer` test ids while component tests still use the old
-  identifier.
-- Legacy `tab=quizzes` route fallback tests, which prove old URLs fall back to
-  the supported tab instead of exposing a removed product surface.
+- Test components and `useDraftMode` require current `test`, `testId`,
+  `assessmentId`, `assessmentTitle`, and `onTestUpdate` props.
+- The student test action footer uses the current
+  `student-test-action-footer` automation id.
+- Exam-mode E2E setup reads only the current Tests API response keys.
 
-The UI no longer accepts quiz-keyed API response payloads. Remaining wrappers
-are component/URL/automation contracts and should be retired independently.
+Retain the legacy `tab=quizzes&quizId=...` route fallback tests. They prove old
+URLs fall back to the supported tab instead of exposing a removed product
+surface. This URL tombstone is separate from component and API contracts.
 
 ### Tests
 
 Remaining quiz references usually fall into one of these groups:
 
-- Compatibility regressions for legacy props, route params, or persisted data.
+- Compatibility regressions for legacy route params or persisted data.
 - Database-shaped mocks that must still use `quiz_id` or legacy table names.
 - Gradebook tests that prove legacy quiz response fields remain inert and the
   active server never queries quiz tables.
@@ -180,9 +180,11 @@ Requires a follow-up design and approval:
    - Completed: removed unused `Quiz*` types, quiz-named assessment helper
      aliases, and dead server/re-export modules after proving they had no
      application callers.
-   - Keep legacy component prop aliases until their UI compatibility window is
-     explicitly closed and visually verified.
-   - Rename remaining test ids if no external automation depends on them.
+   - Completed: removed quiz-named component prop aliases after proving they had
+     no production callers.
+   - Completed: renamed the internal student action-footer test id and updated
+     repository automation.
+   - Retain the old `tab=quizzes&quizId=...` URL tombstone independently.
    - Rollback: restore aliases; no data rollback required.
 
 5. **Gradebook and course package decision**
@@ -242,16 +244,16 @@ For each implementation pass:
 
 ## Next Implementation Pass
 
-The API response-key window, gradebook/course-package decisions, and dead draft
-alias retirement are complete. The next safe pass is UI compatibility-wrapper
-retirement:
+The API response-key window, gradebook/course-package decisions, dead draft
+aliases, and UI compatibility wrappers are complete. The next safe pass is
+unreachable quiz-mode UI and markdown retirement:
 
-- remove `quiz`, `quizId`, `quizTitle`, and `onQuizUpdate` props when their
-  current callers and explicit compatibility tests are gone;
-- rename `student-quiz-action-footer` after checking external automation;
-- retain `tab=quizzes` as a URL tombstone until the old-link window is closed;
-- keep database-shaped `quiz_id` fields wherever persistence still requires
-  them.
+- prove active callers always use Tests mode;
+- remove quiz-only rendering branches and wording from current Test components;
+- remove `src/lib/quiz-markdown.ts` and its compatibility test if no package,
+  import, or persisted-data reader depends on it;
+- retain `tab=quizzes` as a URL tombstone and keep database-shaped `quiz_id`
+  fields wherever persistence still requires them.
 
 Schema removal remains blocked on archive-format support and production
 verification. Gradebook tombstones and course package compatibility fields

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -115,12 +115,12 @@ async function createActiveOpenResponseTest(
   classroomId: string,
   title: string,
 ): Promise<AssessmentRecord> {
-  const created = await sendJson<{ quiz: AssessmentRecord }>(teacherPage, 'POST', '/api/teacher/tests', {
+  const created = await sendJson<{ test: AssessmentRecord }>(teacherPage, 'POST', '/api/teacher/tests', {
     classroom_id: classroomId,
     title,
   })
 
-  const testRecord = created.quiz
+  const testRecord = created.test
   const draft = await loadJson<{ draft: AssessmentDraftRecord }>(
     teacherPage,
     `/api/teacher/tests/${testRecord.id}/draft`,

--- a/e2e/teacher-assessment-url-state.spec.ts
+++ b/e2e/teacher-assessment-url-state.spec.ts
@@ -55,7 +55,7 @@ async function loadTeacherTestWithStudent(page: Page, classroomId: string): Prom
   testRecord: AssessmentRecord
   student: TestGradingStudentRecord
 }> {
-  const data = await loadJson<{ quizzes?: AssessmentRecord[]; tests?: AssessmentRecord[] }>(
+  const data = await loadJson<{ tests?: AssessmentRecord[] }>(
     page,
     `/api/teacher/tests?classroom_id=${encodeURIComponent(classroomId)}`,
   )

--- a/e2e/teacher-exam-mode.spec.ts
+++ b/e2e/teacher-exam-mode.spec.ts
@@ -27,9 +27,6 @@ interface TestResultsRecord {
   test?: {
     status?: 'draft' | 'active' | 'closed'
   }
-  quiz?: {
-    status?: 'draft' | 'active' | 'closed'
-  }
   students?: Array<{
     student_id: string
     effective_access?: 'open' | 'closed'
@@ -96,12 +93,12 @@ async function createDraftOpenResponseTest(
   classroomId: string,
   title: string,
 ): Promise<AssessmentRecord> {
-  const created = await sendJson<{ quiz: AssessmentRecord }>(page, 'POST', '/api/teacher/tests', {
+  const created = await sendJson<{ test: AssessmentRecord }>(page, 'POST', '/api/teacher/tests', {
     classroom_id: classroomId,
     title,
   })
 
-  const testRecord = created.quiz
+  const testRecord = created.test
   const draft = await loadJson<{ draft: AssessmentDraftRecord }>(
     page,
     `/api/teacher/tests/${testRecord.id}/draft`,
@@ -227,7 +224,7 @@ async function prepareExamWindowForViewportCompliance(page: Page): Promise<void>
 }
 
 function getResultsStatus(results: TestResultsRecord): 'draft' | 'active' | 'closed' | undefined {
-  return results.test?.status ?? results.quiz?.status
+  return results.test?.status
 }
 
 test.describe('teacher exam mode', () => {

--- a/src/components/StudentTestForm.tsx
+++ b/src/components/StudentTestForm.tsx
@@ -18,8 +18,7 @@ import {
 import type { TestAssessmentType, TestAssessmentQuestion, TestResponseDraftValue } from '@/types'
 
 interface Props {
-  testId?: string
-  quizId?: string
+  testId: string
   questions: TestAssessmentQuestion[]
   initialResponses?: Record<string, number | TestResponseDraftValue> | TestResponses
   enableDraftAutosave?: boolean
@@ -44,8 +43,7 @@ function isAssessmentAvailabilityError(message: string): boolean {
 }
 
 export function StudentTestForm({
-  testId: testIdProp,
-  quizId,
+  testId,
   questions,
   initialResponses,
   enableDraftAutosave = false,
@@ -56,11 +54,9 @@ export function StudentTestForm({
   onAvailabilityLoss,
   onSubmitted,
 }: Props) {
-  const resolvedTestId = testIdProp ?? quizId
-  if (!resolvedTestId) {
+  if (!testId) {
     throw new Error('StudentTestForm requires testId')
   }
-  const testId: string = resolvedTestId
 
   const OPEN_RESPONSE_TAB_INDENT = '\t'
   const OPEN_RESPONSE_TAB_SIZE = 4
@@ -106,7 +102,7 @@ export function StudentTestForm({
 
   const submitActions = (
     <div
-      data-testid="student-quiz-action-footer"
+      data-testid="student-test-action-footer"
       className={
         isTestAssessment
           ? 'rounded-xl border border-border bg-surface p-4 shadow-sm'

--- a/src/components/StudentTestResults.tsx
+++ b/src/components/StudentTestResults.tsx
@@ -52,8 +52,7 @@ function selectedOptionFromResponse(
 }
 
 interface Props {
-  testId?: string
-  quizId?: string
+  testId: string
   myResponses: Record<string, number | TestResponseDraftValue>
   assessmentType?: TestAssessmentType
   apiBasePath?: string
@@ -61,18 +60,15 @@ interface Props {
 }
 
 export function StudentTestResults({
-  testId: testIdProp,
-  quizId,
+  testId,
   myResponses,
   assessmentType,
   apiBasePath = '/api/student/tests',
   showSubmissionBanner = true,
 }: Props) {
-  const resolvedTestId = testIdProp ?? quizId
-  if (!resolvedTestId) {
+  if (!testId) {
     throw new Error('StudentTestResults requires testId')
   }
-  const testId: string = resolvedTestId
 
   const [payload, setPayload] = useState<ResultsPayload | null>(null)
   const [loading, setLoading] = useState(true)

--- a/src/components/TestDetailPanel.tsx
+++ b/src/components/TestDetailPanel.tsx
@@ -58,12 +58,10 @@ import type {
 } from '@/types'
 
 interface Props {
-  test?: TestAssessmentWithStats
-  quiz?: TestAssessmentWithStats
+  test: TestAssessmentWithStats
   classroomId: string
   apiBasePath?: string
-  onTestUpdate?: (update?: AssessmentEditorSummaryUpdate) => void
-  onQuizUpdate?: (update?: AssessmentEditorSummaryUpdate) => void
+  onTestUpdate: (update?: AssessmentEditorSummaryUpdate) => void
   onDraftSummaryChange?: (update: AssessmentEditorSummaryUpdate) => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
@@ -165,11 +163,9 @@ function summarizeDraftContent(
 
 export function TestDetailPanel({
   test,
-  quiz: legacyQuiz,
   classroomId,
   apiBasePath = '/api/teacher/tests',
   onTestUpdate,
-  onQuizUpdate: legacyOnQuizUpdate,
   onDraftSummaryChange,
   onRequestDelete,
   onRequestTestPreview,
@@ -184,16 +180,14 @@ export function TestDetailPanel({
   titlePortalTarget = null,
   generatedTitleLabel,
 }: Props) {
-  const resolvedTest = test ?? legacyQuiz
-  const resolvedOnTestUpdate = onTestUpdate ?? legacyOnQuizUpdate
-  if (!resolvedTest) {
+  if (!test) {
     throw new Error('TestDetailPanel requires test')
   }
-  if (!resolvedOnTestUpdate) {
+  if (!onTestUpdate) {
     throw new Error('TestDetailPanel requires onTestUpdate')
   }
-  const testAssessment: TestAssessmentWithStats = resolvedTest
-  const notifyTestUpdate: (update?: AssessmentEditorSummaryUpdate) => void = resolvedOnTestUpdate
+  const testAssessment: TestAssessmentWithStats = test
+  const notifyTestUpdate: (update?: AssessmentEditorSummaryUpdate) => void = onTestUpdate
 
   const AUTOSAVE_DEBOUNCE_MS = 3000
   const AUTOSAVE_MIN_INTERVAL_MS = 10_000

--- a/src/components/TestIndividualResponses.tsx
+++ b/src/components/TestIndividualResponses.tsx
@@ -37,8 +37,7 @@ interface Responder {
 }
 
 interface Props {
-  testId?: string
-  quizId?: string
+  testId: string
   apiBasePath?: string
   assessmentType?: 'quiz' | 'test'
   onUpdated?: () => void
@@ -91,17 +90,14 @@ function toTestAnswerDetail(answer: number | TestAnswerDetail | undefined): Test
 }
 
 export function TestIndividualResponses({
-  testId: testIdProp,
-  quizId,
+  testId,
   apiBasePath = '/api/teacher/tests',
   assessmentType = 'test',
   onUpdated,
 }: Props) {
-  const resolvedTestId = testIdProp ?? quizId
-  if (!resolvedTestId) {
+  if (!testId) {
     throw new Error('TestIndividualResponses requires testId')
   }
-  const testId: string = resolvedTestId
 
   const isTestsView = assessmentType === 'test'
   const scope = `${assessmentType}:${apiBasePath}:${testId}`

--- a/src/hooks/useDraftMode.ts
+++ b/src/hooks/useDraftMode.ts
@@ -21,11 +21,9 @@ export type ConflictDraft = {
   content: DraftContent
 } | null
 
-type DraftModeAssessmentIdentity =
-  | { assessmentId: string; assessmentTitle: string; quizId?: string; quizTitle?: string }
-  | { assessmentId?: string; assessmentTitle?: string; quizId: string; quizTitle: string }
-
-type UseDraftModeOptions = DraftModeAssessmentIdentity & {
+type UseDraftModeOptions = {
+  assessmentId: string
+  assessmentTitle: string
   showResults: boolean
   apiBasePath: string
   /** Called after a successful save so the parent can refresh assessment metadata. */
@@ -80,14 +78,14 @@ export interface UseDraftModeReturn {
  */
 export function useDraftMode(options: UseDraftModeOptions): UseDraftModeReturn {
   const {
+    assessmentId,
+    assessmentTitle,
     showResults,
     apiBasePath,
     onUpdate,
     onError,
     onQuestionsChange,
   } = options
-  const assessmentId = options.assessmentId ?? options.quizId
-  const assessmentTitle = options.assessmentTitle ?? options.quizTitle
   if (!assessmentId || !assessmentTitle) {
     throw new Error('useDraftMode requires assessmentId/assessmentTitle')
   }

--- a/tests/architecture/legacy-quiz-alias-retirement.test.ts
+++ b/tests/architecture/legacy-quiz-alias-retirement.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
@@ -96,6 +97,27 @@ describe('legacy quiz alias retirement', () => {
       ...retiredDraftAliases,
     ]) {
       expect(exportedLocations(alias), `${alias} is exported`).toEqual([])
+    }
+  })
+
+  it('does not restore retired quiz-named UI compatibility contracts', () => {
+    const retiredContractsByFile = {
+      'src/hooks/useDraftMode.ts': ['quizId', 'quizTitle'],
+      'src/components/StudentTestForm.tsx': ['quizId', 'student-quiz-action-footer'],
+      'src/components/StudentTestResults.tsx': ['quizId'],
+      'src/components/TestIndividualResponses.tsx': ['quizId'],
+      'src/components/TestDetailPanel.tsx': [
+        'onQuizUpdate',
+        'quiz?: TestAssessmentWithStats',
+      ],
+      'e2e/teacher-assessment-url-state.spec.ts': ['quizzes?: AssessmentRecord[]'],
+    }
+
+    for (const [fileName, retiredContracts] of Object.entries(retiredContractsByFile)) {
+      const source = fs.readFileSync(path.join(root, fileName), 'utf8')
+      for (const retiredContract of retiredContracts) {
+        expect(source, `${retiredContract} restored in ${fileName}`).not.toContain(retiredContract)
+      }
     }
   })
 })

--- a/tests/components/StudentTestForm.test.tsx
+++ b/tests/components/StudentTestForm.test.tsx
@@ -15,31 +15,6 @@ describe('StudentTestForm preview mode', () => {
     localStorage.clear()
   })
 
-  it('accepts legacy quizId as a compatibility alias', () => {
-    render(
-      <StudentTestForm
-        quizId="legacy-test-id"
-        questions={[
-          createMockTestQuestion({
-            id: 'q1',
-            question_text: 'Which option is correct?',
-            options: ['A', 'B'],
-            question_type: 'multiple_choice',
-            position: 0,
-          }),
-        ]}
-        assessmentType="test"
-        previewMode
-        onSubmitted={vi.fn()}
-      />
-    )
-
-    const titleArea = screen.getByText('Q1').closest('[data-question-title-id="q1"]')!
-    fireEvent.click(titleArea)
-
-    expect(JSON.parse(localStorage.getItem('pika:flagged-questions:legacy-test-id') || '[]')).toContain('q1')
-  })
-
   it('simulates submit without saving data', async () => {
     const onSubmitted = vi.fn()
 
@@ -208,7 +183,7 @@ describe('StudentTestForm preview mode', () => {
       />
     )
 
-    const actionPanel = screen.getByTestId('student-quiz-action-footer')
+    const actionPanel = screen.getByTestId('student-test-action-footer')
     const questionsStack = screen.getByText('Question 2?').closest('[data-question-id="q2"]')
       ?.parentElement
 

--- a/tests/components/StudentTestResults.test.tsx
+++ b/tests/components/StudentTestResults.test.tsx
@@ -25,20 +25,6 @@ describe('StudentTestResults', () => {
     return { ok: true, json: async () => body } as Response
   }
 
-  it('accepts legacy quizId as a compatibility alias', async () => {
-    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ results: [] }),
-    })
-
-    render(<StudentTestResults quizId="legacy-test-id" myResponses={{}} />)
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/student/tests/legacy-test-id/results')
-    })
-  })
-
   it('shows loading spinner initially', () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockReturnValue(new Promise(() => {})) // never resolves

--- a/tests/components/StudentTestsTab.test.tsx
+++ b/tests/components/StudentTestsTab.test.tsx
@@ -1270,7 +1270,7 @@ describe('StudentTestsTab exam mode', () => {
     })
 
     const detailPane = screen.getByTestId('student-test-detail-pane')
-    const actionFooter = within(detailPane).getByTestId('student-quiz-action-footer')
+    const actionFooter = within(detailPane).getByTestId('student-test-action-footer')
     const questionsStack = screen.getByText('Question 12?').closest('[data-question-id="q12"]')
       ?.parentElement
 

--- a/tests/components/TestDetailPanel.test.tsx
+++ b/tests/components/TestDetailPanel.test.tsx
@@ -116,25 +116,6 @@ describe('TestDetailPanel', () => {
     return fetchMock
   }
 
-  it('accepts legacy quiz and onQuizUpdate as compatibility aliases', async () => {
-    mockFetchForTest(sampleQuestions)
-    const legacyTest = makeTestWithStats({ title: 'Legacy Alias Test' })
-    const legacyOnQuizUpdate = vi.fn()
-
-    render(
-      <TestDetailPanel
-        quiz={legacyTest}
-        classroomId="classroom-1"
-        onQuizUpdate={legacyOnQuizUpdate}
-      />,
-      { wrapper: Wrapper }
-    )
-
-    await waitFor(() => {
-      expect(screen.getByText('Legacy Alias Test')).toBeInTheDocument()
-    })
-  })
-
   it('ignores stale draft responses after selected assessment changes', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     const staleDraft = createDeferred<Response>()

--- a/tests/components/TestIndividualResponses.test.tsx
+++ b/tests/components/TestIndividualResponses.test.tsx
@@ -95,20 +95,6 @@ describe('TestIndividualResponses', () => {
     vi.restoreAllMocks()
   })
 
-  it('accepts legacy quizId as a compatibility alias', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({
-      questions: [],
-      responders: [],
-    })))
-    vi.stubGlobal('fetch', fetchMock)
-
-    render(<TestIndividualResponses quizId="legacy-test-id" />)
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/legacy-test-id/results')
-    })
-  })
-
   it('ignores stale result responses after selected test changes', async () => {
     const staleResults = createDeferred<Response>()
     const currentResults = createDeferred<Response>()

--- a/tests/hooks/useDraftMode.test.ts
+++ b/tests/hooks/useDraftMode.test.ts
@@ -49,46 +49,6 @@ describe('useDraftMode', () => {
       expect(result.current.editTitle).toBe('My Test')
     })
 
-    it('accepts legacy quizId and quizTitle option aliases', async () => {
-      const fetchSpy = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ version: 2 }),
-      })
-      vi.stubGlobal('fetch', fetchSpy)
-
-      const { result } = renderHook(() =>
-        useDraftMode({
-          quizId: 'legacy-test-1',
-          quizTitle: 'Legacy Test',
-          showResults: false,
-          apiBasePath: '/api/teacher/tests',
-          onUpdate: vi.fn(),
-          onError: vi.fn(),
-          onQuestionsChange: vi.fn(),
-        })
-      )
-
-      expect(result.current.editTitle).toBe('Legacy Test')
-
-      await act(async () => {
-        await result.current.saveDraft({
-          title: 'Updated Title',
-          show_results: false,
-          questions: [],
-        })
-      })
-
-      await waitFor(() => {
-        expect(fetchSpy).toHaveBeenCalledWith(
-          expect.stringContaining('/api/teacher/tests/legacy-test-1/draft'),
-          expect.objectContaining({ method: 'PATCH' })
-        )
-      })
-
-      vi.unstubAllGlobals()
-    })
-
     it('initialises saveStatus as "saved"', () => {
       const { result } = renderHook(() => useDraftMode(makeOptions()))
       expect(result.current.saveStatus).toBe('saved')


### PR DESCRIPTION
## Summary
- remove unused quiz-named Test component and draft-hook prop aliases
- require current Test identity/update contracts and rename the internal student action-footer test id
- update exam-mode E2E setup to decode the current `test` API key
- ratchet the retired contracts and document the remaining URL/data boundaries

## Preserved compatibility
- retain the old `tab=quizzes&quizId=...` URL tombstone
- retain persisted `quiz_id` fields, archive resources, gradebook tombstones, course-package compatibility, and schema
- no visible text, layout, interaction, migration, or production-state changes

## Validation
- focused wrapper/component suites: 7 files / 115 tests
- `pnpm test`: 408 files / 3,670 tests
- exam-mode Playwright discovery: 10 tests
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm build`
- Pika changed-file audit
- `git diff --check`