### PR TITLE
Prepare legacy Quiz freeze and backfill

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -4,7 +4,8 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 
 ## Current Focus
 
-- Migrations 001-105 local; 105 is not hosted. V2 restore is staged; v1 remains current pending version-aware compaction.
+- Local schema: 001-105; 105 is not hosted. Migration 106 is prepared but
+  unapplied pending the version-aware runtime.
 - Product experience: `.ai/features.json`; audit: `docs/guidance/ui/product-experience-audit-2026-07.md`. Safety Wave and Phase 2 are complete. Phase 3 assignment, Daily/Attendance desktop/accessibility, and Tests list reliability plus authoring/grading separation are complete; mobile UX is deferred, Gradex is owned by a separate session, and standalone test preview hardening is next.
 
 ## Environment

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14890,3 +14890,25 @@
 - `node --check scripts/trim-session-log.mjs`
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
+
+<!-- pika-session-log-archive-batch:be04f211c2d3e444995c7a12eeaadae53553cbf89b75daf72a759d36d7954a92 -->
+## 2026-07-20 — Migration 099 local seed compatibility
+
+**Completed:**
+- Fixed `pnpm seed` for databases with migration 099 by creating assignment documents as editable, inserting their baseline/autosave/blur history, and only then finalizing submitted documents.
+- Let migration 099's deferred constraint trigger create each authoritative submit snapshot, preserving the database invariant that editable history cannot be written after submission.
+- Aligned the synthetic writing timelines with the existing 4-day and 2-day submission dates so grading fixtures remain chronologically valid.
+- Added unit and source-order regression coverage for history partitioning and seed lifecycle ordering.
+- Derived the earliest returned-feedback timestamp from the generated submission time after review found an early-day chronology edge case.
+- Re-ran `pnpm seed` against the authorized loopback database; the complete classroom, assignment-review, and test fixtures now seed successfully. No production resources were accessed or modified.
+
+**Validation:**
+- `pnpm test` (376 files / 3,495 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm seed` against the loopback Supabase database through migration 099
+- Direct loopback database checks: one submit row per submitted document, matching content snapshots, all editable history before submission, and returned feedback after submission
+- `git diff --check`
+
+**Audit note:**
+- The Pika pre-commit audit reports the existing CLI progress `console.log` calls throughout `scripts/seed.ts` after that file is touched. No new production logging path was introduced; this is a whole-file false positive for the development seed CLI.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1121,7 +1121,7 @@ future persistence shape without enabling unapproved schema behavior.
 **Completed:**
 - Added migration 106 to freeze the retired Quiz tables and drafts, prove Quiz
   blueprints are empty, and narrow the constraint to Test-only. Archive-ordered
-  `NOWAIT` locks roll back immediately on live conflicts.
+  parent/child `NOWAIT` locks roll back immediately on live conflicts.
 - Added deterministic SQL envelope IDs and canonical payload checksums matching
   the TypeScript adapter, parent and actor preflights, collision checks, and an
   aggregate-only five-resource parity ledger.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1119,18 +1119,16 @@ future persistence shape without enabling unapproved schema behavior.
 **Risk profile:** runtime-platform
 
 **Completed:**
-- Added migration 106 to access-exclusively lock and freeze the four retired
-  Quiz tables plus Quiz drafts, prove blueprint Quiz rows are zero, and narrow
-  the blueprint assessment constraint to Test-only.
+- Added migration 106 to freeze the retired Quiz tables and drafts, prove Quiz
+  blueprints are empty, and narrow the constraint to Test-only. Archive-ordered
+  `NOWAIT` locks roll back immediately on live conflicts.
 - Added deterministic SQL envelope IDs and canonical payload checksums matching
   the TypeScript adapter, parent and actor preflights, collision checks, and an
   aggregate-only five-resource parity ledger.
 - Kept every source row intact for the observation window and added no
   dual-write or active Test-table mapping.
-- Added a disposable database rehearsal that runs the existing non-empty v1
-  restore and v2 contracts at migration 105, seeds all five source resources,
-  applies 106 only to that disposable database, verifies the write freeze and
-  ledger, and compares database envelopes with the TypeScript adapter.
+- Added a disposable rehearsal for v1/v2 compatibility, failed preflights,
+  envelope/source lock contention, the freeze and ledger, and SQL/TS parity.
 - Documented that migration 106 cannot be hosted until direct v2 snapshots,
   version-aware compaction, and v1-to-v2 restore dispatch are current.
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,27 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-20 — Migration 099 local seed compatibility
-
-**Completed:**
-- Fixed `pnpm seed` for databases with migration 099 by creating assignment documents as editable, inserting their baseline/autosave/blur history, and only then finalizing submitted documents.
-- Let migration 099's deferred constraint trigger create each authoritative submit snapshot, preserving the database invariant that editable history cannot be written after submission.
-- Aligned the synthetic writing timelines with the existing 4-day and 2-day submission dates so grading fixtures remain chronologically valid.
-- Added unit and source-order regression coverage for history partitioning and seed lifecycle ordering.
-- Derived the earliest returned-feedback timestamp from the generated submission time after review found an early-day chronology edge case.
-- Re-ran `pnpm seed` against the authorized loopback database; the complete classroom, assignment-review, and test fixtures now seed successfully. No production resources were accessed or modified.
-
-**Validation:**
-- `pnpm test` (376 files / 3,495 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm seed` against the loopback Supabase database through migration 099
-- Direct loopback database checks: one submit row per submitted document, matching content snapshots, all editable history before submission, and returned feedback after submission
-- `git diff --check`
-
-**Audit note:**
-- The Pika pre-commit audit reports the existing CLI progress `console.log` calls throughout `scripts/seed.ts` after that file is touched. No new production logging path was introduced; this is a whole-file false positive for the development seed CLI.
-
 ## 2026-07-20 — Teacher dashboard entry authorization contract
 
 **Completed:**
@@ -1134,3 +1113,34 @@ future persistence shape without enabling unapproved schema behavior.
 **Remaining:**
 - Publish, independently review, and require exact-head CI before merge.
 - Then proceed to the separately authorized atomic Quiz freeze/backfill pass.
+
+## 2026-07-23 — Prepared atomic legacy Quiz freeze and backfill
+
+**Risk profile:** runtime-platform
+
+**Completed:**
+- Added migration 106 to access-exclusively lock and freeze the four retired
+  Quiz tables plus Quiz drafts, prove blueprint Quiz rows are zero, and narrow
+  the blueprint assessment constraint to Test-only.
+- Added deterministic SQL envelope IDs and canonical payload checksums matching
+  the TypeScript adapter, parent and actor preflights, collision checks, and an
+  aggregate-only five-resource parity ledger.
+- Kept every source row intact for the observation window and added no
+  dual-write or active Test-table mapping.
+- Added a disposable database rehearsal that runs the existing non-empty v1
+  restore and v2 contracts at migration 105, seeds all five source resources,
+  applies 106 only to that disposable database, verifies the write freeze and
+  ledger, and compares database envelopes with the TypeScript adapter.
+- Documented that migration 106 cannot be hosted until direct v2 snapshots,
+  version-aware compaction, and v1-to-v2 restore dispatch are current.
+
+**Validation:**
+- Focused migration and archive-v2 unit tests, TypeScript, shell syntax, and
+  `git diff --check` pass.
+- Migration 106 was not applied to the shared local database or a hosted
+  target; its executable rehearsal is reserved for disposable PR CI.
+
+**Remaining:**
+- Run repository checks, independent review, and exact-head CI before merge.
+- Next pass: implement the version-aware archive runtime required before
+  migration 106 can receive target-specific application approval.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,8 @@ jobs:
       - name: Verify atomic archive compaction rollback and cleanup staging
         run: bash scripts/check-classroom-archive-compaction-database.sh
 
-      - name: Verify real compaction and resumable restore round trip
-        run: bash scripts/check-classroom-archive-restore-database.sh
-
-      - name: Verify classroom archive v2 database contract
-        run: bash scripts/check-classroom-archive-v2-database.sh
+      - name: Verify archive compatibility, then rehearse legacy Quiz freeze and backfill
+        run: bash scripts/check-legacy-quiz-freeze-backfill.sh
 
       - name: Verify Gradex extract operations and retention cleanup
         run: bash scripts/check-classroom-gradex-database.sh

--- a/docs/guidance/legacy-quiz-schema-retirement-plan.md
+++ b/docs/guidance/legacy-quiz-schema-retirement-plan.md
@@ -232,6 +232,10 @@ Application rollback leaves the new registry and envelope tables unused.
   drift.
 - Leave the source tables intact for a compatibility observation window.
 
+Migration 106 acquires its envelope and source relations in archive traversal
+order with `NOWAIT`. Any live archive, restore, or source transaction causes the
+whole migration to roll back immediately; retry it during a quiet window.
+
 This pass does not dual-write because there is no active Quiz writer. If the
 preflight finds an unknown writer or changing counts, stop and investigate
 rather than adding a new compatibility producer.

--- a/docs/guidance/legacy-quiz-schema-retirement-plan.md
+++ b/docs/guidance/legacy-quiz-schema-retirement-plan.md
@@ -232,9 +232,10 @@ Application rollback leaves the new registry and envelope tables unused.
   drift.
 - Leave the source tables intact for a compatibility observation window.
 
-Migration 106 acquires its envelope and source relations in archive traversal
-order with `NOWAIT`. Any live archive, restore, or source transaction causes the
-whole migration to roll back immediately; retry it during a quiet window.
+Migration 106 fail-fast locks the `classrooms` and `users` FK parents, then
+acquires its envelope and source relations in archive traversal order with
+`NOWAIT`. Any live archive, restore, parent-write, or source transaction causes
+the whole migration to roll back immediately; retry it during a quiet window.
 
 This pass does not dual-write because there is no active Quiz writer. If the
 preflight finds an unknown writer or changing counts, stop and investigate

--- a/docs/guidance/legacy-quiz-schema-retirement-plan.md
+++ b/docs/guidance/legacy-quiz-schema-retirement-plan.md
@@ -208,8 +208,16 @@ Application rollback leaves the new registry and envelope tables unused.
 
 ### Pass B: Freeze And Backfill
 
+- Prepared in migration 106, but not applied to the shared local database or
+  any hosted target. The database rehearsal rebuilds a disposable schema
+  through migration 105, proves the non-empty v1/v2 compatibility contracts,
+  seeds all five retired source resources, applies 106 there, and compares the
+  resulting records and actors byte-for-byte with the TypeScript adapter.
 - Reject new writes to the four Quiz tables and Quiz drafts before taking the
-  source snapshot. Active Pika has no legitimate producers.
+  source snapshot. Active product code has no legitimate producers. The
+  retained v1 archive restore/compaction path is a compatibility producer, so
+  its non-empty contract is rehearsed before the freeze and must move to the
+  version-aware runtime before 106 is hosted.
 - In the same transaction, take an access-exclusive lock on
   `course_blueprint_assessments`, fail if any Quiz row exists, and replace its
   `assessment_type` check with a Test-only constraint before releasing the
@@ -228,8 +236,19 @@ This pass does not dual-write because there is no active Quiz writer. If the
 preflight finds an unknown writer or changing counts, stop and investigate
 rather than adding a new compatibility producer.
 
+Migration 106 is not independently rollout-ready. Once envelopes exist,
+migration 105 intentionally makes the current v1 export and compaction entry
+points fail closed rather than omit retired data. Before hosted application of
+106, deploy the version-aware archive runtime with direct v2 source snapshots,
+v2 compaction, and v1-to-v2 restore dispatch. Apply 105 first under its own
+authorization; apply 106 only in the coordinated runtime rollout under a new
+target-specific authorization.
+
 ### Pass C: Production Proof
 
+- First complete the version-aware runtime pass required by the migration 106
+  rollout gate; do not use production proof as the first activation of that
+  runtime.
 - Re-run `verify:legacy-quiz-inventory` and compare it with the backfill ledger.
 - Run the database catalog audit and generated-type check.
 - Create and restore a non-empty archive-v2 canary only under separate,

--- a/scripts/check-classroom-archive-restore-database.sh
+++ b/scripts/check-classroom-archive-restore-database.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 DB_CONTAINER="${CLASSROOM_ARCHIVE_DB_CONTAINER:-$(docker ps --filter 'name=supabase_db_' --format '{{.Names}}' | head -n 1)}"
+DB_NAME="${CLASSROOM_ARCHIVE_DATABASE_NAME:-postgres}"
 if [[ -z "$DB_CONTAINER" ]]; then
   echo "Supabase database container is not running." >&2
   exit 2
 fi
 
-docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -v ON_ERROR_STOP=1 <<'SQL'
 begin;
 
 insert into public.users (id, email, role)

--- a/scripts/check-classroom-archive-v2-database.sh
+++ b/scripts/check-classroom-archive-v2-database.sh
@@ -640,7 +640,8 @@ RACE_READY=0
 for _ in {1..40}; do
   RACE_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -Atc \
     "select count(*) from pg_stat_activity
-     where state = 'active'
+     where pid <> pg_backend_pid()
+       and state = 'active'
        and query like '%$RACE_RECORD_ID%pg_sleep(3)%';")"
   [[ "$RACE_READY" -gt 0 ]] && break
   sleep 0.1

--- a/scripts/check-classroom-archive-v2-database.sh
+++ b/scripts/check-classroom-archive-v2-database.sh
@@ -3,12 +3,13 @@ set -euo pipefail
 
 PROJECT_ID="$(sed -n 's/^project_id = "\(.*\)"/\1/p' supabase/config.toml | head -n 1)"
 DB_CONTAINER="${CLASSROOM_ARCHIVE_DB_CONTAINER:-supabase_db_${PROJECT_ID}}"
+DB_NAME="${CLASSROOM_ARCHIVE_DATABASE_NAME:-postgres}"
 if [[ "$(docker inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null || true)" != "true" ]]; then
   echo "Supabase database container is not running: $DB_CONTAINER" >&2
   exit 2
 fi
 
-docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -v ON_ERROR_STOP=1 <<'SQL'
 begin;
 
 do $compatibility$
@@ -583,7 +584,7 @@ RACE_OUTPUT="$(mktemp)"
 
 cleanup_race() {
   rm -f "$RACE_OUTPUT"
-  docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -v ON_ERROR_STOP=1 \
     >/dev/null 2>&1 <<SQL || true
 begin;
 delete from public.classroom_archive_snapshot_actors
@@ -601,7 +602,7 @@ SQL
 }
 trap cleanup_race EXIT
 
-docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<SQL
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -v ON_ERROR_STOP=1 <<SQL
 insert into public.users (id, email, role)
 values ('$RACE_TEACHER_ID', 'archive-v2-race@example.test', 'teacher');
 
@@ -616,7 +617,7 @@ insert into public.classrooms (
 );
 SQL
 
-docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+docker exec "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -v ON_ERROR_STOP=1 \
   -c "begin;
       select revision from public.classroom_archive_revisions
       where classroom_id = '$RACE_CLASSROOM_ID'::uuid for update;
@@ -637,7 +638,7 @@ RACE_WRITER_PID=$!
 
 RACE_READY=0
 for _ in {1..40}; do
-  RACE_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+  RACE_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -Atc \
     "select count(*) from pg_stat_activity
      where state = 'active'
        and query like '%$RACE_RECORD_ID%pg_sleep(3)%';")"
@@ -651,7 +652,7 @@ if [[ "$RACE_READY" -eq 0 ]]; then
   exit 1
 fi
 
-RACE_RESULT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+RACE_RESULT="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -Atc \
   "select public.begin_classroom_archive_export_v2(
     '$RACE_OPERATION_ID'::uuid,
     '$RACE_TEACHER_ID'::uuid,
@@ -671,7 +672,7 @@ if [[ "$RACE_RESULT" != *'"error_code": "archive_v2_envelope_source_not_supporte
   exit 1
 fi
 
-RACE_SNAPSHOT_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d postgres -X -Atc \
+RACE_SNAPSHOT_COUNT="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" -X -Atc \
   "select count(*) from public.classroom_archive_snapshot_resources
    where operation_id = '$RACE_OPERATION_ID'::uuid;")"
 if [[ "$RACE_SNAPSHOT_COUNT" -ne 0 ]]; then

--- a/scripts/check-legacy-quiz-freeze-backfill.sh
+++ b/scripts/check-legacy-quiz-freeze-backfill.sh
@@ -12,8 +12,24 @@ fi
 TMP_DB="${LEGACY_QUIZ_BACKFILL_DATABASE_NAME:-pika_quiz_backfill_${RANDOM}_$$}"
 PAYLOAD_FILE="$(mktemp)"
 PREFLIGHT_OUTPUT="$(mktemp)"
+LOCK_OUTPUT="$(mktemp)"
+ARCHIVE_OUTPUT="$(mktemp)"
+MIGRATION_OUTPUT="$(mktemp)"
 cleanup() {
-  rm -f "$PAYLOAD_FILE" "$PREFLIGHT_OUTPUT"
+  if [[ -n "${LOCK_HOLDER_PID:-}" ]]; then
+    kill "$LOCK_HOLDER_PID" >/dev/null 2>&1 || true
+    wait "$LOCK_HOLDER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${ARCHIVE_READER_PID:-}" ]]; then
+    kill "$ARCHIVE_READER_PID" >/dev/null 2>&1 || true
+    wait "$ARCHIVE_READER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f \
+    "$PAYLOAD_FILE" \
+    "$PREFLIGHT_OUTPUT" \
+    "$LOCK_OUTPUT" \
+    "$ARCHIVE_OUTPUT" \
+    "$MIGRATION_OUTPUT"
   if [[ "${KEEP_LEGACY_QUIZ_BACKFILL_DATABASE:-false}" == "true" ]]; then
     echo "Kept disposable legacy Quiz backfill database: $TMP_DB"
     return
@@ -228,9 +244,137 @@ delete from public.course_blueprint_assessments
 where id = '62000000-0000-4000-8000-000000000003';
 SQL
 
-docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+  -c "begin;
+      lock table public.classroom_retired_assessment_record_actors
+        in access share mode;
+      select pg_sleep(8) /* legacy_quiz_backfill_lock_timeout */;
+      commit;" >"$LOCK_OUTPUT" 2>&1 &
+LOCK_HOLDER_PID=$!
+
+LOCK_READY=0
+for _ in {1..50}; do
+  LOCK_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc \
+    "select count(*)
+     from pg_stat_activity
+     where datname = '$TMP_DB'
+       and pid <> pg_backend_pid()
+       and state = 'active'
+       and query like '%legacy_quiz_backfill_lock_timeout%';")"
+  [[ "$LOCK_READY" -gt 0 ]] && break
+  sleep 0.1
+done
+if [[ "$LOCK_READY" -eq 0 ]]; then
+  cat "$LOCK_OUTPUT" >&2
+  echo "Lock-timeout fixture did not acquire its conflicting lock." >&2
+  exit 1
+fi
+
+LOCK_WAIT_STARTED=$SECONDS
+if docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
   psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
-  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" >/dev/null
+  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
+  >"$PREFLIGHT_OUTPUT" 2>&1
+then
+  echo "Migration 106 ignored a conflicting final-table lock." >&2
+  exit 1
+fi
+LOCK_WAIT_SECONDS=$((SECONDS - LOCK_WAIT_STARTED))
+if ! grep -q "canceling statement due to lock timeout" "$PREFLIGHT_OUTPUT"; then
+  cat "$PREFLIGHT_OUTPUT" >&2
+  echo "Migration 106 failed for an unexpected lock-timeout reason." >&2
+  exit 1
+fi
+if [[ "$LOCK_WAIT_SECONDS" -lt 4 || "$LOCK_WAIT_SECONDS" -gt 7 ]]; then
+  echo "Migration 106 lock timeout was not bounded near five seconds: ${LOCK_WAIT_SECONDS}s" >&2
+  exit 1
+fi
+wait "$LOCK_HOLDER_PID"
+LOCK_HOLDER_PID=
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $timeout_rollback_proof$
+begin
+  if to_regclass('private.legacy_quiz_backfill_ledger') is not null
+    or exists (
+      select 1
+      from pg_trigger
+      where tgname = 'freeze_legacy_quizzes'
+        and not tgisinternal
+    )
+    or not exists (
+      select 1
+      from pg_constraint
+      where conrelid = 'public.course_blueprint_assessments'::regclass
+        and conname = 'course_blueprint_assessments_assessment_type_check'
+        and pg_get_constraintdef(oid) like '%quiz%'
+    )
+  then
+    raise exception 'Lock-timeout migration attempt leaked schema changes';
+  end if;
+end;
+$timeout_rollback_proof$;
+SQL
+
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -qAt -v ON_ERROR_STOP=1 \
+  -c "begin;
+      select revision
+      from public.classroom_archive_revisions
+      where classroom_id = '62000000-0000-4000-8000-000000000001'
+      for update;
+      select pg_sleep(3) /* legacy_quiz_backfill_revision_race */;
+      select count(*)
+      from public.classroom_retired_assessment_records
+      where classroom_id = '62000000-0000-4000-8000-000000000001';
+      commit;" >"$ARCHIVE_OUTPUT" 2>&1 &
+ARCHIVE_READER_PID=$!
+
+REVISION_LOCK_READY=0
+for _ in {1..50}; do
+  REVISION_LOCK_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc \
+    "select count(*)
+     from pg_stat_activity
+     where datname = '$TMP_DB'
+       and pid <> pg_backend_pid()
+       and state = 'active'
+       and query like '%legacy_quiz_backfill_revision_race%';")"
+  [[ "$REVISION_LOCK_READY" -gt 0 ]] && break
+  sleep 0.1
+done
+if [[ "$REVISION_LOCK_READY" -eq 0 ]]; then
+  cat "$ARCHIVE_OUTPUT" >&2
+  echo "Revision-lock fixture did not acquire its row lock." >&2
+  exit 1
+fi
+
+if ! docker exec \
+  -e PGOPTIONS='-c client_min_messages=warning -c timezone=America/Toronto' \
+  -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
+  >"$MIGRATION_OUTPUT" 2>&1
+then
+  wait "$ARCHIVE_READER_PID" || true
+  ARCHIVE_READER_PID=
+  cat "$MIGRATION_OUTPUT" >&2
+  cat "$ARCHIVE_OUTPUT" >&2
+  echo "Migration 106 failed during the revision/envelope lock-order race." >&2
+  exit 1
+fi
+if ! wait "$ARCHIVE_READER_PID"; then
+  ARCHIVE_READER_PID=
+  cat "$ARCHIVE_OUTPUT" >&2
+  echo "Archive reader failed during the revision/envelope lock-order race." >&2
+  exit 1
+fi
+ARCHIVE_READER_PID=
+
+ARCHIVE_ENVELOPE_COUNT="$(tail -n 1 "$ARCHIVE_OUTPUT")"
+if [[ "$ARCHIVE_ENVELOPE_COUNT" -ne 5 ]]; then
+  cat "$ARCHIVE_OUTPUT" >&2
+  echo "Concurrent archive reader did not observe one coherent post-backfill graph." >&2
+  exit 1
+fi
 
 docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
 do $contract$

--- a/scripts/check-legacy-quiz-freeze-backfill.sh
+++ b/scripts/check-legacy-quiz-freeze-backfill.sh
@@ -325,6 +325,30 @@ rehearse_no_wait_lock_conflict() {
 }
 
 rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_classroom_parent_conflict" \
+  "begin;
+   select id
+   from public.classrooms
+   where id = '62000000-0000-4000-8000-000000000001'
+   for update;
+   select pg_sleep(4) /* legacy_quiz_backfill_classroom_parent_conflict */;
+   lock table public.classroom_retired_assessment_records in access share mode;
+   commit;" \
+  "classroom-parent-to-envelope-child traversal"
+
+rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_user_parent_conflict" \
+  "begin;
+   select id
+   from public.users
+   where id = '61000000-0000-4000-8000-000000000001'
+   for update;
+   select pg_sleep(4) /* legacy_quiz_backfill_user_parent_conflict */;
+   lock table public.classroom_retired_assessment_record_actors in access share mode;
+   commit;" \
+  "user-parent-to-envelope-actor traversal"
+
+rehearse_no_wait_lock_conflict \
   "legacy_quiz_backfill_final_table_conflict" \
   "begin;
    lock table public.classroom_retired_assessment_record_actors in access share mode;

--- a/scripts/check-legacy-quiz-freeze-backfill.sh
+++ b/scripts/check-legacy-quiz-freeze-backfill.sh
@@ -187,7 +187,7 @@ insert into public.assessment_drafts (
 SQL
 
 if docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
-  psql -U postgres -d "$TMP_DB" -X -1 -v ON_ERROR_STOP=1 \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
   < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
   >"$PREFLIGHT_OUTPUT" 2>&1
 then
@@ -229,7 +229,7 @@ where id = '62000000-0000-4000-8000-000000000003';
 SQL
 
 docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
-  psql -U postgres -d "$TMP_DB" -X -1 -v ON_ERROR_STOP=1 \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
   < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" >/dev/null
 
 docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'

--- a/scripts/check-legacy-quiz-freeze-backfill.sh
+++ b/scripts/check-legacy-quiz-freeze-backfill.sh
@@ -13,22 +13,16 @@ TMP_DB="${LEGACY_QUIZ_BACKFILL_DATABASE_NAME:-pika_quiz_backfill_${RANDOM}_$$}"
 PAYLOAD_FILE="$(mktemp)"
 PREFLIGHT_OUTPUT="$(mktemp)"
 LOCK_OUTPUT="$(mktemp)"
-ARCHIVE_OUTPUT="$(mktemp)"
 MIGRATION_OUTPUT="$(mktemp)"
 cleanup() {
   if [[ -n "${LOCK_HOLDER_PID:-}" ]]; then
     kill "$LOCK_HOLDER_PID" >/dev/null 2>&1 || true
     wait "$LOCK_HOLDER_PID" >/dev/null 2>&1 || true
   fi
-  if [[ -n "${ARCHIVE_READER_PID:-}" ]]; then
-    kill "$ARCHIVE_READER_PID" >/dev/null 2>&1 || true
-    wait "$ARCHIVE_READER_PID" >/dev/null 2>&1 || true
-  fi
   rm -f \
     "$PAYLOAD_FILE" \
     "$PREFLIGHT_OUTPUT" \
     "$LOCK_OUTPUT" \
-    "$ARCHIVE_OUTPUT" \
     "$MIGRATION_OUTPUT"
   if [[ "${KEEP_LEGACY_QUIZ_BACKFILL_DATABASE:-false}" == "true" ]]; then
     echo "Kept disposable legacy Quiz backfill database: $TMP_DB"
@@ -244,56 +238,9 @@ delete from public.course_blueprint_assessments
 where id = '62000000-0000-4000-8000-000000000003';
 SQL
 
-docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
-  -c "begin;
-      lock table public.classroom_retired_assessment_record_actors
-        in access share mode;
-      select pg_sleep(8) /* legacy_quiz_backfill_lock_timeout */;
-      commit;" >"$LOCK_OUTPUT" 2>&1 &
-LOCK_HOLDER_PID=$!
-
-LOCK_READY=0
-for _ in {1..50}; do
-  LOCK_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc \
-    "select count(*)
-     from pg_stat_activity
-     where datname = '$TMP_DB'
-       and pid <> pg_backend_pid()
-       and state = 'active'
-       and query like '%legacy_quiz_backfill_lock_timeout%';")"
-  [[ "$LOCK_READY" -gt 0 ]] && break
-  sleep 0.1
-done
-if [[ "$LOCK_READY" -eq 0 ]]; then
-  cat "$LOCK_OUTPUT" >&2
-  echo "Lock-timeout fixture did not acquire its conflicting lock." >&2
-  exit 1
-fi
-
-LOCK_WAIT_STARTED=$SECONDS
-if docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
-  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
-  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
-  >"$PREFLIGHT_OUTPUT" 2>&1
-then
-  echo "Migration 106 ignored a conflicting final-table lock." >&2
-  exit 1
-fi
-LOCK_WAIT_SECONDS=$((SECONDS - LOCK_WAIT_STARTED))
-if ! grep -q "canceling statement due to lock timeout" "$PREFLIGHT_OUTPUT"; then
-  cat "$PREFLIGHT_OUTPUT" >&2
-  echo "Migration 106 failed for an unexpected lock-timeout reason." >&2
-  exit 1
-fi
-if [[ "$LOCK_WAIT_SECONDS" -lt 4 || "$LOCK_WAIT_SECONDS" -gt 7 ]]; then
-  echo "Migration 106 lock timeout was not bounded near five seconds: ${LOCK_WAIT_SECONDS}s" >&2
-  exit 1
-fi
-wait "$LOCK_HOLDER_PID"
-LOCK_HOLDER_PID=
-
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
-do $timeout_rollback_proof$
+assert_lock_conflict_rolled_back() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $lock_conflict_rollback_proof$
 begin
   if to_regclass('private.legacy_quiz_backfill_ledger') is not null
     or exists (
@@ -310,40 +257,120 @@ begin
         and pg_get_constraintdef(oid) like '%quiz%'
     )
   then
-    raise exception 'Lock-timeout migration attempt leaked schema changes';
+    raise exception 'Lock-conflict migration attempt leaked schema changes';
   end if;
 end;
-$timeout_rollback_proof$;
+$lock_conflict_rollback_proof$;
 SQL
+}
 
-docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -qAt -v ON_ERROR_STOP=1 \
-  -c "begin;
-      select revision
-      from public.classroom_archive_revisions
-      where classroom_id = '62000000-0000-4000-8000-000000000001'
-      for update;
-      select pg_sleep(3) /* legacy_quiz_backfill_revision_race */;
-      select count(*)
-      from public.classroom_retired_assessment_records
-      where classroom_id = '62000000-0000-4000-8000-000000000001';
-      commit;" >"$ARCHIVE_OUTPUT" 2>&1 &
-ARCHIVE_READER_PID=$!
+rehearse_no_wait_lock_conflict() {
+  local marker="$1"
+  local fixture_sql="$2"
+  local description="$3"
+  local lock_ready=0
+  local lock_wait_started
+  local lock_wait_seconds
 
-REVISION_LOCK_READY=0
-for _ in {1..50}; do
-  REVISION_LOCK_READY="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc \
-    "select count(*)
-     from pg_stat_activity
-     where datname = '$TMP_DB'
-       and pid <> pg_backend_pid()
-       and state = 'active'
-       and query like '%legacy_quiz_backfill_revision_race%';")"
-  [[ "$REVISION_LOCK_READY" -gt 0 ]] && break
-  sleep 0.1
-done
-if [[ "$REVISION_LOCK_READY" -eq 0 ]]; then
-  cat "$ARCHIVE_OUTPUT" >&2
-  echo "Revision-lock fixture did not acquire its row lock." >&2
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -qAt -v ON_ERROR_STOP=1 \
+    -c "$fixture_sql" >"$LOCK_OUTPUT" 2>&1 &
+  LOCK_HOLDER_PID=$!
+
+  for _ in {1..50}; do
+    lock_ready="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc \
+      "select count(*)
+       from pg_stat_activity
+       where datname = '$TMP_DB'
+         and pid <> pg_backend_pid()
+         and state = 'active'
+         and query like '%$marker%';")"
+    [[ "$lock_ready" -gt 0 ]] && break
+    sleep 0.1
+  done
+  if [[ "$lock_ready" -eq 0 ]]; then
+    cat "$LOCK_OUTPUT" >&2
+    echo "$description fixture did not acquire its conflicting lock." >&2
+    exit 1
+  fi
+
+  lock_wait_started=$SECONDS
+  if docker exec \
+    -e PGOPTIONS='-c client_min_messages=warning -c timezone=America/Toronto' \
+    -i "$DB_CONTAINER" \
+    psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+    < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
+    >"$PREFLIGHT_OUTPUT" 2>&1
+  then
+    echo "Migration 106 ignored the $description conflict." >&2
+    exit 1
+  fi
+  lock_wait_seconds=$((SECONDS - lock_wait_started))
+  if ! grep -q "could not obtain lock on relation" "$PREFLIGHT_OUTPUT"; then
+    cat "$PREFLIGHT_OUTPUT" >&2
+    echo "Migration 106 failed for an unexpected $description reason." >&2
+    exit 1
+  fi
+  if [[ "$lock_wait_seconds" -gt 3 ]]; then
+    echo "Migration 106 did not fail fast for $description: ${lock_wait_seconds}s" >&2
+    exit 1
+  fi
+  if ! wait "$LOCK_HOLDER_PID"; then
+    LOCK_HOLDER_PID=
+    cat "$LOCK_OUTPUT" >&2
+    echo "$description fixture was aborted instead of completing." >&2
+    exit 1
+  fi
+  LOCK_HOLDER_PID=
+  assert_lock_conflict_rolled_back
+}
+
+rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_final_table_conflict" \
+  "begin;
+   lock table public.classroom_retired_assessment_record_actors in access share mode;
+   select pg_sleep(4) /* legacy_quiz_backfill_final_table_conflict */;
+   commit;" \
+  "final envelope table"
+
+rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_drafts_quizzes_conflict" \
+  "begin;
+   lock table public.assessment_drafts in access share mode;
+   select pg_sleep(4) /* legacy_quiz_backfill_drafts_quizzes_conflict */;
+   lock table public.quizzes in access share mode;
+   commit;" \
+  "assessment_drafts-to-quizzes traversal"
+
+rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_scores_responses_conflict" \
+  "begin;
+   lock table public.quiz_student_scores in access share mode;
+   select pg_sleep(4) /* legacy_quiz_backfill_scores_responses_conflict */;
+   lock table public.quiz_responses in access share mode;
+   commit;" \
+  "quiz_student_scores-to-quiz_responses traversal"
+
+rehearse_no_wait_lock_conflict \
+  "legacy_quiz_backfill_envelope_source_conflict" \
+  "begin;
+   select revision
+   from public.classroom_archive_revisions
+   where classroom_id = '62000000-0000-4000-8000-000000000001'
+   for update;
+   lock table public.classroom_retired_assessment_records in access share mode;
+   select pg_sleep(4) /* legacy_quiz_backfill_envelope_source_conflict */;
+   lock table public.assessment_drafts in access share mode;
+   lock table public.quizzes in access share mode;
+   select count(*)
+   from public.classroom_retired_assessment_records
+   where classroom_id = '62000000-0000-4000-8000-000000000001';
+   commit;" \
+  "envelope-to-source archive traversal"
+
+ARCHIVE_ENVELOPE_COUNT="$(tail -n 1 "$LOCK_OUTPUT")"
+if [[ "$ARCHIVE_ENVELOPE_COUNT" -ne 0 ]]; then
+  cat "$LOCK_OUTPUT" >&2
+  echo "Concurrent archive reader did not retain the coherent pre-backfill graph." >&2
   exit 1
 fi
 
@@ -354,25 +381,8 @@ if ! docker exec \
   < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
   >"$MIGRATION_OUTPUT" 2>&1
 then
-  wait "$ARCHIVE_READER_PID" || true
-  ARCHIVE_READER_PID=
   cat "$MIGRATION_OUTPUT" >&2
-  cat "$ARCHIVE_OUTPUT" >&2
-  echo "Migration 106 failed during the revision/envelope lock-order race." >&2
-  exit 1
-fi
-if ! wait "$ARCHIVE_READER_PID"; then
-  ARCHIVE_READER_PID=
-  cat "$ARCHIVE_OUTPUT" >&2
-  echo "Archive reader failed during the revision/envelope lock-order race." >&2
-  exit 1
-fi
-ARCHIVE_READER_PID=
-
-ARCHIVE_ENVELOPE_COUNT="$(tail -n 1 "$ARCHIVE_OUTPUT")"
-if [[ "$ARCHIVE_ENVELOPE_COUNT" -ne 5 ]]; then
-  cat "$ARCHIVE_OUTPUT" >&2
-  echo "Concurrent archive reader did not observe one coherent post-backfill graph." >&2
+  echo "Migration 106 failed after all conflicting transactions completed." >&2
   exit 1
 fi
 

--- a/scripts/check-legacy-quiz-freeze-backfill.sh
+++ b/scripts/check-legacy-quiz-freeze-backfill.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+PROJECT_ID="$(sed -n 's/^project_id = "\(.*\)"/\1/p' "$ROOT/supabase/config.toml" | head -n 1)"
+DB_CONTAINER="${CLASSROOM_ARCHIVE_DB_CONTAINER:-supabase_db_${PROJECT_ID}}"
+if [[ "$(docker inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null || true)" != "true" ]]; then
+  echo "Supabase database container is not running: $DB_CONTAINER" >&2
+  exit 2
+fi
+
+TMP_DB="${LEGACY_QUIZ_BACKFILL_DATABASE_NAME:-pika_quiz_backfill_${RANDOM}_$$}"
+PAYLOAD_FILE="$(mktemp)"
+PREFLIGHT_OUTPUT="$(mktemp)"
+cleanup() {
+  rm -f "$PAYLOAD_FILE" "$PREFLIGHT_OUTPUT"
+  if [[ "${KEEP_LEGACY_QUIZ_BACKFILL_DATABASE:-false}" == "true" ]]; then
+    echo "Kept disposable legacy Quiz backfill database: $TMP_DB"
+    return
+  fi
+  docker exec "$DB_CONTAINER" dropdb -U postgres --if-exists "$TMP_DB" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker exec "$DB_CONTAINER" createdb -U postgres "$TMP_DB"
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c '
+  drop schema public;
+  create schema extensions;
+  create extension "uuid-ossp" with schema extensions;
+  create extension pgcrypto with schema extensions;
+  create extension pg_stat_statements with schema extensions;
+  create schema vault;
+  create extension supabase_vault with schema vault;
+' >/dev/null
+
+docker exec "$DB_CONTAINER" pg_dump -U postgres -d postgres --schema-only --no-owner --no-privileges \
+  --schema=public --schema=private --schema=auth --schema=storage \
+  | sed '/^SET log_min_messages =/d; /^CREATE SCHEMA extensions;/d; /^CREATE SCHEMA vault;/d' \
+  | docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+set client_min_messages = warning;
+do $$
+declare
+  v_policy record;
+begin
+  for v_policy in
+    select schemaname, tablename, policyname
+    from pg_policies
+    where schemaname = 'storage'
+  loop
+    execute format(
+      'drop policy %I on %I.%I',
+      v_policy.policyname,
+      v_policy.schemaname,
+      v_policy.tablename
+    );
+  end loop;
+end;
+$$;
+drop schema public cascade;
+drop schema private cascade;
+create schema public;
+SQL
+
+for migration in "$ROOT"/supabase/migrations/*.sql; do
+  if [[ "$(basename "$migration")" == 106_* ]]; then
+    break
+  fi
+  docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+    psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+    < "$migration" >/dev/null
+done
+
+CLASSROOM_ARCHIVE_DB_CONTAINER="$DB_CONTAINER" \
+CLASSROOM_ARCHIVE_DATABASE_NAME="$TMP_DB" \
+  bash "$ROOT/scripts/check-classroom-archive-restore-database.sh"
+CLASSROOM_ARCHIVE_DB_CONTAINER="$DB_CONTAINER" \
+CLASSROOM_ARCHIVE_DATABASE_NAME="$TMP_DB" \
+  bash "$ROOT/scripts/check-classroom-archive-v2-database.sh"
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+insert into public.users (id, email, role, email_verified_at) values
+  ('61000000-0000-4000-8000-000000000001', 'quiz-backfill-teacher@example.invalid', 'teacher', clock_timestamp()),
+  ('61000000-0000-4000-8000-000000000002', 'quiz-backfill-student@example.invalid', 'student', clock_timestamp());
+
+insert into public.classrooms (id, teacher_id, title, class_code) values (
+  '62000000-0000-4000-8000-000000000001',
+  '61000000-0000-4000-8000-000000000001',
+  'Legacy Quiz backfill',
+  'QBACK106'
+);
+
+insert into public.course_blueprints (
+  id, teacher_id, title
+) values (
+  '62000000-0000-4000-8000-000000000002',
+  '61000000-0000-4000-8000-000000000001',
+  'Legacy Quiz backfill blueprint'
+);
+
+insert into public.course_blueprint_assessments (
+  id, course_blueprint_id, assessment_type, title, content, position
+) values (
+  '62000000-0000-4000-8000-000000000003',
+  '62000000-0000-4000-8000-000000000002',
+  'quiz',
+  'Blocking historical Quiz blueprint',
+  '{}'::jsonb,
+  0
+);
+
+insert into public.quizzes (
+  id, classroom_id, title, status, show_results, position, created_by,
+  created_at, updated_at, points_possible, include_in_final, opens_at,
+  gradebook_weight
+) values (
+  '63000000-0000-4000-8000-000000000001',
+  '62000000-0000-4000-8000-000000000001',
+  'Historical Quiz',
+  'closed',
+  true,
+  2,
+  '61000000-0000-4000-8000-000000000001',
+  '2026-01-02T03:04:05+00',
+  '2026-01-03T03:04:05+00',
+  12.50,
+  true,
+  '2026-01-04T03:04:05+00',
+  25
+);
+
+insert into public.quiz_questions (
+  id, quiz_id, question_text, options, position, created_at, updated_at,
+  correct_option
+) values (
+  '63000000-0000-4000-8000-000000000002',
+  '63000000-0000-4000-8000-000000000001',
+  'Historical question',
+  '["First","Second"]'::jsonb,
+  0,
+  '2026-01-02T03:05:05+00',
+  '2026-01-03T03:05:05+00',
+  1
+);
+
+insert into public.quiz_responses (
+  id, quiz_id, question_id, student_id, selected_option, submitted_at
+) values (
+  '63000000-0000-4000-8000-000000000003',
+  '63000000-0000-4000-8000-000000000001',
+  '63000000-0000-4000-8000-000000000002',
+  '61000000-0000-4000-8000-000000000002',
+  1,
+  '2026-01-05T03:04:05+00'
+);
+
+insert into public.quiz_student_scores (
+  id, quiz_id, student_id, manual_override_score, graded_at, graded_by,
+  created_at, updated_at
+) values (
+  '63000000-0000-4000-8000-000000000004',
+  '63000000-0000-4000-8000-000000000001',
+  '61000000-0000-4000-8000-000000000002',
+  9.25,
+  '2026-01-06T03:04:05+00',
+  'teacher',
+  '2026-01-06T03:04:05+00',
+  '2026-01-06T03:04:05+00'
+);
+
+insert into public.assessment_drafts (
+  id, assessment_type, assessment_id, classroom_id, content, version,
+  created_by, updated_by, created_at, updated_at
+) values (
+  '63000000-0000-4000-8000-000000000005',
+  'quiz',
+  '63000000-0000-4000-8000-000000000001',
+  '62000000-0000-4000-8000-000000000001',
+  '{"z":1.00,"a":{"b":2,"a":1},"0":"zero","10":"ten","tiny":0.0000001}'::jsonb,
+  3,
+  '61000000-0000-4000-8000-000000000001',
+  '61000000-0000-4000-8000-000000000001',
+  '2026-01-07T03:04:05+00',
+  '2026-01-08T03:04:05+00'
+);
+SQL
+
+if docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -1 -v ON_ERROR_STOP=1 \
+  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" \
+  >"$PREFLIGHT_OUTPUT" 2>&1
+then
+  echo "Migration 106 accepted a legacy Quiz blueprint row." >&2
+  exit 1
+fi
+if ! grep -q "Legacy Quiz blueprint rows must be zero before retirement" "$PREFLIGHT_OUTPUT"; then
+  cat "$PREFLIGHT_OUTPUT" >&2
+  echo "Migration 106 failed for an unexpected blueprint preflight reason." >&2
+  exit 1
+fi
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $rollback_proof$
+begin
+  if to_regclass('private.legacy_quiz_backfill_ledger') is not null
+    or exists (
+      select 1
+      from pg_trigger
+      where tgname = 'freeze_legacy_quizzes'
+        and not tgisinternal
+    )
+  then
+    raise exception 'Failed migration 106 attempt leaked schema changes';
+  end if;
+  if not exists (
+    select 1
+    from public.course_blueprint_assessments
+    where id = '62000000-0000-4000-8000-000000000003'
+      and assessment_type = 'quiz'
+  ) then
+    raise exception 'Failed migration 106 attempt changed the blocking blueprint row';
+  end if;
+end;
+$rollback_proof$;
+
+delete from public.course_blueprint_assessments
+where id = '62000000-0000-4000-8000-000000000003';
+SQL
+
+docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -1 -v ON_ERROR_STOP=1 \
+  < "$ROOT/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql" >/dev/null
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $contract$
+begin
+  if (
+    select count(*)
+    from private.legacy_quiz_backfill_ledger
+    where source_count = 1
+      and envelope_count = 1
+      and source_aggregate_sha256 = envelope_aggregate_sha256
+  ) <> 5 then
+    raise exception 'Backfill ledger does not prove five-resource parity';
+  end if;
+  if (select count(*) from public.quizzes) <> 1
+    or (select count(*) from public.quiz_questions) <> 1
+    or (select count(*) from public.quiz_responses) <> 1
+    or (select count(*) from public.quiz_student_scores) <> 1
+    or (
+      select count(*)
+      from public.assessment_drafts
+      where assessment_type = 'quiz'
+    ) <> 1
+  then
+    raise exception 'Backfill changed the retained legacy Quiz source rows';
+  end if;
+  if (
+    select count(*)
+    from public.classroom_retired_assessment_records
+    where source_contract = 'pika.classroom-archive@1/legacy-quiz'
+  ) <> 5 then
+    raise exception 'Backfill did not create all retired-assessment records';
+  end if;
+  if (
+    select count(*)
+    from public.classroom_retired_assessment_record_actors
+  ) <> 5 then
+    raise exception 'Backfill did not normalize all actor references';
+  end if;
+end;
+$contract$;
+
+do $write_freeze$
+begin
+  begin
+    update public.quizzes set title = 'blocked';
+    raise exception 'Legacy Quiz update unexpectedly succeeded';
+  exception when feature_not_supported then null;
+  end;
+
+  begin
+    delete from public.quiz_questions;
+    raise exception 'Legacy Quiz delete unexpectedly succeeded';
+  exception when feature_not_supported then null;
+  end;
+
+  begin
+    insert into public.assessment_drafts (
+      assessment_type, assessment_id, classroom_id, content, version,
+      created_by, updated_by
+    ) values (
+      'quiz',
+      '63000000-0000-4000-8000-000000000009',
+      '62000000-0000-4000-8000-000000000001',
+      '{}'::jsonb,
+      1,
+      '61000000-0000-4000-8000-000000000001',
+      '61000000-0000-4000-8000-000000000001'
+    );
+    raise exception 'Legacy Quiz draft insert unexpectedly succeeded';
+  exception when feature_not_supported then null;
+  end;
+
+  insert into public.tests (
+    id, classroom_id, title, status, show_results, created_by
+  ) values (
+    '63000000-0000-4000-8000-000000000010',
+    '62000000-0000-4000-8000-000000000001',
+    'Current Test',
+    'draft',
+    false,
+    '61000000-0000-4000-8000-000000000001'
+  );
+  insert into public.assessment_drafts (
+    assessment_type, assessment_id, classroom_id, content, version,
+    created_by, updated_by
+  ) values (
+    'test',
+    '63000000-0000-4000-8000-000000000010',
+    '62000000-0000-4000-8000-000000000001',
+    '{}'::jsonb,
+    1,
+    '61000000-0000-4000-8000-000000000001',
+    '61000000-0000-4000-8000-000000000001'
+  );
+
+  begin
+    insert into public.course_blueprint_assessments (
+      course_blueprint_id, assessment_type, title, content, position
+    ) values (
+      '62000000-0000-4000-8000-000000000002',
+      'quiz',
+      'blocked',
+      '{}'::jsonb,
+      0
+    );
+    raise exception 'Legacy Quiz blueprint insert unexpectedly succeeded';
+  exception when check_violation then null;
+  end;
+end;
+$write_freeze$;
+SQL
+
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -A -t -v ON_ERROR_STOP=1 -c "
+select jsonb_build_object(
+  'classroomId', '62000000-0000-4000-8000-000000000001'::text,
+  'archiveActors', jsonb_build_array(
+    jsonb_build_object('id', '61000000-0000-4000-8000-000000000001'),
+    jsonb_build_object('id', '61000000-0000-4000-8000-000000000002')
+  ),
+  'resources', jsonb_build_object(
+    'quizzes', (select jsonb_agg(to_jsonb(row) order by row.id) from public.quizzes row),
+    'quiz_questions', (select jsonb_agg(to_jsonb(row) order by row.id) from public.quiz_questions row),
+    'quiz_responses', (select jsonb_agg(to_jsonb(row) order by row.id) from public.quiz_responses row),
+    'quiz_student_scores', (select jsonb_agg(to_jsonb(row) order by row.id) from public.quiz_student_scores row),
+    'assessment_drafts', (
+      select jsonb_agg(to_jsonb(row) order by row.id)
+      from public.assessment_drafts row
+      where row.assessment_type = 'quiz'
+    )
+  ),
+  'envelopeRecords', (
+    select jsonb_agg(to_jsonb(row) order by row.source_resource, row.source_row_id)
+    from public.classroom_retired_assessment_records row
+    where row.classroom_id = '62000000-0000-4000-8000-000000000001'
+  ),
+  'envelopeActors', (
+    select jsonb_agg(to_jsonb(actor) order by actor.id)
+    from public.classroom_retired_assessment_record_actors actor
+    join public.classroom_retired_assessment_records record on record.id = actor.record_id
+    where record.classroom_id = '62000000-0000-4000-8000-000000000001'
+  )
+);" > "$PAYLOAD_FILE"
+
+pnpm exec tsx scripts/validate-legacy-quiz-backfill.ts < "$PAYLOAD_FILE"
+
+echo "Legacy Quiz freeze and backfill database contract passes."

--- a/scripts/validate-legacy-quiz-backfill.ts
+++ b/scripts/validate-legacy-quiz-backfill.ts
@@ -15,24 +15,31 @@ async function readInput(): Promise<Input> {
   return JSON.parse(input) as Input
 }
 
-const input = await readInput()
-const expected = adaptLegacyQuizArchiveResources({
-  classroomId: input.classroomId,
-  resources: input.resources,
-  actors: input.archiveActors,
+async function main() {
+  const input = await readInput()
+  const expected = adaptLegacyQuizArchiveResources({
+    classroomId: input.classroomId,
+    resources: input.resources,
+    actors: input.archiveActors,
+  })
+
+  if (
+    canonicalJsonStringify(expected.records) !==
+    canonicalJsonStringify(input.envelopeRecords)
+  ) {
+    throw new Error('Database backfill records differ from the TypeScript adapter')
+  }
+  if (
+    canonicalJsonStringify(expected.actors) !==
+    canonicalJsonStringify(input.envelopeActors)
+  ) {
+    throw new Error('Database backfill actors differ from the TypeScript adapter')
+  }
+
+  process.stdout.write('Legacy Quiz database backfill matches the TypeScript adapter.\n')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
 })
-
-if (
-  canonicalJsonStringify(expected.records) !==
-  canonicalJsonStringify(input.envelopeRecords)
-) {
-  throw new Error('Database backfill records differ from the TypeScript adapter')
-}
-if (
-  canonicalJsonStringify(expected.actors) !==
-  canonicalJsonStringify(input.envelopeActors)
-) {
-  throw new Error('Database backfill actors differ from the TypeScript adapter')
-}
-
-process.stdout.write('Legacy Quiz database backfill matches the TypeScript adapter.\n')

--- a/scripts/validate-legacy-quiz-backfill.ts
+++ b/scripts/validate-legacy-quiz-backfill.ts
@@ -1,0 +1,38 @@
+import { canonicalJsonStringify } from '@/lib/server/classroom-archive-canonical'
+import { adaptLegacyQuizArchiveResources } from '@/lib/server/classroom-archive-quiz-retirement'
+
+type Input = {
+  classroomId: string
+  archiveActors: Array<{ id: string }>
+  resources: Record<string, Array<Record<string, unknown>>>
+  envelopeRecords: Array<Record<string, unknown>>
+  envelopeActors: Array<Record<string, unknown>>
+}
+
+async function readInput(): Promise<Input> {
+  let input = ''
+  for await (const chunk of process.stdin) input += String(chunk)
+  return JSON.parse(input) as Input
+}
+
+const input = await readInput()
+const expected = adaptLegacyQuizArchiveResources({
+  classroomId: input.classroomId,
+  resources: input.resources,
+  actors: input.archiveActors,
+})
+
+if (
+  canonicalJsonStringify(expected.records) !==
+  canonicalJsonStringify(input.envelopeRecords)
+) {
+  throw new Error('Database backfill records differ from the TypeScript adapter')
+}
+if (
+  canonicalJsonStringify(expected.actors) !==
+  canonicalJsonStringify(input.envelopeActors)
+) {
+  throw new Error('Database backfill actors differ from the TypeScript adapter')
+}
+
+process.stdout.write('Legacy Quiz database backfill matches the TypeScript adapter.\n')

--- a/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
+++ b/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
@@ -250,18 +250,19 @@ begin
 end;
 $$;
 
--- The locks serialize the final source snapshot with trigger installation and
--- the blueprint zero-row proof. They remain held through migration commit.
+-- Acquire relations in archive traversal order and fail immediately when any
+-- live transaction conflicts. Retrying a rolled-back migration during a quiet
+-- window is safer than joining an archive/source lock cycle.
 lock table
+  public.classroom_retired_assessment_records,
+  public.classroom_retired_assessment_record_actors,
+  public.assessment_drafts,
   public.quizzes,
   public.quiz_questions,
-  public.quiz_responses,
   public.quiz_student_scores,
-  public.assessment_drafts,
-  public.course_blueprint_assessments,
-  public.classroom_retired_assessment_records,
-  public.classroom_retired_assessment_record_actors
-in access exclusive mode;
+  public.quiz_responses,
+  public.course_blueprint_assessments
+in access exclusive mode nowait;
 
 -- The source rows already contribute to the classroom revision. Moving their
 -- representation into envelopes must not bump that revision or take revision

--- a/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
+++ b/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
@@ -250,9 +250,17 @@ begin
 end;
 $$;
 
--- Acquire relations in archive traversal order and fail immediately when any
--- live transaction conflicts. Retrying a rolled-back migration during a quiet
--- window is safer than joining an archive/source lock cycle.
+-- Block parent writes and row locks before taking child locks so the envelope
+-- FK checks cannot wait behind a transaction that later needs a child relation.
+-- Ordinary parent reads remain available.
+lock table
+  public.classrooms,
+  public.users
+in exclusive mode nowait;
+
+-- Acquire child relations in archive traversal order and fail immediately when
+-- any live transaction conflicts. Retrying a rolled-back migration during a
+-- quiet window is safer than joining an archive/source lock cycle.
 lock table
   public.classroom_retired_assessment_records,
   public.classroom_retired_assessment_record_actors,

--- a/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
+++ b/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
@@ -5,6 +5,8 @@
 -- version-aware archive runtime. Backfilled envelopes intentionally make the
 -- legacy v1 export/compaction entry points fail closed.
 
+begin;
+
 create or replace function private.legacy_quiz_deterministic_uuid_v1(
   p_parts text[]
 )
@@ -755,3 +757,5 @@ begin
   end if;
 end;
 $parity_postflight$;
+
+commit;

--- a/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
+++ b/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
@@ -1,0 +1,757 @@
+-- Freeze the retired Quiz source contract and preserve every remaining row in
+-- the generic retired-assessment envelope introduced by migration 105.
+--
+-- Rollout guard: do not apply this migration until the application uses the
+-- version-aware archive runtime. Backfilled envelopes intentionally make the
+-- legacy v1 export/compaction entry points fail closed.
+
+create or replace function private.legacy_quiz_deterministic_uuid_v1(
+  p_parts text[]
+)
+returns uuid
+language plpgsql
+immutable
+strict
+set search_path = ''
+as $$
+declare
+  v_input bytea := ''::bytea;
+  v_digest bytea;
+  v_part text;
+  v_index integer := 0;
+  v_hex text;
+begin
+  foreach v_part in array p_parts
+  loop
+    if v_part is null then
+      raise exception 'Deterministic UUID parts cannot be null'
+        using errcode = '22004';
+    end if;
+    if v_index > 0 then
+      v_input := v_input || decode('00', 'hex');
+    end if;
+    v_input := v_input || convert_to(v_part, 'UTF8');
+    v_index := v_index + 1;
+  end loop;
+
+  v_digest := extensions.digest(v_input, 'sha256');
+  v_digest := set_byte(v_digest, 6, (get_byte(v_digest, 6) & 15) | 128);
+  v_digest := set_byte(v_digest, 8, (get_byte(v_digest, 8) & 63) | 128);
+  v_hex := encode(substring(v_digest from 1 for 16), 'hex');
+
+  return (
+    substring(v_hex from 1 for 8) || '-' ||
+    substring(v_hex from 9 for 4) || '-' ||
+    substring(v_hex from 13 for 4) || '-' ||
+    substring(v_hex from 17 for 4) || '-' ||
+    substring(v_hex from 21 for 12)
+  )::uuid;
+end;
+$$;
+
+create or replace function private.legacy_quiz_json_number_v1(
+  p_value jsonb
+)
+returns text
+language plpgsql
+immutable
+strict
+set search_path = ''
+set extra_float_digits = 3
+as $$
+declare
+  v_number double precision;
+  v_text text;
+begin
+  if jsonb_typeof(p_value) <> 'number' then
+    raise exception 'Canonical JSON number input must be numeric'
+      using errcode = '22023';
+  end if;
+
+  v_number := (p_value #>> '{}')::double precision;
+  if v_number = 0 then
+    return '0';
+  end if;
+
+  v_text := v_number::text;
+  if abs(v_number) >= 1e21::double precision
+    or abs(v_number) < 1e-6::double precision
+  then
+    if position('e' in v_text) = 0 then
+      raise exception 'Cannot encode legacy Quiz payload number canonically: %', v_text
+        using errcode = '22023';
+    end if;
+    return regexp_replace(v_text, 'e([+-])0+([0-9]+)$', 'e\1\2');
+  end if;
+
+  if position('e' in v_text) > 0 then
+    return trim_scale(v_text::numeric)::text;
+  end if;
+  return v_text;
+end;
+$$;
+
+create or replace function private.legacy_quiz_json_object_index_v1(
+  p_key text
+)
+returns numeric
+language plpgsql
+immutable
+strict
+set search_path = ''
+as $$
+declare
+  v_index numeric;
+begin
+  if p_key !~ '^(0|[1-9][0-9]{0,9})$' then
+    return null;
+  end if;
+  v_index := p_key::numeric;
+  if v_index > 4294967294 then
+    return null;
+  end if;
+  return v_index;
+end;
+$$;
+
+create or replace function private.legacy_quiz_canonical_json_v1(
+  p_value jsonb
+)
+returns text
+language plpgsql
+immutable
+strict
+set search_path = ''
+as $$
+declare
+  v_result text;
+begin
+  case jsonb_typeof(p_value)
+    when 'object' then
+      select '{' || coalesce(
+        string_agg(
+          to_jsonb(entry.key)::text || ':' ||
+            private.legacy_quiz_canonical_json_v1(entry.value),
+          ','
+          order by
+            case
+              when private.legacy_quiz_json_object_index_v1(entry.key) is not null then 0
+              else 1
+            end,
+            private.legacy_quiz_json_object_index_v1(entry.key),
+            convert_to(entry.key, 'UTF8')
+        ),
+        ''
+      ) || '}'
+      into v_result
+      from jsonb_each(p_value) entry;
+      return v_result;
+    when 'array' then
+      select '[' || coalesce(
+        string_agg(
+          private.legacy_quiz_canonical_json_v1(item.value),
+          ','
+          order by item.ordinality
+        ),
+        ''
+      ) || ']'
+      into v_result
+      from jsonb_array_elements(p_value) with ordinality item(value, ordinality);
+      return v_result;
+    when 'number' then
+      return private.legacy_quiz_json_number_v1(p_value);
+    when 'string' then
+      return p_value::text;
+    when 'boolean' then
+      return p_value::text;
+    when 'null' then
+      return 'null';
+    else
+      raise exception 'Unsupported JSON value in legacy Quiz payload'
+        using errcode = '22023';
+  end case;
+end;
+$$;
+
+create or replace function private.legacy_quiz_payload_sha256_v1(
+  p_payload jsonb
+)
+returns text
+language sql
+immutable
+strict
+set search_path = ''
+as $$
+  select encode(
+    extensions.digest(
+      convert_to(private.legacy_quiz_canonical_json_v1(p_payload), 'UTF8'),
+      'sha256'
+    ),
+    'hex'
+  );
+$$;
+
+create table private.legacy_quiz_backfill_ledger (
+  backfill_id uuid not null,
+  migration_name text not null,
+  source_contract text not null,
+  source_contract_version integer not null,
+  source_resource text not null,
+  source_count bigint not null check (source_count >= 0),
+  envelope_count bigint not null check (envelope_count >= 0),
+  source_aggregate_sha256 text not null check (
+    source_aggregate_sha256 ~ '^[a-f0-9]{64}$'
+  ),
+  envelope_aggregate_sha256 text not null check (
+    envelope_aggregate_sha256 ~ '^[a-f0-9]{64}$'
+  ),
+  applied_at timestamptz not null default transaction_timestamp(),
+  primary key (backfill_id, source_resource),
+  unique (migration_name, source_resource),
+  check (source_count = envelope_count),
+  check (source_aggregate_sha256 = envelope_aggregate_sha256)
+);
+
+revoke all on table private.legacy_quiz_backfill_ledger
+  from public, anon, authenticated, service_role;
+
+comment on table private.legacy_quiz_backfill_ledger is
+  'Aggregate-only parity evidence for the one-time legacy Quiz envelope backfill.';
+
+create or replace function private.reject_legacy_quiz_source_write()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_table_name = 'assessment_drafts' and tg_op <> 'TRUNCATE' then
+    if tg_op = 'INSERT' and new.assessment_type <> 'quiz' then
+      return new;
+    end if;
+    if tg_op = 'UPDATE'
+      and old.assessment_type <> 'quiz'
+      and new.assessment_type <> 'quiz'
+    then
+      return new;
+    end if;
+    if tg_op = 'DELETE' and old.assessment_type <> 'quiz' then
+      return old;
+    end if;
+  end if;
+
+  raise exception 'Legacy Quiz source is frozen: %.% %',
+    tg_table_schema, tg_table_name, tg_op
+    using errcode = '0A000';
+end;
+$$;
+
+-- The locks serialize the final source snapshot with trigger installation and
+-- the blueprint zero-row proof. They remain held through migration commit.
+lock table
+  public.quizzes,
+  public.quiz_questions,
+  public.quiz_responses,
+  public.quiz_student_scores,
+  public.assessment_drafts,
+  public.course_blueprint_assessments,
+  public.classroom_retired_assessment_records,
+  public.classroom_retired_assessment_record_actors
+in access exclusive mode;
+
+do $blueprint_preflight$
+begin
+  if exists (
+    select 1
+    from public.course_blueprint_assessments
+    where assessment_type = 'quiz'
+  ) then
+    raise exception 'Legacy Quiz blueprint rows must be zero before retirement'
+      using errcode = '23514';
+  end if;
+end;
+$blueprint_preflight$;
+
+alter table public.course_blueprint_assessments
+  drop constraint course_blueprint_assessments_assessment_type_check;
+alter table public.course_blueprint_assessments
+  add constraint course_blueprint_assessments_assessment_type_check
+    check (assessment_type = 'test');
+
+create trigger freeze_legacy_quizzes
+before insert or update or delete on public.quizzes
+for each row execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_questions
+before insert or update or delete on public.quiz_questions
+for each row execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_responses
+before insert or update or delete on public.quiz_responses
+for each row execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_student_scores
+before insert or update or delete on public.quiz_student_scores
+for each row execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_drafts
+before insert or update or delete on public.assessment_drafts
+for each row execute function private.reject_legacy_quiz_source_write();
+
+create trigger freeze_legacy_quizzes_truncate
+before truncate on public.quizzes
+for each statement execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_questions_truncate
+before truncate on public.quiz_questions
+for each statement execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_responses_truncate
+before truncate on public.quiz_responses
+for each statement execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_student_scores_truncate
+before truncate on public.quiz_student_scores
+for each statement execute function private.reject_legacy_quiz_source_write();
+create trigger freeze_legacy_quiz_drafts_truncate
+before truncate on public.assessment_drafts
+for each statement execute function private.reject_legacy_quiz_source_write();
+
+do $source_preflight$
+begin
+  if exists (
+    select 1
+    from public.quiz_questions question
+    left join public.quizzes quiz on quiz.id = question.quiz_id
+    where quiz.id is null
+  ) then
+    raise exception 'Legacy Quiz question has no parent Quiz'
+      using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from public.quiz_responses response
+    left join public.quiz_questions question on question.id = response.question_id
+    left join public.quizzes quiz on quiz.id = response.quiz_id
+    where question.id is null
+      or quiz.id is null
+      or question.quiz_id <> response.quiz_id
+  ) then
+    raise exception 'Legacy Quiz response has an invalid parent graph'
+      using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from public.quiz_student_scores score
+    left join public.quizzes quiz on quiz.id = score.quiz_id
+    where quiz.id is null
+  ) then
+    raise exception 'Legacy Quiz score has no parent Quiz'
+      using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from public.assessment_drafts draft
+    left join public.quizzes quiz on quiz.id = draft.assessment_id
+    where draft.assessment_type = 'quiz'
+      and (
+        quiz.id is null
+        or quiz.classroom_id <> draft.classroom_id
+      )
+  ) then
+    raise exception 'Legacy Quiz draft has an invalid parent Quiz'
+      using errcode = '23503';
+  end if;
+end;
+$source_preflight$;
+
+create temporary table legacy_quiz_expected_records (
+  id uuid not null,
+  classroom_id uuid not null,
+  source_contract text not null,
+  source_contract_version integer not null,
+  source_resource text not null,
+  source_row_id uuid not null,
+  parent_source_resource text,
+  parent_source_row_id uuid,
+  payload jsonb not null,
+  payload_sha256 text not null,
+  checksum_algorithm text not null,
+  source_created_at timestamptz,
+  source_updated_at timestamptz
+) on commit drop;
+
+insert into legacy_quiz_expected_records
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    'pika.classroom-archive@1/legacy-quiz',
+    quiz.classroom_id::text,
+    'quizzes',
+    quiz.id::text
+  ]),
+  quiz.classroom_id,
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  'quizzes',
+  quiz.id,
+  null,
+  null,
+  to_jsonb(quiz),
+  private.legacy_quiz_payload_sha256_v1(to_jsonb(quiz)),
+  'sha256-canonical-json-v1',
+  quiz.created_at,
+  quiz.updated_at
+from public.quizzes quiz
+union all
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    'pika.classroom-archive@1/legacy-quiz',
+    quiz.classroom_id::text,
+    'quiz_questions',
+    question.id::text
+  ]),
+  quiz.classroom_id,
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  'quiz_questions',
+  question.id,
+  'quizzes',
+  question.quiz_id,
+  to_jsonb(question),
+  private.legacy_quiz_payload_sha256_v1(to_jsonb(question)),
+  'sha256-canonical-json-v1',
+  question.created_at,
+  question.updated_at
+from public.quiz_questions question
+join public.quizzes quiz on quiz.id = question.quiz_id
+union all
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    'pika.classroom-archive@1/legacy-quiz',
+    quiz.classroom_id::text,
+    'quiz_responses',
+    response.id::text
+  ]),
+  quiz.classroom_id,
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  'quiz_responses',
+  response.id,
+  'quiz_questions',
+  response.question_id,
+  to_jsonb(response),
+  private.legacy_quiz_payload_sha256_v1(to_jsonb(response)),
+  'sha256-canonical-json-v1',
+  null,
+  null
+from public.quiz_responses response
+join public.quizzes quiz on quiz.id = response.quiz_id
+union all
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    'pika.classroom-archive@1/legacy-quiz',
+    quiz.classroom_id::text,
+    'quiz_student_scores',
+    score.id::text
+  ]),
+  quiz.classroom_id,
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  'quiz_student_scores',
+  score.id,
+  'quizzes',
+  score.quiz_id,
+  to_jsonb(score),
+  private.legacy_quiz_payload_sha256_v1(to_jsonb(score)),
+  'sha256-canonical-json-v1',
+  score.created_at,
+  score.updated_at
+from public.quiz_student_scores score
+join public.quizzes quiz on quiz.id = score.quiz_id
+union all
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    'pika.classroom-archive@1/legacy-quiz',
+    draft.classroom_id::text,
+    'assessment_drafts',
+    draft.id::text
+  ]),
+  draft.classroom_id,
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  'assessment_drafts',
+  draft.id,
+  'quizzes',
+  draft.assessment_id,
+  to_jsonb(draft),
+  private.legacy_quiz_payload_sha256_v1(to_jsonb(draft)),
+  'sha256-canonical-json-v1',
+  draft.created_at,
+  draft.updated_at
+from public.assessment_drafts draft
+where draft.assessment_type = 'quiz';
+
+do $record_collision_preflight$
+begin
+  if exists (
+    select 1
+    from legacy_quiz_expected_records
+    group by id
+    having count(*) > 1
+  ) then
+    raise exception 'Legacy Quiz deterministic record UUID collision'
+      using errcode = '23505';
+  end if;
+
+  if exists (
+    select 1
+    from legacy_quiz_expected_records expected
+    join public.classroom_retired_assessment_records existing
+      on existing.id = expected.id
+      or (
+        existing.classroom_id = expected.classroom_id
+        and existing.source_contract = expected.source_contract
+        and existing.source_contract_version = expected.source_contract_version
+        and existing.source_resource = expected.source_resource
+        and existing.source_row_id = expected.source_row_id
+      )
+  ) then
+    raise exception 'Legacy Quiz retired-assessment record collision'
+      using errcode = '23505';
+  end if;
+end;
+$record_collision_preflight$;
+
+create temporary table legacy_quiz_expected_actors (
+  id uuid not null,
+  record_id uuid not null,
+  actor_id uuid not null,
+  source_column text not null
+) on commit drop;
+
+insert into legacy_quiz_expected_actors
+select
+  private.legacy_quiz_deterministic_uuid_v1(array[
+    record.id::text,
+    actor.source_column,
+    actor.actor_id
+  ]),
+  record.id,
+  actor.actor_id::uuid,
+  actor.source_column
+from legacy_quiz_expected_records record
+cross join lateral (
+  select 'created_by'::text, record.payload->>'created_by'
+  where record.source_resource = 'quizzes'
+  union all
+  select 'student_id', record.payload->>'student_id'
+  where record.source_resource in ('quiz_responses', 'quiz_student_scores')
+  union all
+  select 'created_by', record.payload->>'created_by'
+  where record.source_resource = 'assessment_drafts'
+  union all
+  select 'updated_by', record.payload->>'updated_by'
+  where record.source_resource = 'assessment_drafts'
+) actor(source_column, actor_id);
+
+do $actor_preflight$
+begin
+  if exists (
+    select 1
+    from legacy_quiz_expected_actors
+    group by id
+    having count(*) > 1
+  ) then
+    raise exception 'Legacy Quiz deterministic actor UUID collision'
+      using errcode = '23505';
+  end if;
+
+  if exists (
+    select 1
+    from legacy_quiz_expected_actors expected
+    left join public.users actor on actor.id = expected.actor_id
+    where actor.id is null
+  ) then
+    raise exception 'Legacy Quiz envelope actor cannot be resolved'
+      using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from legacy_quiz_expected_actors expected
+    join public.classroom_retired_assessment_record_actors existing
+      on existing.id = expected.id
+  ) then
+    raise exception 'Legacy Quiz retired-assessment actor collision'
+      using errcode = '23505';
+  end if;
+end;
+$actor_preflight$;
+
+insert into public.classroom_retired_assessment_records (
+  id,
+  classroom_id,
+  source_contract,
+  source_contract_version,
+  source_resource,
+  source_row_id,
+  parent_source_resource,
+  parent_source_row_id,
+  payload,
+  payload_sha256,
+  checksum_algorithm,
+  source_created_at,
+  source_updated_at
+)
+select
+  id,
+  classroom_id,
+  source_contract,
+  source_contract_version,
+  source_resource,
+  source_row_id,
+  parent_source_resource,
+  parent_source_row_id,
+  payload,
+  payload_sha256,
+  checksum_algorithm,
+  source_created_at,
+  source_updated_at
+from legacy_quiz_expected_records
+order by source_resource, source_row_id;
+
+insert into public.classroom_retired_assessment_record_actors (
+  id,
+  record_id,
+  actor_id,
+  source_column
+)
+select id, record_id, actor_id, source_column
+from legacy_quiz_expected_actors
+order by id;
+
+insert into private.legacy_quiz_backfill_ledger (
+  backfill_id,
+  migration_name,
+  source_contract,
+  source_contract_version,
+  source_resource,
+  source_count,
+  envelope_count,
+  source_aggregate_sha256,
+  envelope_aggregate_sha256
+)
+with resources(source_resource) as (
+  values
+    ('quizzes'::text),
+    ('quiz_questions'),
+    ('quiz_responses'),
+    ('quiz_student_scores'),
+    ('assessment_drafts')
+),
+source_summary as (
+  select
+    source_resource,
+    count(*)::bigint as row_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          coalesce(
+            string_agg(
+              source_row_id::text || ':' || payload_sha256,
+              E'\n'
+              order by source_row_id::text
+            ),
+            ''
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as aggregate_sha256
+  from legacy_quiz_expected_records
+  group by source_resource
+),
+envelope_summary as (
+  select
+    source_resource,
+    count(*)::bigint as row_count,
+    encode(
+      extensions.digest(
+        convert_to(
+          coalesce(
+            string_agg(
+              source_row_id::text || ':' || payload_sha256,
+              E'\n'
+              order by source_row_id::text
+            ),
+            ''
+          ),
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    ) as aggregate_sha256
+  from public.classroom_retired_assessment_records
+  where source_contract = 'pika.classroom-archive@1/legacy-quiz'
+    and source_contract_version = 1
+  group by source_resource
+)
+select
+  '10600000-0000-8000-8000-000000000001'::uuid,
+  '106_freeze_and_backfill_legacy_quiz',
+  'pika.classroom-archive@1/legacy-quiz',
+  1,
+  resource.source_resource,
+  coalesce(source.row_count, 0),
+  coalesce(envelope.row_count, 0),
+  coalesce(
+    source.aggregate_sha256,
+    encode(extensions.digest(''::bytea, 'sha256'), 'hex')
+  ),
+  coalesce(
+    envelope.aggregate_sha256,
+    encode(extensions.digest(''::bytea, 'sha256'), 'hex')
+  )
+from resources resource
+left join source_summary source using (source_resource)
+left join envelope_summary envelope using (source_resource)
+order by resource.source_resource;
+
+do $parity_postflight$
+begin
+  if (
+    select count(*)
+    from private.legacy_quiz_backfill_ledger
+    where backfill_id = '10600000-0000-8000-8000-000000000001'::uuid
+  ) <> 5 then
+    raise exception 'Legacy Quiz backfill ledger is incomplete'
+      using errcode = '23514';
+  end if;
+
+  if (
+    select count(*)
+    from legacy_quiz_expected_records
+  ) <> (
+    select count(*)
+    from public.classroom_retired_assessment_records
+    where source_contract = 'pika.classroom-archive@1/legacy-quiz'
+      and source_contract_version = 1
+  ) then
+    raise exception 'Legacy Quiz source and envelope counts differ'
+      using errcode = '23514';
+  end if;
+
+  if (
+    select count(*)
+    from legacy_quiz_expected_actors
+  ) <> (
+    select count(*)
+    from public.classroom_retired_assessment_record_actors actor
+    join public.classroom_retired_assessment_records record
+      on record.id = actor.record_id
+    where record.source_contract = 'pika.classroom-archive@1/legacy-quiz'
+      and record.source_contract_version = 1
+  ) then
+    raise exception 'Legacy Quiz actor source and envelope counts differ'
+      using errcode = '23514';
+  end if;
+end;
+$parity_postflight$;

--- a/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
+++ b/supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql
@@ -7,6 +7,9 @@
 
 begin;
 
+set local timezone = 'UTC';
+set local lock_timeout = '5s';
+
 create or replace function private.legacy_quiz_deterministic_uuid_v1(
   p_parts text[]
 )
@@ -259,6 +262,11 @@ lock table
   public.classroom_retired_assessment_records,
   public.classroom_retired_assessment_record_actors
 in access exclusive mode;
+
+-- The source rows already contribute to the classroom revision. Moving their
+-- representation into envelopes must not bump that revision or take revision
+-- row locks in the opposite order from an in-flight archive snapshot.
+select set_config('pika.classroom_archive_compaction', 'on', true);
 
 do $blueprint_preflight$
 begin

--- a/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
+++ b/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/106_freeze_and_backfill_legacy_quiz.sql',
+  ),
+  'utf8',
+)
+
+describe('legacy Quiz freeze and backfill migration', () => {
+  it('serializes the freeze, blueprint narrowing, and source snapshot', () => {
+    expect(migration).toContain('in access exclusive mode;')
+    for (const table of [
+      'public.quizzes',
+      'public.quiz_questions',
+      'public.quiz_responses',
+      'public.quiz_student_scores',
+      'public.assessment_drafts',
+      'public.course_blueprint_assessments',
+    ]) {
+      expect(migration).toContain(table)
+    }
+    expect(migration).toContain(
+      "where assessment_type = 'quiz'",
+    )
+    expect(migration).toContain(
+      "check (assessment_type = 'test')",
+    )
+    expect(migration).toContain(
+      'create or replace function private.reject_legacy_quiz_source_write()',
+    )
+    expect(migration.match(/create trigger freeze_legacy_/g)).toHaveLength(10)
+  })
+
+  it('uses the application envelope identity and checksum contracts', () => {
+    expect(migration).toContain(
+      "'pika.classroom-archive@1/legacy-quiz'",
+    )
+    expect(migration).toContain(
+      "'sha256-canonical-json-v1'",
+    )
+    expect(migration).toContain(
+      'private.legacy_quiz_deterministic_uuid_v1(array[',
+    )
+    expect(migration).toContain(
+      'private.legacy_quiz_payload_sha256_v1(to_jsonb(',
+    )
+    expect(migration).toContain(
+      'private.legacy_quiz_json_object_index_v1(entry.key)',
+    )
+    expect(migration).toContain(
+      "abs(v_number) >= 1e21::double precision",
+    )
+  })
+
+  it('fails closed on graph, actor, collision, and parity defects', () => {
+    for (const marker of [
+      'Legacy Quiz response has an invalid parent graph',
+      'Legacy Quiz draft has an invalid parent Quiz',
+      'Legacy Quiz retired-assessment record collision',
+      'Legacy Quiz envelope actor cannot be resolved',
+      'Legacy Quiz source and envelope counts differ',
+      'Legacy Quiz actor source and envelope counts differ',
+    ]) {
+      expect(migration).toContain(marker)
+    }
+    expect(migration).toContain(
+      'create table private.legacy_quiz_backfill_ledger (',
+    )
+    expect(migration).toContain(
+      'check (source_count = envelope_count)',
+    )
+    expect(migration).toContain(
+      'check (source_aggregate_sha256 = envelope_aggregate_sha256)',
+    )
+  })
+
+  it('preserves source rows and active Test tables', () => {
+    expect(migration).not.toMatch(
+      /\b(?:drop|delete from|update)\s+public\.(?:quizzes|quiz_questions|quiz_responses|quiz_student_scores)\b/i,
+    )
+    expect(migration).not.toMatch(
+      /\b(?:insert into|update|delete from|drop table)\s+public\.(?:tests|test_questions|test_responses|test_attempts)\b/i,
+    )
+  })
+})

--- a/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
+++ b/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
@@ -24,9 +24,12 @@ describe('legacy Quiz freeze and backfill migration', () => {
     expect(migration.trimEnd()).toMatch(/commit;$/)
     expect(migration).toContain("set local timezone = 'UTC';")
     expect(migration).toContain("set local lock_timeout = '5s';")
-    expect(migration).toContain('in access exclusive mode;')
+    expect(migration).toContain('in access exclusive mode nowait;')
     expect(migration).toContain(
       "set_config('pika.classroom_archive_compaction', 'on', true)",
+    )
+    expect(migration).toMatch(
+      /classroom_retired_assessment_records,[\s\S]*classroom_retired_assessment_record_actors,[\s\S]*assessment_drafts,[\s\S]*quizzes,[\s\S]*quiz_questions,[\s\S]*quiz_student_scores,[\s\S]*quiz_responses,[\s\S]*course_blueprint_assessments[\s\S]*in access exclusive mode nowait;/,
     )
     for (const table of [
       'public.quizzes',
@@ -102,10 +105,17 @@ describe('legacy Quiz freeze and backfill migration', () => {
     )
   })
 
-  it('rehearses lock timeout, lock ordering, timezone, and adapter parity', () => {
-    expect(databaseHarness).toContain('legacy_quiz_backfill_lock_timeout')
-    expect(databaseHarness).toContain('canceling statement due to lock timeout')
-    expect(databaseHarness).toContain('legacy_quiz_backfill_revision_race')
+  it('rehearses fail-fast lock conflicts, ordering, timezone, and adapter parity', () => {
+    expect(databaseHarness).toContain('could not obtain lock on relation')
+    expect(databaseHarness).toContain(
+      'legacy_quiz_backfill_drafts_quizzes_conflict',
+    )
+    expect(databaseHarness).toContain(
+      'legacy_quiz_backfill_scores_responses_conflict',
+    )
+    expect(databaseHarness).toContain(
+      'legacy_quiz_backfill_envelope_source_conflict',
+    )
     expect(databaseHarness).toContain('pid <> pg_backend_pid()')
     expect(databaseHarness).toContain('timezone=America/Toronto')
     expect(databaseHarness).toContain(

--- a/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
+++ b/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
@@ -24,6 +24,9 @@ describe('legacy Quiz freeze and backfill migration', () => {
     expect(migration.trimEnd()).toMatch(/commit;$/)
     expect(migration).toContain("set local timezone = 'UTC';")
     expect(migration).toContain("set local lock_timeout = '5s';")
+    expect(migration).toMatch(
+      /public\.classrooms,[\s\S]*public\.users[\s\S]*in exclusive mode nowait;/,
+    )
     expect(migration).toContain('in access exclusive mode nowait;')
     expect(migration).toContain(
       "set_config('pika.classroom_archive_compaction', 'on', true)",
@@ -107,6 +110,12 @@ describe('legacy Quiz freeze and backfill migration', () => {
 
   it('rehearses fail-fast lock conflicts, ordering, timezone, and adapter parity', () => {
     expect(databaseHarness).toContain('could not obtain lock on relation')
+    expect(databaseHarness).toContain(
+      'legacy_quiz_backfill_classroom_parent_conflict',
+    )
+    expect(databaseHarness).toContain(
+      'legacy_quiz_backfill_user_parent_conflict',
+    )
     expect(databaseHarness).toContain(
       'legacy_quiz_backfill_drafts_quizzes_conflict',
     )

--- a/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
+++ b/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
@@ -9,12 +9,25 @@ const migration = readFileSync(
   ),
   'utf8',
 )
+const databaseHarness = readFileSync(
+  resolve(process.cwd(), 'scripts/check-legacy-quiz-freeze-backfill.sh'),
+  'utf8',
+)
+const adapterValidator = readFileSync(
+  resolve(process.cwd(), 'scripts/validate-legacy-quiz-backfill.ts'),
+  'utf8',
+)
 
 describe('legacy Quiz freeze and backfill migration', () => {
   it('serializes the freeze, blueprint narrowing, and source snapshot', () => {
     expect(migration).toMatch(/^--[\s\S]*\nbegin;\n/)
     expect(migration.trimEnd()).toMatch(/commit;$/)
+    expect(migration).toContain("set local timezone = 'UTC';")
+    expect(migration).toContain("set local lock_timeout = '5s';")
     expect(migration).toContain('in access exclusive mode;')
+    expect(migration).toContain(
+      "set_config('pika.classroom_archive_compaction', 'on', true)",
+    )
     for (const table of [
       'public.quizzes',
       'public.quiz_questions',
@@ -87,5 +100,18 @@ describe('legacy Quiz freeze and backfill migration', () => {
     expect(migration).not.toMatch(
       /\b(?:insert into|update|delete from|drop table)\s+public\.(?:tests|test_questions|test_responses|test_attempts)\b/i,
     )
+  })
+
+  it('rehearses lock timeout, lock ordering, timezone, and adapter parity', () => {
+    expect(databaseHarness).toContain('legacy_quiz_backfill_lock_timeout')
+    expect(databaseHarness).toContain('canceling statement due to lock timeout')
+    expect(databaseHarness).toContain('legacy_quiz_backfill_revision_race')
+    expect(databaseHarness).toContain('pid <> pg_backend_pid()')
+    expect(databaseHarness).toContain('timezone=America/Toronto')
+    expect(databaseHarness).toContain(
+      'pnpm exec tsx scripts/validate-legacy-quiz-backfill.ts',
+    )
+    expect(adapterValidator).toContain('async function main()')
+    expect(adapterValidator).not.toMatch(/^const input = await/m)
   })
 })

--- a/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
+++ b/tests/unit/legacy-quiz-freeze-backfill-migration.test.ts
@@ -12,6 +12,8 @@ const migration = readFileSync(
 
 describe('legacy Quiz freeze and backfill migration', () => {
   it('serializes the freeze, blueprint narrowing, and source snapshot', () => {
+    expect(migration).toMatch(/^--[\s\S]*\nbegin;\n/)
+    expect(migration.trimEnd()).toMatch(/commit;$/)
     expect(migration).toContain('in access exclusive mode;')
     for (const table of [
       'public.quizzes',


### PR DESCRIPTION
## Summary
- add migration 106 to atomically freeze legacy Quiz sources, reject Quiz blueprints, and backfill deterministic retired-assessment envelopes
- record aggregate-only per-resource count/checksum parity evidence while retaining source rows
- rehearse v1/v2 compatibility at migration 105 and the real 106 backfill in a disposable CI database
- document that 106 remains unapplied and cannot be hosted before the version-aware archive runtime pass

## Remediation
- wrap migration 106 in an explicit transaction and pin checksum serialization to UTC
- fail-fast lock `classrooms` and `users` FK parents, then envelope/source children in archive traversal order with `NOWAIT`
- suppress representation-only archive revision bumps to avoid revision row lock inversion
- rehearse parent-to-child, final-table, drafts-to-quizzes, scores-to-responses, and envelope-to-source contention before a quiet retry
- execute the TypeScript adapter validator without CJS top-level await

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- focused migration/archive/startup contracts: 60 passed
- full suite before final lock remediation: 3,715 passed
- shell syntax, diff check, and Pika changed-file audit pass
- disposable migration replay and contention rehearsal run in exact-head CI only

## Rollout
- No migration was applied to the shared local database or any hosted target.
- Migration 106 application requires separate authorization naming the exact target and migration.
- Apply migration 106 only during a quiet window; any lock conflict is an expected full rollback and retry.
- Migration 105 and the version-aware archive runtime must be current before migration 106 is hosted.