### PR TITLE
Fix course package import dropping tests and lesson plans

### DIFF
--- a/src/lib/server/course-blueprint-operations.ts
+++ b/src/lib/server/course-blueprint-operations.ts
@@ -406,6 +406,30 @@ function normalizeBlueprintAssignment(
   }
 }
 
+// Markdown parsers carry an `id` for matching against existing rows. Creation
+// plans never use it, and the write schemas are strict, so pick only the
+// fields the plan declares.
+function normalizeBlueprintAssessment(assessment: CreateBlueprintWritePlan['assessments'][number]) {
+  return {
+    assessment_type: assessment.assessment_type,
+    title: assessment.title,
+    content: assessment.content,
+    documents: assessment.documents,
+    points_possible: assessment.points_possible,
+    gradebook_weight: assessment.gradebook_weight ?? 10,
+    include_in_final: assessment.include_in_final,
+    position: assessment.position,
+  }
+}
+
+function normalizeBlueprintLessonTemplate(template: CreateBlueprintWritePlan['lesson_templates'][number]) {
+  return {
+    title: template.title,
+    content_markdown: template.content_markdown,
+    position: template.position,
+  }
+}
+
 function normalizeRequirementsForBlueprint(
   requirements: CourseBlueprintAssignment['submission_requirements_json'],
 ) {
@@ -430,8 +454,8 @@ export function buildCreateBlueprintWritePlan(args: {
   return createBlueprintWritePlanSchema.parse({
     blueprint: args.blueprint,
     assignments: args.assignments.map(normalizeBlueprintAssignment),
-    assessments: args.assessments,
-    lesson_templates: args.lessonTemplates,
+    assessments: args.assessments.map(normalizeBlueprintAssessment),
+    lesson_templates: args.lessonTemplates.map(normalizeBlueprintLessonTemplate),
     manifest_version: args.manifestVersion,
     source_package_exported_at: args.sourcePackageExportedAt ?? null,
   })

--- a/tests/lib/server/course-blueprint-operations.test.ts
+++ b/tests/lib/server/course-blueprint-operations.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_ACTUAL_COURSE_SITE_CONFIG,
   DEFAULT_PLANNED_COURSE_SITE_CONFIG,
 } from '@/lib/course-site-publishing'
+import { parseCourseBlueprintImportBundle } from '@/lib/course-blueprint-package'
 
 const operationId = '10000000-0000-4000-8000-000000000020'
 
@@ -277,5 +278,103 @@ describe('atomic blueprint operation contracts', () => {
       manifestVersion: '3',
       operationId,
     })).toEqual(expect.objectContaining({ ok: false, status: 400 }))
+  })
+})
+
+describe('importing a course package that contains tests and lesson plans', () => {
+  // The markdown parsers attach `id: existingMatch?.id` for matching against
+  // existing rows. On a fresh import there is no match, so the key is present
+  // with value `undefined` — which zod 4 rejects as an unrecognized key on the
+  // strict write schemas. Assignments were already normalized; assessments and
+  // lesson templates were passed through raw and blew up.
+  function bundleWithAssessmentsAndLessons() {
+    return {
+      manifest: {
+        version: '4' as const,
+        exported_at: '2026-01-01T00:00:00.000Z',
+        title: 'Package With Tests',
+        subject: 'Computer Science',
+        grade_level: '10',
+        course_code: 'ICS2O',
+        term_template: 'Semester',
+      },
+      files: {
+        'course-overview.md': '',
+        'course-outline.md': '',
+        'resources.md': '',
+        'assignments.md': [
+          '## Warm-Up',
+          'Due Days: 7',
+          'Due Time: 23:59',
+          'Gradebook Weight: 10',
+          'Include In Final: true',
+          '',
+          'Do the warm-up.',
+        ].join('\n'),
+        'tests.md': [
+          '# Test',
+          'Title: Unit 1 Quiz',
+          'Points Possible: 5',
+          'Gradebook Weight: 10',
+          'Include In Final: true',
+          'Show Results: false',
+          '',
+          '## Questions',
+          '### Question 1',
+          'Type: multiple_choice',
+          'Points: 5',
+          'Prompt:',
+          'Which keyword cannot be reassigned?',
+          'Options:',
+          '- let',
+          '- const',
+          'Correct Option: 2',
+        ].join('\n'),
+        'lesson-plans.md': ['## Lesson 1', '', 'Introduce variables.', '', '---'].join('\n'),
+      },
+    }
+  }
+
+  // Mirrors the mapping in importCourseBlueprintBundle.
+  function planFromBundle() {
+    const parsed = parseCourseBlueprintImportBundle(bundleWithAssessmentsAndLessons())
+    expect(parsed.errors).toEqual([])
+    return buildCreateBlueprintWritePlan({
+      blueprint: parsed.blueprint,
+      assignments: parsed.assignments.map((assignment) => ({
+        ...assignment,
+        submission_requirements_json: assignment.submission_requirements || [],
+      })),
+      assessments: parsed.assessments.map((assessment) => ({
+        ...assessment,
+        points_possible: assessment.points_possible ?? null,
+        gradebook_weight: assessment.gradebook_weight ?? 10,
+        include_in_final: assessment.include_in_final !== false,
+      })),
+      lessonTemplates: parsed.lesson_templates,
+      manifestVersion: parsed.manifest!.version,
+      sourcePackageExportedAt: parsed.manifest!.exported_at,
+    })
+  }
+
+  it('builds a write plan instead of rejecting the unmatched id key', () => {
+    expect(() => planFromBundle()).not.toThrow()
+  })
+
+  it('keeps the parsed tests and lesson plans in the write plan', () => {
+    const plan = planFromBundle()
+    expect(plan.assessments).toHaveLength(1)
+    expect(plan.assessments[0]).toEqual(
+      expect.objectContaining({ assessment_type: 'test', title: 'Unit 1 Quiz', position: 0 })
+    )
+    expect(plan.lesson_templates).toHaveLength(1)
+    expect(plan.assignments).toHaveLength(1)
+  })
+
+  it('does not carry an id into the create plan', () => {
+    const plan = planFromBundle()
+    expect(plan.assessments[0]).not.toHaveProperty('id')
+    expect(plan.lesson_templates[0]).not.toHaveProperty('id')
+    expect(plan.assignments[0]).not.toHaveProperty('id')
   })
 })


### PR DESCRIPTION
## Problem

Importing a course blueprint package containing tests failed with:

```
400 assessments.0: Unrecognized key: "id"; assessments.1: Unrecognized key: "id"
```

This affected **both** import paths — the JSON bundle API and the UI's tar upload, since `importCourseBlueprintArchive` delegates to `importCourseBlueprintBundle`. Because `exportCourseBlueprintArchive` emits `tests.md`, **export → import round-trips were broken for any course containing assessments.**

## Root cause

The markdown parsers attach `id: existingMatch?.id` so re-imports can match existing rows. On a fresh import there is no match, so the key is present with value `undefined` — and zod 4 treats an `undefined`-valued key as *unrecognized* on a `.strict()` schema.

In `buildCreateBlueprintWritePlan`, assignments were already normalized before reaching the strict write schema, but assessments and lesson templates were passed through raw:

```ts
assignments: args.assignments.map(normalizeBlueprintAssignment),  // normalized
assessments: args.assessments,                                     // raw → failed
lesson_templates: args.lessonTemplates,                            // raw → same latent bug
```

Lesson templates had the identical defect; it just hadn't been hit in practice.

## Fix

Normalize all three consistently by adding `normalizeBlueprintAssessment` and `normalizeBlueprintLessonTemplate`, mirroring the existing `normalizeBlueprintAssignment` pattern — pick only the fields the write plan declares.

## Test coverage

The existing route test mocks `importCourseBlueprintBundle` entirely, which is why this slipped through. Added regression coverage at the write-plan layer that parses a real bundle containing `tests.md` and `lesson-plans.md`.

Verified the new tests **fail without the fix** with the exact production error, and pass with it.

## Verification

- Full suite: 413 files, 3688 tests passing
- Typecheck clean
- `pnpm check:architecture` passes (624 modules)
- Fixed code exercised against a real course fixture: 3 assignments + 2 quizzes build correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)