### PR TITLE
chore(workflow): align Claude guidance prompts

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -14959,3 +14959,27 @@
 
 **Remaining:**
 - Merge PR #895 after required checks/review. Phase 2 begins after that merge.
+
+<!-- pika-session-log-archive-batch:a73dcf9eb7487dcd0acaba81544d6e7333f6addb1ad942ce89748d8c50d1b45b -->
+## 2026-07-20 — Phase 2 semantic-token contrast contract
+
+**Completed:**
+- Merged PR #895, completing the Product Experience Safety Wave and beginning Phase 2.
+- Added a WCAG AA contract that evaluates semantic foreground/background pairs in both themes, including translucent selected and status surfaces.
+- Split semantic foreground colors from opaque solid action fills, migrated filled controls to the new solid tokens, and corrected failing muted, status, accent, and selected-state combinations.
+- Preserved a persistent selected-row cue in the gradebook after reducing the dark selected-surface opacity.
+- Resolved all findings from two independent reviews, including omitted hover/subtle pairs, solid-fill opacity enforcement, inverse-text bypasses, and missing direct component coverage.
+- Visually verified representative teacher and student routes at desktop/mobile sizes in light/dark themes, plus selected gradebook rows in both themes. No overflow, overlap, console, or page errors were found.
+
+**Validation:**
+- `pnpm test` (378 files / 3,523 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Custom Playwright teacher/student desktop/mobile light/dark matrix and gradebook selected-row checks
+- `git diff --check`
+
+**Remaining:**
+- Review and merge PR #896. Then implement Phase 2's shared modal-layer contract as a separate slice.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,29 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-20 — Phase 2 semantic-token contrast contract
-
-**Completed:**
-- Merged PR #895, completing the Product Experience Safety Wave and beginning Phase 2.
-- Added a WCAG AA contract that evaluates semantic foreground/background pairs in both themes, including translucent selected and status surfaces.
-- Split semantic foreground colors from opaque solid action fills, migrated filled controls to the new solid tokens, and corrected failing muted, status, accent, and selected-state combinations.
-- Preserved a persistent selected-row cue in the gradebook after reducing the dark selected-surface opacity.
-- Resolved all findings from two independent reviews, including omitted hover/subtle pairs, solid-fill opacity enforcement, inverse-text bypasses, and missing direct component coverage.
-- Visually verified representative teacher and student routes at desktop/mobile sizes in light/dark themes, plus selected gradebook rows in both themes. No overflow, overlap, console, or page errors were found.
-
-**Validation:**
-- `pnpm test` (378 files / 3,523 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Custom Playwright teacher/student desktop/mobile light/dark matrix and gradebook selected-row checks
-- `git diff --check`
-
-**Remaining:**
-- Review and merge PR #896. Then implement Phase 2's shared modal-layer contract as a separate slice.
-
 ## 2026-07-20 — Phase 2 shared modal-layer contract
 
 **Completed:**
@@ -1181,3 +1158,21 @@ future persistence shape without enabling unapproved schema behavior.
 **Remaining:**
 - Complete PR review/remediation, exact-head CI, and merge. Applying migration
   108 remains separately target-authorized.
+
+## 2026-07-24 — Aligned Claude workflow guidance
+
+**Risk profile:** none
+
+**Completed:**
+- Aligned the Claude session-start and workflow-reset commands with the
+  canonical startup and worktree guidance.
+- Simplified the Claude issue helper to route worktree setup through
+  `docs/dev-workflow.md` instead of hardcoding one named-worktree layout.
+- Added semantic prompt invariants covering both Claude and Codex startup,
+  workflow-reset, and issue-helper surfaces.
+
+**Validation:**
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts` passes: 31 tests.
+
+**Remaining:**
+- None.

--- a/.claude/commands/follow-workflow.md
+++ b/.claude/commands/follow-workflow.md
@@ -1,19 +1,12 @@
-STOP and re-read the workflow docs before continuing.
+Stop and reload the canonical workflow context before continuing.
 
-You may have drifted from the required workflow. Follow these steps:
-
-1) Check the repo root first: `git rev-parse --show-toplevel`
-2) Read the workflow docs:
-   - Read `.ai/START-HERE.md`
-   - Read `docs/dev-workflow.md`
-
-Key rules to remember:
-
-- Resolve and use the current repo root consistently.
-- Use absolute paths or paths relative to the current repo root.
-- Hub (`$HOME/Repos/pika`) is for managing worktrees, NOT feature development
+Read these files in order:
+1. `.ai/START-HERE.md`
+2. `.ai/CURRENT.md`
+3. `docs/ai-instructions.md`
+4. `docs/dev-workflow.md`
 
 After reading, confirm:
-1. What repo root are you in?
+1. What repo root does `git rev-parse --show-toplevel` report?
 2. What branch are you on, or are you on detached HEAD?
 3. What task are you working on?

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -20,16 +20,17 @@ Steps:
 2) Recover recent context
    - Run: `git log --oneline -10`
    - Run: `git status -sb`
-   - Read `.ai/CURRENT.md`.
    - Read `.ai/SESSION-LOG.md` only if recent handoff context is needed.
    - Summarize: current branch or detached HEAD state, last few commits, uncommitted changes.
 
 3) Load documentation
    - Read in order:
      1. `.ai/START-HERE.md`
-     2. `.ai/features.json`
-     3. `docs/ai-instructions.md`
-     4. Task-specific docs routed by `docs/ai-instructions.md`
+     2. `.ai/CURRENT.md`
+     3. `.ai/features.json`
+     4. `docs/ai-instructions.md`
+     5. `docs/dev-workflow.md`
+     6. Task-specific docs routed by `docs/ai-instructions.md`
    - Briefly confirm: current feature area being developed.
 
 4) Check feature inventory

--- a/.claude/commands/work-on-issue.md
+++ b/.claude/commands/work-on-issue.md
@@ -1,47 +1,15 @@
-Load a GitHub issue, set up a worktree, and prepare a plan before coding.
+Load a GitHub issue, inspect affected code, and draft a plan before coding.
 
-Takes the issue number as $ARGUMENTS (e.g. `382`).
-
-This command operates on the current repo/worktree.
-
-Rules:
-- Resolve the current repo root with `git rev-parse --show-toplevel`.
-- Use the hub path only for creating a new worktree.
-- Plan before coding — wait for my approval before writing any files.
+Assume the startup context from `.ai/START-HERE.md` is already loaded. If not, run `/session-start` first.
 
 Steps:
-
-1) Load the issue
-   - Run: `gh issue view $ARGUMENTS --json number,title,body,labels,assignees,milestone`
-   - Read and summarize: title, description, acceptance criteria, affected areas.
-
-2) Read relevant docs
-   - `docs/ai-instructions.md` (if not already read this session)
-   - `docs/core/architecture.md` (relevant sections)
-   - Any guidance doc under `docs/guidance/` related to the issue.
-
-3) Explore affected code
-   - Identify which files will likely change (API routes, components, lib utilities, tests).
-   - Read those files to understand current state.
-   - Note: do NOT modify anything yet.
-
-4) Draft a branch name and plan
-   - Branch name: `issue/<number>-<kebab-slug>` (e.g. `issue/382-fix-gradebook-cache`)
-   - Plan:
-     - What is the root cause / goal?
-     - What files will change and how?
-     - What tests will you write first (TDD)?
-     - Any migration required? (NEVER apply migrations — human does this)
-     - Any UI changes? (will need /ui-verify after)
-
-5) Present plan and wait for approval
-   - Show the plan clearly.
-   - Do NOT start writing code until I confirm.
-
-6) After approval: set up worktree (if not already on correct branch)
-   ```bash
-   HUB="$HOME/Repos/pika"
-   git -C "$HUB" fetch origin
-   git -C "$HUB" worktree add "$HOME/.codex/worktrees/pika/issue-$ARGUMENTS-<slug>" -b "issue/$ARGUMENTS-<slug>" origin/main
-   ```
-   Then open the new worktree before editing.
+1. Run `gh issue view $ARGUMENTS --json number,title,body,labels,assignees`.
+2. Read `docs/workflow/handle-issue.md` plus the task-specific docs selected by `docs/ai-instructions.md`.
+   - For UI work, include a UI guidance declaration.
+   - Record: stable guidance followed
+   - Record: experimental guidance introduced: yes/no
+   - Record: human promotion needed: yes/no
+3. Inspect the affected files and the nearest tests without editing anything yet.
+4. Draft the plan: worktree or branch name, files to change, tests to write first, and whether a migration file is needed.
+5. Present the plan and wait for approval.
+6. After approval, create or open the dedicated worktree using `docs/dev-workflow.md`, then continue the work from that worktree.

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -82,6 +82,13 @@ const requiredStartupFiles = [
   '.ai/features.json',
   'docs/ai-instructions.md',
 ]
+const requiredStartupGuidanceFiles = [...requiredStartupFiles, 'docs/dev-workflow.md']
+const requiredWorkflowRecoveryFiles = [
+  '.ai/START-HERE.md',
+  '.ai/CURRENT.md',
+  'docs/ai-instructions.md',
+  'docs/dev-workflow.md',
+]
 
 describe('AI startup docs', () => {
   it('keeps the default startup set under the budget', () => {
@@ -128,13 +135,44 @@ describe('AI startup docs', () => {
     expect(readRepoFile('.ai/JOURNAL-ARCHIVE.md')).toContain('# Pika Project Journal')
   })
 
-  it('keeps the manual startup prompt aligned with the required startup set', () => {
-    const prompt = readRepoFile('.codex/prompts/session-start.md')
+  it('keeps startup prompts aligned with the canonical guidance set', () => {
+    const prompts = ['.claude/commands/session-start.md', '.codex/prompts/session-start.md']
 
-    for (const file of requiredStartupFiles) {
-      expect(prompt).toContain(file)
+    for (const promptPath of prompts) {
+      const prompt = readRepoFile(promptPath)
+
+      for (const file of requiredStartupGuidanceFiles) {
+        expect(prompt).toContain(file)
+      }
+      expect(prompt).toContain('--orient-only')
     }
-    expect(prompt).toContain('--orient-only')
+  })
+
+  it('keeps workflow reset prompts aligned with the canonical recovery set', () => {
+    const prompts = ['.claude/commands/follow-workflow.md', '.codex/prompts/follow-workflow.md']
+
+    for (const promptPath of prompts) {
+      const prompt = readRepoFile(promptPath)
+
+      for (const file of requiredWorkflowRecoveryFiles) {
+        expect(prompt).toContain(file)
+      }
+      expect(prompt).toContain('git rev-parse --show-toplevel')
+      expect(prompt).toContain('detached HEAD')
+    }
+  })
+
+  it('keeps issue prompts on the canonical worktree workflow', () => {
+    const prompts = ['.claude/commands/work-on-issue.md', '.codex/prompts/work-on-issue.md']
+
+    for (const promptPath of prompts) {
+      const prompt = readRepoFile(promptPath)
+
+      expect(prompt).toContain('docs/workflow/handle-issue.md')
+      expect(prompt).toContain('docs/dev-workflow.md')
+      expect(prompt).not.toContain('$HOME/.codex/worktrees/pika/issue-')
+      expect(prompt).not.toContain('git -C "$HUB" worktree add')
+    }
   })
 
   it('documents both named and app-managed Codex worktree locations', () => {


### PR DESCRIPTION
## Summary
- align Claude session-start and workflow-reset commands with canonical guidance
- route Claude issue worktree setup through docs/dev-workflow.md
- add semantic parity checks across Claude and Codex prompt families

## Validation
- pnpm vitest run tests/unit/ai-startup-docs.test.ts
- pnpm lint
- pnpm exec tsc --noEmit
- node scripts/trim-session-log.mjs --check
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh