### PR TITLE
Classify tidy worktrees by PR state instead of remote presence

### DIFF
--- a/scripts/repo-tidy.sh
+++ b/scripts/repo-tidy.sh
@@ -49,7 +49,10 @@ while IFS='|' read -r name track wt; do
   fi
 done < <(git for-each-ref refs/heads --format='%(refname:short)|%(upstream:track)|%(worktreepath)')
 
-# 3) Worktrees: flag dirty state and unpushed commits so nothing is lost blindly.
+# 3) Worktrees: classify by PR state, same as remote branches above.
+#    A missing remote branch is NOT a risk signal here: with squash merges and
+#    delete-on-merge, it is the normal end state of merged work. Asking the PR
+#    map instead distinguishes "already merged" from "only exists here".
 #    The hub (main worktree) and the production release worktree are infrastructure.
 echo ""
 echo "── Worktrees ────────────────────────────────────"
@@ -58,21 +61,46 @@ while read -r wt; do
   [[ "$wt" == "$HUB_WT" ]] && continue
   dirty="$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
   branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
-  label="${branch:-DETACHED}"
   if [[ "$branch" == "production" ]]; then
     echo "  🏛  $wt (production) — release infrastructure, keep"
     continue
   fi
-  flags=""
-  [[ "$dirty" != "0" ]] && flags+=" dirty:$dirty"
-  if [[ -n "$branch" ]] && ! git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
-    flags+=" not-on-remote"
+
+  # Uncommitted work outranks every other signal: never suggest removing it.
+  if [[ "$dirty" != "0" ]]; then
+    echo "  ⚠️  $wt (${branch:-DETACHED}) dirty:$dirty — uncommitted work, inspect before removing"
+    ISSUES=$((ISSUES + 1))
+    continue
   fi
-  if [[ -n "$flags" ]]; then
-    echo "  ⚠️  $wt ($label)$flags — inspect before removing"
+
+  if [[ -z "$branch" ]]; then
+    echo "  ✓  $wt (DETACHED) — clean; removable with: git worktree remove $wt"
+    ISSUES=$((ISSUES + 1))
+    continue
+  fi
+
+  entry="$(jq -r --arg b "$branch" '.[] | select(.branch == $b)' <<<"$PR_MAP")"
+  pr="$(jq -r '.number // empty' <<<"$entry")"
+  if [[ -z "$entry" ]]; then
+    if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+      echo "  ⚠️  $wt ($branch) — pushed but no PR; inspect before removing"
+    else
+      echo "  ⚠️  $wt ($branch) — no PR and not on remote; commits may exist only here"
+    fi
+    ISSUES=$((ISSUES + 1))
+  elif jq -e '.states | index("OPEN")' <<<"$entry" > /dev/null; then
+    echo "  🔨 $wt ($branch) — PR #$pr open; active work, keep"
+  elif jq -e '.states | index("MERGED")' <<<"$entry" > /dev/null; then
+    echo "  ✓  $wt ($branch) — PR #$pr merged; remove with: git worktree remove $wt && git branch -D $branch"
     ISSUES=$((ISSUES + 1))
   else
-    echo "  ✓  $wt ($label) — clean; removable with: git worktree remove $wt"
+    if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+      recover="remote branch still exists, restorable"
+    else
+      recover="NO remote copy — rescue before deleting"
+    fi
+    echo "  ⚠️  $wt ($branch) — PR #$pr closed unmerged; decide before removing ($recover)"
+    ISSUES=$((ISSUES + 1))
   fi
 done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
 


### PR DESCRIPTION
## Problem

`scripts/repo-tidy.sh` flagged any worktree whose branch was missing from the remote as:

```
⚠️  <path> (<branch>) not-on-remote — inspect before removing
```

But this repo squash-merges with delete-on-merge, so **a missing remote branch is the normal end state of merged work** — not a risk signal. The warning fired hardest on exactly the branches that were safest to delete.

On a real cleanup run this inverted the signal: **33 of 44 flagged worktrees were already merged**, which buried the handful that actually needed a judgement call. A report where most warnings are false alarms trains you to skim past it.

## Fix

The script already maps branches through the PR list for the *remote branch* section (line 21 comment says why: "squash merges hide this from `git branch --merged`"). That `PR_MAP` was simply never reused in the worktree loop.

Now it is:

| PR state | Result |
| --- | --- |
| open | `🔨 active work, keep` |
| merged | `✓ removable`, with the exact `worktree remove && branch -D` command |
| closed unmerged | `⚠️ decide`, and reports whether a remote copy still exists to restore from |
| no PR | `⚠️ inspect`, distinguishing "pushed but no PR" from "not on remote; commits may exist only here" |

Uncommitted changes are checked **first** and always win, so a dirty worktree is never suggested for removal regardless of PR state.

## Before / after

Before — 44 items, mostly noise:
```
⚠️  .../classroom-gradex-extract (codex/classroom-gradex-extract) not-on-remote — inspect before removing
⚠️  .../drop-legacy-quiz-schema (codex/drop-legacy-quiz-schema) not-on-remote — inspect before removing
```

After:
```
✓  .../drop-legacy-quiz-schema (codex/drop-legacy-quiz-schema) — PR #931 merged; remove with: git worktree remove ... && git branch -D ...
⚠️  .../atomic-blueprint-roundtrip (codex/atomic-blueprint-roundtrip) — PR #850 closed unmerged; decide before removing (remote branch still exists, restorable)
🔨 .../test-preview-authorization-framing (codex/test-preview-authorization-framing) — PR #920 open; active work, keep
⚠️  .../cli-probe (cli-probe) — no PR and not on remote; commits may exist only here
```

## Verification

Ran against the live repo and confirmed all five paths classify correctly, using temporary worktrees on branches with known PR outcomes (#931 merged, #850 closed-unmerged) to exercise the two paths not present in the current tree. `bash -n` clean. The script remains read-only — it prints commands and deletes nothing.

## Note, not fixed here

The remote-branch section reports state via `.states[0]`, which can mislabel a branch that has more than one PR. The new worktree code uses `index("MERGED")` / `index("OPEN")` instead. Left the existing section alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)