### PR TITLE
feat(student): rotating daily reflection prompt in Daily tab

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -58,6 +58,45 @@ function resolveEntryContent(entry: Entry | null): TiptapContent {
   return EMPTY_DOC
 }
 
+// Daily reflection openers, rotated by calendar date so the whole class sees the
+// same prompt on a given day. Recurs roughly every 4 weeks over a semester.
+const DAILY_REFLECTION_PROMPTS = [
+  "What's one thing you're proud of from last time?",
+  "What's something you figured out recently?",
+  'What went well, and what felt tricky?',
+  'How did your last plan turn out?',
+  "What's a small win from your last session?",
+  'Where did you get stuck last time — and what did you try?',
+  "What's one thing you want to keep doing?",
+  'What would you do differently from last time?',
+  'What surprised you in your recent work?',
+  'What are you curious to dig into more?',
+  "What's starting to click for you lately?",
+  "What's a question you're still sitting with?",
+  'Who or what helped you recently?',
+  'What felt like hard work worth doing?',
+  "What's something you almost gave up on but didn't?",
+  'How are you feeling about your progress so far?',
+  "What's one habit you want to build this week?",
+  'What did a recent mistake teach you?',
+  'What do you want to get better at?',
+  'What are you looking forward to?',
+] as const
+
+// Shown when there's no prior post to reflect on yet.
+const NO_LAST_LOG_PROMPT = 'Fresh start — how are you feeling about today?'
+const DAILY_PLAN_PROMPT = "What's your plan for today?"
+
+// Deterministic day index from a 'YYYY-MM-DD' string (timezone-independent), so
+// every student in the class lands on the same prompt for a given date.
+function getDailyReflectionPrompt(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  if (!year || !month || !day) return DAILY_REFLECTION_PROMPTS[0]
+  const dayIndex = Math.floor(Date.UTC(year, month - 1, day) / 86_400_000)
+  const count = DAILY_REFLECTION_PROMPTS.length
+  return DAILY_REFLECTION_PROMPTS[((dayIndex % count) + count) % count]
+}
+
 
 interface StudentTodayTabProps {
   classroom: Classroom
@@ -619,6 +658,12 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   }
 
   const pastHistoryEntries = historyEntries.filter(entry => entry.date !== today)
+  const lastLog = pastHistoryEntries[0] ?? null
+  const hasLastLog =
+    !!lastLog && (!!lastLog.text?.trim() || !isEmpty(resolveEntryContent(lastLog)))
+  const reflectionPrompt = hasLastLog
+    ? getDailyReflectionPrompt(today)
+    : NO_LAST_LOG_PROMPT
 
   function toggleHistoryEntry(entryId: string) {
     setExpandedHistoryIds(prev => {
@@ -657,9 +702,14 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           </div>
         ) : (
           <div className="space-y-4">
-            <div className="flex items-center justify-between mb-2">
-              <label className="text-sm font-medium text-text-muted">
-                What did you do today?
+            <div className="flex items-start justify-between mb-2">
+              <label className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-text-default">
+                  {reflectionPrompt}
+                </span>
+                <span className="text-sm text-text-muted">
+                  {DAILY_PLAN_PROMPT}
+                </span>
               </label>
               <span
                 role="status"

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -59,7 +59,8 @@ function resolveEntryContent(entry: Entry | null): TiptapContent {
 }
 
 // Daily reflection openers, rotated by calendar date so the whole class sees the
-// same prompt on a given day. Recurs roughly every 4 weeks over a semester.
+// same prompt on a given day. 20 prompts at ~5 school days a week means a given
+// prompt comes back around every few weeks.
 const DAILY_REFLECTION_PROMPTS = [
   "What's one thing you're proud of from last time?",
   "What's something you figured out recently?",


### PR DESCRIPTION
## Summary

Replaces the static **"What did you do today?"** label in the student Daily tab with a two-line prompt that pairs a rotating reflection opener with a steady planning ask:

> **What do you want to get better at?**  ← rotates daily
> What's your plan for today?  ← fixed

## Details

- **20 reflection prompts** rotate **daily**, **class-synced by calendar date** — a deterministic, timezone-independent day index means every student in a class sees the same prompt each day. Recurs ~every 4 weeks over an ~18-week semester.
- **No-post fallback:** when there's no prior log to reflect on, line 1 becomes *"Fresh start — how are you feeling about today?"*
- `hasLastLog` treats an entry as written if `rich_content` **or** `text` has content, so legacy/text-only entries count correctly (caught during browser verification — seed entries store content in `text` with an empty `rich_content`).

## Verification

- ✅ `tsc --noEmit` clean
- ✅ Verified live in the dev server as Student 1: two-line label renders with correct hierarchy; Jul 24 shows prompt #19 as expected
- ✅ Rotation math checked — consecutive days advance by one prompt and wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)