### PR TITLE
Make the CLI smoke test clean up after itself

### DIFF
--- a/scripts/pika-cli-README.md
+++ b/scripts/pika-cli-README.md
@@ -77,12 +77,20 @@ from it — those are independent copies.
 ## Testing
 
 ```bash
-pnpm smoke:pika-cli          # auth + markdown round-trip (idempotent)
-pnpm smoke:pika-cli --full   # also creates a blueprint + classroom
+pnpm smoke:pika-cli                 # auth + markdown round-trip (idempotent)
+pnpm smoke:pika-cli --full          # also imports a course and instantiates it
+pnpm smoke:pika-cli --full --keep   # same, but leave the artifacts for inspection
 ```
 
 The `pull → push → pull` round-trip is the drift detector: if a route or a
 shared contract changes shape, it stops matching and the smoke test fails.
+
+`--full` removes the blueprint and classroom it creates, even if an assertion
+fails partway through, so repeated runs don't pile up duplicates. The blueprint
+goes through the API; the classroom is deleted directly, since classrooms have
+no DELETE route by design and every foreign key into them cascades. That
+teardown needs `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SECRET_KEY`, which
+`.env.local` already provides.
 
 ## Curriculum-as-code loop
 

--- a/scripts/pika-cli-smoke.ts
+++ b/scripts/pika-cli-smoke.ts
@@ -10,23 +10,43 @@
  * drift detector — if a route or contract changes shape, it stops matching.
  *
  * Phases 1-3 are idempotent (no data created). Phase 4 creates a blueprint +
- * classroom and is opt-in via --full.
+ * classroom and is opt-in via --full; both are removed again afterwards unless
+ * --keep is passed. Without teardown, repeated runs pile up duplicates.
  */
 import { writeFileSync, readFileSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { config } from 'dotenv'
+import { createClient } from '@supabase/supabase-js'
 import { login, pikaJson } from './pika-api'
 import { testToMarkdown, markdownToTest } from '../src/lib/test-markdown'
 
 config({ path: '.env.local' })
 
 const FULL = process.argv.includes('--full')
+const KEEP = process.argv.includes('--keep')
 let failures = 0
 
 function check(label: string, ok: boolean, detail = ''): void {
   console.log(`${ok ? '✅' : '❌'} ${label}${detail ? ` — ${detail}` : ''}`)
   if (!ok) failures++
+}
+
+/**
+ * Classrooms have no DELETE route (that is deliberate — the product path is
+ * archiving, which is built for real end-of-term retention, not test junk).
+ * Every foreign key into classrooms is ON DELETE CASCADE, so teardown removes
+ * the row directly and lets the database clean up the rest.
+ */
+async function deleteClassroom(classroomId: string): Promise<string | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SECRET_KEY
+  if (!url || !key) {
+    return 'NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY not set'
+  }
+  const supabase = createClient(url, key, { auth: { persistSession: false } })
+  const { error } = await supabase.from('classrooms').delete().eq('id', classroomId)
+  return error ? error.message : null
 }
 
 async function main(): Promise<void> {
@@ -124,33 +144,59 @@ async function main(): Promise<void> {
     const manifest = JSON.parse(readFileSync(join(dir, 'manifest.json'), 'utf8')) as Record<string, unknown>
     manifest.exported_at = new Date().toISOString()
 
-    const imported = await pikaJson<{ blueprint: { id: string } }>('/api/teacher/course-blueprints/import', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ manifest, files }),
-    })
-    check('course import', Boolean(imported.blueprint?.id), imported.blueprint?.id)
-
-    const created = await pikaJson<{ classroom: { id: string } }>(
-      `/api/teacher/course-blueprints/${imported.blueprint.id}/instantiate`,
-      {
+    // Track what this run creates so teardown can remove it even if an
+    // assertion below throws.
+    let blueprintId = ''
+    let classroomId = ''
+    try {
+      const imported = await pikaJson<{ blueprint: { id: string } }>('/api/teacher/course-blueprints/import', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ title: `CLI Smoke ${Date.now()}`, semester: 'semester1', year: 2026 }),
+        body: JSON.stringify({ manifest, files }),
+      })
+      blueprintId = imported.blueprint?.id ?? ''
+      check('course import', Boolean(blueprintId), blueprintId)
+
+      const created = await pikaJson<{ classroom: { id: string } }>(
+        `/api/teacher/course-blueprints/${blueprintId}/instantiate`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ title: `CLI Smoke ${Date.now()}`, semester: 'semester1', year: 2026 }),
+        }
+      )
+      classroomId = created.classroom?.id ?? ''
+      check('course instantiate', Boolean(classroomId), classroomId)
+
+      const { assignments = [] } = await pikaJson<{ assignments: unknown[] }>(
+        `/api/teacher/assignments?classroom_id=${classroomId}`
+      )
+      check('assignments materialized', assignments.length === 3, `${assignments.length}/3`)
+
+      // The #932 regression guard: tests from tests.md must land as real tests.
+      const { tests = [] } = await pikaJson<{ tests: unknown[] }>(
+        `/api/teacher/tests?classroom_id=${classroomId}`
+      )
+      check('tests materialized (#932)', tests.length === 2, `${tests.length}/2`)
+    } finally {
+      if (KEEP) {
+        console.log(`ℹ️  --keep: left blueprint ${blueprintId || '(none)'} and classroom ${classroomId || '(none)'} in place`)
+      } else {
+        const problems: string[] = []
+        if (classroomId) {
+          const err = await deleteClassroom(classroomId)
+          if (err) problems.push(`classroom: ${err}`)
+        }
+        if (blueprintId) {
+          try {
+            await pikaJson(`/api/teacher/course-blueprints/${blueprintId}`, { method: 'DELETE' })
+          } catch (err) {
+            problems.push(`blueprint: ${(err as Error).message}`)
+          }
+        }
+        check('cleaned up what this run created', problems.length === 0, problems.join('; '))
       }
-    )
-    check('course instantiate', Boolean(created.classroom?.id), created.classroom?.id)
-
-    const { assignments = [] } = await pikaJson<{ assignments: unknown[] }>(
-      `/api/teacher/assignments?classroom_id=${created.classroom.id}`
-    )
-    check('assignments materialized', assignments.length === 3, `${assignments.length}/3`)
-
-    // The #932 regression guard: tests from tests.md must land as real tests.
-    const { tests = [] } = await pikaJson<{ tests: unknown[] }>(
-      `/api/teacher/tests?classroom_id=${created.classroom.id}`
-    )
-    check('tests materialized (#932)', tests.length === 2, `${tests.length}/2`)
+    }
   }
 
   console.log(`\n${failures === 0 ? 'PASS' : `FAIL (${failures})`}`)


### PR DESCRIPTION
## Problem

`pnpm smoke:pika-cli --full` imported a course and instantiated a classroom on every run, and removed neither. Two days of development left **9 duplicate blueprints and 9 stray classrooms** in the local database, which is what made `pika course list` unreadable.

## Change

Track what a run creates and tear it down in a `finally` block, so cleanup also runs when an assertion throws partway through.

- **Blueprint** — deleted through the API (`DELETE /api/teacher/course-blueprints/{id}`).
- **Classroom** — deleted directly against the database. Classrooms deliberately have no DELETE route; the product path is archiving, which is built for real end-of-term retention rather than test junk and would swap one kind of residue for another. Every foreign key into `classrooms` is `ON DELETE CASCADE`, so removing the row cleans up assignments, tests, class days and drafts with it.

`--keep` retains the artifacts when you want to inspect them.

## Verification

Against a live local stack:

- Three consecutive `--full` runs leave row counts unchanged (`classrooms=1, blueprints=0` before and after).
- `--keep` retains exactly one blueprint and one classroom.
- An injected mid-phase failure still tears down — the run reports `FAIL`, and nothing leaks.

Typecheck and `pnpm check:architecture` (628 modules) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)