### PR TITLE
perf(test): run DOM-free suites under the node environment

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,20 +6,23 @@ if (process.env.VITEST_SHOW_CONSOLE !== 'true') {
   console.warn = (() => {}) as typeof console.warn
 }
 
-// Mock window.matchMedia for responsive hooks used by tiptap UI components
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-})
+// Mock window.matchMedia for responsive hooks used by tiptap UI components.
+// Guarded because the `node` project runs DOM-free suites without a window.
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}
 
 // Mock environment variables for testing
 process.env.SESSION_SECRET = 'a3f8d2e1c4b6a9f7e3d5c8b2a1f9e6d4c7b3a8f5e2d9c6b4a7f3e1d8c5b2a9f6' // 64 hex chars

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,45 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, defaultExclude } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+
+// Constructing a jsdom environment costs roughly a second per test file, and
+// most suites here (API routes, server helpers, pure utilities) never touch the
+// DOM. Those run under `node` instead; only the suites below need a window.
+//
+// To find this list empirically after adding tests:
+//   npx vitest run --project node
+// Any suite that fails on a missing DOM global belongs in `jsdomOnlyTsSuites`.
+const jsdomOnlyTsSuites = [
+  'tests/hooks/**/*.{test,spec}.ts',
+  'tests/lib/flag-questions.test.ts',
+  'tests/unit/classroom-ux-metrics.test.ts',
+  'tests/unit/client-storage.test.ts',
+]
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
-    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'node',
+          environment: 'node',
+          include: ['tests/**/*.{test,spec}.ts'],
+          exclude: [...defaultExclude, ...jsdomOnlyTsSuites],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'jsdom',
+          environment: 'jsdom',
+          include: ['tests/**/*.{test,spec}.tsx', ...jsdomOnlyTsSuites],
+        },
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Problem

CI's critical path is a single step: **`Run tests with coverage` at 204s**. It is not the 3,767 tests, and it is not e2e — CI runs exactly one Playwright spec (4 tests, 61s); the other 12 e2e specs are config-gated to local and never run in CI.

Vitest's own breakdown on `main`:

```
Duration 143.13s (transform 41.95s, setup 63.35s, import 202.44s, tests 164.89s, environment 435.62s)
```

`environment 435.62s` is jsdom construction — **2.6× more than actually running the tests** (164.89s). Every one of the 421 files gets a fresh jsdom, but **307 of them (73%) never touch the DOM**: API route handlers, server helpers, pure utilities.

## Change

Split into two vitest projects. Vitest 4 removed `environmentMatchGlobs`, so this uses `test.projects`:

- **`node`** — 307 files
- **`jsdom`** — 114 files (all `*.test.tsx` plus 9 DOM-dependent `.ts` suites)

The sole blocker was [`tests/setup.ts`](tests/setup.ts) touching `window` at module scope, which crashed every non-jsdom file with `ReferenceError: window is not defined`. It is now guarded.

The jsdom exception list was derived **empirically** — I ran every `.test.ts` under `node` and took the nine that actually failed on a missing DOM global (all 6 in `tests/hooks/`, plus `flag-questions`, `classroom-ux-metrics`, `client-storage`) rather than grepping for DOM references, which over-matches on strings. The regeneration command is documented in a config comment so the list does not rot.

`jsdomOnlyTsSuites` is deliberately used twice — as `node`'s `exclude` and `jsdom`'s `include` — so a path added to that one array moves between projects atomically and the two cannot drift.

## Results (measured locally)

| | before | after |
|---|---|---|
| `test:coverage` (the CI step) | 140.55s | **106.84s** |
| `vitest run` | 143.13s | **95.87s** |
| cumulative `environment` | 435.62s | **113.20s** |
| `node` project environment | — | **169ms** (307 files) |

Local wall-clock gain is ~24%. I initially predicted a 2-core `ubuntu-latest` runner would do considerably better, on the theory that the cumulative `environment` cost was CPU work that would serialize when cores are scarce. **That prediction was wrong** — CI improved by the same ratio, because the runner still parallelizes environment setup across workers.

Measured on this PR's own CI run vs. `main`:

| | before | after |
|---|---|---|
| `Run tests with coverage` | 204s | **153s** (-25%) |
| Test & Build job total | 331s | **275s** |
| CI wall clock | ~331s | **~279s** (-16%) |

**Test & Build is no longer the critical path.** At 275s it now sits below Architecture Database Contracts (279s), whose floor is the 83-90s `supabase start`. Further optimization of the unit suite will not move total CI much.

## Test plan

- [x] `vitest run` — 421 files / 3,767 tests pass, identical to baseline
- [x] `pnpm test:coverage` — exit 0, all thresholds still enforced
- [x] `npx tsc --noEmit`
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm check:architecture` — 628 modules pass
- [x] 307 + 114 = 421 verified — the invariant guarding against a suite landing in neither project

## Notes / not addressed

- **Unit tests shell out to real `git`.** `tests/unit/ai-startup-docs.test.ts` is the slowest single file (19s) and creates real branches; with four other suites that's ~30s of subprocess work sitting in the unit suite.
- **`supabase start` (83–90s)** in the other two jobs becomes the critical path once this lands, setting the new CI floor.
- Globs cover `.ts`/`.tsx` only, so a `.mts`/`.cts` test would be skipped — but the previous root `include` used the same `{ts,tsx}` pattern, so this is not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
