### PR TITLE
Add classroom archive and restore to the pika CLI

### DIFF
--- a/scripts/pika-cli-README.md
+++ b/scripts/pika-cli-README.md
@@ -41,6 +41,9 @@ quiz.md` writes `quiz.md` where you are, not inside the checkout.
 | `pnpm pika whoami` | Show the logged-in user (verifies the saved session). |
 | `pnpm pika test pull <testId> [--out f.md]` | Export a test to markdown (stdout or file). |
 | `pnpm pika test push <testId> <f.md> [--yes]` | Parse markdown → replace the test's draft. **Dry-run without `--yes`.** |
+| `pnpm pika classroom list [--archived]` | List active classrooms, or archived ones. |
+| `pnpm pika classroom archive <id> [--yes]` | Archive a classroom: hidden from your list, student access blocked. Reversible. |
+| `pnpm pika classroom restore <id> [--yes]` | Unarchive a classroom. |
 | `pnpm pika course list` | List course blueprints. |
 | `pnpm pika course pull <blueprintId> <dir>` | Export a blueprint to an editable directory (manifest.json + markdown). |
 | `pnpm pika course push <dir> [--replace \| --new] [--yes]` | Import a course directory as a blueprint. |
@@ -111,6 +114,26 @@ tests failed with `400 assessments.N: Unrecognized key: "id"`, through both this
 CLI and the UI's tar upload. Fixed in
 [#932](https://github.com/codepetca/pika/pull/932); `pnpm smoke:pika-cli --full`
 now guards it.
+
+## Removing a classroom
+
+There is no delete: classrooms hold student work, so the product exposes
+archiving instead. `classroom archive` flips `archived_at` on the classroom —
+it disappears from your list and students lose access — and `classroom restore`
+undoes it. That is the practical way to retire a classroom created by mistake,
+including in production.
+
+```bash
+pika classroom archive <id>          # dry run
+pika classroom archive <id> --yes    # apply; prints the restore command
+pika classroom list --archived       # find it again
+pika classroom restore <id> --yes    # undo
+```
+
+Not to be confused with `POST /classrooms/{id}/archives`, the cold-storage
+export with checksummed copies and retention policy. That is a separate,
+feature-gated operation (`CLASSROOM_ARCHIVE_EXPORT_ENABLED` plus a per-teacher
+allowlist) and is not what these commands use.
 
 ## Scope / known gaps
 

--- a/scripts/pika.ts
+++ b/scripts/pika.ts
@@ -188,6 +188,61 @@ async function cmdTestPush(testId: string, fileArg: string, flags: Flags): Promi
   console.log(`Pushed ${questionCount} question(s) to test ${testId} (draft v${draft.version} → v${draft.version + 1}).`)
 }
 
+interface ClassroomSummary {
+  id: string
+  title?: string
+  archived_at?: string | null
+}
+
+async function cmdClassroomList(flags: Flags): Promise<void> {
+  const archived = Boolean(flags.archived)
+  const data = await pikaJson<{ classrooms?: ClassroomSummary[] }>(
+    `/api/teacher/classrooms${archived ? '?archived=true' : ''}`
+  )
+  const classrooms = data.classrooms ?? []
+  if (classrooms.length === 0) {
+    console.log(archived ? 'No archived classrooms.' : 'No classrooms.')
+    return
+  }
+  for (const c of classrooms) console.log(`${c.id}  ${c.title ?? '(untitled)'}`)
+}
+
+/**
+ * Archiving is a reversible toggle on the classroom row: it hides the classroom
+ * from the teacher list and blocks student access. It is not the cold-storage
+ * export under /archives, which is a separate, feature-gated operation.
+ */
+async function setClassroomArchived(id: string, archived: boolean, flags: Flags): Promise<void> {
+  const verb = archived ? 'Archive' : 'Restore'
+  const { classroom } = await pikaJson<{ classroom: ClassroomSummary }>(`/api/teacher/classrooms/${id}`)
+  const title = classroom?.title ?? '(untitled)'
+  const alreadyArchived = Boolean(classroom?.archived_at)
+
+  if (archived === alreadyArchived) {
+    console.log(`"${title}" is already ${archived ? 'archived' : 'active'}. Nothing to do.`)
+    return
+  }
+
+  if (!flags.yes) {
+    console.log(`DRY RUN. Would ${verb.toLowerCase()} "${title}" (${id}) @ ${getBaseUrl()}.`)
+    console.log('Re-run with --yes to apply.')
+    return
+  }
+
+  await pikaJson(`/api/teacher/classrooms/${id}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ archived }),
+  })
+
+  if (archived) {
+    console.log(`Archived "${title}". Students can no longer access it, and it is hidden from your list.`)
+    console.log(`Undo with: pika classroom restore ${id} --yes`)
+  } else {
+    console.log(`Restored "${title}".`)
+  }
+}
+
 interface BlueprintSummary {
   id: string
   title: string
@@ -340,6 +395,9 @@ function printHelp(): void {
       '  pnpm pika whoami',
       '  pnpm pika test pull <testId> [--out <file.md>]',
       '  pnpm pika test push <testId> <file.md> [--yes]',
+      '  pnpm pika classroom list [--archived]',
+      '  pnpm pika classroom archive <classroomId> [--yes]',
+      '  pnpm pika classroom restore <classroomId> [--yes]',
       '  pnpm pika course list',
       '  pnpm pika course pull <blueprintId> <dir>',
       '  pnpm pika course push <dir> [--replace | --new] [--yes]',
@@ -369,6 +427,17 @@ async function main(): Promise<void> {
         else if (sub === 'push' && rest[0] && rest[1]) await cmdTestPush(rest[0], rest[1], flags)
         else {
           console.error('Usage: pnpm pika test pull <testId> | test push <testId> <file.md>')
+          process.exitCode = 1
+        }
+        break
+      case 'classroom':
+        if (sub === 'list') await cmdClassroomList(flags)
+        else if (sub === 'archive' && rest[0]) await setClassroomArchived(rest[0], true, flags)
+        else if (sub === 'restore' && rest[0]) await setClassroomArchived(rest[0], false, flags)
+        else {
+          console.error(
+            'Usage: pnpm pika classroom list [--archived] | classroom archive <id> | classroom restore <id>'
+          )
           process.exitCode = 1
         }
         break


### PR DESCRIPTION
## Problem

A classroom created by mistake — in production especially — had no way out from the CLI.

Classrooms deliberately have no DELETE route, because they hold student work: submissions, grades, feedback. That is the right default, but it left no answer for "I instantiated the wrong course, remove it."

## What this uses

`PATCH /api/teacher/classrooms/{id}` already accepts a standalone `archived` boolean that sets `archived_at`. The classroom drops out of the teacher list and students lose access; clearing the flag restores it. No feature flags, works against production today.

This is deliberately **not** `POST /classrooms/{id}/archives`, the cold-storage export with checksummed copies and retention policy. That one is gated behind `CLASSROOM_ARCHIVE_EXPORT_ENABLED` plus a per-teacher allowlist, and is unset in production — a heavier operation aimed at end-of-term data lifecycle, not at retiring a mistake.

## Commands

```bash
pika classroom list [--archived]
pika classroom archive <id> [--yes]
pika classroom restore <id> [--yes]
```

Archive is dry-run unless `--yes`, resolves and reports the classroom title before acting, is a no-op when already in the requested state, and prints the exact restore command afterwards. `--yes` rather than a typed confirmation is proportionate here because the operation is fully reversible with one command.

## Verification

Against a live local stack, on a throwaway classroom (seeded data untouched):

- dry run reports the intended change without applying it
- `--yes` archives; the classroom disappears from `classroom list` and appears under `--archived`
- re-archiving is a no-op ("already archived. Nothing to do.")
- `restore --yes` returns it to the active list

Full smoke passes, typecheck and `pnpm check:architecture` (628 modules) clean. Test data cleaned up afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)