### PR TITLE
fix(audit): detect arrow-style route handlers missing withErrorHandler

### DIFF
--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -23,6 +23,10 @@ declare -a COMPOSITE_FILES=()
 # variable. Keep a sentinel so no-test changes report audit violations.
 declare -a TEST_FILES=("__pika_no_changed_tests__")
 
+# Route handler exports, in either the legacy `export async function GET()` form
+# or the arrow form `export const GET = ...` used by every current route.
+HANDLER_EXPORT_RE='^[[:space:]]*export[[:space:]]+((async[[:space:]]+)?function|const|let|var)[[:space:]]+(GET|POST|PATCH|PUT|DELETE)[[:space:]]*[=(<:]'
+
 # Collect changed .ts/.tsx files
 CHANGED=$(git -C "$WORKTREE" diff --name-only HEAD 2>/dev/null || true)
 STAGED=$(git -C "$WORKTREE" diff --name-only --cached 2>/dev/null || true)
@@ -216,8 +220,11 @@ while IFS= read -r file; do
       HAS_WRAPPER=1
     fi
 
-    # Exported handler without withErrorHandler
-    if grep -qE 'export async function (GET|POST|PATCH|PUT|DELETE)' "$FULL" 2>/dev/null; then
+    # Exported handler without withErrorHandler.
+    # Matches both the legacy `export async function GET()` form and the house
+    # style every route now uses, `export const GET = withErrorHandler(...)`.
+    # The trailing [=(<:] stops GETTER/POSTAL_CODE from matching the method name.
+    if grep -qE "$HANDLER_EXPORT_RE" "$FULL" 2>/dev/null; then
       if [[ "$HAS_WRAPPER" -eq 0 ]]; then
         report_violation "no-withErrorHandler" "$file" "run /migrate-error-handler to wrap handlers"
       fi

--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -220,15 +220,23 @@ while IFS= read -r file; do
       HAS_WRAPPER=1
     fi
 
-    # Exported handler without withErrorHandler.
-    # Matches both the legacy `export async function GET()` form and the house
-    # style every route now uses, `export const GET = withErrorHandler(...)`.
-    # The trailing [=(<:] stops GETTER/POSTAL_CODE from matching the method name.
-    if grep -qE "$HANDLER_EXPORT_RE" "$FULL" 2>/dev/null; then
-      if [[ "$HAS_WRAPPER" -eq 0 ]]; then
-        report_violation "no-withErrorHandler" "$file" "run /migrate-error-handler to wrap handlers"
+    # Exported handler without withErrorHandler, checked per handler rather than
+    # per file: every route imports withErrorHandler, so a file-level grep passes
+    # any route that imports it and then forgets to wrap the handler.
+    while IFS= read -r handler_line; do
+      [[ -z "$handler_line" ]] && continue
+
+      # Wrapped on the same line, e.g. `export const GET = withErrorHandler(...)`.
+      printf '%s' "$handler_line" | grep -q 'withErrorHandler' && continue
+
+      # `export const POST = PUT` aliases a handler checked on its own line.
+      if printf '%s' "$handler_line" | grep -qE '=[[:space:]]*[A-Za-z_$][A-Za-z0-9_$]*[[:space:]]*;?[[:space:]]*$'; then
+        continue
       fi
-    fi
+
+      report_violation "no-withErrorHandler" "$file" "run /migrate-error-handler to wrap handlers"
+      break
+    done < <(grep -hE "$HANDLER_EXPORT_RE" "$FULL" 2>/dev/null || true)
 
     # Manual catch blocks are only flagged for unwrapped route files.
     if [[ "$HAS_WRAPPER" -eq 0 ]]; then

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -439,6 +439,84 @@ describe('AI startup docs', () => {
     }
   })
 
+  function runAuditOnChangedRoute(routePath: string, before: string[], after: string[]) {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+    const fullPath = join(repoRoot, routePath)
+
+    mkdirSync(dirname(fullPath), { recursive: true })
+    writeFileSync(fullPath, `${before.join('\n')}\n`)
+    commitAll(repoRoot, 'add route handler')
+    writeFileSync(fullPath, `${after.join('\n')}\n`)
+
+    try {
+      const result = spawnSync('bash', [scriptPath], { cwd: repoRoot, encoding: 'utf8' })
+      return { status: result.status, output: `${result.stdout}\n${result.stderr}` }
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  }
+
+  // Every route in the repo is written as `export const GET = withErrorHandler(...)`.
+  // The audit only recognised the legacy `export async function GET` form, so a new
+  // route written in the house style but missing the wrapper went unreported.
+  it('rejects an arrow-style route handler that is missing withErrorHandler', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      ['export const GET = async () => {', '  return Response.json({ ok: true })', '}'],
+      ['export const GET = async () => {', "  return Response.json({ ok: 'changed' })", '}'],
+    )
+
+    expect(status).not.toBe(0)
+    expect(output).toContain('no-withErrorHandler')
+    expect(output).toContain('src/app/api/profile/route.ts')
+  })
+
+  it('rejects a legacy function route handler that is missing withErrorHandler', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      ['export async function GET() {', '  return Response.json({ ok: true })', '}'],
+      ['export async function GET() {', "  return Response.json({ ok: 'changed' })", '}'],
+    )
+
+    expect(status).not.toBe(0)
+    expect(output).toContain('no-withErrorHandler')
+  })
+
+  it('allows an arrow-style route handler that is wrapped with withErrorHandler', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        "export const GET = withErrorHandler('GetProfile', async () => {",
+        '  return Response.json({ ok: true })',
+        '})',
+      ],
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        "export const GET = withErrorHandler('GetProfile', async () => {",
+        "  return Response.json({ ok: 'changed' })",
+        '})',
+      ],
+    )
+
+    expect(status).toBe(0)
+    expect(output).not.toContain('no-withErrorHandler')
+  })
+
+  it('does not flag exported names that merely start with an HTTP method', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      ['export const GETTER = 1', 'export const POSTAL_CODE = 2'],
+      ['export const GETTER = 3', 'export const POSTAL_CODE = 4'],
+    )
+
+    expect(status).toBe(0)
+    expect(output).not.toContain('no-withErrorHandler')
+  })
+
   it('allows the canonical parseContentField definition to change', () => {
     const repoRoot = makeFixtureWorktree()
     const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -506,6 +506,58 @@ describe('AI startup docs', () => {
     expect(output).not.toContain('no-withErrorHandler')
   })
 
+  // Every route imports withErrorHandler, so a file-level grep for the name
+  // passes any route that imports it and then forgets to wrap the handler.
+  it('rejects a handler that imports withErrorHandler without wrapping', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        'export const GET = async () => {',
+        '  return Response.json({ ok: true })',
+        '}',
+      ],
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        'export const GET = async () => {',
+        "  return Response.json({ ok: 'changed' })",
+        '}',
+      ],
+    )
+
+    expect(status).not.toBe(0)
+    expect(output).toContain('no-withErrorHandler')
+  })
+
+  it('allows a handler aliased to an already-wrapped handler', () => {
+    const { status, output } = runAuditOnChangedRoute(
+      'src/app/api/profile/route.ts',
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        "export const PUT = withErrorHandler('PutProfile', async () => {",
+        '  return Response.json({ ok: true })',
+        '})',
+        '',
+        'export const POST = PUT',
+      ],
+      [
+        "import { withErrorHandler } from '@/lib/api-handler'",
+        '',
+        "export const PUT = withErrorHandler('PutProfile', async () => {",
+        "  return Response.json({ ok: 'changed' })",
+        '})',
+        '',
+        'export const POST = PUT',
+      ],
+    )
+
+    expect(status).toBe(0)
+    expect(output).not.toContain('no-withErrorHandler')
+  })
+
   it('does not flag exported names that merely start with an HTTP method', () => {
     const { status, output } = runAuditOnChangedRoute(
       'src/app/api/profile/route.ts',


### PR DESCRIPTION
## The bug

`audit.sh`'s `no-withErrorHandler` check matched only the legacy form:

```bash
grep -qE 'export async function (GET|POST|PATCH|PUT|DELETE)'
```

But **every one of the 135 routes** in `src/app/api` is written as `export const GET = withErrorHandler(...)`. So the old pattern matched **zero real files**. A new route written in the house style but missing the wrapper was never reported.

Measured reach against the current tree:

| | route files matched |
|---|---|
| old regex | **0 of 135** |
| new regex | **135 of 135** (0 flagged — all already wrapped) |

This was found while auditing why `tests/unit/ai-startup-docs.test.ts` is slow. The rule was not dead — it correctly fires on the legacy form, which is why the tests passed — it simply had no reach on the style the codebase actually uses.

## The fix

```
^[[:space:]]*export[[:space:]]+((async[[:space:]]+)?function|const|let|var)[[:space:]]+(GET|POST|PATCH|PUT|DELETE)[[:space:]]*[=(<:]
```

Covers `export async function GET()`, `export function GET()`, `export const GET = …`, and `export const GET: RouteHandler = …`. The trailing `[=(<:]` is what prevents `GETTER` and `POSTAL_CODE` from matching a method name — a character class rather than `\b`, for BSD/GNU grep portability.

`manual-catch` is gated behind the same `HAS_WRAPPER` flag and is unaffected.

## Tests

Four new cases, written before the fix:

- **`rejects an arrow-style route handler that is missing withErrorHandler`** — the gap. Verified failing before the change (audit exited 0), passing after.
- **`rejects a legacy function route handler…`** — regression guard; passed before *and* after, proving the old form still works.
- **`allows an arrow-style route handler that is wrapped`** — no false positive.
- **`does not flag exported names that merely start with an HTTP method`** — `GETTER` / `POSTAL_CODE`.

They share a `runAuditOnChangedRoute` helper that builds a throwaway git repo, commits a baseline, modifies it, and runs the real script — matching the existing fixture style in that file.

## Test plan

- [x] `vitest run` — 421 files, 3,771 tests pass (3,767 + 4 new)
- [x] New arrow-style test confirmed **failing before** the fix, passing after
- [x] `npx tsc --noEmit`
- [x] Regex verified against all 135 real routes: 135 matched, 0 false positives
- [x] `audit.sh` run on this change itself — passes

## Second gap, found on re-review: per-file vs per-handler

`HAS_WRAPPER` grepped the whole file for the string `withErrorHandler` — and **every route imports it**. So this passed the audit clean:

```ts
import { withErrorHandler } from '@/lib/api-handler'

export const GET = async () => {   // never wrapped, never reported
  return Response.json({ ok: true })
}
```

That is the likelier real-world mistake than the one the first commit fixed, since new routes get copied from existing ones and arrive with the import already present.

Now checked per handler export line. A line is accepted when it wraps on the same line — 176 of the 177 handler exports in the tree do — or when it aliases another handler (`export const POST = PUT`), the single remaining case.

Verified against the real tree: **0 of 135 route files flagged.**

Remaining limitation: `export const GET = someLocalHandler` is treated as an alias and not inspected further. Resolving that needs real parsing rather than line matching.

## Follow-ups (not in this PR)

- `console.log` currently has 34 hits — 24 in `src/lib/email.ts`, the rest in vendored `tiptap-ui/**`, the same tree `vitest.config.ts` excludes from coverage. Worth deciding whether vendored code is exempt before that rule could be enforced anywhere.
- With this gap closed, the deterministic audit rules are all at zero violations, which is the cheapest point to promote them to CI as a ratchet. Note `audit.sh` diffs `git diff HEAD`, so it no-ops on a clean checkout — CI use needs an explicit base ref.
- `tests/unit/ai-startup-docs.test.ts` now holds 17 audit-script tests under a name about startup docs; worth splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

