### PR TITLE
test(preview): await the back-button focus assertion

### DIFF
--- a/tests/components/TeacherTestPreviewPage.test.tsx
+++ b/tests/components/TeacherTestPreviewPage.test.tsx
@@ -489,9 +489,14 @@ describe('TeacherTestPreviewPage', () => {
     expect(screen.getByTestId('text-document-viewer')).toHaveTextContent(
       'Updated content',
     )
-    expect(screen.getByRole('button', {
-      name: 'Back to documents list',
-    })).toHaveFocus()
+    // Focus lands a commit later than the refreshed text: the allowedDocs effect
+    // calls setActiveDoc, and only the resulting re-render runs the effect that
+    // focuses the back button. Asserting synchronously here raced under load.
+    await waitFor(() => {
+      expect(screen.getByRole('button', {
+        name: 'Back to documents list',
+      })).toHaveFocus()
+    })
 
     window.dispatchEvent(new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, {
       detail: { classroomId: 'classroom-1' },


### PR DESCRIPTION
## Problem

`tests/components/TeacherTestPreviewPage.test.tsx > refreshes an open same-id document and closes it when the document is removed` fails intermittently. It is failing on `main` today, independent of any change.

Evidence it is pre-existing: the very first full run in my session, on unmodified `main`, reported `1 failed | 420 passed` — this exact file and test title. It later failed a CI run on an unrelated PR, and passed on rerun with no code change. It passes 6/6 in isolation locally, and only fails under parallel-worker contention.

## Root cause

Focus is applied a commit later than the text the test waits on.

1. The update event recomputes `allowedDocs`; the effect at [`TeacherTestPreviewPage.tsx:113`](src/components/TeacherTestPreviewPage.tsx#L113) calls `setActiveDoc(...)`.
2. That state change re-renders, and only then does the effect at [`:120`](src/components/TeacherTestPreviewPage.tsx#L120) call `backToDocumentsButtonRef.current?.focus()`.

The test's preceding `await screen.findByText('Updated reference')` resolves on the **earlier** commit. The `toHaveFocus()` that followed was synchronous, so under load it ran before the focus effect.

The component is correct — a two-pass focus update is normal React. The test was asserting an inherently async outcome synchronously.

## Fix

Wrap the assertion in `waitFor`. This matches the **two other** `toHaveFocus` assertions in this same file (lines 435 and 444), which already use `waitFor` — line 494 was the lone outlier.

## Verification

The risk with `waitFor` is turning a racy assertion into one that can never fail. I checked that directly with a mutation test: with `backToDocumentsButtonRef.current?.focus()` removed from the component, the wrapped assertion **still fails**. It tolerates the extra commit without losing its teeth.

- [x] Target file: 8/8 tests pass
- [x] Full suite: 421 files, 3,767 tests pass
- [x] `npx tsc --noEmit`
- [x] Mutation test — assertion still fails when the component's `focus()` call is removed
- [x] Test-only change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)