### PR TITLE
Rename the CLI's course commands to blueprint, and add delete

### DIFF
--- a/scripts/pika-cli-README.md
+++ b/scripts/pika-cli-README.md
@@ -44,10 +44,11 @@ quiz.md` writes `quiz.md` where you are, not inside the checkout.
 | `pnpm pika classroom list [--archived]` | List active classrooms, or archived ones. |
 | `pnpm pika classroom archive <id> [--yes]` | Archive a classroom: hidden from your list, student access blocked. Reversible. |
 | `pnpm pika classroom restore <id> [--yes]` | Unarchive a classroom. |
-| `pnpm pika course list` | List course blueprints. |
-| `pnpm pika course pull <blueprintId> <dir>` | Export a blueprint to an editable directory (manifest.json + markdown). |
-| `pnpm pika course push <dir> [--replace \| --new] [--yes]` | Import a course directory as a blueprint. |
-| `pnpm pika course instantiate <id> --title <name> --semester semester1 --year 2026 [--yes]` | Turn a blueprint into a real classroom. |
+| `pnpm pika blueprint list` | List course blueprints. |
+| `pnpm pika blueprint delete <id> [--yes]` | Delete a blueprint. Permanent; classrooms made from it are unaffected. |
+| `pnpm pika blueprint pull <blueprintId> <dir>` | Export a blueprint to an editable directory (manifest.json + markdown). |
+| `pnpm pika blueprint push <dir> [--replace \| --new] [--yes]` | Import a course directory as a blueprint. |
+| `pnpm pika blueprint instantiate <id> --title <name> --semester semester1 --year 2026 [--yes]` | Turn a blueprint into a real classroom. |
 
 ## Creating a whole course
 
@@ -57,18 +58,18 @@ A course is a directory: `manifest.json` plus up to six markdown files
 `scripts/fixtures/dummy-course/` for a working example an agent can copy.
 
 ```bash
-pnpm pika course push scripts/fixtures/dummy-course            # dry run
-pnpm pika course push scripts/fixtures/dummy-course --yes      # → blueprint
-pnpm pika course instantiate <blueprintId> --title "CS 101" \
+pnpm pika blueprint push scripts/fixtures/dummy-course            # dry run
+pnpm pika blueprint push scripts/fixtures/dummy-course --yes      # → blueprint
+pnpm pika blueprint instantiate <blueprintId> --title "CS 101" \
   --semester semester1 --year 2026 --yes                       # → classroom
 ```
 
 ### Editing an existing course (round-trip)
 
 ```bash
-pnpm pika course pull <blueprintId> course/            # export to markdown
+pnpm pika blueprint pull <blueprintId> course/            # export to markdown
 $EDITOR course/assignments.md course/tests.md          # edit
-pnpm pika course push course/ --replace --yes          # delete + recreate
+pnpm pika blueprint push course/ --replace --yes          # delete + recreate
 ```
 
 `course push` refuses by default when a blueprint with the same course code (or
@@ -114,6 +115,20 @@ tests failed with `400 assessments.N: Unrecognized key: "id"`, through both this
 CLI and the UI's tar upload. Fixed in
 [#932](https://github.com/codepetca/pika/pull/932); `pnpm smoke:pika-cli --full`
 now guards it.
+
+## Two different nouns
+
+`blueprint` and `classroom` are distinct things, and the commands do not cross
+over:
+
+| Noun | What it is | How it is removed |
+| --- | --- | --- |
+| `blueprint` | The reusable **template** — what `blueprint push` creates | `blueprint delete`, permanent |
+| `classroom` | The **live class** with students, created by `blueprint instantiate` | `classroom archive`, reversible |
+
+Deleting a blueprint never deletes a classroom. Classrooms are independent
+copies; the foreign key is `ON DELETE SET NULL`, so they keep every assignment,
+test and submission and only lose the link back to the template.
 
 ## Removing a classroom
 

--- a/scripts/pika.ts
+++ b/scripts/pika.ts
@@ -10,9 +10,9 @@
  *   pnpm pika whoami
  *   pnpm pika test pull <testId> [--out <file.md>]
  *   pnpm pika test push <testId> <file.md> [--yes]
- *   pnpm pika course list
- *   pnpm pika course push <dir> [--yes]
- *   pnpm pika course instantiate <blueprintId> --title <name> [--yes]
+ *   pnpm pika blueprint list
+ *   pnpm pika blueprint push <dir> [--yes]
+ *   pnpm pika blueprint instantiate <blueprintId> --title <name> [--yes]
  *
  * Writes are DRY-RUN by default; pass --yes to apply. Targets local dev
  * (localhost:3000) unless PIKA_BASE_URL / E2E_BASE_URL is set.
@@ -254,7 +254,7 @@ async function listBlueprints(): Promise<BlueprintSummary[]> {
   return data.blueprints ?? []
 }
 
-async function cmdCourseList(): Promise<void> {
+async function cmdBlueprintList(): Promise<void> {
   const blueprints = await listBlueprints()
   if (blueprints.length === 0) {
     console.log('No course blueprints.')
@@ -263,7 +263,35 @@ async function cmdCourseList(): Promise<void> {
   for (const bp of blueprints) console.log(`${bp.id}  ${bp.title}`)
 }
 
-async function cmdCoursePull(blueprintId: string, dirArg: string): Promise<void> {
+/**
+ * Blueprints are authoring templates, so deletion is permanent — there is no
+ * archive for them, unlike classrooms. Classrooms instantiated from a blueprint
+ * are independent copies; the foreign key is ON DELETE SET NULL, so they keep
+ * all their data and only lose the link back to the template.
+ */
+async function cmdBlueprintDelete(blueprintId: string, flags: Flags): Promise<void> {
+  const blueprint = (await listBlueprints()).find((bp) => bp.id === blueprintId)
+  if (!blueprint) {
+    console.error(`No blueprint ${blueprintId}. List them with: pika blueprint list`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(`Blueprint "${blueprint.title}" (${blueprintId}) @ ${getBaseUrl()}`)
+  console.log('  Deleting removes the template and its assignments, tests and lesson templates.')
+  console.log('  Classrooms already created from it keep their data and are not deleted.')
+  console.log('  This cannot be undone — re-push the directory to recreate it.')
+
+  if (!flags.yes) {
+    console.log('DRY RUN. Re-run with --yes to delete.')
+    return
+  }
+
+  await pikaJson(`/api/teacher/course-blueprints/${blueprintId}`, { method: 'DELETE' })
+  console.log(`Deleted blueprint ${blueprintId}.`)
+}
+
+async function cmdBlueprintPull(blueprintId: string, dirArg: string): Promise<void> {
   const dir = userPath(dirArg)
   const res = await pikaFetch(`/api/teacher/course-blueprints/${blueprintId}/export`)
   if (!res.ok) {
@@ -305,7 +333,7 @@ function readCourseBundle(dirArg: string): { manifest: Record<string, unknown>; 
   return { manifest, files }
 }
 
-async function cmdCoursePush(dir: string, flags: Flags): Promise<void> {
+async function cmdBlueprintPush(dir: string, flags: Flags): Promise<void> {
   const bundle = readCourseBundle(dir)
   const title = String(bundle.manifest.title ?? '')
   const courseCode = String(bundle.manifest.course_code ?? '')
@@ -348,10 +376,10 @@ async function cmdCoursePush(dir: string, flags: Flags): Promise<void> {
     }
   )
   console.log(`Imported blueprint ${result.blueprint.id} — "${result.blueprint.title}"`)
-  console.log(`Next: pnpm pika course instantiate ${result.blueprint.id} --title "<classroom name>" --semester semester1 --year 2026 --yes`)
+  console.log(`Next: pnpm pika blueprint instantiate ${result.blueprint.id} --title "<classroom name>" --semester semester1 --year 2026 --yes`)
 }
 
-async function cmdCourseInstantiate(blueprintId: string, flags: Flags): Promise<void> {
+async function cmdBlueprintInstantiate(blueprintId: string, flags: Flags): Promise<void> {
   const title = (flags.title as string) || ''
   if (!title) {
     console.error('--title <classroom name> is required.')
@@ -398,10 +426,11 @@ function printHelp(): void {
       '  pnpm pika classroom list [--archived]',
       '  pnpm pika classroom archive <classroomId> [--yes]',
       '  pnpm pika classroom restore <classroomId> [--yes]',
-      '  pnpm pika course list',
-      '  pnpm pika course pull <blueprintId> <dir>',
-      '  pnpm pika course push <dir> [--replace | --new] [--yes]',
-      '  pnpm pika course instantiate <blueprintId> --title <name>',
+      '  pnpm pika blueprint list',
+      '  pnpm pika blueprint pull <blueprintId> <dir>',
+      '  pnpm pika blueprint push <dir> [--replace | --new] [--yes]',
+      '  pnpm pika blueprint delete <blueprintId> [--yes]',
+      '  pnpm pika blueprint instantiate <blueprintId> --title <name>',
       '      (--semester <semester1|semester2> --year <YYYY>) | (--start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>) [--yes]',
       '',
       'Writes are dry-run unless --yes is passed.',
@@ -441,14 +470,15 @@ async function main(): Promise<void> {
           process.exitCode = 1
         }
         break
-      case 'course':
-        if (sub === 'list') await cmdCourseList()
-        else if (sub === 'pull' && rest[0] && rest[1]) await cmdCoursePull(rest[0], rest[1])
-        else if (sub === 'push' && rest[0]) await cmdCoursePush(rest[0], flags)
-        else if (sub === 'instantiate' && rest[0]) await cmdCourseInstantiate(rest[0], flags)
+      case 'blueprint':
+        if (sub === 'list') await cmdBlueprintList()
+        else if (sub === 'pull' && rest[0] && rest[1]) await cmdBlueprintPull(rest[0], rest[1])
+        else if (sub === 'push' && rest[0]) await cmdBlueprintPush(rest[0], flags)
+        else if (sub === 'delete' && rest[0]) await cmdBlueprintDelete(rest[0], flags)
+        else if (sub === 'instantiate' && rest[0]) await cmdBlueprintInstantiate(rest[0], flags)
         else {
           console.error(
-            'Usage: pnpm pika course list | course pull <id> <dir> | course push <dir> | course instantiate <id> --title <name>'
+            'Usage: pnpm pika blueprint list | course pull <id> <dir> | course push <dir> | course instantiate <id> --title <name>'
           )
           process.exitCode = 1
         }


### PR DESCRIPTION
## Why rename

"Course" reads as "the class I teach", but the commands operate on the reusable **template**. That made `course delete` sound like it would remove a classroom and its student work — it would not, but the naming invited exactly that misreading.

`blueprint` matches the API path, the `course_blueprints` table and the UI, and leaves `classroom` as the only word for a live class:

| Noun | What it is | How it is removed |
| --- | --- | --- |
| `blueprint` | reusable template | `blueprint delete`, permanent |
| `classroom` | live class with students | `classroom archive`, reversible |

`course list/pull/push/instantiate` become `blueprint list/pull/push/instantiate`. No alias for the old noun — the CLI has a single user today, so the break is cheap now and only gets more expensive.

## New: `blueprint delete <id>`

Dry-run unless `--yes`. Resolves the title first, rejects an unknown id, and states plainly what deletion does:

```
Blueprint "Intro to Programming" (0467496b-…) @ http://localhost:3000
  Deleting removes the template and its assignments, tests and lesson templates.
  Classrooms already created from it keep their data and are not deleted.
  This cannot be undone — re-push the directory to recreate it.
```

Blueprints get a hard delete rather than an archive because they are authoring material, not student work — and if the course lives in git, it is re-pushable.

## Verification

Against a live stack, the claim that matters was tested directly: a classroom was instantiated from a blueprint, the blueprint deleted, and the classroom kept **all three assignments** with `source_blueprint_id` set to `NULL` — matching the `ON DELETE SET NULL` constraint.

Also: dry run does not mutate, an unknown id is rejected, `pika course …` now reports an unknown command, full smoke passes, typecheck and `pnpm check:architecture` (628 modules) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)