### PR TITLE
Add the Pika Pal achievements pilot

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -4,11 +4,10 @@ Default handoff. Epic status: `.ai/features.json`; recent detail: `.ai/SESSION-L
 
 ## Current Focus
 
-- Legacy Quiz removal is complete through migration 108.
-- PR 920 test-preview/document-snapshot hardening uses migrations 109-110;
-  review remediation is complete and exact-head CI is next.
-- Shared local is reset and seeded through 104; migrations 105-110 are
-  unapplied there, and 109-110 are unapplied on hosted targets.
+- Design consolidation and portable foundations through PR 950 are on `main`;
+  root `DESIGN.md` is canonical.
+- The Pal pilot remains disabled; migration 111 is human-applied and the native
+  widget package is an external release dependency.
 - Product status: `.ai/features.json`; mobile is deferred and Gradex is owned
   by a separate session.
 

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15259,3 +15259,78 @@
 
 **Remaining:**
 - Complete repository gates, independent review, and merge. Then continue the assignment slice with mobile workspace modes, save announcements/dialog semantics, and the Gradex status boundary.
+
+<!-- pika-session-log-archive-batch:bbd0df49fc4bc409dad26d65a4126a87cd29dbcb2f866302833ac8ef50cd0b0e -->
+## 2026-07-21 — Internal grading core review remediation
+
+**Risk profile:** async-grading
+
+**Completed:**
+- Opened PR #906 and completed the initial independent review wave for the assignment grading core.
+- Preserved the legacy direct-grading behavior by creating an abort signal only when the caller supplies a timeout; durable background runs continue to supply their existing 25-second timeout.
+- Classified response-body `AbortError` and `TimeoutError` failures, including browser-style `DOMException` aborts, as retryable provider timeouts.
+- Kept aggregate token usage unknown when either request in the output-cap fallback sequence omits usage, avoiding silently incomplete cost telemetry.
+- Added a provider-to-run regression proving a response-body timeout requeues the assignment item with a future retry and leaves the batch running rather than failing it closed.
+- No migration was applied, no live provider call was made, and no production state changed.
+
+**Validation:**
+- `pnpm test` (396 files / 3,597 tests)
+- Focused grading, provider, and durable assignment-run suites (3 files / 27 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (619 modules / 0 allowances)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+
+**Remaining:**
+- Complete targeted remediation and final cumulative reviews for PR #906, then obtain the required external approval before merge.
+- Continue the active internal grading subsystem goal with assignment audit persistence, followed by test and repository-review profiles.
+
+## 2026-07-21 — Durable assignment grading provenance
+
+**Risk profile:** async-grading
+
+**Completed:**
+- Fixed the cumulative PR #906 review finding that versioned assignment grading metadata was computed but not durably persisted.
+- Added a strict, bounded, pseudonymous provenance contract containing only provider/model, profile/rubric/prompt/policy versions, provider request count, and nullable token usage.
+- Added migration 101 with an `assignment_docs.ai_grading_provenance` JSONB contract and additive service-role-only wrappers around the existing direct-grade and durable-item atomic RPCs, preserving rolling compatibility for old application instances.
+- Added a compatibility trigger that clears provenance whenever legacy direct, durable, batch, repository-review, manual-grade, or missing-work writers replace grade/audit fields without supplying replacement provenance.
+- Routed native Pika assignment grading through both provenance-aware persistence paths while legacy Gradex, missing-work, and repository-review callers write null provenance until their profiles migrate.
+- Extended the CI database harness to verify wrapper privileges, direct persistence, durable-item persistence, transactionality, replay preservation, and stale-provenance clearing across old direct, durable, batch, and missing-work writers; updated generated and refined database contracts.
+- No migration was applied locally, no live model call was made, and no production state changed.
+
+**Validation:**
+- `pnpm test` (401 files / 3,619 tests after rebasing onto `origin/main`)
+- Focused grading, persistence, migration, Gradex compatibility, and database-contract suites (9 files / 64 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (619 modules / 0 allowances)
+- `pnpm build`
+- `bash -n scripts/check-atomic-assignment-feedback-returns.sh`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+
+**Remaining:**
+- Confirm migration replay, generated-type parity, and the database-backed provenance contract in PR CI, then complete the final independent re-review.
+- Obtain required external approval before merge; continue with test and repository-review profile migration after this assignment foundation lands.
+
+## 2026-07-22 — Phase 3 assignment accessibility evidence
+
+**Completed:**
+- Audited the remaining non-mobile assignment backlog against current `main` and confirmed #891 already shipped polite atomic save announcements and the shared restore-confirmation dialog.
+- Replaced the assignment suite's hand-built confirmation stub with the real `ConfirmDialog`, added focused initial-focus coverage, and locked the visible save-status live-region attributes with regression assertions.
+- Updated the product audit and current context to remove completed assignment work from the backlog. No runtime UI, API, schema, migration, production state, or production data changed.
+
+**Validation:**
+- `pnpm test tests/components/StudentAssignmentEditor.save-submit.test.tsx tests/ui/ModalLayer.test.tsx` (2 files / 52 tests)
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`
+
+**Remaining:**
+- Complete repository gates, independent review, and merge this evidence slice. Then start Daily/Attendance; assignment mobile UX remains deferred and Gradex remains owned by a separate session.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15178,7 +15178,6 @@
 
 **Remaining:**
 - Complete full repository verification, independent review, and merge for the student navigation slice. Then continue Phase 2 with specialized-control policy enforcement.
-
 <!-- pika-session-log-archive-batch:3089d6a80b2753bc18d829552723282eaafafc7461893512878aca5bdf07faa1 -->
 ## 2026-07-21 — Phase 2 specialized-control policy
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,6 +11,85 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
+## 2026-07-21 — Phase 2 specialized-control policy
+
+**Completed:**
+- Merged independently reviewed PR #904 as `f614fa61`, fast-forwarded the hub, and started Phase 2 item 8 from current `main` in a dedicated worktree.
+- Replaced the brittle UI import grep with a TypeScript-AST policy checker and a versioned, Zod-validated exception registry covering 215 native controls across 67 files.
+- Required exact per-file/per-kind counts, constrained rationale categories, explicit Phase 2/3/6 review ownership, canonical `@/ui` imports, and rejection of legacy UI component paths.
+- Converted 22 remaining `@/ui/*` imports to the canonical barrel and retained narrow compatibility exports for existing component paths.
+- Corrected seven full `@/ui` test mocks to preserve unmocked barrel exports after the full suite exposed their hidden coupling.
+- Added direct semantic coverage for calendar navigation, creation dialogs, multiple-choice review states, announcement menus, edit toggles, split panes, and teacher action menus.
+- No runtime UI behavior, schema, migration, API contract, production state, or data changed; visual verification is not required for this import/tooling-only slice.
+- Opened PR #905 for independent review.
+- Accepted initial review findings covering dynamic/CommonJS/import-equals bypasses, literal React factory controls, complete static input classification, and overly broad Tiptap exclusions; remediated them together with direct regression fixtures.
+- Kept roadmap ownership in `reviewBy` and `.ai/features.json` rather than introducing date-dependent CI expiry for source exceptions.
+- Targeted re-review found import-option/import-type bypasses, case/template static-input gaps, and missing namespace/root fixtures; closed all four in the second remediation batch.
+- With explicit approval to exceed the default review budget, the third remediation batch closed final cumulative findings for relative UI paths, CommonJS/import-equals React factories, shorthand input props, strict registry metadata, and stale Phase 1 audit evidence.
+
+**Validation:**
+- `pnpm test --run` (full repository suite)
+- Focused UI-policy, guidance, and composite-control suites
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `pnpm check:architecture`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+
+**Remaining:**
+- Publish, independently review, remediate, and merge the specialized-control policy PR. Then continue Phase 2 with mobile and light/dark Playwright projects plus representative teacher/student CI coverage.
+
+## 2026-07-21 — Phase 2 browser experience matrix
+
+**Completed:**
+- Merged independently reviewed PR #905 as `126658e0`, fast-forwarded the hub, and started Phase 2 item 9 from current `main` in a dedicated worktree.
+- Added desktop light, desktop dark, mobile light, and mobile dark Chromium projects while preserving the established `chromium-desktop` snapshot identity.
+- Kept the broad feature and manual snapshot suites on the desktop-light project and limited the additional three projects to a focused experience contract, preventing a fourfold expansion of the full E2E suite.
+- Added read-only seeded browser coverage for teacher Daily attendance, student Today, teacher Blueprints navigation, and student History navigation. The contract verifies real role authentication, classroom data, active navigation, mobile drawer behavior, persisted themes, viewport geometry, and horizontal overflow.
+- Added a dedicated GitHub Actions job that starts ephemeral local Supabase, replays migrations, exports local-only credentials, runs `pnpm seed`, installs Chromium, executes the matrix, uploads failure diagnostics, and always tears down the database.
+- Updated testing guidance and Phase 2 audit evidence. No runtime UI, API, schema, migration, production state, or production data changed.
+
+**Validation:**
+- `pnpm e2e:matrix` (18 checks across setup and four projects)
+- `pnpm test` (397 files / 3,603 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+
+**Remaining:**
+- Publish, independently review, remediate, and merge the browser matrix PR. Then confirm Phase 2 exit evidence and begin Phase 3 with the first independently releasable vertical product slice.
+
+## 2026-07-21 — Phase 3 Classwork list states
+
+**Completed:**
+- Began Phase 3 with a narrow assignment slice that preserves the existing class-wide teacher workflow and student assignment list.
+- Replaced ambiguous initial loading and failed-read empty states with governed `PageState` loading, error, and successful-empty states for teacher and student Classwork.
+- Added bounded Retry actions that invalidate assignment, material, and survey list caches before reloading; failures never render "No classwork yet," and successful retry restores the normal list.
+- Added focused role regressions and browser-verified loading, error, empty, retry, and restored-list states at desktop/mobile widths in light/dark themes. No API, schema, migration, production state, or production data changed.
+- Independent review found that reactivating Classwork after a failed load used the content-preserving refresh path and could expose the empty state while retrying. Reactivation from an error now uses the blocking load path; both roles prove pending reactivation, repeated failure, and recovery.
+- Final cumulative review found the remaining survey-list exception could still turn survey failures into empty or partial Classwork. Survey reads now participate in the same required failure/retry contract, with teacher and student survey-specific recovery regressions.
+
+**Validation:**
+- Focused Classwork component suites (2 files / 61 tests)
+- `pnpm test --run` (397 files / 3,605 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (613 modules / 0 allowances)
+- `pnpm check:ui-policy` (215 controls / 67 files)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- Playwright forced-state matrix (16 checks across two focused local runs)
+
+**Remaining:**
+- Complete repository gates, independent review, and merge. Then continue the assignment slice with mobile workspace modes, save announcements/dialog semantics, and the Gradex status boundary.
+
 ## 2026-07-21 — Internal grading core foundation
 
 **Risk profile:** async-grading
@@ -1283,3 +1362,48 @@ requires exact cross-repository contract and semantic-token drift checks.
 - Complete independent review and exact-head CI for the isolated adapter PR.
 - Replace the vendored manifest with a direct package import when Pal publishes
   `@pal/widget`; mount it only as part of the separately reviewed native pilot.
+## 2026-07-25 — Pika-side Pal achievements pilot
+
+**Risk profile:** integration, privacy, database, cross-origin embed
+
+**Completed:**
+- Implemented the disabled-by-default `PAL_ENABLED` pilot on
+  `codex/pal-pilot`, with pinned Pal v1 contract fixtures and stable HMAC
+  learner/classroom/item/fact tokens. Outbound payloads exclude raw IDs,
+  assignment names, work, grades, deadlines, and teacher-maintained catalogs.
+- Drafted unapplied migration 111 for a service-role-only transactional
+  outbox, leases, retries, non-retryable visibility/requeue, and monotonic
+  learner/week opportunity revisions.
+- Wired authenticated session, new enrollment, the real daily-log autosave
+  creation path, genuine first assignment open, and first valid assignment
+  completion to the outbox. Duplicate daily logs and resubmissions retain one
+  fact identity.
+- Added daily Monday–Friday opportunity reconciliation across learner
+  enrollments and class days, including short weeks, schedule/archive changes,
+  completion floors, and terminal prior-week closure.
+- Added the student-only Achievements navigation item and secure
+  `/embed/roadmap` iframe with origin/source/nonce validation, short-lived
+  read-token handoff, bounded failure/retry, and light/dark appearance
+  messages. Pika retains its shell; Pal owns roadmap and reward rendering.
+- Added the Pika operations/rollout guide, including week-boundary rollout,
+  no historical backfill, at-least-once/out-of-order delivery, and current Pal
+  prerequisites. No migration was applied and no environment was enabled.
+
+**Validation:**
+- `pnpm test` (440 files / 3,850 tests).
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (648 modules / 0 allowances)
+- `pnpm check:ui-policy` (202 controls / 64 files)
+- `pnpm build`
+- Desktop/mobile and light/dark Playwright inspection using a temporary Pal
+  handshake harness; selected navigation, ready embed, and live theme changes
+  were verified.
+- `git diff --check`
+
+**Remaining:**
+- Apply migration 111 only through the separately authorized target-specific
+  process.
+- Complete Pal v1 ingest, read-token, and `/embed/roadmap` dependencies, then
+  run the real duplicate/retry/out-of-order vertical slice before enabling the
+  pilot or merging the integration branch to `main`.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,80 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-21 — Internal grading core review remediation
-
-**Risk profile:** async-grading
-
-**Completed:**
-- Opened PR #906 and completed the initial independent review wave for the assignment grading core.
-- Preserved the legacy direct-grading behavior by creating an abort signal only when the caller supplies a timeout; durable background runs continue to supply their existing 25-second timeout.
-- Classified response-body `AbortError` and `TimeoutError` failures, including browser-style `DOMException` aborts, as retryable provider timeouts.
-- Kept aggregate token usage unknown when either request in the output-cap fallback sequence omits usage, avoiding silently incomplete cost telemetry.
-- Added a provider-to-run regression proving a response-body timeout requeues the assignment item with a future retry and leaves the batch running rather than failing it closed.
-- No migration was applied, no live provider call was made, and no production state changed.
-
-**Validation:**
-- `pnpm test` (396 files / 3,597 tests)
-- Focused grading, provider, and durable assignment-run suites (3 files / 27 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (619 modules / 0 allowances)
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
-**Remaining:**
-- Complete targeted remediation and final cumulative reviews for PR #906, then obtain the required external approval before merge.
-- Continue the active internal grading subsystem goal with assignment audit persistence, followed by test and repository-review profiles.
-
-## 2026-07-21 — Durable assignment grading provenance
-
-**Risk profile:** async-grading
-
-**Completed:**
-- Fixed the cumulative PR #906 review finding that versioned assignment grading metadata was computed but not durably persisted.
-- Added a strict, bounded, pseudonymous provenance contract containing only provider/model, profile/rubric/prompt/policy versions, provider request count, and nullable token usage.
-- Added migration 101 with an `assignment_docs.ai_grading_provenance` JSONB contract and additive service-role-only wrappers around the existing direct-grade and durable-item atomic RPCs, preserving rolling compatibility for old application instances.
-- Added a compatibility trigger that clears provenance whenever legacy direct, durable, batch, repository-review, manual-grade, or missing-work writers replace grade/audit fields without supplying replacement provenance.
-- Routed native Pika assignment grading through both provenance-aware persistence paths while legacy Gradex, missing-work, and repository-review callers write null provenance until their profiles migrate.
-- Extended the CI database harness to verify wrapper privileges, direct persistence, durable-item persistence, transactionality, replay preservation, and stale-provenance clearing across old direct, durable, batch, and missing-work writers; updated generated and refined database contracts.
-- No migration was applied locally, no live model call was made, and no production state changed.
-
-**Validation:**
-- `pnpm test` (401 files / 3,619 tests after rebasing onto `origin/main`)
-- Focused grading, persistence, migration, Gradex compatibility, and database-contract suites (9 files / 64 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (619 modules / 0 allowances)
-- `pnpm build`
-- `bash -n scripts/check-atomic-assignment-feedback-returns.sh`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
-**Remaining:**
-- Confirm migration replay, generated-type parity, and the database-backed provenance contract in PR CI, then complete the final independent re-review.
-- Obtain required external approval before merge; continue with test and repository-review profile migration after this assignment foundation lands.
-
-## 2026-07-22 — Phase 3 assignment accessibility evidence
-
-**Completed:**
-- Audited the remaining non-mobile assignment backlog against current `main` and confirmed #891 already shipped polite atomic save announcements and the shared restore-confirmation dialog.
-- Replaced the assignment suite's hand-built confirmation stub with the real `ConfirmDialog`, added focused initial-focus coverage, and locked the visible save-status live-region attributes with regression assertions.
-- Updated the product audit and current context to remove completed assignment work from the backlog. No runtime UI, API, schema, migration, production state, or production data changed.
-
-**Validation:**
-- `pnpm test tests/components/StudentAssignmentEditor.save-submit.test.tsx tests/ui/ModalLayer.test.tsx` (2 files / 52 tests)
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm check:architecture` (613 modules / 0 allowances)
-- `pnpm check:ui-policy` (215 controls / 67 files)
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `node scripts/trim-session-log.mjs --check`
-- `git diff --check`
-
-**Remaining:**
-- Complete repository gates, independent review, and merge this evidence slice. Then start Daily/Attendance; assignment mobile UX remains deferred and Gradex remains owned by a separate session.
-
 ## 2026-07-22 — Internal repository-review grading profile and provenance
 
 **Risk profile:** async-grading
@@ -1145,6 +1071,8 @@ consistency review.
   run the real duplicate/retry/out-of-order vertical slice before enabling the
   pilot or merging the integration branch to `main`.
 
+## 2026-07-25 — Pika-side Pal achievements pilot
+
 ## 2026-07-26 — DESIGN.md product-conformance loop
 
 **Risk profile:** none
@@ -1301,7 +1229,6 @@ requires exact cross-repository contract and semantic-token drift checks.
 - Complete independent review and exact-head CI for the isolated adapter PR.
 - Replace the vendored manifest with a direct package import when Pal publishes
   `@pal/widget`; mount it only as part of the separately reviewed native pilot.
-## 2026-07-25 — Pika-side Pal achievements pilot
 
 ## 2026-07-26 — Pika-to-Pal widget theme contract
 
@@ -1338,3 +1265,47 @@ requires exact cross-repository contract and semantic-token drift checks.
 - Replace the disabled iframe with the native provider/surfaces, then run the
   authenticated Pika student visual matrix and real delivery vertical slice.
 - Migration 111 and feature enablement remain human-controlled.
+
+## 2026-07-27 — PR 951 rebase and hardening
+
+**Risk profile:** high — privacy contract, service-role SQL, transactional
+source writes, background delivery, and cross-repository integration.
+
+**Completed:**
+- Rebased `codex/pal-pilot` onto current `origin/main`; retained migration 111
+  without a sequence collision and dropped duplicate adapter content already
+  merged through PR 953.
+- Hardened Pal's authoritative v1 contract on Pal PR 39 at commit
+  `cd9fc872b646b8c91551fd44f9b4b36725ab0fe4`, then synchronized Pika's
+  vendored validator and privacy fixtures. Event envelopes and metadata are
+  both closed allow-lists.
+- Made enabled configuration fail closed; restricted Pal to HTTPS origins
+  (loopback HTTP only in development); required distinct 32-character minimum
+  integration/pseudonym secrets; capped read tokens at ten minutes.
+- Removed silent null-event fallbacks from authoritative learner transitions.
+  Empty/format-only logs no longer qualify, while empty autosaves emit
+  atomically when they first gain real content.
+- Preserved journal mood/minutes and optimistic version checks across the
+  Pal-enabled POST/PATCH transaction paths.
+- Added bounded missed-week recovery (12 periods/run) and a deadline-aware
+  outbox drain (20-row batches, concurrency 10, 10 batches/run) with remaining
+  ready-row reporting.
+- Added the CI-generated Pal tables/functions to
+  `src/types/database.generated.ts` and replaced new Pal persistence `any`
+  boundaries with the generated service-role client types.
+
+**Validation:**
+- Clean ephemeral Supabase replay confirmed migration 111 and generated types
+  are exact; no local or hosted migration was applied.
+- Focused hardening suite: 80/80 tests.
+- TypeScript, lint, architecture, UI policy, Pika audit-equivalent committed
+  diff scan, and `git diff --check` passed.
+- Independent security and operability reviewers found the lease/budget and
+  journal-field parity issues above; their remediation passes targeted review.
+
+**Remaining:**
+- Publish the final remediation commit and require exact-head CI plus final
+  independent security confirmation.
+- Keep PR 951 draft and `PAL_ENABLED=false`; the published native widget,
+  authenticated vertical slice, and one-time human authorization for the
+  named migration target remain rollout gates.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,113 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-21 — Phase 2 specialized-control policy
-
-**Completed:**
-- Merged independently reviewed PR #904 as `f614fa61`, fast-forwarded the hub, and started Phase 2 item 8 from current `main` in a dedicated worktree.
-- Replaced the brittle UI import grep with a TypeScript-AST policy checker and a versioned, Zod-validated exception registry covering 215 native controls across 67 files.
-- Required exact per-file/per-kind counts, constrained rationale categories, explicit Phase 2/3/6 review ownership, canonical `@/ui` imports, and rejection of legacy UI component paths.
-- Converted 22 remaining `@/ui/*` imports to the canonical barrel and retained narrow compatibility exports for existing component paths.
-- Corrected seven full `@/ui` test mocks to preserve unmocked barrel exports after the full suite exposed their hidden coupling.
-- Added direct semantic coverage for calendar navigation, creation dialogs, multiple-choice review states, announcement menus, edit toggles, split panes, and teacher action menus.
-- No runtime UI behavior, schema, migration, API contract, production state, or data changed; visual verification is not required for this import/tooling-only slice.
-- Opened PR #905 for independent review.
-- Accepted initial review findings covering dynamic/CommonJS/import-equals bypasses, literal React factory controls, complete static input classification, and overly broad Tiptap exclusions; remediated them together with direct regression fixtures.
-- Kept roadmap ownership in `reviewBy` and `.ai/features.json` rather than introducing date-dependent CI expiry for source exceptions.
-- Targeted re-review found import-option/import-type bypasses, case/template static-input gaps, and missing namespace/root fixtures; closed all four in the second remediation batch.
-- With explicit approval to exceed the default review budget, the third remediation batch closed final cumulative findings for relative UI paths, CommonJS/import-equals React factories, shorthand input props, strict registry metadata, and stale Phase 1 audit evidence.
-
-**Validation:**
-- `pnpm test --run` (full repository suite)
-- Focused UI-policy, guidance, and composite-control suites
-- `pnpm check:ui-policy` (215 controls / 67 files)
-- `pnpm check:architecture`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
-**Remaining:**
-- Publish, independently review, remediate, and merge the specialized-control policy PR. Then continue Phase 2 with mobile and light/dark Playwright projects plus representative teacher/student CI coverage.
-
-## 2026-07-21 — Phase 2 browser experience matrix
-
-**Completed:**
-- Merged independently reviewed PR #905 as `126658e0`, fast-forwarded the hub, and started Phase 2 item 9 from current `main` in a dedicated worktree.
-- Added desktop light, desktop dark, mobile light, and mobile dark Chromium projects while preserving the established `chromium-desktop` snapshot identity.
-- Kept the broad feature and manual snapshot suites on the desktop-light project and limited the additional three projects to a focused experience contract, preventing a fourfold expansion of the full E2E suite.
-- Added read-only seeded browser coverage for teacher Daily attendance, student Today, teacher Blueprints navigation, and student History navigation. The contract verifies real role authentication, classroom data, active navigation, mobile drawer behavior, persisted themes, viewport geometry, and horizontal overflow.
-- Added a dedicated GitHub Actions job that starts ephemeral local Supabase, replays migrations, exports local-only credentials, runs `pnpm seed`, installs Chromium, executes the matrix, uploads failure diagnostics, and always tears down the database.
-- Updated testing guidance and Phase 2 audit evidence. No runtime UI, API, schema, migration, production state, or production data changed.
-
-**Validation:**
-- `pnpm e2e:matrix` (18 checks across setup and four projects)
-- `pnpm test` (397 files / 3,603 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (613 modules / 0 allowances)
-- `pnpm check:ui-policy` (215 controls / 67 files)
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
-**Remaining:**
-- Publish, independently review, remediate, and merge the browser matrix PR. Then confirm Phase 2 exit evidence and begin Phase 3 with the first independently releasable vertical product slice.
-
-## 2026-07-21 — Phase 3 Classwork list states
-
-**Completed:**
-- Began Phase 3 with a narrow assignment slice that preserves the existing class-wide teacher workflow and student assignment list.
-- Replaced ambiguous initial loading and failed-read empty states with governed `PageState` loading, error, and successful-empty states for teacher and student Classwork.
-- Added bounded Retry actions that invalidate assignment, material, and survey list caches before reloading; failures never render "No classwork yet," and successful retry restores the normal list.
-- Added focused role regressions and browser-verified loading, error, empty, retry, and restored-list states at desktop/mobile widths in light/dark themes. No API, schema, migration, production state, or production data changed.
-- Independent review found that reactivating Classwork after a failed load used the content-preserving refresh path and could expose the empty state while retrying. Reactivation from an error now uses the blocking load path; both roles prove pending reactivation, repeated failure, and recovery.
-- Final cumulative review found the remaining survey-list exception could still turn survey failures into empty or partial Classwork. Survey reads now participate in the same required failure/retry contract, with teacher and student survey-specific recovery regressions.
-
-**Validation:**
-- Focused Classwork component suites (2 files / 61 tests)
-- `pnpm test --run` (397 files / 3,605 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (613 modules / 0 allowances)
-- `pnpm check:ui-policy` (215 controls / 67 files)
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- Playwright forced-state matrix (16 checks across two focused local runs)
-
-**Remaining:**
-- Complete repository gates, independent review, and merge. Then continue the assignment slice with mobile workspace modes, save announcements/dialog semantics, and the Gradex status boundary.
-
-## 2026-07-21 — Internal grading core foundation
-
-**Risk profile:** async-grading
-
-**Model recommendation:** GPT-5 Codex - grading contracts, provider error semantics, reproducibility metadata, and database security require cross-layer invariant analysis.
-
-**Completed:**
-- Started the internal modular-grading direction from current `main` without modifying the open remote Gradex worker branch or enabling remote grading.
-- Added a database-independent grading core with Zod rubric/result contracts, profile and provider interfaces, canonical weighted criterion results, and versioned policy, prompt, profile, rubric, usage, and provider-request metadata.
-- Extracted the OpenAI Responses structured-output transport behind the provider interface, including timeout/status classification, bounded output-cap fallback, structured response extraction, and cumulative token usage.
-- Moved native assignment grading onto a pure Pika assignment profile while preserving the existing Completion/Thinking/Workflow rubric, prompt text, sanitization, teacher routes, durable run orchestration, retry semantics, and atomic writes.
-- Added migration 100 to replace the legacy assignment-run claim with an empty search path, validated lease arguments, and service-role-only execution. No migration was applied.
-- Added core engine/profile, assignment compatibility, usage, retry/error, and migration security regressions. No live provider call, production change, deployment setting, or data mutation occurred.
-
-**Validation:**
-- `pnpm test` (396 files / 3,593 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (619 modules / 0 allowances)
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- Focused grading and assignment route suites (59 tests)
-- `git diff --check`
-
-**Remaining:**
-- Add fully fenced assignment lease mutation contracts and durable grading audit/suggested-score persistence through the authorized schema workflow.
-- Migrate test and repository-review profiles to the shared core, then add teacher-correction evaluation datasets and metrics.
-
 ## 2026-07-21 — Internal grading core review remediation
 
 **Risk profile:** async-grading
@@ -1206,6 +1099,52 @@ consistency review.
 - In Phase 2, add the missing portable foundation tokens and policy checks
   before implementing the Pika-to-Pal semantic bridge.
 
+## 2026-07-25 — Pika-side Pal achievements pilot
+
+**Risk profile:** integration, privacy, database, cross-origin embed
+
+**Completed:**
+- Implemented the disabled-by-default `PAL_ENABLED` pilot on
+  `codex/pal-pilot`, with pinned Pal v1 contract fixtures and stable HMAC
+  learner/classroom/item/fact tokens. Outbound payloads exclude raw IDs,
+  assignment names, work, grades, deadlines, and teacher-maintained catalogs.
+- Drafted unapplied migration 111 for a service-role-only transactional
+  outbox, leases, retries, non-retryable visibility/requeue, and monotonic
+  learner/week opportunity revisions.
+- Wired authenticated session, new enrollment, the real daily-log autosave
+  creation path, genuine first assignment open, and first valid assignment
+  completion to the outbox. Duplicate daily logs and resubmissions retain one
+  fact identity.
+- Added daily Monday–Friday opportunity reconciliation across learner
+  enrollments and class days, including short weeks, schedule/archive changes,
+  completion floors, and terminal prior-week closure.
+- Added the student-only Achievements navigation item and secure
+  `/embed/roadmap` iframe with origin/source/nonce validation, short-lived
+  read-token handoff, bounded failure/retry, and light/dark appearance
+  messages. Pika retains its shell; Pal owns roadmap and reward rendering.
+- Added the Pika operations/rollout guide, including week-boundary rollout,
+  no historical backfill, at-least-once/out-of-order delivery, and current Pal
+  prerequisites. No migration was applied and no environment was enabled.
+
+**Validation:**
+- `pnpm test` (440 files / 3,850 tests).
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (648 modules / 0 allowances)
+- `pnpm check:ui-policy` (202 controls / 64 files)
+- `pnpm build`
+- Desktop/mobile and light/dark Playwright inspection using a temporary Pal
+  handshake harness; selected navigation, ready embed, and live theme changes
+  were verified.
+- `git diff --check`
+
+**Remaining:**
+- Apply migration 111 only through the separately authorized target-specific
+  process.
+- Complete Pal v1 ingest, read-token, and `/embed/roadmap` dependencies, then
+  run the real duplicate/retry/out-of-order vertical slice before enabling the
+  pilot or merging the integration branch to `main`.
+
 ## 2026-07-26 — DESIGN.md product-conformance loop
 
 **Risk profile:** none
@@ -1364,46 +1303,38 @@ requires exact cross-repository contract and semantic-token drift checks.
   `@pal/widget`; mount it only as part of the separately reviewed native pilot.
 ## 2026-07-25 — Pika-side Pal achievements pilot
 
-**Risk profile:** integration, privacy, database, cross-origin embed
+## 2026-07-26 — Pika-to-Pal widget theme contract
+
+**Risk profile:** cross-repository UI contract, accessibility, package release
 
 **Completed:**
-- Implemented the disabled-by-default `PAL_ENABLED` pilot on
-  `codex/pal-pilot`, with pinned Pal v1 contract fixtures and stable HMAC
-  learner/classroom/item/fact tokens. Outbound payloads exclude raw IDs,
-  assignment names, work, grades, deadlines, and teacher-maintained catalogs.
-- Drafted unapplied migration 111 for a service-role-only transactional
-  outbox, leases, retries, non-retryable visibility/requeue, and monotonic
-  learner/week opportunity revisions.
-- Wired authenticated session, new enrollment, the real daily-log autosave
-  creation path, genuine first assignment open, and first valid assignment
-  completion to the outbox. Duplicate daily logs and resubmissions retain one
-  fact identity.
-- Added daily Monday–Friday opportunity reconciliation across learner
-  enrollments and class days, including short weeks, schedule/archive changes,
-  completion floors, and terminal prior-week closure.
-- Added the student-only Achievements navigation item and secure
-  `/embed/roadmap` iframe with origin/source/nonce validation, short-lived
-  read-token handoff, bounded failure/retry, and light/dark appearance
-  messages. Pika retains its shell; Pal owns roadmap and reward rendering.
-- Added the Pika operations/rollout guide, including week-boundary rollout,
-  no historical backfill, at-least-once/out-of-order delivery, and current Pal
-  prerequisites. No migration was applied and no environment was enabled.
+- Pal commit `7a6d869` defines theme contract v1 with 36 optional scoped
+  properties, explicit theme/density/viewport/motion provider values, portable
+  light/dark fallbacks, focus/target/motion handling, and contract tests.
+- Added the Pika `PalWidgetThemeBoundary` and one CSS-module adapter that maps
+  every Pal input to an existing Pika semantic token without copied raw values.
+- Vendored only Pal's dependency-free property manifest while `@pal/widget`
+  remains private; documented its upstream commit and mandatory deletion after
+  the package can be imported directly.
+- Updated `DESIGN.md`, the pilot runbook, startup context, and hierarchy tests
+  to record the confirmed native-widget boundary. The disabled iframe remains
+  an interim prototype and is not an enablement target.
+- Registered the interim iframe's two existing raw height utilities under the
+  native-widget release owner so current design-policy CI remains exact.
 
 **Validation:**
-- `pnpm test` (440 files / 3,850 tests).
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (648 modules / 0 allowances)
-- `pnpm check:ui-policy` (202 controls / 64 files)
-- `pnpm build`
-- Desktop/mobile and light/dark Playwright inspection using a temporary Pal
-  handshake harness; selected navigation, ready embed, and live theme changes
-  were verified.
-- `git diff --check`
+- Pal widget tests: 37/37; Pal widget/web lint and typecheck passed.
+- Pal sandbox reviewed at 1440x900 and 390x844 in light/dark, including visible
+  keyboard focus and reward/companion layers; desktop is the default.
+- Pika adapter, hierarchy, startup-budget, and design-policy tests passed.
+- Pika audit, lint, typecheck, architecture, UI policy, design policy, build,
+  and `git diff --check` passed.
+- Full Pika suite passed 443/444 files and 3,870/3,871 tests; the sole
+  unrelated `TestDetailPanel` timeout passed in isolation in 0.54s.
 
 **Remaining:**
-- Apply migration 111 only through the separately authorized target-specific
-  process.
-- Complete Pal v1 ingest, read-token, and `/embed/roadmap` dependencies, then
-  run the real duplicate/retry/out-of-order vertical slice before enabling the
-  pilot or merging the integration branch to `main`.
+- Publish a reviewed non-private `@pal/widget` package and import its contract
+  directly.
+- Replace the disabled iframe with the native provider/surfaces, then run the
+  authenticated Pika student visual matrix and real delivery vertical slice.
+- Migration 111 and feature enablement remain human-controlled.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,13 +1,8 @@
 {
   "meta": {
-    "project": "pika",
-    "lastUpdated": "2026-07-16",
-    "phase": "Product Experience Architecture",
-    "DO_NOT_DELETE_FEATURES": "APPEND-ONLY. Never delete entries.",
-    "deletionPolicy": "PROHIBITED",
-    "totalFeatures": 14,
-    "passing": 13,
-    "failing": 1
+    "project": "pika", "lastUpdated": "2026-07-25", "phase": "Pal Achievements Pilot",
+    "DO_NOT_DELETE_FEATURES": "APPEND-ONLY. Never delete entries.", "deletionPolicy": "PROHIBITED",
+    "totalFeatures": 15, "passing": 13, "failing": 2
   },
   "features": [
     {
@@ -16,9 +11,7 @@
       "description": "Next.js, TypeScript, Tailwind, and Supabase bootstrap",
       "passes": true,
       "verification": "Run: pnpm test",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-auth",
@@ -26,9 +19,7 @@
       "description": "Email-code auth, password login, secure sessions, lockout, and role routing",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: signup → verify → create password → login → logout → reset password",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-student-experience",
@@ -36,9 +27,7 @@
       "description": "Student journal, attendance, and dashboard flows per classroom",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: student submits entry for today and sees history update",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-teacher-dashboard",
@@ -46,9 +35,7 @@
       "description": "Teacher attendance matrix, entry drill-down, class day management, and CSV export",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: teacher views classroom attendance and exports CSV",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-classrooms-rosters",
@@ -56,9 +43,7 @@
       "description": "Classrooms, join codes/links, enrollments, roster CSV, and class days",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: teacher creates classroom and uploads roster; student joins by code",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-assignments",
@@ -66,9 +51,7 @@
       "description": "Classroom assignments with autosave, submit/unsubmit, late detection, and teacher views",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: student edits + submits; teacher views submission status",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12"
     },
     {
       "id": "epic-tests-polish",
@@ -76,10 +59,7 @@
       "description": "Expand coverage, harden security, and keep docs in sync (coverage thresholds met and stable)",
       "passes": true,
       "verification": "Run: pnpm test:coverage (and meet thresholds). Add missing tests as needed.",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2025-12-12",
-      "completedDate": "2025-12-14"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2025-12-12", "completedDate": "2025-12-14"
     },
     {
       "id": "epic-ai-effectiveness-layer",
@@ -87,12 +67,7 @@
       "description": "AI continuity layer (.ai/) and standardized protocols",
       "passes": true,
       "verification": "Run: bash scripts/verify-env.sh and node scripts/features.mjs validate.",
-      "issueRefs": [
-        "#8"
-      ],
-      "blockedBy": [],
-      "addedDate": "2025-12-12",
-      "completedDate": "2025-12-14"
+      "issueRefs": ["#8"], "blockedBy": [], "addedDate": "2025-12-12", "completedDate": "2025-12-14"
     },
     {
       "id": "epic-daily-log-summaries",
@@ -100,10 +75,7 @@
       "description": "Legacy entry_summaries per-entry log snippets. Removed; distinct from active classroom/day log_summaries.",
       "passes": true,
       "verification": "Removed in #241; migration 032 drops entry_summaries.",
-      "issueRefs": ["#241"],
-      "blockedBy": [],
-      "addedDate": "2025-12-13",
-      "completedDate": "2025-12-14",
+      "issueRefs": ["#241"], "blockedBy": [], "addedDate": "2025-12-13", "completedDate": "2025-12-14",
       "removedDate": "2026-01-31"
     },
     {
@@ -112,10 +84,7 @@
       "description": "Teacher-owned flat course blueprints with markdown-first editing, classroom instantiation, and portable package import/export",
       "passes": true,
       "verification": "Run: pnpm lint && pnpm build && pnpm test tests/lib/course-blueprint-package.test.ts tests/api/teacher/course-blueprints-route.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2026-04-17",
-      "completedDate": "2026-04-17"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2026-04-17", "completedDate": "2026-04-17"
     },
     {
       "id": "epic-classwork-surveys",
@@ -123,10 +92,7 @@
       "description": "Classwork surveys: MC/text/link, updates, results",
       "passes": true,
       "verification": "pnpm lint && pnpm test && pnpm build",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2026-05-13",
-      "completedDate": "2026-05-13"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2026-05-13", "completedDate": "2026-05-13"
     },
     {
       "id": "epic-developer-feedback-helper",
@@ -134,10 +100,7 @@
       "description": "Agent queue for Pika improvement candidates from logs and Send Feedback",
       "passes": true,
       "verification": "focused developer feedback tests",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2026-05-21",
-      "completedDate": "2026-05-21"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2026-05-21", "completedDate": "2026-05-21"
     },
     {
       "id": "epic-classroom-lifecycle-archives",
@@ -145,10 +108,7 @@
       "description": "Reversible hot/cold classroom archives with managed storage and deidentified Gradex extracts",
       "passes": true,
       "verification": "Contract/DB audit, restore equality canary, cold recovery drill, production verification",
-      "issueRefs": [],
-      "blockedBy": [],
-      "addedDate": "2026-07-13",
-      "completedDate": "2026-07-15"
+      "issueRefs": [], "blockedBy": [], "addedDate": "2026-07-13", "completedDate": "2026-07-15"
     },
     {
       "id": "epic-product-experience-architecture",
@@ -157,8 +117,8 @@
       "passes": false,
       "verification": "Complete the exit evidence in docs/guidance/ui/product-experience-audit-2026-07.md",
       "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902", "#903", "#904", "#905"],
-      "blockedBy": [],
-      "addedDate": "2026-07-16"
-    }
+      "blockedBy": [], "addedDate": "2026-07-16"
+    },
+    {"id":"epic-pal-achievements-pilot","phase":"Pal Pilot","description":"Feature-gated Pika facts, outbox, weekly config, and Pal embed","passes":false,"verification":"Tests plus real duplicate-safe Pika–Pal slice","issueRefs":["pal#32","pal#35"],"blockedBy":["migration 111","Pal v1 runtime"],"addedDate":"2026-07-25"}
   ]
 }

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -119,6 +119,6 @@
       "issueRefs": ["#889", "#890", "#891", "#893", "#894", "#895", "#896", "#897", "#898", "#899", "#900", "#902", "#903", "#904", "#905"],
       "blockedBy": [], "addedDate": "2026-07-16"
     },
-    {"id":"epic-pal-achievements-pilot","phase":"Pal Pilot","description":"Feature-gated Pika facts, outbox, weekly config, and Pal embed","passes":false,"verification":"Tests plus real duplicate-safe Pika–Pal slice","issueRefs":["pal#32","pal#35"],"blockedBy":["migration 111","Pal v1 runtime"],"addedDate":"2026-07-25"}
+    {"id":"epic-pal-achievements-pilot","phase":"Pal Pilot","description":"Feature-gated Pika facts, outbox, weekly config, and native Pal widget","passes":false,"verification":"Tests plus duplicate-safe vertical slice","issueRefs":["pal#32","pal#35"],"blockedBy":[],"addedDate":"2026-07-25"}
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,16 @@ CLASSROOM_GRADEX_CLEANUP_TRIGGER_ENABLED=false
 CLASSROOM_GRADEX_CLEANUP_OPERATION_ID=
 GRADEX_PIKA_PSEUDONYM_SALT=
 
+# Pal achievements pilot (server-only, disabled by default)
+# PAL_ENABLED is the pilot's only feature flag. The other values are connection
+# settings and are ignored while the flag is disabled.
+PAL_ENABLED=false
+PAL_API_URL=
+PAL_INTEGRATION_SECRET=
+# Stable HMAC secret used only to make opaque Pal learner/classroom/item tokens.
+# Keep stable for the pilot; rotating it changes every Pal identity and fact key.
+PAL_PSEUDONYM_SECRET=
+
 # GitHub API (optional for repo review helpers)
 # Token needs `repo` scope, or `public_repo` if the repo is public.
 GITHUB_PAT=

--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,7 @@ GRADEX_PIKA_PSEUDONYM_SALT=
 # PAL_ENABLED is the pilot's only feature flag. The other values are connection
 # settings and are ignored while the flag is disabled.
 PAL_ENABLED=false
+# HTTPS origin only (no path/query/credentials). Loopback HTTP is development-only.
 PAL_API_URL=
 PAL_INTEGRATION_SECRET=
 # Stable HMAC secret used only to make opaque Pal learner/classroom/item tokens.

--- a/.env.example
+++ b/.env.example
@@ -91,9 +91,11 @@ GRADEX_PIKA_PSEUDONYM_SALT=
 PAL_ENABLED=false
 # HTTPS origin only (no path/query/credentials). Loopback HTTP is development-only.
 PAL_API_URL=
+# Distinct high-entropy secret, at least 32 characters.
 PAL_INTEGRATION_SECRET=
 # Stable HMAC secret used only to make opaque Pal learner/classroom/item tokens.
-# Keep stable for the pilot; rotating it changes every Pal identity and fact key.
+# Keep stable and distinct from the integration secret; minimum 32 characters.
+# Rotating it changes every Pal identity and fact key.
 PAL_PSEUDONYM_SECRET=
 
 # GitHub API (optional for repo review helpers)

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -32,6 +32,13 @@ learner widget reads. `PAL_INTEGRATION_SECRET` authenticates Pika's backend.
 `PAL_PSEUDONYM_SECRET` creates stable HMAC tokens and must never be shared with
 Pal or the browser.
 
+`PAL_API_URL` must be an HTTPS origin with no credentials, path, query, or
+fragment. Loopback HTTP is allowed only outside production. When
+`PAL_ENABLED=true`, incomplete or unsafe configuration fails at the feature
+gate instead of silently running authoritative learner actions without their
+achievement fact. Authenticated-session telemetry remains best-effort so an
+adapter outage cannot invalidate a genuine login.
+
 When the switch is false or absent:
 
 - Achievements is absent from student navigation.
@@ -73,7 +80,7 @@ point forward, so a clean pilot comparison should start at a week boundary.
 Learner action
   -> Pika validates and commits its authoritative source record
   -> the same database transaction inserts a privacy-safe Pal event
-  -> daily sync claims a bounded outbox batch with a lease
+  -> daily sync drains bounded outbox batches with leases
   -> POST <PAL_API_URL>/api/v1/events
   -> 2xx marks delivered
   -> network/408/429/5xx schedules bounded exponential retry
@@ -102,9 +109,11 @@ unsubmit/resubmit, so a second submission cannot create a second version 1
 fact.
 
 All event builders execute the exact dependency-free validator copied from
-Pal commit `db9f22e22cbf971744bea7a78a8306f2ae787d65`. Its matching valid and
-invalid fixtures live in `tests/fixtures/pal-contract-v1`. Change the contract
-in Pal first, then replace the vendored source and fixtures together.
+Pal commit `cd9fc872b646b8c91551fd44f9b4b36725ab0fe4`. Its matching valid and
+invalid fixtures live in `tests/fixtures/pal-contract-v1`. Both the event
+envelope and each event's metadata are closed allow-lists; unexpected fields
+are rejected before delivery. Change the contract in Pal first, then replace
+the vendored source and fixtures together.
 
 ## Weekly Rhythm
 
@@ -113,17 +122,21 @@ currently enrolled learner and revises any existing configuration affected by
 a schedule change, midweek enrollment, withdrawal, or archive. It unions class
 days across classrooms, so the same date counts once.
 
-The prior week is closed once. Eligible days can fall when an unmet
-opportunity disappears, but never below the number of distinct completion
-dates Pika already asserted. Short weeks therefore reach Pal as their actual
-opportunity count; Pal owns the grace-day target and recurring Weekly Rhythm
-award.
+Every open week before the current week is closed once. Recovery handles up to
+12 missed periods per daily run and reports whether another catch-up run is
+needed. Eligible days can fall when an unmet opportunity disappears, but never
+below the number of distinct completion dates Pika already asserted. Short
+weeks therefore reach Pal as their actual opportunity count; Pal owns the
+grace-day target and recurring Weekly Rhythm award.
 
 ## Delivery and reconciliation
 
 Vercel calls `GET /api/cron/pal-sync` daily with
 `Authorization: Bearer <CRON_SECRET>`. It reconciles weekly configurations
-before draining one delivery batch.
+before draining up to 10 batches of 50 events within an eight-second worker
+budget. The response reports batches, stop reason, and the number of rows still
+ready, so capacity exhaustion is visible rather than silently deferred for a
+day.
 
 The same credential protects the focused outbox operations:
 
@@ -166,7 +179,8 @@ package release.
 The integration secret and raw learner ID never enter the browser. The token
 is supplied only through Pal's learner client. An unavailable or incomplete Pal
 implementation produces a bounded retry state while the rest of Pika remains
-usable.
+usable. Pika rejects malformed or already-expired read tokens and caps accepted
+token lifetime at ten minutes, with a small allowance for server clock skew.
 
 ## Verification
 

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -30,7 +30,8 @@ The other values are server-only connection settings, not feature flags.
 `PAL_API_URL` is the Pal origin used for event ingest, read-token minting, and
 learner widget reads. `PAL_INTEGRATION_SECRET` authenticates Pika's backend.
 `PAL_PSEUDONYM_SECRET` creates stable HMAC tokens and must never be shared with
-Pal or the browser.
+Pal or the browser. Both secrets must be distinct and at least 32 characters;
+use independently generated high-entropy values rather than human phrases.
 
 `PAL_API_URL` must be an HTTPS origin with no credentials, path, query, or
 fragment. Loopback HTTP is allowed only outside production. When
@@ -133,10 +134,14 @@ grace-day target and recurring Weekly Rhythm award.
 
 Vercel calls `GET /api/cron/pal-sync` daily with
 `Authorization: Bearer <CRON_SECRET>`. It reconciles weekly configurations
-before draining up to 10 batches of 50 events within an eight-second worker
+before draining up to 10 batches of 20 events within an eight-second worker
 budget. The response reports batches, stop reason, and the number of rows still
 ready, so capacity exhaustion is visible rather than silently deferred for a
 day.
+
+Each batch uses at most 10 concurrent deliveries. Network attempts are bounded
+by the worker's remaining deadline, which stays well inside the 60-second row
+lease so an overlapping worker cannot reclaim a slow in-flight batch.
 
 The same credential protects the focused outbox operations:
 

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -28,9 +28,9 @@ PAL_PSEUDONYM_SECRET=
 
 The other values are server-only connection settings, not feature flags.
 `PAL_API_URL` is the Pal origin used for event ingest, read-token minting, and
-the chrome-free `/embed/roadmap` route. `PAL_INTEGRATION_SECRET` authenticates
-Pika's backend. `PAL_PSEUDONYM_SECRET` creates stable HMAC tokens and must never
-be shared with Pal or the browser.
+learner widget reads. `PAL_INTEGRATION_SECRET` authenticates Pika's backend.
+`PAL_PSEUDONYM_SECRET` creates stable HMAC tokens and must never be shared with
+Pal or the browser.
 
 When the switch is false or absent:
 
@@ -49,14 +49,19 @@ Do not enable the switch until all prerequisites are true:
 2. Configure all server-only Pal settings.
 3. Confirm Pal accepts the six version 1 event shapes.
 4. Confirm Pal implements `POST /api/v1/integration/read-token`.
-5. Confirm Pal serves `/embed/roadmap` and supports the nonce-bound
-   `postMessage` handshake below.
-6. Enable `PAL_ENABLED=true` in the pilot environment only, preferably before
+5. Publish a reviewed `@pal/widget` package version exposing
+   `@pal/widget/theme-contract`.
+6. Replace the interim iframe host with the native widget surfaces, import
+   `@pal/widget/styles.css` once, wrap the provider in
+   `PalWidgetThemeBoundary`, and pass Pika's scoped theme, density, viewport,
+   and motion values.
+7. Run the Pika/Pal theme-contract drift test and visual verification matrix.
+8. Enable `PAL_ENABLED=true` in the pilot environment only, preferably before
    learners act on the first day of a pilot week.
 
-Pal must support a contract version before Pika emits it. The current Pal
-prototype does not yet satisfy steps 3–5; keeping the switch off is the safe
-default while those Pal-side dependencies are completed.
+Pal must support a contract version before Pika emits it. The current package is
+private and unpublished, so the switch must remain off until steps 3–7 are
+complete.
 
 The pilot does not backfill actions that happened while the switch was off.
 Enabling midweek is safe, but Pal will only receive facts asserted from that
@@ -138,30 +143,28 @@ re-evaluate affected achievement progress when a related fact or later
 configuration revision arrives; correctness must not depend on HTTP arrival
 order.
 
-## Embedded roadmap
+## Native widget boundary
 
-When enabled, students see Achievements in the existing classroom sidebar.
-Pika loads Pal's chrome-free roadmap inside the normal content pane; the full
-roadmap is not a Pika overlay.
+The rollout target is the native React `@pal/widget` package. When enabled,
+students see Achievements in the existing classroom sidebar.
+`PalAchievements` renders inside the normal content pane; the full roadmap is
+not a Pika overlay. `PalCompanion` and `PalRewardCelebration` mount only in
+Pika-approved host layers.
 
-The iframe authentication exchange is:
+Pika imports Pal's stylesheet but does not copy it. The
+`PalWidgetThemeBoundary` wrapper aliases current Pika semantic tokens into the
+public `--pal-*` inputs. `PalProvider` receives the active theme plus explicit
+`density`, `viewport`, and motion values. Pal does not inspect Pika routes,
+roles, Tailwind breakpoints, theme context, or `@/ui` components.
 
-1. Pika loads `/embed/roadmap#pika_nonce=<per-load-random-nonce>`.
-2. Pal posts `{ type: "pal.embed.ready", nonce }`.
-3. Pika verifies the exact Pal origin, iframe window, and nonce.
-4. Pika's authenticated backend mints a learner-scoped short-lived token from
-   `POST /api/v1/integration/read-token`.
-5. Pika posts `{ type: "pal.embed.authenticate", nonce, token, theme }` using
-   the exact Pal `targetOrigin`. `theme` is either `light` or `dark`.
-6. Pal posts `{ type: "pal.embed.authenticated", nonce }` before Pika reveals
-   the iframe.
-7. After authentication, Pika posts
-   `{ type: "pal.embed.appearance", nonce, theme }` whenever its theme changes.
-   Pal owns applying that appearance to the roadmap; Pika does not restyle or
-   recreate Pal content.
+The adapter, vendored contract manifest, and their drift tests can land before
+package publication. They do not make the interim iframe themeable: CSS custom
+properties do not cross an iframe origin. `StudentAchievementsTab` remains a
+disabled prototype on this branch and must be replaced, not enabled, after the
+package release.
 
 The integration secret and raw learner ID never enter the browser. The token
-is never placed in the iframe URL. An unavailable or incomplete Pal
+is supplied only through Pal's learner client. An unavailable or incomplete Pal
 implementation produces a bounded retry state while the rest of Pika remains
 usable.
 

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -1,0 +1,191 @@
+# Pal achievements pilot
+
+This document is the Pika-side implementation and operations guide for the
+achievement pilot designed in [Pal PR #32](https://github.com/codepetca/pal/pull/32)
+and made executable by the shared event contract in
+[Pal PR #35](https://github.com/codepetca/pal/pull/35).
+
+The ownership boundary is intentionally small:
+
+> Pika determines what happened and sends a privacy-safe fact. Pal determines
+> what that fact earns and renders the achievement roadmap.
+
+Pika does not send assignment titles, work, grades, raw IDs, deadlines, or an
+assignment catalog. A deleted assignment or archived classroom therefore does
+not require a mirrored cleanup operation in Pal. Facts that were true when
+they occurred remain historical.
+
+## Pilot switch and configuration
+
+`PAL_ENABLED` is the pilot's only feature flag. It defaults to disabled.
+
+```dotenv
+PAL_ENABLED=false
+PAL_API_URL=
+PAL_INTEGRATION_SECRET=
+PAL_PSEUDONYM_SECRET=
+```
+
+The other values are server-only connection settings, not feature flags.
+`PAL_API_URL` is the Pal origin used for event ingest, read-token minting, and
+the chrome-free `/embed/roadmap` route. `PAL_INTEGRATION_SECRET` authenticates
+Pika's backend. `PAL_PSEUDONYM_SECRET` creates stable HMAC tokens and must never
+be shared with Pal or the browser.
+
+When the switch is false or absent:
+
+- Achievements is absent from student navigation.
+- No new Pal outbox rows or weekly configurations are written.
+- The read-token route returns unavailable.
+- Delivery workers do not claim queued rows.
+- Existing queued and failed rows are preserved.
+
+## Required rollout order
+
+Do not enable the switch until all prerequisites are true:
+
+1. Apply `111_pal_pilot_transactional_outbox.sql` to the intended Pika
+   environment using the normal human-authorized migration procedure.
+2. Configure all server-only Pal settings.
+3. Confirm Pal accepts the six version 1 event shapes.
+4. Confirm Pal implements `POST /api/v1/integration/read-token`.
+5. Confirm Pal serves `/embed/roadmap` and supports the nonce-bound
+   `postMessage` handshake below.
+6. Enable `PAL_ENABLED=true` in the pilot environment only, preferably before
+   learners act on the first day of a pilot week.
+
+Pal must support a contract version before Pika emits it. The current Pal
+prototype does not yet satisfy steps 3–5; keeping the switch off is the safe
+default while those Pal-side dependencies are completed.
+
+The pilot does not backfill actions that happened while the switch was off.
+Enabling midweek is safe, but Pal will only receive facts asserted from that
+point forward, so a clean pilot comparison should start at a week boundary.
+
+## Signal chain
+
+```text
+Learner action
+  -> Pika validates and commits its authoritative source record
+  -> the same database transaction inserts a privacy-safe Pal event
+  -> daily sync claims a bounded outbox batch with a lease
+  -> POST <PAL_API_URL>/api/v1/events
+  -> 2xx marks delivered
+  -> network/408/429/5xx schedules bounded exponential retry
+  -> other 4xx or contract-invalid payloads become non-retryable
+  -> an operator inspects or explicitly requeues the retained row
+```
+
+Pal being unavailable never rolls back a Pika learner action. The outbox
+stores its local source references for Pika reconciliation, but only `payload`
+is transmitted.
+
+## Initial source facts
+
+| Fact | Authoritative Pika transition | Durable identity |
+|---|---|---|
+| `platform.session.started` | A student session cookie was successfully saved | learner + generated source session |
+| `classroom.joined` | A new classroom enrollment row was inserted | learner + classroom |
+| `daily_log_week.configured` | Pika calculated or revised that learner's weekly opportunities | learner + period + monotonic version |
+| `daily_log.completed` | A qualifying log was saved | learner + Toronto activity date |
+| `learning_item.viewed` | The learner's assignment document was created by a genuine first open | learner + item |
+| `learning_item.completed` | The first authoritative valid submission transition succeeded | learner + item |
+
+Daily log identity deliberately omits classroom, so several logs on the same
+date produce one outbound fact. Learning-item identity deliberately survives
+unsubmit/resubmit, so a second submission cannot create a second version 1
+fact.
+
+All event builders execute the exact dependency-free validator copied from
+Pal commit `db9f22e22cbf971744bea7a78a8306f2ae787d65`. Its matching valid and
+invalid fixtures live in `tests/fixtures/pal-contract-v1`. Change the contract
+in Pal first, then replace the vendored source and fixtures together.
+
+## Weekly Rhythm
+
+The daily Pal sync calculates the current Toronto Monday–Friday week for every
+currently enrolled learner and revises any existing configuration affected by
+a schedule change, midweek enrollment, withdrawal, or archive. It unions class
+days across classrooms, so the same date counts once.
+
+The prior week is closed once. Eligible days can fall when an unmet
+opportunity disappears, but never below the number of distinct completion
+dates Pika already asserted. Short weeks therefore reach Pal as their actual
+opportunity count; Pal owns the grace-day target and recurring Weekly Rhythm
+award.
+
+## Delivery and reconciliation
+
+Vercel calls `GET /api/cron/pal-sync` daily with
+`Authorization: Bearer <CRON_SECRET>`. It reconciles weekly configurations
+before draining one delivery batch.
+
+The same credential protects the focused outbox operations:
+
+- `GET /api/cron/pal-outbox` — counts plus up to 25 privacy-safe pending or
+  failed summaries; no payloads or learner/source IDs.
+- `POST /api/cron/pal-outbox` — deliver one bounded batch.
+- `PATCH /api/cron/pal-outbox` with `{ "outbox_id": "<uuid>" }` — explicitly
+  requeue a retained non-retryable row after its cause is corrected.
+
+Delivery rows use leases and `FOR UPDATE SKIP LOCKED`, so overlapping workers
+cannot process the same attempt concurrently. Pal independently deduplicates
+by the integration-scoped idempotency key.
+
+Delivery is at least once and may be delayed or out of order. Pal must retain
+qualified facts, apply weekly configuration revisions monotonically, and
+re-evaluate affected achievement progress when a related fact or later
+configuration revision arrives; correctness must not depend on HTTP arrival
+order.
+
+## Embedded roadmap
+
+When enabled, students see Achievements in the existing classroom sidebar.
+Pika loads Pal's chrome-free roadmap inside the normal content pane; the full
+roadmap is not a Pika overlay.
+
+The iframe authentication exchange is:
+
+1. Pika loads `/embed/roadmap#pika_nonce=<per-load-random-nonce>`.
+2. Pal posts `{ type: "pal.embed.ready", nonce }`.
+3. Pika verifies the exact Pal origin, iframe window, and nonce.
+4. Pika's authenticated backend mints a learner-scoped short-lived token from
+   `POST /api/v1/integration/read-token`.
+5. Pika posts `{ type: "pal.embed.authenticate", nonce, token, theme }` using
+   the exact Pal `targetOrigin`. `theme` is either `light` or `dark`.
+6. Pal posts `{ type: "pal.embed.authenticated", nonce }` before Pika reveals
+   the iframe.
+7. After authentication, Pika posts
+   `{ type: "pal.embed.appearance", nonce, theme }` whenever its theme changes.
+   Pal owns applying that appearance to the roadmap; Pika does not restyle or
+   recreate Pal content.
+
+The integration secret and raw learner ID never enter the browser. The token
+is never placed in the iframe URL. An unavailable or incomplete Pal
+implementation produces a bounded retry state while the rest of Pika remains
+usable.
+
+## Verification
+
+Before enabling an environment:
+
+```bash
+pnpm exec vitest run \
+  tests/lib/server/pal-contract.test.ts \
+  tests/lib/server/pal-events.test.ts \
+  tests/lib/server/pal-outbox.test.ts \
+  tests/lib/server/pal-weekly-config.test.ts
+
+pnpm exec tsc --noEmit
+pnpm check:architecture
+pnpm check:ui-policy
+```
+
+Then run a real pilot vertical slice only after Pal's prerequisites exist:
+
+1. Start one authenticated student session.
+2. Inspect a pending Pika outbox row without exposing its payload.
+3. Run the delivery worker.
+4. Confirm Pal records the fact once.
+5. Replay the same Pika delivery and confirm no extra Pal progress or reward.
+6. Open Achievements and confirm the token handshake and roadmap state.

--- a/scripts/design-value-exceptions.json
+++ b/scripts/design-value-exceptions.json
@@ -26,6 +26,18 @@
       ]
     },
     {
+      "file": "src/app/classrooms/[classroomId]/StudentAchievementsTab.tsx",
+      "reviewBy": "pal-native-widget-release",
+      "values": [
+        {
+          "kind": "arbitrary-spacing",
+          "count": 2,
+          "fingerprint": "68103de61fbb3b27",
+          "reason": "layout-geometry"
+        }
+      ]
+    },
+    {
       "file": "src/app/classrooms/[classroomId]/loading.tsx",
       "reviewBy": "phase-2-design-foundation-debt",
       "values": [

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -15,6 +15,9 @@ import {
   loadUserGitHubIdentity,
 } from '@/lib/server/assignment-submission-artifacts'
 import { assignmentDocSaveRequestSchema } from '@/lib/validations/assignment-doc-submissions'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { buildLearningItemViewedEvent } from '@/lib/server/pal-events'
+import { createAssignmentDocWithPalEvent } from '@/lib/server/pal-source-writes'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -171,67 +174,112 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
         })
       }
 
-      const { data: created, error: createError } = await supabase
-        .from('assignment_docs')
-        .insert({
-          assignment_id: assignmentId,
-          student_id: user.id,
-          content: { type: 'doc', content: [] },
-          repo_url: null,
-          github_username: null,
-          is_submitted: false,
-          submitted_at: null,
-          viewed_at: new Date().toISOString(),
-        })
-        .select()
-        .single()
+      const viewedAt = new Date()
+      let created: any = null
+      let createdByThisRequest = true
 
-      if (createError || !created) {
-        // If we raced another create, re-fetch.
-        if (createError?.code === '23505') {
-          const { data: raced } = await supabase
-            .from('assignment_docs')
-            .select('*')
-            .eq('assignment_id', assignmentId)
-            .eq('student_id', user.id)
-            .single()
-          // Parse content if it's a string (for backwards compatibility)
-          if (raced) {
-            raced.content = parseContentField(raced.content)
+      if (isPalEnabled()) {
+        let palEvent = null
+        const effectiveReleaseAt = assignment.released_at ?? assignment.created_at
+        if (effectiveReleaseAt) {
+          try {
+            palEvent = buildLearningItemViewedEvent({
+              learnerId: user.id,
+              itemId: assignmentId,
+              occurredAt: viewedAt,
+              releasedAt: effectiveReleaseAt,
+            })
+          } catch (error) {
+            console.error('Failed to build Pal assignment view event:', error)
           }
-          // Race condition: another request created the doc, so this wasn't first view
-          const feedbackEntries = raced ? await loadAssignmentFeedbackEntries(assignmentId, user.id) : []
-          const submissionContext = await loadStudentSubmissionContext(supabase, assignmentId, raced?.id ?? null, user.id)
-          return NextResponse.json({
-            assignment: {
-              ...assignment,
-              instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
-            },
-            doc: raced ? sanitizeDocForStudent(raced) : raced,
-            feedback_entries: feedbackEntries,
-            ...submissionContext,
-            wasFirstView: false,
-          })
         }
 
-        console.error('Error creating assignment doc:', createError)
-        return NextResponse.json(
-          { error: 'Failed to create assignment doc' },
-          { status: 500 }
-        )
+        try {
+          const result = await createAssignmentDocWithPalEvent({
+            supabase,
+            assignmentId,
+            studentId: user.id,
+            viewedAt: viewedAt.toISOString(),
+            event: palEvent,
+          })
+          created = result.doc
+          createdByThisRequest = result.created
+        } catch (error) {
+          console.error('Error creating assignment doc with Pal outbox:', error)
+          return NextResponse.json(
+            { error: 'Failed to create assignment doc' },
+            { status: 500 }
+          )
+        }
+      } else {
+        const { data, error: createError } = await supabase
+          .from('assignment_docs')
+          .insert({
+            assignment_id: assignmentId,
+            student_id: user.id,
+            content: { type: 'doc', content: [] },
+            repo_url: null,
+            github_username: null,
+            is_submitted: false,
+            submitted_at: null,
+            viewed_at: viewedAt.toISOString(),
+          })
+          .select()
+          .single()
+
+        if (createError || !data) {
+          // If we raced another create, re-fetch.
+          if (createError?.code === '23505') {
+            const { data: raced } = await supabase
+              .from('assignment_docs')
+              .select('*')
+              .eq('assignment_id', assignmentId)
+              .eq('student_id', user.id)
+              .single()
+            // Parse content if it's a string (for backwards compatibility)
+            if (raced) {
+              raced.content = parseContentField(raced.content)
+            }
+            // Race condition: another request created the doc, so this wasn't first view
+            const feedbackEntries = raced ? await loadAssignmentFeedbackEntries(assignmentId, user.id) : []
+            const submissionContext = await loadStudentSubmissionContext(supabase, assignmentId, raced?.id ?? null, user.id)
+            return NextResponse.json({
+              assignment: {
+                ...assignment,
+                instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
+              },
+              doc: raced ? sanitizeDocForStudent(raced) : raced,
+              feedback_entries: feedbackEntries,
+              ...submissionContext,
+              wasFirstView: false,
+            })
+          }
+
+          console.error('Error creating assignment doc:', createError)
+          return NextResponse.json(
+            { error: 'Failed to create assignment doc' },
+            { status: 500 }
+          )
+        }
+        created = data
       }
+
+      created.content = parseContentField(created.content)
 
       // New doc created = first view
       const submissionContext = await loadStudentSubmissionContext(supabase, assignmentId, created.id, user.id)
+      const feedbackEntries = createdByThisRequest
+        ? []
+        : await loadAssignmentFeedbackEntries(assignmentId, user.id)
       return NextResponse.json({
         assignment: {
           ...assignment,
           instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
         },
         doc: sanitizeDocForStudent(created),
-        feedback_entries: [],
+        feedback_entries: feedbackEntries,
         ...submissionContext,
-        wasFirstView: true,
+        wasFirstView: createdByThisRequest,
       })
     }
     console.error('Error fetching assignment doc:', docError)

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -179,20 +179,16 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
       let createdByThisRequest = true
 
       if (isPalEnabled()) {
-        let palEvent = null
         const effectiveReleaseAt = assignment.released_at ?? assignment.created_at
-        if (effectiveReleaseAt) {
-          try {
-            palEvent = buildLearningItemViewedEvent({
-              learnerId: user.id,
-              itemId: assignmentId,
-              occurredAt: viewedAt,
-              releasedAt: effectiveReleaseAt,
-            })
-          } catch (error) {
-            console.error('Failed to build Pal assignment view event:', error)
-          }
+        if (!effectiveReleaseAt) {
+          throw new Error('Assignment is missing its authoritative release timestamp')
         }
+        const palEvent = buildLearningItemViewedEvent({
+          learnerId: user.id,
+          itemId: assignmentId,
+          occurredAt: viewedAt,
+          releasedAt: effectiveReleaseAt,
+        })
 
         try {
           const result = await createAssignmentDocWithPalEvent({

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -19,6 +19,8 @@ import { assignmentDocSubmitRequestSchema } from '@/lib/validations/assignment-d
 import { submitAssignmentDocAtomic } from '@/lib/server/assignment-doc-submissions'
 import { createJsonPatch } from '@/lib/json-patch'
 import type { AssignmentDocHistoryEntry, TiptapContent } from '@/types'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { buildLearningItemCompletedEvent } from '@/lib/server/pal-events'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -40,7 +42,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   // Get assignment and verify enrollment
   const { data: assignment, error: assignmentError } = await supabase
     .from('assignments')
-    .select('classroom_id, is_draft, released_at')
+    .select('classroom_id, is_draft, released_at, due_at')
     .eq('id', assignmentId)
     .single()
 
@@ -129,12 +131,28 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
     }
   }
 
+  const palEnabled = isPalEnabled()
+  let palEvent = null
+  if (palEnabled) {
+    try {
+      palEvent = buildLearningItemCompletedEvent({
+        learnerId: user.id,
+        itemId: assignmentId,
+        occurredAt: new Date(),
+        dueAt: assignment.due_at,
+      })
+    } catch (error) {
+      console.error('Failed to build Pal assignment completion event:', error)
+    }
+  }
+
   const submitResult = await submitAssignmentDocAtomic({
     supabase,
     assignmentId,
     studentId: user.id,
     content: submissionContent as TiptapContent,
     expectedUpdatedAt: submitRequest.expected_updated_at,
+    ...(palEnabled ? { palEvent } : {}),
   })
 
   if (!submitResult.ok) {

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -132,19 +132,14 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   }
 
   const palEnabled = isPalEnabled()
-  let palEvent = null
-  if (palEnabled) {
-    try {
-      palEvent = buildLearningItemCompletedEvent({
+  const palEvent = palEnabled
+    ? buildLearningItemCompletedEvent({
         learnerId: user.id,
         itemId: assignmentId,
         occurredAt: new Date(),
         dueAt: assignment.due_at,
       })
-    } catch (error) {
-      console.error('Failed to build Pal assignment completion event:', error)
-    }
-  }
+    : null
 
   const submitResult = await submitAssignmentDocAtomic({
     supabase,

--- a/src/app/api/cron/pal-outbox/route.ts
+++ b/src/app/api/cron/pal-outbox/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { withErrorHandler } from '@/lib/api-handler'
+import { deliverPalOutboxBatch } from '@/lib/server/pal-outbox'
+import {
+  loadPalOutboxStatus,
+  requeuePalOutboxEvent,
+} from '@/lib/server/pal-operations'
+import { palOutboxRequeueRequestSchema } from '@/lib/validations/pal'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+function isAuthorized(request: NextRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET
+  return Boolean(cronSecret && request.headers.get('authorization') === `Bearer ${cronSecret}`)
+}
+
+export const GET = withErrorHandler('GetPalOutboxStatus', async (request: NextRequest) => {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return NextResponse.json(await loadPalOutboxStatus())
+})
+
+export const POST = withErrorHandler('PostPalOutboxDelivery', async (request: NextRequest) => {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return NextResponse.json(await deliverPalOutboxBatch())
+})
+
+export const PATCH = withErrorHandler('PatchPalOutboxRequeue', async (request: NextRequest) => {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { outbox_id: outboxId } = palOutboxRequeueRequestSchema.parse(
+    await request.json(),
+  )
+  const requeued = await requeuePalOutboxEvent({ outboxId })
+  if (!requeued) {
+    return NextResponse.json(
+      { error: 'Only a non-retryable Pal event can be requeued' },
+      { status: 409 },
+    )
+  }
+  return NextResponse.json({ requeued: true })
+})

--- a/src/app/api/cron/pal-sync/route.ts
+++ b/src/app/api/cron/pal-sync/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { withErrorHandler } from '@/lib/api-handler'
+import { deliverPalOutboxBatch } from '@/lib/server/pal-outbox'
+import { syncPalWeeklyConfigurations } from '@/lib/server/pal-weekly-config'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetPalPilotSync', async (request: NextRequest) => {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 500 })
+  }
+
+  if (request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let weekly: Awaited<ReturnType<typeof syncPalWeeklyConfigurations>> | {
+    status: 'error'
+    error: 'weekly_sync_failed'
+  }
+
+  try {
+    weekly = await syncPalWeeklyConfigurations()
+  } catch (error) {
+    console.error('Pal weekly configuration sync failed', error)
+    weekly = { status: 'error', error: 'weekly_sync_failed' }
+  }
+
+  let delivery: Awaited<ReturnType<typeof deliverPalOutboxBatch>> | {
+    status: 'error'
+    error: 'outbox_delivery_failed'
+  }
+
+  try {
+    delivery = await deliverPalOutboxBatch()
+  } catch (error) {
+    console.error('Pal outbox delivery failed', error)
+    delivery = { status: 'error', error: 'outbox_delivery_failed' }
+  }
+
+  const status = weekly.status === 'error' || delivery.status === 'error'
+    ? 'partial'
+    : 'ok'
+
+  return NextResponse.json({ status, weekly, delivery })
+})

--- a/src/app/api/cron/pal-sync/route.ts
+++ b/src/app/api/cron/pal-sync/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { withErrorHandler } from '@/lib/api-handler'
-import { deliverPalOutboxBatch } from '@/lib/server/pal-outbox'
+import { drainPalOutbox } from '@/lib/server/pal-outbox'
 import { syncPalWeeklyConfigurations } from '@/lib/server/pal-weekly-config'
 
 export const dynamic = 'force-dynamic'
@@ -29,13 +29,13 @@ export const GET = withErrorHandler('GetPalPilotSync', async (request: NextReque
     weekly = { status: 'error', error: 'weekly_sync_failed' }
   }
 
-  let delivery: Awaited<ReturnType<typeof deliverPalOutboxBatch>> | {
+  let delivery: Awaited<ReturnType<typeof drainPalOutbox>> | {
     status: 'error'
     error: 'outbox_delivery_failed'
   }
 
   try {
-    delivery = await deliverPalOutboxBatch()
+    delivery = await drainPalOutbox()
   } catch (error) {
     console.error('Pal outbox delivery failed', error)
     delivery = { status: 'error', error: 'outbox_delivery_failed' }

--- a/src/app/api/student/classrooms/join/route.ts
+++ b/src/app/api/student/classrooms/join/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { buildClassroomJoinedEvent } from '@/lib/server/pal-events'
+import { createClassroomEnrollmentWithPalEvent } from '@/lib/server/pal-source-writes'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -176,22 +179,60 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
     }
   }
 
-  // Enroll student
-  const { data: enrollment, error: enrollError } = await supabase
-    .from('classroom_enrollments')
-    .insert({
-      classroom_id: classroom.id,
-      student_id: user.id,
-    })
-    .select()
-    .single()
+  let enrollment
+  if (isPalEnabled()) {
+    const occurredAt = new Date()
+    let palEvent = null
+    try {
+      palEvent = buildClassroomJoinedEvent({
+        learnerId: user.id,
+        classroomId: classroom.id,
+        occurredAt,
+      })
+    } catch (error) {
+      console.error('Failed to build Pal classroom join event:', error)
+    }
 
-  if (enrollError) {
-    console.error('Error enrolling student:', enrollError)
-    return NextResponse.json(
-      { error: 'Failed to join classroom' },
-      { status: 500 }
-    )
+    try {
+      const result = await createClassroomEnrollmentWithPalEvent({
+        supabase,
+        classroomId: classroom.id,
+        studentId: user.id,
+        event: palEvent,
+      })
+      enrollment = result.enrollment
+      if (!result.created) {
+        return NextResponse.json({
+          success: true,
+          classroom,
+          alreadyEnrolled: true,
+        })
+      }
+    } catch (error) {
+      console.error('Error enrolling student with Pal outbox:', error)
+      return NextResponse.json(
+        { error: 'Failed to join classroom' },
+        { status: 500 }
+      )
+    }
+  } else {
+    const { data, error: enrollError } = await supabase
+      .from('classroom_enrollments')
+      .insert({
+        classroom_id: classroom.id,
+        student_id: user.id,
+      })
+      .select()
+      .single()
+
+    if (enrollError) {
+      console.error('Error enrolling student:', enrollError)
+      return NextResponse.json(
+        { error: 'Failed to join classroom' },
+        { status: 500 }
+      )
+    }
+    enrollment = data
   }
 
   if (effectiveRosterEntry?.first_name && effectiveRosterEntry?.last_name) {

--- a/src/app/api/student/classrooms/join/route.ts
+++ b/src/app/api/student/classrooms/join/route.ts
@@ -182,16 +182,11 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
   let enrollment
   if (isPalEnabled()) {
     const occurredAt = new Date()
-    let palEvent = null
-    try {
-      palEvent = buildClassroomJoinedEvent({
-        learnerId: user.id,
-        classroomId: classroom.id,
-        occurredAt,
-      })
-    } catch (error) {
-      console.error('Failed to build Pal classroom join event:', error)
-    }
+    const palEvent = buildClassroomJoinedEvent({
+      learnerId: user.id,
+      classroomId: classroom.id,
+      occurredAt,
+    })
 
     try {
       const result = await createClassroomEnrollmentWithPalEvent({

--- a/src/app/api/student/entries/route.ts
+++ b/src/app/api/student/entries/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/tiptap-content'
 import { tryApplyJsonPatch } from '@/lib/json-patch'
 import { withErrorHandler } from '@/lib/api-handler'
+import { hasQualifyingDailyLogContent } from '@/lib/attendance'
 import { isPalEnabled } from '@/lib/server/pal-config'
 import { buildDailyLogCompletedEvent } from '@/lib/server/pal-events'
 import { upsertStudentEntryWithPalEvent } from '@/lib/server/pal-source-writes'
@@ -254,16 +255,13 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
   let entry
 
   if (isPalEnabled()) {
-    let palEvent = null
-    try {
-      palEvent = buildDailyLogCompletedEvent({
+    const palEvent = hasQualifyingDailyLogContent(entryText)
+      ? buildDailyLogCompletedEvent({
         learnerId: user.id,
         activityDay: date,
         occurredAt: now,
       })
-    } catch (error) {
-      console.error('Failed to build Pal daily log event:', error)
-    }
+      : null
 
     try {
       const result = await upsertStudentEntryWithPalEvent({
@@ -276,8 +274,15 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
         minutesReported: minutes_reported,
         mood,
         onTime,
+        expectedVersion: existing?.version ?? null,
         event: palEvent,
       })
+      if (!result.ok) {
+        return NextResponse.json(
+          { error: result.error, entry: result.entry },
+          { status: result.status },
+        )
+      }
       entry = result.entry
     } catch (error) {
       console.error('Error saving entry with Pal outbox:', error)
@@ -456,16 +461,13 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
     const onTime = isOnTime(now, date)
 
     if (isPalEnabled()) {
-      let palEvent = null
-      try {
-        palEvent = buildDailyLogCompletedEvent({
+      const palEvent = hasQualifyingDailyLogContent(entryText)
+        ? buildDailyLogCompletedEvent({
           learnerId: user.id,
           activityDay: date,
           occurredAt: now,
         })
-      } catch (error) {
-        console.error('Failed to build Pal daily log event:', error)
-      }
+        : null
 
       try {
         const result = await upsertStudentEntryWithPalEvent({
@@ -476,8 +478,15 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
           text: entryText,
           richContent: content,
           onTime,
+          expectedVersion: null,
           event: palEvent,
         })
+        if (!result.ok) {
+          return NextResponse.json(
+            { error: result.error, entry: result.entry },
+            { status: result.status },
+          )
+        }
         return NextResponse.json({ entry: result.entry })
       } catch (error) {
         console.error('Error creating entry with Pal outbox:', error)
@@ -551,6 +560,43 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
   const now = new Date()
   const onTime = isOnTime(now, date)
   const nextVersion = currentVersion + 1
+
+  if (isPalEnabled()) {
+    const palEvent = hasQualifyingDailyLogContent(entryText)
+      ? buildDailyLogCompletedEvent({
+        learnerId: user.id,
+        activityDay: date,
+        occurredAt: now,
+      })
+      : null
+
+    try {
+      const result = await upsertStudentEntryWithPalEvent({
+        supabase,
+        studentId: user.id,
+        classroomId: classroom_id,
+        date,
+        text: entryText,
+        richContent: nextContent,
+        onTime,
+        expectedVersion: currentVersion,
+        event: palEvent,
+      })
+      if (!result.ok) {
+        return NextResponse.json(
+          { error: result.error, entry: result.entry },
+          { status: result.status },
+        )
+      }
+      return NextResponse.json({ entry: result.entry })
+    } catch (error) {
+      console.error('Error updating entry with Pal outbox:', error)
+      return NextResponse.json(
+        { error: 'Failed to update entry' },
+        { status: 500 },
+      )
+    }
+  }
 
   const { data, error } = await supabase
     .from('entries')

--- a/src/app/api/student/entries/route.ts
+++ b/src/app/api/student/entries/route.ts
@@ -238,7 +238,7 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
 
   const { data: existing, error: existingError } = await supabase
     .from('entries')
-    .select('id, version')
+    .select('id, version, minutes_reported, mood')
     .eq('student_id', user.id)
     .eq('classroom_id', classroom_id)
     .eq('date', date)
@@ -255,6 +255,10 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
   let entry
 
   if (isPalEnabled()) {
+    const preservedMinutes = minutes_reported === undefined
+      ? existing?.minutes_reported
+      : minutes_reported
+    const preservedMood = mood === undefined ? existing?.mood : mood
     const palEvent = hasQualifyingDailyLogContent(entryText)
       ? buildDailyLogCompletedEvent({
         learnerId: user.id,
@@ -271,8 +275,8 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
         date,
         text: entryText,
         richContent: content,
-        minutesReported: minutes_reported,
-        mood,
+        minutesReported: preservedMinutes,
+        mood: preservedMood,
         onTime,
         expectedVersion: existing?.version ?? null,
         event: palEvent,
@@ -423,7 +427,7 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
 
   let entryQuery = supabase
     .from('entries')
-    .select('id, version, text, rich_content')
+    .select('id, version, text, rich_content, minutes_reported, mood')
     .eq('student_id', user.id)
     .eq('classroom_id', classroom_id)
     .eq('date', date)
@@ -578,6 +582,8 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
         date,
         text: entryText,
         richContent: nextContent,
+        minutesReported: existing.minutes_reported,
+        mood: existing.mood,
         onTime,
         expectedVersion: currentVersion,
         event: palEvent,

--- a/src/app/api/student/entries/route.ts
+++ b/src/app/api/student/entries/route.ts
@@ -11,6 +11,9 @@ import {
 } from '@/lib/tiptap-content'
 import { tryApplyJsonPatch } from '@/lib/json-patch'
 import { withErrorHandler } from '@/lib/api-handler'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { buildDailyLogCompletedEvent } from '@/lib/server/pal-events'
+import { upsertStudentEntryWithPalEvent } from '@/lib/server/pal-source-writes'
 import type { JsonPatchOperation, MoodEmoji, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -250,7 +253,40 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
 
   let entry
 
-  if (existing) {
+  if (isPalEnabled()) {
+    let palEvent = null
+    try {
+      palEvent = buildDailyLogCompletedEvent({
+        learnerId: user.id,
+        activityDay: date,
+        occurredAt: now,
+      })
+    } catch (error) {
+      console.error('Failed to build Pal daily log event:', error)
+    }
+
+    try {
+      const result = await upsertStudentEntryWithPalEvent({
+        supabase,
+        studentId: user.id,
+        classroomId: classroom_id,
+        date,
+        text: entryText,
+        richContent: content,
+        minutesReported: minutes_reported,
+        mood,
+        onTime,
+        event: palEvent,
+      })
+      entry = result.entry
+    } catch (error) {
+      console.error('Error saving entry with Pal outbox:', error)
+      return NextResponse.json(
+        { error: existing ? 'Failed to update entry' : 'Failed to create entry' },
+        { status: 500 }
+      )
+    }
+  } else if (existing) {
     const nextVersion = (existing.version ?? 1) + 1
     const { data, error } = await supabase
       .from('entries')
@@ -418,6 +454,39 @@ export const PATCH = withErrorHandler('PatchStudentEntry', async (request, conte
     const entryText = extractPlainText(content)
     const now = new Date()
     const onTime = isOnTime(now, date)
+
+    if (isPalEnabled()) {
+      let palEvent = null
+      try {
+        palEvent = buildDailyLogCompletedEvent({
+          learnerId: user.id,
+          activityDay: date,
+          occurredAt: now,
+        })
+      } catch (error) {
+        console.error('Failed to build Pal daily log event:', error)
+      }
+
+      try {
+        const result = await upsertStudentEntryWithPalEvent({
+          supabase,
+          studentId: user.id,
+          classroomId: classroom_id,
+          date,
+          text: entryText,
+          richContent: content,
+          onTime,
+          event: palEvent,
+        })
+        return NextResponse.json({ entry: result.entry })
+      } catch (error) {
+        console.error('Error creating entry with Pal outbox:', error)
+        return NextResponse.json(
+          { error: 'Failed to create entry' },
+          { status: 500 }
+        )
+      }
+    }
 
     const { data, error } = await supabase
       .from('entries')

--- a/src/app/api/student/pal/read-token/route.ts
+++ b/src/app/api/student/pal/read-token/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+
+import { withErrorHandler } from '@/lib/api-handler'
+import { requireRole } from '@/lib/auth'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { mintPalReadToken } from '@/lib/server/pal-read-token'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const POST = withErrorHandler('PostStudentPalReadToken', async () => {
+  const user = await requireRole('student')
+  if (!isPalEnabled()) {
+    return NextResponse.json({ error: 'Achievements are unavailable' }, { status: 404 })
+  }
+
+  try {
+    const token = await mintPalReadToken({ studentId: user.id })
+    return NextResponse.json(token, {
+      headers: { 'Cache-Control': 'no-store' },
+    })
+  } catch (error) {
+    console.error('Failed to mint Pal read token:', error)
+    return NextResponse.json(
+      { error: 'Achievements are temporarily unavailable' },
+      { status: 503 },
+    )
+  }
+})

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -19,6 +19,7 @@ import { TeacherAnnouncementsTab } from './TeacherAnnouncementsTab'
 import { StudentAnnouncementsTab } from './StudentAnnouncementsTab'
 import { TeacherTestsTab } from './TeacherTestsTab'
 import { StudentTestsTab } from './StudentTestsTab'
+import { StudentAchievementsTab } from './StudentAchievementsTab'
 import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
 import { ClassDaysProvider, useClassDaysContext } from '@/hooks/useClassDays'
 import { getMostRecentClassDayBefore } from '@/lib/class-days'
@@ -77,6 +78,8 @@ interface ClassroomPageClientProps {
   teacherClassrooms: Classroom[]
   initialTab?: string
   initialSearchParams?: Record<string, string | undefined>
+  palEnabled?: boolean
+  palEmbedUrl?: string | null
 }
 
 type UpdateSearchOptions = {
@@ -124,6 +127,8 @@ export function ClassroomPageClient({
   teacherClassrooms,
   initialTab,
   initialSearchParams,
+  palEnabled = false,
+  palEmbedUrl = null,
 }: ClassroomPageClientProps) {
   const { leftSidebarExpanded } = useLayoutInitialState()
   const [clientClassroom, setClientClassroom] = useState(classroom)
@@ -138,8 +143,16 @@ export function ClassroomPageClient({
     () =>
       isTeacher
         ? (['attendance', 'gradebook', 'assignments', 'tests', 'calendar', 'resources', 'announcements', 'roster', 'settings'] as const)
-        : (['today', 'assignments', 'tests', 'calendar', 'resources', 'announcements'] as const),
-    [isTeacher]
+        : ([
+            'today',
+            ...(palEnabled ? ['achievements'] as const : []),
+            'assignments',
+            'tests',
+            'calendar',
+            'resources',
+            'announcements',
+          ] as const),
+    [isTeacher, palEnabled]
   )
 
   const initialQueryString = buildInitialQueryString(initialSearchParams, initialTab)
@@ -251,6 +264,8 @@ export function ClassroomPageClient({
           searchParams={activeSearchParams}
           updateSearchParams={updateSearchParams}
           onClassroomUpdated={handleClassroomUpdated}
+          palEnabled={palEnabled}
+          palEmbedUrl={palEmbedUrl}
         />
       </ClassDaysProvider>
     </ThreePanelProvider>
@@ -397,6 +412,8 @@ function ClassroomPageContent({
   searchParams,
   updateSearchParams,
   onClassroomUpdated,
+  palEnabled,
+  palEmbedUrl,
 }: {
   classroom: Classroom
   user: UserInfo
@@ -406,6 +423,8 @@ function ClassroomPageContent({
   searchParams: URLSearchParams
   updateSearchParams: UpdateSearchParamsFn
   onClassroomUpdated: (classroom: Classroom) => void
+  palEnabled: boolean
+  palEmbedUrl: string | null
 }) {
   const { openLeft, close: closeMobileDrawer } = useMobileDrawer()
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
@@ -1110,7 +1129,7 @@ function ClassroomPageContent({
   ])
   const pageDensity = isTeacher ? 'teacher' : 'student'
   const mainContentClassName =
-    activeTab === 'calendar'
+    activeTab === 'calendar' || activeTab === 'achievements'
       ? 'px-0 pt-0 pb-0'
       : activeTab === 'tests'
         ? 'pb-0'
@@ -1227,6 +1246,7 @@ function ClassroomPageContent({
               onTabChange={handleTabChange}
               onTabIntent={prefetchTabData}
               updateSearchParams={navigateInClassroom}
+              palEnabled={palEnabled}
             />
           </LeftSidebar>
         )}
@@ -1373,6 +1393,14 @@ function ClassroomPageContent({
                         lastClassDate={lastClassLessonPlanDate}
                         lastClassLoading={lastClassLessonPlanLoading}
                         onLessonPlanLoad={handleSetLessonPlan}
+                      />
+                    </TabContentTransition>
+                  )}
+                  {mountedTabs.achievements && (
+                    <TabContentTransition isActive={activeTab === 'achievements'}>
+                      <StudentAchievementsTab
+                        embedUrl={palEmbedUrl}
+                        isActive={activeTab === 'achievements'}
                       />
                     </TabContentTransition>
                   )}

--- a/src/app/classrooms/[classroomId]/StudentAchievementsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAchievementsTab.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Button, PageState } from '@/ui'
+
+type EmbedState = 'loading' | 'authenticating' | 'ready' | 'error'
+type EmbedTheme = 'light' | 'dark'
+
+type PalEmbedMessage = {
+  type?: unknown
+  nonce?: unknown
+}
+
+export function StudentAchievementsTab({
+  embedUrl,
+  isActive,
+}: {
+  embedUrl: string | null
+  isActive: boolean
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const authRequestedRef = useRef(false)
+  const themeRef = useRef<EmbedTheme>('light')
+  const [loadKey, setLoadKey] = useState(0)
+  const [nonce, setNonce] = useState<string | null>(null)
+  const [state, setState] = useState<EmbedState>('loading')
+  const [theme, setTheme] = useState<EmbedTheme>('light')
+  const embedOrigin = useMemo(() => {
+    if (!embedUrl) return null
+    try {
+      return new URL(embedUrl).origin
+    } catch {
+      return null
+    }
+  }, [embedUrl])
+  const iframeUrl = useMemo(() => {
+    if (!embedUrl || !nonce) return null
+    try {
+      const url = new URL(embedUrl)
+      url.hash = `pika_nonce=${encodeURIComponent(nonce)}`
+      return url.toString()
+    } catch {
+      return null
+    }
+  }, [embedUrl, nonce])
+
+  useEffect(() => {
+    const root = document.documentElement
+    const updateTheme = () => {
+      const nextTheme = root.classList.contains('dark') ? 'dark' : 'light'
+      themeRef.current = nextTheme
+      setTheme(nextTheme)
+    }
+    updateTheme()
+
+    const observer = new MutationObserver(updateTheme)
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!isActive || !embedOrigin) return
+    authRequestedRef.current = false
+    setNonce(crypto.randomUUID())
+    setState('loading')
+  }, [embedOrigin, isActive, loadKey])
+
+  useEffect(() => {
+    if (!isActive || !embedOrigin || !nonce) return
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => setState('error'), 12_000)
+
+    async function handleMessage(event: MessageEvent<PalEmbedMessage>) {
+      if (
+        event.origin !== embedOrigin
+        || event.source !== iframeRef.current?.contentWindow
+        || event.data?.nonce !== nonce
+      ) {
+        return
+      }
+
+      if (event.data.type === 'pal.embed.authenticated') {
+        window.clearTimeout(timeout)
+        setState('ready')
+        return
+      }
+      if (event.data.type === 'pal.embed.error') {
+        window.clearTimeout(timeout)
+        setState('error')
+        return
+      }
+      if (event.data.type !== 'pal.embed.ready' || authRequestedRef.current) return
+
+      authRequestedRef.current = true
+      setState('authenticating')
+      try {
+        const response = await fetch('/api/student/pal/read-token', {
+          method: 'POST',
+          signal: controller.signal,
+        })
+        if (!response.ok) throw new Error('Pal token request failed')
+        const body = await response.json() as { token?: unknown }
+        if (typeof body.token !== 'string' || !body.token) {
+          throw new Error('Pal token response was invalid')
+        }
+        iframeRef.current?.contentWindow?.postMessage(
+          {
+            type: 'pal.embed.authenticate',
+            nonce,
+            token: body.token,
+            theme: themeRef.current,
+          },
+          embedOrigin,
+        )
+      } catch {
+        if (!controller.signal.aborted) {
+          window.clearTimeout(timeout)
+          setState('error')
+        }
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => {
+      controller.abort()
+      window.clearTimeout(timeout)
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [embedOrigin, isActive, nonce])
+
+  useEffect(() => {
+    if (state !== 'ready' || !embedOrigin || !nonce) return
+    iframeRef.current?.contentWindow?.postMessage(
+      {
+        type: 'pal.embed.appearance',
+        nonce,
+        theme,
+      },
+      embedOrigin,
+    )
+  }, [embedOrigin, nonce, state, theme])
+
+  const retry = useCallback(() => {
+    setLoadKey((current) => current + 1)
+  }, [])
+
+  if (!embedOrigin) {
+    return (
+      <PageState
+        kind="error"
+        title="Achievements are unavailable"
+        description="The Pal roadmap has not been configured for this Pika environment."
+        compact
+      />
+    )
+  }
+
+  return (
+    <div className="relative flex min-h-[28rem] flex-1 overflow-hidden rounded-card border border-border bg-surface">
+      {iframeUrl ? (
+        <iframe
+          key={iframeUrl}
+          ref={iframeRef}
+          src={iframeUrl}
+          title="Pal achievements roadmap"
+          sandbox="allow-scripts allow-same-origin"
+          referrerPolicy="no-referrer"
+          style={{ colorScheme: theme }}
+          className={[
+            'min-h-[28rem] w-full flex-1 border-0 bg-surface transition-opacity',
+            state === 'ready' ? 'opacity-100' : 'pointer-events-none opacity-0',
+          ].join(' ')}
+        />
+      ) : null}
+
+      {state === 'loading' || state === 'authenticating' ? (
+        <PageState
+          kind="loading"
+          title="Loading achievements"
+          description="Connecting securely to Pal."
+          compact
+          className="absolute inset-0 bg-surface"
+        />
+      ) : null}
+      {state === 'error' ? (
+        <PageState
+          kind="error"
+          title="Achievements are temporarily unavailable"
+          description="Your Pika work is safe. Try loading the roadmap again."
+          action={<Button variant="secondary" onClick={retry}>Try again</Button>}
+          compact
+          className="absolute inset-0 bg-surface"
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/classrooms/[classroomId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/page.tsx
@@ -6,6 +6,7 @@ import { listActiveTeacherClassrooms } from '@/lib/server/classroom-order'
 import { hydrateClassroomRecord, hydrateClassroomRecords } from '@/lib/server/classrooms'
 import { ClassroomPageClient } from './ClassroomPageClient'
 import type { Classroom } from '@/types'
+import { getPalEmbedUrl, isPalEnabled } from '@/lib/server/pal-config'
 
 // Force dynamic rendering (no caching) since data is user-specific
 export const dynamic = 'force-dynamic'
@@ -74,6 +75,8 @@ export default async function ClassroomPage({ params, searchParams }: PageProps)
         teacherClassrooms={teacherClassrooms}
         initialTab={tab}
         initialSearchParams={initialSearchParams}
+        palEnabled={false}
+        palEmbedUrl={null}
       />
     )
   }
@@ -118,6 +121,8 @@ export default async function ClassroomPage({ params, searchParams }: PageProps)
       teacherClassrooms={[]} // Students don't need this
       initialTab={tab}
       initialSearchParams={initialSearchParams}
+      palEnabled={isPalEnabled()}
+      palEmbedUrl={getPalEmbedUrl()}
     />
   )
 }

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   PenSquare,
   SquarePercent,
+  Trophy,
   Users,
   type LucideIcon,
 } from 'lucide-react'
@@ -35,6 +36,7 @@ export type ClassroomNavItemId =
   | 'roster'
   | 'settings'
   | 'today'
+  | 'achievements'
 
 type NavItem = {
   id: ClassroomNavItemId
@@ -60,6 +62,7 @@ const teacherItems: NavItem[] = [
 
 const studentItems: NavItem[] = [
   { id: 'today', label: 'Today', icon: PenSquare },
+  { id: 'achievements', label: 'Achievements', icon: Trophy },
   { id: 'assignments', label: 'Classwork', icon: ClipboardList },
   { id: 'tests', label: 'Tests', icon: FileCheck },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
@@ -71,8 +74,11 @@ const studentItems: NavItem[] = [
 // Utilities
 // ============================================================================
 
-function getItems(role: 'student' | 'teacher') {
-  return role === 'teacher' ? teacherItems : studentItems
+function getItems(role: 'student' | 'teacher', palEnabled: boolean) {
+  if (role === 'teacher') return teacherItems
+  return palEnabled
+    ? studentItems
+    : studentItems.filter((item) => item.id !== 'achievements')
 }
 
 function tabHref(classroomId: string, tabId: ClassroomNavItemId) {
@@ -110,6 +116,7 @@ export interface NavItemsProps {
   onTabChange: (tab: ClassroomNavItemId) => void
   onTabIntent?: (tab: ClassroomNavItemId) => void
   updateSearchParams: (updater: (params: URLSearchParams) => void, options?: { replace?: boolean }) => void
+  palEnabled?: boolean
 }
 
 export function NavItems({
@@ -119,6 +126,7 @@ export function NavItems({
   onTabChange,
   onTabIntent = () => {},
   updateSearchParams,
+  palEnabled = false,
 }: NavItemsProps) {
   const { isExpanded } = useLeftSidebar()
   const { isLeftOpen, close: closeMobileDrawer } = useMobileDrawer()
@@ -141,7 +149,7 @@ export function NavItems({
     !notifications?.loading &&
     (notifications?.unreadAnnouncementsCount ?? 0) > 0
 
-  const items = useMemo(() => getItems(role), [role])
+  const items = useMemo(() => getItems(role, palEnabled), [palEnabled, role])
   const handleTabIntent = useCallback((tab: ClassroomNavItemId) => {
     onTabIntent(tab)
   }, [onTabIntent])

--- a/src/lib/attendance.ts
+++ b/src/lib/attendance.ts
@@ -3,8 +3,14 @@ import type { AttendanceStatus, ClassDay, Entry, AttendanceRecord } from '@/type
 /**
  * Checks if an entry has actual content (non-whitespace text)
  */
+export function hasQualifyingDailyLogContent(
+  text: string | null | undefined,
+): boolean {
+  return (text || '').trim().length > 0
+}
+
 export function entryHasContent(entry: Entry): boolean {
-  return (entry.text || '').trim().length > 0
+  return hasQualifyingDailyLogContent(entry.text)
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,8 @@
 import { getIronSession, IronSession } from 'iron-session'
 import { cookies } from 'next/headers'
+import { randomUUID } from 'node:crypto'
 import type { SessionData, UserRole } from '@/types'
+import { recordPalAuthenticatedSession } from '@/lib/server/pal-signals'
 
 /**
  * Custom error class for authentication failures (401)
@@ -54,12 +56,20 @@ export async function getSession(): Promise<IronSession<SessionData>> {
  */
 export async function createSession(userId: string, email: string, role: UserRole) {
   const session = await getSession()
+  const sessionId = randomUUID()
   session.user = {
     id: userId,
     email,
     role,
   }
   await session.save()
+
+  if (role === 'student') {
+    await recordPalAuthenticatedSession({
+      studentId: userId,
+      sessionId,
+    })
+  }
 }
 
 /**

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -54,6 +54,7 @@ export type RouteKey =
   | 'resources-student'
   | 'announcements-teacher'
   | 'announcements-student'
+  | 'achievements-student'
 
 // ============================================================================
 // Constants
@@ -152,6 +153,10 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
     mainContent: { maxWidth: 'full' },
   },
+  'achievements-student': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'full' },
+  },
 }
 
 // ============================================================================
@@ -219,6 +224,7 @@ export function getRouteKeyFromTab(
   if (tab === 'roster') return 'roster'
   if (tab === 'gradebook') return 'gradebook'
   if (tab === 'today') return 'today'
+  if (tab === 'achievements' && role === 'student') return 'achievements-student'
 
   if (tab === 'calendar') {
     return role === 'teacher' ? 'calendar-teacher' : 'calendar-student'

--- a/src/lib/server/assignment-doc-submissions.ts
+++ b/src/lib/server/assignment-doc-submissions.ts
@@ -3,6 +3,7 @@ import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import { countCharacters, countWords } from '@/lib/tiptap-content'
 import { assignmentSubmissionContentSchema } from '@/lib/validations/assignment-doc-submissions'
 import type { AssignmentDoc, AssignmentDocHistoryEntry, TiptapContent } from '@/types'
+import type { v1 } from '@/vendor/pal-contract'
 
 type SupabaseLike = any
 
@@ -224,15 +225,23 @@ export async function submitAssignmentDocAtomic(input: {
   studentId: string
   content: TiptapContent
   expectedUpdatedAt: string
+  palEvent?: v1.LearningItemCompletedEvent | null
 }): Promise<AssignmentDocMutationResult> {
-  const { data, error } = await input.supabase.rpc('submit_assignment_doc_atomic', {
-    p_assignment_id: input.assignmentId,
-    p_student_id: input.studentId,
-    p_content: input.content,
-    p_expected_updated_at: input.expectedUpdatedAt,
-    p_word_count: countWords(input.content),
-    p_char_count: countCharacters(input.content),
-  })
+  const usePalOutbox = input.palEvent !== undefined
+  const { data, error } = await input.supabase.rpc(
+    usePalOutbox
+      ? 'submit_assignment_doc_with_pal_event_atomic'
+      : 'submit_assignment_doc_atomic',
+    {
+      p_assignment_id: input.assignmentId,
+      p_student_id: input.studentId,
+      p_content: input.content,
+      p_expected_updated_at: input.expectedUpdatedAt,
+      p_word_count: countWords(input.content),
+      p_char_count: countCharacters(input.content),
+      ...(usePalOutbox ? { p_pal_event: input.palEvent } : {}),
+    },
+  )
 
   if (error) return mapRpcError(error, 'submit')
 

--- a/src/lib/server/pal-config.ts
+++ b/src/lib/server/pal-config.ts
@@ -1,5 +1,53 @@
-export function isPalEnabled(): boolean {
+function isPalFlagEnabled(): boolean {
   return process.env.PAL_ENABLED?.trim().toLowerCase() === 'true'
+}
+
+export function isPalEnabled(): boolean {
+  if (!isPalFlagEnabled()) return false
+  requirePalEnvironment()
+  return true
+}
+
+export function requirePalPseudonymSecret(): string {
+  const secret = process.env.PAL_PSEUDONYM_SECRET?.trim()
+  if (!secret) {
+    throw new Error('PAL_PSEUDONYM_SECRET is not configured')
+  }
+  return secret
+}
+
+function parsePalOrigin(rawUrl: string): string {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new Error('PAL_API_URL must be an absolute URL')
+  }
+
+  if (
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error('PAL_API_URL must contain only an origin')
+  }
+
+  if (url.protocol === 'https:') return url.origin
+
+  const loopbackHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+  if (
+    url.protocol === 'http:' &&
+    process.env.NODE_ENV !== 'production' &&
+    loopbackHosts.has(url.hostname)
+  ) {
+    return url.origin
+  }
+
+  throw new Error(
+    'PAL_API_URL must use HTTPS (HTTP is allowed only for loopback development)',
+  )
 }
 
 export function requirePalEnvironment(): {
@@ -16,18 +64,9 @@ export function requirePalEnvironment(): {
       'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
     )
   }
-  let parsedApiUrl: URL
-  try {
-    parsedApiUrl = new URL(apiUrl)
-  } catch {
-    throw new Error('PAL_API_URL must be a valid http or https URL')
-  }
-  if (parsedApiUrl.protocol !== 'https:' && parsedApiUrl.protocol !== 'http:') {
-    throw new Error('PAL_API_URL must be a valid http or https URL')
-  }
 
   return {
-    apiUrl: parsedApiUrl.toString().replace(/\/+$/, ''),
+    apiUrl: parsePalOrigin(apiUrl),
     integrationSecret,
     pseudonymSecret,
   }
@@ -36,16 +75,6 @@ export function requirePalEnvironment(): {
 export function getPalEmbedUrl(): string | null {
   if (!isPalEnabled()) return null
 
-  const apiUrl = process.env.PAL_API_URL?.trim()
-  if (!apiUrl) return null
-
-  try {
-    const parsedApiUrl = new URL(apiUrl)
-    if (parsedApiUrl.protocol !== 'https:' && parsedApiUrl.protocol !== 'http:') {
-      return null
-    }
-    return new URL('/embed/roadmap', parsedApiUrl).toString()
-  } catch {
-    return null
-  }
+  const { apiUrl } = requirePalEnvironment()
+  return new URL('/embed/roadmap', apiUrl).toString()
 }

--- a/src/lib/server/pal-config.ts
+++ b/src/lib/server/pal-config.ts
@@ -1,0 +1,51 @@
+export function isPalEnabled(): boolean {
+  return process.env.PAL_ENABLED?.trim().toLowerCase() === 'true'
+}
+
+export function requirePalEnvironment(): {
+  apiUrl: string
+  integrationSecret: string
+  pseudonymSecret: string
+} {
+  const apiUrl = process.env.PAL_API_URL?.trim()
+  const integrationSecret = process.env.PAL_INTEGRATION_SECRET?.trim()
+  const pseudonymSecret = process.env.PAL_PSEUDONYM_SECRET?.trim()
+
+  if (!apiUrl || !integrationSecret || !pseudonymSecret) {
+    throw new Error(
+      'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
+    )
+  }
+  let parsedApiUrl: URL
+  try {
+    parsedApiUrl = new URL(apiUrl)
+  } catch {
+    throw new Error('PAL_API_URL must be a valid http or https URL')
+  }
+  if (parsedApiUrl.protocol !== 'https:' && parsedApiUrl.protocol !== 'http:') {
+    throw new Error('PAL_API_URL must be a valid http or https URL')
+  }
+
+  return {
+    apiUrl: parsedApiUrl.toString().replace(/\/+$/, ''),
+    integrationSecret,
+    pseudonymSecret,
+  }
+}
+
+export function getPalEmbedUrl(): string | null {
+  if (!isPalEnabled()) return null
+
+  const apiUrl = process.env.PAL_API_URL?.trim()
+  if (!apiUrl) return null
+
+  try {
+    const parsedApiUrl = new URL(apiUrl)
+    if (parsedApiUrl.protocol !== 'https:' && parsedApiUrl.protocol !== 'http:') {
+      return null
+    }
+    return new URL('/embed/roadmap', parsedApiUrl).toString()
+  } catch {
+    return null
+  }
+}

--- a/src/lib/server/pal-config.ts
+++ b/src/lib/server/pal-config.ts
@@ -13,6 +13,9 @@ export function requirePalPseudonymSecret(): string {
   if (!secret) {
     throw new Error('PAL_PSEUDONYM_SECRET is not configured')
   }
+  if (secret.length < 32) {
+    throw new Error('PAL_PSEUDONYM_SECRET must be at least 32 characters')
+  }
   return secret
 }
 
@@ -62,6 +65,16 @@ export function requirePalEnvironment(): {
   if (!apiUrl || !integrationSecret || !pseudonymSecret) {
     throw new Error(
       'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
+    )
+  }
+  if (integrationSecret.length < 32 || pseudonymSecret.length < 32) {
+    throw new Error(
+      'PAL_INTEGRATION_SECRET and PAL_PSEUDONYM_SECRET must each be at least 32 characters',
+    )
+  }
+  if (integrationSecret === pseudonymSecret) {
+    throw new Error(
+      'PAL_INTEGRATION_SECRET and PAL_PSEUDONYM_SECRET must be distinct',
     )
   }
 

--- a/src/lib/server/pal-events.ts
+++ b/src/lib/server/pal-events.ts
@@ -1,0 +1,220 @@
+import { createHmac } from 'node:crypto'
+
+import { formatDateInToronto } from '@/lib/timezone'
+import { requirePalEnvironment } from '@/lib/server/pal-config'
+import { v1 } from '@/vendor/pal-contract'
+
+type PalTokenKind = 'learner' | 'classroom' | 'item' | 'session' | 'fact'
+
+function requiredSecret(explicitSecret?: string): string {
+  const secret = explicitSecret?.trim() || requirePalEnvironment().pseudonymSecret
+  if (!secret) {
+    throw new Error('PAL_PSEUDONYM_SECRET is not configured')
+  }
+  return secret
+}
+
+export function pseudonymizePalRef(
+  kind: PalTokenKind,
+  rawValue: string,
+  explicitSecret?: string,
+): string {
+  if (!rawValue) {
+    throw new Error(`Cannot pseudonymize an empty Pal ${kind} reference`)
+  }
+
+  const digest = createHmac('sha256', requiredSecret(explicitSecret))
+    .update(`pal-v1:${kind}:${rawValue}`)
+    .digest('base64url')
+
+  return `pika-${kind}-${digest}`
+}
+
+function mondayForCalendarDay(activityDay: string): string {
+  const date = new Date(`${activityDay}T00:00:00Z`)
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== activityDay) {
+    throw new Error('Pal activity day must be a real YYYY-MM-DD calendar date')
+  }
+
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7
+  date.setUTCDate(date.getUTCDate() - daysSinceMonday)
+  return date.toISOString().slice(0, 10)
+}
+
+export function palPeriodKeyForActivityDay(activityDay: string): string {
+  return `pika-week-${mondayForCalendarDay(activityDay)}`
+}
+
+export function palPeriodKeyForInstant(occurredAt: Date): string {
+  return palPeriodKeyForActivityDay(formatDateInToronto(occurredAt))
+}
+
+function factIdempotencyKey(
+  factIdentity: string,
+  explicitSecret?: string,
+): string {
+  return `pika:v1:${pseudonymizePalRef('fact', factIdentity, explicitSecret)}`
+}
+
+function validateBuiltEvent<T extends v1.V1EventType>(
+  event: v1.V1Envelope<T>,
+): v1.V1Envelope<T> {
+  const result = v1.validateV1Event(event)
+  if (!result.ok) {
+    throw new Error(`Pika built an invalid Pal event: ${result.error}: ${result.detail}`)
+  }
+  return event
+}
+
+type CommonEventInput = {
+  learnerId: string
+  occurredAt: Date
+  pseudonymSecret?: string
+}
+
+export function buildSessionStartedEvent(
+  input: CommonEventInput & { sessionId: string },
+): v1.SessionStartedEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `platform.session.started:${input.learnerId}:${input.sessionId}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'platform.session.started',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {},
+  })
+}
+
+export function buildClassroomJoinedEvent(
+  input: CommonEventInput & { classroomId: string },
+): v1.ClassroomJoinedEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `classroom.joined:${input.learnerId}:${input.classroomId}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'classroom.joined',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {
+      classroom_token: pseudonymizePalRef('classroom', input.classroomId, secret),
+    },
+  })
+}
+
+export function buildDailyLogWeekConfiguredEvent(
+  input: CommonEventInput & {
+    periodKey: string
+    configVersion: number
+    periodStatus: 'open' | 'closed'
+    eligibleDays: number
+  },
+): v1.DailyLogWeekConfiguredEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `daily_log_week.configured:${input.learnerId}:${input.periodKey}:${input.configVersion}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'daily_log_week.configured',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {
+      period_key: input.periodKey,
+      config_version: input.configVersion,
+      period_status: input.periodStatus,
+      eligible_days: input.eligibleDays,
+    },
+  })
+}
+
+export function buildDailyLogCompletedEvent(
+  input: CommonEventInput & { activityDay: string },
+): v1.DailyLogCompletedEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `daily_log.completed:${input.learnerId}:${input.activityDay}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'daily_log.completed',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {
+      period_key: palPeriodKeyForActivityDay(input.activityDay),
+      activity_day: input.activityDay,
+    },
+  })
+}
+
+export function buildLearningItemViewedEvent(
+  input: CommonEventInput & {
+    itemId: string
+    releasedAt: string
+  },
+): v1.LearningItemViewedEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  const releasedAt = new Date(input.releasedAt)
+  if (Number.isNaN(releasedAt.getTime())) {
+    throw new Error('Cannot classify a Pal item view without a valid release timestamp')
+  }
+
+  const timing = input.occurredAt.getTime() <= releasedAt.getTime() + 24 * 60 * 60 * 1000
+    ? 'within_24h_of_release'
+    : 'later'
+
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `learning_item.viewed:${input.learnerId}:${input.itemId}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'learning_item.viewed',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {
+      item_token: pseudonymizePalRef('item', input.itemId, secret),
+      kind: 'assignment',
+      period_key: palPeriodKeyForInstant(input.occurredAt),
+      timing,
+    },
+  })
+}
+
+export function buildLearningItemCompletedEvent(
+  input: CommonEventInput & {
+    itemId: string
+    dueAt: string
+  },
+): v1.LearningItemCompletedEvent {
+  const secret = requiredSecret(input.pseudonymSecret)
+  const dueAt = new Date(input.dueAt)
+  if (Number.isNaN(dueAt.getTime())) {
+    throw new Error('Cannot classify a Pal item completion without a valid due timestamp')
+  }
+
+  return validateBuiltEvent({
+    schema_version: 1,
+    idempotency_key: factIdempotencyKey(
+      `learning_item.completed:${input.learnerId}:${input.itemId}`,
+      secret,
+    ),
+    learner_id: pseudonymizePalRef('learner', input.learnerId, secret),
+    event_type: 'learning_item.completed',
+    occurred_at: input.occurredAt.toISOString(),
+    metadata: {
+      item_token: pseudonymizePalRef('item', input.itemId, secret),
+      kind: 'assignment',
+      period_key: palPeriodKeyForInstant(input.occurredAt),
+      timing: input.occurredAt.getTime() <= dueAt.getTime() ? 'on_time' : 'late',
+    },
+  })
+}

--- a/src/lib/server/pal-events.ts
+++ b/src/lib/server/pal-events.ts
@@ -8,8 +8,8 @@ type PalTokenKind = 'learner' | 'classroom' | 'item' | 'session' | 'fact'
 
 function requiredSecret(explicitSecret?: string): string {
   const secret = explicitSecret?.trim() || requirePalPseudonymSecret()
-  if (!secret) {
-    throw new Error('PAL_PSEUDONYM_SECRET is not configured')
+  if (secret.length < 32) {
+    throw new Error('PAL_PSEUDONYM_SECRET must be at least 32 characters')
   }
   return secret
 }

--- a/src/lib/server/pal-events.ts
+++ b/src/lib/server/pal-events.ts
@@ -1,13 +1,13 @@
 import { createHmac } from 'node:crypto'
 
 import { formatDateInToronto } from '@/lib/timezone'
-import { requirePalEnvironment } from '@/lib/server/pal-config'
+import { requirePalPseudonymSecret } from '@/lib/server/pal-config'
 import { v1 } from '@/vendor/pal-contract'
 
 type PalTokenKind = 'learner' | 'classroom' | 'item' | 'session' | 'fact'
 
 function requiredSecret(explicitSecret?: string): string {
-  const secret = explicitSecret?.trim() || requirePalEnvironment().pseudonymSecret
+  const secret = explicitSecret?.trim() || requirePalPseudonymSecret()
   if (!secret) {
     throw new Error('PAL_PSEUDONYM_SECRET is not configured')
   }
@@ -192,12 +192,12 @@ export function buildLearningItemViewedEvent(
 export function buildLearningItemCompletedEvent(
   input: CommonEventInput & {
     itemId: string
-    dueAt: string
+    dueAt: string | null
   },
 ): v1.LearningItemCompletedEvent {
   const secret = requiredSecret(input.pseudonymSecret)
-  const dueAt = new Date(input.dueAt)
-  if (Number.isNaN(dueAt.getTime())) {
+  const dueAt = input.dueAt === null ? null : new Date(input.dueAt)
+  if (dueAt && Number.isNaN(dueAt.getTime())) {
     throw new Error('Cannot classify a Pal item completion without a valid due timestamp')
   }
 
@@ -214,7 +214,10 @@ export function buildLearningItemCompletedEvent(
       item_token: pseudonymizePalRef('item', input.itemId, secret),
       kind: 'assignment',
       period_key: palPeriodKeyForInstant(input.occurredAt),
-      timing: input.occurredAt.getTime() <= dueAt.getTime() ? 'on_time' : 'late',
+      // An assignment without a deadline cannot be late.
+      timing: dueAt === null || input.occurredAt.getTime() <= dueAt.getTime()
+        ? 'on_time'
+        : 'late',
     },
   })
 }

--- a/src/lib/server/pal-operations.ts
+++ b/src/lib/server/pal-operations.ts
@@ -1,12 +1,12 @@
 import { getServiceRoleClient } from '@/lib/supabase'
 import { isPalEnabled } from '@/lib/server/pal-config'
 
-type SupabaseLike = any
+type PalOperationsClient = ReturnType<typeof getServiceRoleClient>
 
 const STATUSES = ['pending', 'processing', 'delivered', 'non_retryable'] as const
 
 export async function loadPalOutboxStatus(input: {
-  supabase?: SupabaseLike
+  supabase?: PalOperationsClient
 } = {}) {
   const supabase = input.supabase ?? getServiceRoleClient()
   const counts: Record<(typeof STATUSES)[number], number> = {
@@ -48,7 +48,7 @@ export async function loadPalOutboxStatus(input: {
 
 export async function requeuePalOutboxEvent(input: {
   outboxId: string
-  supabase?: SupabaseLike
+  supabase?: PalOperationsClient
 }): Promise<boolean> {
   const supabase = input.supabase ?? getServiceRoleClient()
   const { data, error } = await supabase.rpc('requeue_pal_event_outbox', {

--- a/src/lib/server/pal-operations.ts
+++ b/src/lib/server/pal-operations.ts
@@ -1,0 +1,61 @@
+import { getServiceRoleClient } from '@/lib/supabase'
+import { isPalEnabled } from '@/lib/server/pal-config'
+
+type SupabaseLike = any
+
+const STATUSES = ['pending', 'processing', 'delivered', 'non_retryable'] as const
+
+export async function loadPalOutboxStatus(input: {
+  supabase?: SupabaseLike
+} = {}) {
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const counts: Record<(typeof STATUSES)[number], number> = {
+    pending: 0,
+    processing: 0,
+    delivered: 0,
+    non_retryable: 0,
+  }
+
+  for (const status of STATUSES) {
+    const { count, error } = await supabase
+      .from('pal_event_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', status)
+    if (error) {
+      throw new Error(`Failed to load Pal outbox ${status} count: ${error.message}`)
+    }
+    counts[status] = count ?? 0
+  }
+
+  const { data, error } = await supabase
+    .from('pal_event_outbox')
+    .select(
+      'id, event_type, status, attempts, next_attempt_at, last_attempt_at, last_error_code, last_error_detail, created_at, updated_at',
+    )
+    .in('status', ['pending', 'processing', 'non_retryable'])
+    .order('created_at', { ascending: true })
+    .limit(25)
+  if (error) {
+    throw new Error(`Failed to load Pal outbox exceptions: ${error.message}`)
+  }
+
+  return {
+    enabled: isPalEnabled(),
+    counts,
+    exceptions: data ?? [],
+  }
+}
+
+export async function requeuePalOutboxEvent(input: {
+  outboxId: string
+  supabase?: SupabaseLike
+}): Promise<boolean> {
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await supabase.rpc('requeue_pal_event_outbox', {
+    p_outbox_id: input.outboxId,
+  })
+  if (error) {
+    throw new Error(`Failed to requeue Pal outbox event: ${error.message}`)
+  }
+  return data === true
+}

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod'
+
+import { getServiceRoleClient } from '@/lib/supabase'
+import { isPalEnabled, requirePalEnvironment } from '@/lib/server/pal-config'
+import { v1 } from '@/vendor/pal-contract'
+
+type SupabaseLike = any
+
+const claimedOutboxRowSchema = z.object({
+  id: z.string().uuid(),
+  payload: z.unknown(),
+  attempts: z.number().int().positive(),
+  lease_token: z.string().uuid(),
+}).passthrough()
+
+export type PalOutboxDeliverySummary = {
+  status: 'disabled' | 'ok'
+  claimed: number
+  delivered: number
+  retrying: number
+  nonRetryable: number
+}
+
+function retryDelayMs(attempts: number): number {
+  return Math.min(30_000 * 2 ** Math.max(0, attempts - 1), 6 * 60 * 60 * 1000)
+}
+
+function retryAt(attempts: number, now: Date): string {
+  return new Date(now.getTime() + retryDelayMs(attempts)).toISOString()
+}
+
+async function transition(
+  supabase: SupabaseLike,
+  functionName:
+    | 'complete_pal_event_outbox'
+    | 'retry_pal_event_outbox'
+    | 'fail_pal_event_outbox',
+  args: Record<string, unknown>,
+): Promise<void> {
+  const { data, error } = await supabase.rpc(functionName, args)
+  if (error) {
+    throw new Error(`Failed to transition Pal outbox row: ${error.message ?? 'unknown error'}`)
+  }
+  if (data !== true) {
+    throw new Error('Pal outbox lease was lost before delivery state could be recorded')
+  }
+}
+
+async function markRetry(
+  supabase: SupabaseLike,
+  row: z.infer<typeof claimedOutboxRowSchema>,
+  now: Date,
+  errorCode: string,
+  errorDetail: string,
+): Promise<void> {
+  await transition(supabase, 'retry_pal_event_outbox', {
+    p_outbox_id: row.id,
+    p_lease_token: row.lease_token,
+    p_next_attempt_at: retryAt(row.attempts, now),
+    p_error_code: errorCode,
+    p_error_detail: errorDetail,
+  })
+}
+
+async function markNonRetryable(
+  supabase: SupabaseLike,
+  row: z.infer<typeof claimedOutboxRowSchema>,
+  errorCode: string,
+  errorDetail: string,
+): Promise<void> {
+  await transition(supabase, 'fail_pal_event_outbox', {
+    p_outbox_id: row.id,
+    p_lease_token: row.lease_token,
+    p_error_code: errorCode,
+    p_error_detail: errorDetail,
+  })
+}
+
+export async function enqueueStandalonePalEvent(input: {
+  studentId: string
+  sourceKind: string
+  sourceId: string
+  event: v1.V1Envelope
+  supabase?: SupabaseLike
+}): Promise<'disabled' | 'enqueued'> {
+  if (!isPalEnabled()) return 'disabled'
+
+  const validation = v1.validateV1Event(input.event)
+  if (!validation.ok) {
+    throw new Error(`Cannot enqueue invalid Pal event: ${validation.error}`)
+  }
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { error } = await supabase.rpc('enqueue_pal_event', {
+    p_student_id: input.studentId,
+    p_source_kind: input.sourceKind,
+    p_source_id: input.sourceId,
+    p_event: input.event,
+  })
+
+  if (error) {
+    if (error.code === '42883' || error.code === 'PGRST202') {
+      throw new Error('Pal outbox migration is required')
+    }
+    throw new Error(`Failed to enqueue Pal event: ${error.message ?? 'unknown error'}`)
+  }
+
+  return 'enqueued'
+}
+
+export async function deliverPalOutboxBatch(input: {
+  supabase?: SupabaseLike
+  fetchImpl?: typeof fetch
+  now?: Date
+  limit?: number
+} = {}): Promise<PalOutboxDeliverySummary> {
+  if (!isPalEnabled()) {
+    return {
+      status: 'disabled',
+      claimed: 0,
+      delivered: 0,
+      retrying: 0,
+      nonRetryable: 0,
+    }
+  }
+
+  const { apiUrl, integrationSecret } = requirePalEnvironment()
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const fetchImpl = input.fetchImpl ?? fetch
+  const now = input.now ?? new Date()
+  const { data, error } = await supabase.rpc('claim_pal_event_outbox', {
+    p_limit: input.limit ?? 10,
+    p_lease_seconds: 60,
+  })
+
+  if (error) {
+    if (error.code === '42883' || error.code === 'PGRST202') {
+      throw new Error('Pal outbox migration is required')
+    }
+    throw new Error(`Failed to claim Pal outbox rows: ${error.message ?? 'unknown error'}`)
+  }
+
+  const rows = z.array(claimedOutboxRowSchema).parse(data ?? [])
+  const summary: PalOutboxDeliverySummary = {
+    status: 'ok',
+    claimed: rows.length,
+    delivered: 0,
+    retrying: 0,
+    nonRetryable: 0,
+  }
+
+  for (const row of rows) {
+    const validation = v1.validateV1Event(row.payload)
+    if (!validation.ok) {
+      await markNonRetryable(
+        supabase,
+        row,
+        validation.error,
+        'Pika outbox payload failed the pinned Pal v1 validator',
+      )
+      summary.nonRetryable += 1
+      continue
+    }
+
+    let response: Response
+    try {
+      response = await fetchImpl(`${apiUrl}/api/v1/events`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${integrationSecret}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(validation.event),
+        signal: AbortSignal.timeout(3_000),
+      })
+    } catch {
+      await markRetry(
+        supabase,
+        row,
+        now,
+        'network_error',
+        'Pal delivery failed before an HTTP response was received',
+      )
+      summary.retrying += 1
+      continue
+    }
+
+    if (response.ok) {
+      await transition(supabase, 'complete_pal_event_outbox', {
+        p_outbox_id: row.id,
+        p_lease_token: row.lease_token,
+      })
+      summary.delivered += 1
+      continue
+    }
+
+    const errorCode = `http_${response.status}`
+    const errorDetail = `Pal returned HTTP ${response.status}`
+    if (response.status === 408 || response.status === 429 || response.status >= 500) {
+      await markRetry(supabase, row, now, errorCode, errorDetail)
+      summary.retrying += 1
+    } else {
+      await markNonRetryable(supabase, row, errorCode, errorDetail)
+      summary.nonRetryable += 1
+    }
+  }
+
+  return summary
+}

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -4,7 +4,10 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { isPalEnabled, requirePalEnvironment } from '@/lib/server/pal-config'
 import { v1 } from '@/vendor/pal-contract'
 
-type SupabaseLike = any
+export type PalOutboxClient = Pick<
+  ReturnType<typeof getServiceRoleClient>,
+  'rpc'
+>
 
 const claimedOutboxRowSchema = z.object({
   id: z.string().uuid(),
@@ -35,15 +38,51 @@ function retryAt(attempts: number, now: Date): string {
   return new Date(now.getTime() + retryDelayMs(attempts)).toISOString()
 }
 
+type PalOutboxTransition =
+  | {
+    functionName: 'complete_pal_event_outbox'
+    args: {
+      p_outbox_id: string
+      p_lease_token: string
+    }
+  }
+  | {
+    functionName: 'retry_pal_event_outbox'
+    args: {
+      p_outbox_id: string
+      p_lease_token: string
+      p_next_attempt_at: string
+      p_error_code: string
+      p_error_detail: string
+    }
+  }
+  | {
+    functionName: 'fail_pal_event_outbox'
+    args: {
+      p_outbox_id: string
+      p_lease_token: string
+      p_error_code: string
+      p_error_detail: string
+    }
+  }
+
 async function transition(
-  supabase: SupabaseLike,
-  functionName:
-    | 'complete_pal_event_outbox'
-    | 'retry_pal_event_outbox'
-    | 'fail_pal_event_outbox',
-  args: Record<string, unknown>,
+  supabase: PalOutboxClient,
+  transition: PalOutboxTransition,
 ): Promise<void> {
-  const { data, error } = await supabase.rpc(functionName, args)
+  let result: { data: boolean | null; error: { message?: string } | null }
+  switch (transition.functionName) {
+    case 'complete_pal_event_outbox':
+      result = await supabase.rpc(transition.functionName, transition.args)
+      break
+    case 'retry_pal_event_outbox':
+      result = await supabase.rpc(transition.functionName, transition.args)
+      break
+    case 'fail_pal_event_outbox':
+      result = await supabase.rpc(transition.functionName, transition.args)
+      break
+  }
+  const { data, error } = result
   if (error) {
     throw new Error(`Failed to transition Pal outbox row: ${error.message ?? 'unknown error'}`)
   }
@@ -53,32 +92,38 @@ async function transition(
 }
 
 async function markRetry(
-  supabase: SupabaseLike,
+  supabase: PalOutboxClient,
   row: z.infer<typeof claimedOutboxRowSchema>,
   now: Date,
   errorCode: string,
   errorDetail: string,
 ): Promise<void> {
-  await transition(supabase, 'retry_pal_event_outbox', {
-    p_outbox_id: row.id,
-    p_lease_token: row.lease_token,
-    p_next_attempt_at: retryAt(row.attempts, now),
-    p_error_code: errorCode,
-    p_error_detail: errorDetail,
+  await transition(supabase, {
+    functionName: 'retry_pal_event_outbox',
+    args: {
+      p_outbox_id: row.id,
+      p_lease_token: row.lease_token,
+      p_next_attempt_at: retryAt(row.attempts, now),
+      p_error_code: errorCode,
+      p_error_detail: errorDetail,
+    },
   })
 }
 
 async function markNonRetryable(
-  supabase: SupabaseLike,
+  supabase: PalOutboxClient,
   row: z.infer<typeof claimedOutboxRowSchema>,
   errorCode: string,
   errorDetail: string,
 ): Promise<void> {
-  await transition(supabase, 'fail_pal_event_outbox', {
-    p_outbox_id: row.id,
-    p_lease_token: row.lease_token,
-    p_error_code: errorCode,
-    p_error_detail: errorDetail,
+  await transition(supabase, {
+    functionName: 'fail_pal_event_outbox',
+    args: {
+      p_outbox_id: row.id,
+      p_lease_token: row.lease_token,
+      p_error_code: errorCode,
+      p_error_detail: errorDetail,
+    },
   })
 }
 
@@ -87,7 +132,7 @@ export async function enqueueStandalonePalEvent(input: {
   sourceKind: string
   sourceId: string
   event: v1.V1Envelope
-  supabase?: SupabaseLike
+  supabase?: PalOutboxClient
 }): Promise<'disabled' | 'enqueued'> {
   if (!isPalEnabled()) return 'disabled'
 
@@ -115,7 +160,7 @@ export async function enqueueStandalonePalEvent(input: {
 }
 
 export async function deliverPalOutboxBatch(input: {
-  supabase?: SupabaseLike
+  supabase?: PalOutboxClient
   fetchImpl?: typeof fetch
   now?: Date
   limit?: number
@@ -192,9 +237,12 @@ export async function deliverPalOutboxBatch(input: {
     }
 
     if (response.ok) {
-      await transition(supabase, 'complete_pal_event_outbox', {
-        p_outbox_id: row.id,
-        p_lease_token: row.lease_token,
+      await transition(supabase, {
+        functionName: 'complete_pal_event_outbox',
+        args: {
+          p_outbox_id: row.id,
+          p_lease_token: row.lease_token,
+        },
       })
       summary.delivered += 1
       continue
@@ -215,7 +263,7 @@ export async function deliverPalOutboxBatch(input: {
 }
 
 export async function drainPalOutbox(input: {
-  supabase?: SupabaseLike
+  supabase?: PalOutboxClient
   fetchImpl?: typeof fetch
   now?: Date
   batchSize?: number

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -164,6 +164,9 @@ export async function deliverPalOutboxBatch(input: {
   fetchImpl?: typeof fetch
   now?: Date
   limit?: number
+  concurrency?: number
+  deadlineAtMs?: number
+  clock?: () => number
 } = {}): Promise<PalOutboxDeliverySummary> {
   if (!isPalEnabled()) {
     return {
@@ -179,6 +182,7 @@ export async function deliverPalOutboxBatch(input: {
   const supabase = input.supabase ?? getServiceRoleClient()
   const fetchImpl = input.fetchImpl ?? fetch
   const now = input.now ?? new Date()
+  const clock = input.clock ?? Date.now
   const { data, error } = await supabase.rpc('claim_pal_event_outbox', {
     p_limit: input.limit ?? 10,
     p_lease_seconds: 60,
@@ -200,7 +204,13 @@ export async function deliverPalOutboxBatch(input: {
     nonRetryable: 0,
   }
 
-  for (const row of rows) {
+  let nextRow = 0
+  const deliverNext = async (): Promise<void> => {
+    const rowIndex = nextRow
+    nextRow += 1
+    if (rowIndex >= rows.length) return
+    const row = rows[rowIndex]
+
     const validation = v1.validateV1Event(row.payload)
     if (!validation.ok) {
       await markNonRetryable(
@@ -210,7 +220,22 @@ export async function deliverPalOutboxBatch(input: {
         'Pika outbox payload failed the pinned Pal v1 validator',
       )
       summary.nonRetryable += 1
-      continue
+      return deliverNext()
+    }
+
+    const remainingMs = input.deadlineAtMs === undefined
+      ? 3_000
+      : input.deadlineAtMs - clock()
+    if (remainingMs <= 0) {
+      await markRetry(
+        supabase,
+        row,
+        now,
+        'worker_deadline',
+        'Pal delivery worker reached its bounded execution deadline',
+      )
+      summary.retrying += 1
+      return deliverNext()
     }
 
     let response: Response
@@ -222,7 +247,7 @@ export async function deliverPalOutboxBatch(input: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(validation.event),
-        signal: AbortSignal.timeout(3_000),
+        signal: AbortSignal.timeout(Math.max(1, Math.min(3_000, remainingMs))),
       })
     } catch {
       await markRetry(
@@ -233,7 +258,7 @@ export async function deliverPalOutboxBatch(input: {
         'Pal delivery failed before an HTTP response was received',
       )
       summary.retrying += 1
-      continue
+      return deliverNext()
     }
 
     if (response.ok) {
@@ -245,7 +270,7 @@ export async function deliverPalOutboxBatch(input: {
         },
       })
       summary.delivered += 1
-      continue
+      return deliverNext()
     }
 
     const errorCode = `http_${response.status}`
@@ -257,7 +282,14 @@ export async function deliverPalOutboxBatch(input: {
       await markNonRetryable(supabase, row, errorCode, errorDetail)
       summary.nonRetryable += 1
     }
+    return deliverNext()
   }
+
+  const concurrency = Math.max(
+    1,
+    Math.min(input.concurrency ?? 10, rows.length || 1),
+  )
+  await Promise.all(Array.from({ length: concurrency }, () => deliverNext()))
 
   return summary
 }
@@ -271,11 +303,12 @@ export async function drainPalOutbox(input: {
   maxDurationMs?: number
   clock?: () => number
 } = {}): Promise<PalOutboxDrainSummary> {
-  const batchSize = input.batchSize ?? 50
+  const batchSize = input.batchSize ?? 20
   const maxBatches = input.maxBatches ?? 10
   const maxDurationMs = input.maxDurationMs ?? 8_000
   const clock = input.clock ?? Date.now
   const startedAt = clock()
+  const deliveryDeadlineAt = startedAt + Math.max(1_000, maxDurationMs - 1_000)
   const summary: PalOutboxDrainSummary = {
     status: 'ok',
     claimed: 0,
@@ -288,7 +321,7 @@ export async function drainPalOutbox(input: {
   }
 
   for (let batch = 0; batch < maxBatches; batch += 1) {
-    if (batch > 0 && clock() - startedAt >= maxDurationMs) {
+    if (batch > 0 && clock() >= deliveryDeadlineAt) {
       summary.stoppedReason = 'time_limit'
       break
     }
@@ -298,6 +331,9 @@ export async function drainPalOutbox(input: {
       fetchImpl: input.fetchImpl,
       now: input.now,
       limit: batchSize,
+      concurrency: 10,
+      deadlineAtMs: deliveryDeadlineAt,
+      clock,
     })
     if (delivered.status === 'disabled') {
       return { ...summary, status: 'disabled', stoppedReason: 'disabled' }
@@ -311,6 +347,10 @@ export async function drainPalOutbox(input: {
 
     if (delivered.claimed === 0) {
       summary.stoppedReason = summary.claimed === 0 ? 'empty' : 'drained'
+      break
+    }
+    if (clock() >= deliveryDeadlineAt) {
+      summary.stoppedReason = 'time_limit'
       break
     }
     if (delivered.claimed < batchSize) {

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -21,6 +21,12 @@ export type PalOutboxDeliverySummary = {
   nonRetryable: number
 }
 
+export type PalOutboxDrainSummary = PalOutboxDeliverySummary & {
+  batches: number
+  remainingReady: number
+  stoppedReason: 'disabled' | 'empty' | 'drained' | 'batch_limit' | 'time_limit'
+}
+
 function retryDelayMs(attempts: number): number {
   return Math.min(30_000 * 2 ** Math.max(0, attempts - 1), 6 * 60 * 60 * 1000)
 }
@@ -205,5 +211,74 @@ export async function deliverPalOutboxBatch(input: {
     }
   }
 
+  return summary
+}
+
+export async function drainPalOutbox(input: {
+  supabase?: SupabaseLike
+  fetchImpl?: typeof fetch
+  now?: Date
+  batchSize?: number
+  maxBatches?: number
+  maxDurationMs?: number
+  clock?: () => number
+} = {}): Promise<PalOutboxDrainSummary> {
+  const batchSize = input.batchSize ?? 50
+  const maxBatches = input.maxBatches ?? 10
+  const maxDurationMs = input.maxDurationMs ?? 8_000
+  const clock = input.clock ?? Date.now
+  const startedAt = clock()
+  const summary: PalOutboxDrainSummary = {
+    status: 'ok',
+    claimed: 0,
+    delivered: 0,
+    retrying: 0,
+    nonRetryable: 0,
+    batches: 0,
+    remainingReady: 0,
+    stoppedReason: 'empty',
+  }
+
+  for (let batch = 0; batch < maxBatches; batch += 1) {
+    if (batch > 0 && clock() - startedAt >= maxDurationMs) {
+      summary.stoppedReason = 'time_limit'
+      break
+    }
+
+    const delivered = await deliverPalOutboxBatch({
+      supabase: input.supabase,
+      fetchImpl: input.fetchImpl,
+      now: input.now,
+      limit: batchSize,
+    })
+    if (delivered.status === 'disabled') {
+      return { ...summary, status: 'disabled', stoppedReason: 'disabled' }
+    }
+
+    summary.batches += 1
+    summary.claimed += delivered.claimed
+    summary.delivered += delivered.delivered
+    summary.retrying += delivered.retrying
+    summary.nonRetryable += delivered.nonRetryable
+
+    if (delivered.claimed === 0) {
+      summary.stoppedReason = summary.claimed === 0 ? 'empty' : 'drained'
+      break
+    }
+    if (delivered.claimed < batchSize) {
+      summary.stoppedReason = 'drained'
+      break
+    }
+    summary.stoppedReason = batch + 1 === maxBatches
+      ? 'batch_limit'
+      : summary.stoppedReason
+  }
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await supabase.rpc('count_pal_event_outbox_ready')
+  if (error) {
+    throw new Error(`Failed to count ready Pal outbox rows: ${error.message ?? 'unknown error'}`)
+  }
+  summary.remainingReady = z.number().int().nonnegative().parse(data)
   return summary
 }

--- a/src/lib/server/pal-read-token.ts
+++ b/src/lib/server/pal-read-token.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+import { requirePalEnvironment } from '@/lib/server/pal-config'
+import { pseudonymizePalRef } from '@/lib/server/pal-events'
+
+const palReadTokenResponseSchema = z.object({
+  token: z.string().min(1),
+  expires_at: z.string().datetime({ offset: true }),
+}).strip()
+
+export async function mintPalReadToken(input: {
+  studentId: string
+  fetchImpl?: typeof fetch
+}) {
+  const { apiUrl, integrationSecret, pseudonymSecret } = requirePalEnvironment()
+  const learnerId = pseudonymizePalRef(
+    'learner',
+    input.studentId,
+    pseudonymSecret,
+  )
+  const response = await (input.fetchImpl ?? fetch)(
+    `${apiUrl}/api/v1/integration/read-token`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${integrationSecret}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ learner_id: learnerId }),
+      signal: AbortSignal.timeout(5_000),
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error(`Pal read-token endpoint returned HTTP ${response.status}`)
+  }
+  return palReadTokenResponseSchema.parse(await response.json())
+}

--- a/src/lib/server/pal-read-token.ts
+++ b/src/lib/server/pal-read-token.ts
@@ -8,9 +8,13 @@ const palReadTokenResponseSchema = z.object({
   expires_at: z.string().datetime({ offset: true }),
 }).strip()
 
+export const PAL_READ_TOKEN_MAX_TTL_MS = 10 * 60 * 1_000
+const PAL_READ_TOKEN_CLOCK_SKEW_MS = 30 * 1_000
+
 export async function mintPalReadToken(input: {
   studentId: string
   fetchImpl?: typeof fetch
+  now?: Date
 }) {
   const { apiUrl, integrationSecret, pseudonymSecret } = requirePalEnvironment()
   const learnerId = pseudonymizePalRef(
@@ -34,5 +38,16 @@ export async function mintPalReadToken(input: {
   if (!response.ok) {
     throw new Error(`Pal read-token endpoint returned HTTP ${response.status}`)
   }
-  return palReadTokenResponseSchema.parse(await response.json())
+  const token = palReadTokenResponseSchema.parse(await response.json())
+  const nowMs = (input.now ?? new Date()).getTime()
+  const expiresAtMs = Date.parse(token.expires_at)
+
+  if (expiresAtMs <= nowMs) {
+    throw new Error('Pal returned an expired read token')
+  }
+  if (expiresAtMs - nowMs > PAL_READ_TOKEN_MAX_TTL_MS + PAL_READ_TOKEN_CLOCK_SKEW_MS) {
+    throw new Error('Pal returned a read token beyond Pika’s maximum TTL')
+  }
+
+  return token
 }

--- a/src/lib/server/pal-signals.ts
+++ b/src/lib/server/pal-signals.ts
@@ -1,0 +1,27 @@
+import { buildSessionStartedEvent } from '@/lib/server/pal-events'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { enqueueStandalonePalEvent } from '@/lib/server/pal-outbox'
+
+export async function recordPalAuthenticatedSession(input: {
+  studentId: string
+  sessionId: string
+  occurredAt?: Date
+}): Promise<void> {
+  if (!isPalEnabled()) return
+
+  try {
+    await enqueueStandalonePalEvent({
+      studentId: input.studentId,
+      sourceKind: 'authenticated_session',
+      sourceId: input.sessionId,
+      event: buildSessionStartedEvent({
+        learnerId: input.studentId,
+        sessionId: input.sessionId,
+        occurredAt: input.occurredAt ?? new Date(),
+      }),
+    })
+  } catch (error) {
+    // A Pal adapter problem must never invalidate a genuine Pika login.
+    console.error('Failed to record Pal authenticated session:', error)
+  }
+}

--- a/src/lib/server/pal-signals.ts
+++ b/src/lib/server/pal-signals.ts
@@ -7,9 +7,8 @@ export async function recordPalAuthenticatedSession(input: {
   sessionId: string
   occurredAt?: Date
 }): Promise<void> {
-  if (!isPalEnabled()) return
-
   try {
+    if (!isPalEnabled()) return
     await enqueueStandalonePalEvent({
       studentId: input.studentId,
       sourceKind: 'authenticated_session',

--- a/src/lib/server/pal-source-writes.ts
+++ b/src/lib/server/pal-source-writes.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod'
+
+import type { TiptapContent } from '@/types'
+import type { v1 } from '@/vendor/pal-contract'
+
+type SupabaseLike = any
+
+const enrollmentResultSchema = z.object({
+  ok: z.literal(true),
+  created: z.boolean(),
+  enrollment: z.object({ id: z.string().min(1) }).passthrough(),
+}).strip()
+
+const entryResultSchema = z.object({
+  ok: z.literal(true),
+  created: z.boolean(),
+  entry: z.object({ id: z.string().min(1) }).passthrough(),
+}).strip()
+
+const assignmentDocResultSchema = z.object({
+  ok: z.literal(true),
+  created: z.boolean(),
+  doc: z.object({ id: z.string().min(1) }).passthrough(),
+}).strip()
+
+function mapPalSourceWriteError(error: any, operation: string): never {
+  if (error?.code === '42883' || error?.code === 'PGRST202') {
+    throw new Error('Pal outbox migration is required')
+  }
+  throw new Error(`Failed to ${operation}: ${error?.message ?? 'unknown database error'}`)
+}
+
+export async function createClassroomEnrollmentWithPalEvent(input: {
+  supabase: SupabaseLike
+  classroomId: string
+  studentId: string
+  event: v1.ClassroomJoinedEvent | null
+}) {
+  const { data, error } = await input.supabase.rpc(
+    'create_classroom_enrollment_with_pal_event_atomic',
+    {
+      p_classroom_id: input.classroomId,
+      p_student_id: input.studentId,
+      p_pal_event: input.event,
+    },
+  )
+  if (error) mapPalSourceWriteError(error, 'create classroom enrollment')
+  return enrollmentResultSchema.parse(data)
+}
+
+export async function upsertStudentEntryWithPalEvent(input: {
+  supabase: SupabaseLike
+  studentId: string
+  classroomId: string
+  date: string
+  text: string
+  richContent: TiptapContent
+  minutesReported?: number | null
+  mood?: string | null
+  onTime: boolean
+  event: v1.DailyLogCompletedEvent | null
+}) {
+  const { data, error } = await input.supabase.rpc(
+    'upsert_student_entry_with_pal_event_atomic',
+    {
+      p_student_id: input.studentId,
+      p_classroom_id: input.classroomId,
+      p_date: input.date,
+      p_text: input.text,
+      p_rich_content: input.richContent,
+      p_minutes_reported: input.minutesReported ?? null,
+      p_mood: input.mood ?? null,
+      p_on_time: input.onTime,
+      p_pal_event: input.event,
+    },
+  )
+  if (error) mapPalSourceWriteError(error, 'save daily log')
+  return entryResultSchema.parse(data)
+}
+
+export async function createAssignmentDocWithPalEvent(input: {
+  supabase: SupabaseLike
+  assignmentId: string
+  studentId: string
+  viewedAt: string
+  event: v1.LearningItemViewedEvent | null
+}) {
+  const { data, error } = await input.supabase.rpc(
+    'create_assignment_doc_with_pal_event_atomic',
+    {
+      p_assignment_id: input.assignmentId,
+      p_student_id: input.studentId,
+      p_viewed_at: input.viewedAt,
+      p_pal_event: input.event,
+    },
+  )
+  if (error) mapPalSourceWriteError(error, 'create assignment document')
+  return assignmentDocResultSchema.parse(data)
+}

--- a/src/lib/server/pal-source-writes.ts
+++ b/src/lib/server/pal-source-writes.ts
@@ -11,11 +11,19 @@ const enrollmentResultSchema = z.object({
   enrollment: z.object({ id: z.string().min(1) }).passthrough(),
 }).strip()
 
-const entryResultSchema = z.object({
-  ok: z.literal(true),
-  created: z.boolean(),
-  entry: z.object({ id: z.string().min(1) }).passthrough(),
-}).strip()
+const entryResultSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    created: z.boolean(),
+    entry: z.object({ id: z.string().min(1) }).passthrough(),
+  }).strip(),
+  z.object({
+    ok: z.literal(false),
+    status: z.literal(409),
+    error: z.string().min(1),
+    entry: z.object({ id: z.string().min(1) }).passthrough().nullable(),
+  }).strip(),
+])
 
 const assignmentDocResultSchema = z.object({
   ok: z.literal(true),
@@ -58,6 +66,7 @@ export async function upsertStudentEntryWithPalEvent(input: {
   minutesReported?: number | null
   mood?: string | null
   onTime: boolean
+  expectedVersion?: number | null
   event: v1.DailyLogCompletedEvent | null
 }) {
   const { data, error } = await input.supabase.rpc(
@@ -71,6 +80,7 @@ export async function upsertStudentEntryWithPalEvent(input: {
       p_minutes_reported: input.minutesReported ?? null,
       p_mood: input.mood ?? null,
       p_on_time: input.onTime,
+      p_expected_version: input.expectedVersion ?? null,
       p_pal_event: input.event,
     },
   )

--- a/src/lib/server/pal-source-writes.ts
+++ b/src/lib/server/pal-source-writes.ts
@@ -1,9 +1,14 @@
 import { z } from 'zod'
 
+import { getServiceRoleClient } from '@/lib/supabase'
 import type { TiptapContent } from '@/types'
+import type { Json } from '@/types/database.generated'
 import type { v1 } from '@/vendor/pal-contract'
 
-type SupabaseLike = any
+export type PalSourceWriteClient = Pick<
+  ReturnType<typeof getServiceRoleClient>,
+  'rpc'
+>
 
 const enrollmentResultSchema = z.object({
   ok: z.literal(true),
@@ -31,15 +36,21 @@ const assignmentDocResultSchema = z.object({
   doc: z.object({ id: z.string().min(1) }).passthrough(),
 }).strip()
 
-function mapPalSourceWriteError(error: any, operation: string): never {
-  if (error?.code === '42883' || error?.code === 'PGRST202') {
+function mapPalSourceWriteError(error: unknown, operation: string): never {
+  const rpcError = typeof error === 'object' && error !== null
+    ? error as { code?: unknown; message?: unknown }
+    : {}
+  if (rpcError.code === '42883' || rpcError.code === 'PGRST202') {
     throw new Error('Pal outbox migration is required')
   }
-  throw new Error(`Failed to ${operation}: ${error?.message ?? 'unknown database error'}`)
+  const message = typeof rpcError.message === 'string'
+    ? rpcError.message
+    : 'unknown database error'
+  throw new Error(`Failed to ${operation}: ${message}`)
 }
 
 export async function createClassroomEnrollmentWithPalEvent(input: {
-  supabase: SupabaseLike
+  supabase: PalSourceWriteClient
   classroomId: string
   studentId: string
   event: v1.ClassroomJoinedEvent | null
@@ -57,7 +68,7 @@ export async function createClassroomEnrollmentWithPalEvent(input: {
 }
 
 export async function upsertStudentEntryWithPalEvent(input: {
-  supabase: SupabaseLike
+  supabase: PalSourceWriteClient
   studentId: string
   classroomId: string
   date: string
@@ -76,12 +87,16 @@ export async function upsertStudentEntryWithPalEvent(input: {
       p_classroom_id: input.classroomId,
       p_date: input.date,
       p_text: input.text,
-      p_rich_content: input.richContent,
-      p_minutes_reported: input.minutesReported ?? null,
-      p_mood: input.mood ?? null,
+      p_rich_content: input.richContent as unknown as Json,
       p_on_time: input.onTime,
-      p_expected_version: input.expectedVersion ?? null,
       p_pal_event: input.event,
+      ...(input.minutesReported == null
+        ? {}
+        : { p_minutes_reported: input.minutesReported }),
+      ...(input.mood == null ? {} : { p_mood: input.mood }),
+      ...(input.expectedVersion == null
+        ? {}
+        : { p_expected_version: input.expectedVersion }),
     },
   )
   if (error) mapPalSourceWriteError(error, 'save daily log')
@@ -89,7 +104,7 @@ export async function upsertStudentEntryWithPalEvent(input: {
 }
 
 export async function createAssignmentDocWithPalEvent(input: {
-  supabase: SupabaseLike
+  supabase: PalSourceWriteClient
   assignmentId: string
   studentId: string
   viewedAt: string

--- a/src/lib/server/pal-weekly-config.ts
+++ b/src/lib/server/pal-weekly-config.ts
@@ -39,11 +39,34 @@ export type PalDailyLogCompletion = {
 export type PalWeeklyConfigurationRevision = PalWeeklyConfiguration
 
 const PAGE_SIZE = 500
+export const MAX_PAL_WEEKLY_CATCH_UP_PERIODS = 12
 
 function addCalendarDays(day: string, amount: number): string {
   const date = new Date(`${day}T00:00:00Z`)
   date.setUTCDate(date.getUTCDate() + amount)
   return date.toISOString().slice(0, 10)
+}
+
+export function palWeeklyCatchUpPeriodStarts(input: {
+  oldestOpenPeriodStart: string | null
+  currentPeriodStart: string
+  maxPeriods?: number
+}): { periods: string[]; remaining: boolean } {
+  if (
+    !input.oldestOpenPeriodStart
+    || input.oldestOpenPeriodStart >= input.currentPeriodStart
+  ) {
+    return { periods: [], remaining: false }
+  }
+
+  const maxPeriods = input.maxPeriods ?? MAX_PAL_WEEKLY_CATCH_UP_PERIODS
+  const periods: string[] = []
+  let period = input.oldestOpenPeriodStart
+  while (period < input.currentPeriodStart && periods.length < maxPeriods) {
+    periods.push(period)
+    period = addCalendarDays(period, 7)
+  }
+  return { periods, remaining: period < input.currentPeriodStart }
 }
 
 function activityDayForTimestamp(value: string): string | null {
@@ -354,9 +377,21 @@ async function syncPeriod(input: {
 export async function syncPalWeeklyConfigurations(input: {
   supabase?: SupabaseLike
   now?: Date
-} = {}): Promise<{ status: 'disabled' | 'ok'; configured: number; closed: number }> {
+} = {}): Promise<{
+  status: 'disabled' | 'ok'
+  configured: number
+  closed: number
+  catchUpPeriods: number
+  remainingCatchUp: boolean
+}> {
   if (!isPalEnabled()) {
-    return { status: 'disabled', configured: 0, closed: 0 }
+    return {
+      status: 'disabled',
+      configured: 0,
+      closed: 0,
+      catchUpPeriods: 0,
+      remainingCatchUp: false,
+    }
   }
 
   const supabase = input.supabase ?? getServiceRoleClient()
@@ -364,15 +399,37 @@ export async function syncPalWeeklyConfigurations(input: {
   const activityDay = formatDateInToronto(now)
   const currentPeriodStart = palPeriodKeyForActivityDay(activityDay)
     .replace(/^pika-week-/, '')
-  const previousPeriodStart = addCalendarDays(currentPeriodStart, -7)
-
-  const closed = await syncPeriod({
-    supabase,
-    periodStart: previousPeriodStart,
-    periodStatus: 'closed',
-    createIfMissing: false,
-    configuredAt: now,
+  const currentPeriodKey = palPeriodKeyForActivityDay(currentPeriodStart)
+  const { data: oldestOpenRows, error: oldestOpenError } = await supabase
+    .from('pal_daily_log_week_configurations')
+    .select('period_key')
+    .eq('period_status', 'open')
+    .lt('period_key', currentPeriodKey)
+    .order('period_key', { ascending: true })
+    .limit(1)
+  if (oldestOpenError) {
+    throw new Error(`Failed to find Pal weekly catch-up boundary: ${oldestOpenError.message}`)
+  }
+  const oldestPeriodKey = oldestOpenRows?.[0]?.period_key
+  const oldestOpenPeriodStart = typeof oldestPeriodKey === 'string'
+    && oldestPeriodKey.startsWith('pika-week-')
+    ? oldestPeriodKey.replace(/^pika-week-/, '')
+    : null
+  const catchUp = palWeeklyCatchUpPeriodStarts({
+    oldestOpenPeriodStart,
+    currentPeriodStart,
   })
+
+  let closed = 0
+  for (const periodStart of catchUp.periods) {
+    closed += await syncPeriod({
+      supabase,
+      periodStart,
+      periodStatus: 'closed',
+      createIfMissing: false,
+      configuredAt: now,
+    })
+  }
   const configured = await syncPeriod({
     supabase,
     periodStart: currentPeriodStart,
@@ -381,5 +438,11 @@ export async function syncPalWeeklyConfigurations(input: {
     configuredAt: now,
   })
 
-  return { status: 'ok', configured, closed }
+  return {
+    status: 'ok',
+    configured,
+    closed,
+    catchUpPeriods: catchUp.periods.length,
+    remainingCatchUp: catchUp.remaining,
+  }
 }

--- a/src/lib/server/pal-weekly-config.ts
+++ b/src/lib/server/pal-weekly-config.ts
@@ -7,7 +7,7 @@ import { isPalEnabled } from '@/lib/server/pal-config'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 
-type SupabaseLike = any
+type PalWeeklyClient = ReturnType<typeof getServiceRoleClient>
 
 export type PalEnrollmentSchedule = {
   studentId: string
@@ -236,7 +236,7 @@ type CompletionRow = {
 }
 
 async function loadPeriodInputs(
-  supabase: SupabaseLike,
+  supabase: PalWeeklyClient,
   periodStart: string,
 ): Promise<{
   schedules: PalEnrollmentSchedule[]
@@ -331,7 +331,7 @@ async function loadPeriodInputs(
 }
 
 async function syncPeriod(input: {
-  supabase: SupabaseLike
+  supabase: PalWeeklyClient
   periodStart: string
   periodStatus: 'open' | 'closed'
   createIfMissing: boolean
@@ -375,7 +375,7 @@ async function syncPeriod(input: {
 }
 
 export async function syncPalWeeklyConfigurations(input: {
-  supabase?: SupabaseLike
+  supabase?: PalWeeklyClient
   now?: Date
 } = {}): Promise<{
   status: 'disabled' | 'ok'

--- a/src/lib/server/pal-weekly-config.ts
+++ b/src/lib/server/pal-weekly-config.ts
@@ -1,0 +1,385 @@
+import { formatDateInToronto } from '@/lib/timezone'
+import {
+  buildDailyLogWeekConfiguredEvent,
+  palPeriodKeyForActivityDay,
+} from '@/lib/server/pal-events'
+import { isPalEnabled } from '@/lib/server/pal-config'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
+
+type SupabaseLike = any
+
+export type PalEnrollmentSchedule = {
+  studentId: string
+  classroomId: string
+  enrolledAt: string
+  classroomStart: string | null
+  classroomEnd: string | null
+  archivedAt: string | null
+}
+
+export type PalClassDay = {
+  classroomId: string
+  date: string
+}
+
+export type PalWeeklyConfiguration = {
+  studentId: string
+  periodKey: string
+  configVersion: number
+  periodStatus: 'open' | 'closed'
+  eligibleDays: number
+}
+
+export type PalDailyLogCompletion = {
+  studentId: string
+  activityDay: string
+}
+
+export type PalWeeklyConfigurationRevision = PalWeeklyConfiguration
+
+const PAGE_SIZE = 500
+
+function addCalendarDays(day: string, amount: number): string {
+  const date = new Date(`${day}T00:00:00Z`)
+  date.setUTCDate(date.getUTCDate() + amount)
+  return date.toISOString().slice(0, 10)
+}
+
+function activityDayForTimestamp(value: string): string | null {
+  const instant = new Date(value)
+  return Number.isNaN(instant.getTime()) ? null : formatDateInToronto(instant)
+}
+
+function scheduleOverlapsPeriod(
+  schedule: PalEnrollmentSchedule,
+  periodStart: string,
+  periodEnd: string,
+): boolean {
+  const enrollmentDay = activityDayForTimestamp(schedule.enrolledAt)
+  const archiveDay = schedule.archivedAt
+    ? activityDayForTimestamp(schedule.archivedAt)
+    : null
+  const firstDay = [periodStart, schedule.classroomStart, enrollmentDay]
+    .filter((value): value is string => Boolean(value))
+    .sort()
+    .at(-1) ?? periodStart
+  const lastCandidates = [periodEnd, schedule.classroomEnd]
+    .filter((value): value is string => Boolean(value))
+  if (archiveDay) {
+    lastCandidates.push(addCalendarDays(archiveDay, -1))
+  }
+  const lastDay = lastCandidates.sort().at(0) ?? periodEnd
+  return firstDay <= lastDay
+}
+
+function isEligibleForSchedule(
+  schedule: PalEnrollmentSchedule,
+  date: string,
+): boolean {
+  const enrollmentDay = activityDayForTimestamp(schedule.enrolledAt)
+  const archiveDay = schedule.archivedAt
+    ? activityDayForTimestamp(schedule.archivedAt)
+    : null
+
+  return (
+    (!enrollmentDay || date >= enrollmentDay)
+    && (!schedule.classroomStart || date >= schedule.classroomStart)
+    && (!schedule.classroomEnd || date <= schedule.classroomEnd)
+    && (!archiveDay || date < archiveDay)
+  )
+}
+
+export function planPalWeeklyConfigurationRevisions(input: {
+  periodStart: string
+  periodStatus: 'open' | 'closed'
+  createIfMissing: boolean
+  schedules: PalEnrollmentSchedule[]
+  classDays: PalClassDay[]
+  existing: PalWeeklyConfiguration[]
+  completions: PalDailyLogCompletion[]
+}): PalWeeklyConfigurationRevision[] {
+  const periodKey = palPeriodKeyForActivityDay(input.periodStart)
+  const periodEnd = addCalendarDays(input.periodStart, 4)
+  const existingByStudent = new Map<string, PalWeeklyConfiguration>()
+  for (const configuration of input.existing) {
+    const previous = existingByStudent.get(configuration.studentId)
+    if (!previous || configuration.configVersion > previous.configVersion) {
+      existingByStudent.set(configuration.studentId, configuration)
+    }
+  }
+
+  const schedulesByStudent = new Map<string, PalEnrollmentSchedule[]>()
+  for (const schedule of input.schedules) {
+    if (!scheduleOverlapsPeriod(schedule, input.periodStart, periodEnd)) continue
+    const schedules = schedulesByStudent.get(schedule.studentId) ?? []
+    schedules.push(schedule)
+    schedulesByStudent.set(schedule.studentId, schedules)
+  }
+
+  const classDaysByClassroom = new Map<string, Set<string>>()
+  for (const classDay of input.classDays) {
+    if (classDay.date < input.periodStart || classDay.date > periodEnd) continue
+    const dates = classDaysByClassroom.get(classDay.classroomId) ?? new Set<string>()
+    dates.add(classDay.date)
+    classDaysByClassroom.set(classDay.classroomId, dates)
+  }
+
+  const completionDaysByStudent = new Map<string, Set<string>>()
+  for (const completion of input.completions) {
+    const dates = completionDaysByStudent.get(completion.studentId) ?? new Set<string>()
+    dates.add(completion.activityDay)
+    completionDaysByStudent.set(completion.studentId, dates)
+  }
+
+  const studentIds = new Set([
+    ...existingByStudent.keys(),
+    ...schedulesByStudent.keys(),
+  ])
+  const revisions: PalWeeklyConfigurationRevision[] = []
+
+  for (const studentId of [...studentIds].sort()) {
+    const previous = existingByStudent.get(studentId)
+    if (previous?.periodStatus === 'closed') continue
+    if (!previous && !input.createIfMissing) continue
+
+    const eligibleDates = new Set<string>()
+    for (const schedule of schedulesByStudent.get(studentId) ?? []) {
+      for (const date of classDaysByClassroom.get(schedule.classroomId) ?? []) {
+        if (isEligibleForSchedule(schedule, date)) eligibleDates.add(date)
+      }
+    }
+
+    const completionFloor = completionDaysByStudent.get(studentId)?.size ?? 0
+    const eligibleDays = Math.max(eligibleDates.size, completionFloor)
+    if (eligibleDays > 5) {
+      throw new Error('Pal v1 weekly configuration cannot exceed five eligible days')
+    }
+
+    if (
+      previous
+      && previous.eligibleDays === eligibleDays
+      && previous.periodStatus === input.periodStatus
+    ) {
+      continue
+    }
+
+    revisions.push({
+      studentId,
+      periodKey,
+      configVersion: (previous?.configVersion ?? 0) + 1,
+      periodStatus: input.periodStatus,
+      eligibleDays,
+    })
+  }
+
+  return revisions
+}
+
+type EnrollmentRow = {
+  student_id: string
+  classroom_id: string
+  created_at: string
+  classrooms:
+    | {
+      start_date: string | null
+      end_date: string | null
+      archived_at: string | null
+    }
+    | Array<{
+      start_date: string | null
+      end_date: string | null
+      archived_at: string | null
+    }>
+}
+
+type ClassDayRow = {
+  classroom_id: string
+  date: string
+  is_class_day: boolean
+}
+
+type ConfigurationRow = {
+  student_id: string
+  period_key: string
+  config_version: number
+  period_status: 'open' | 'closed'
+  eligible_days: number
+}
+
+type CompletionRow = {
+  student_id: string
+  payload: { metadata?: { activity_day?: unknown } }
+}
+
+async function loadPeriodInputs(
+  supabase: SupabaseLike,
+  periodStart: string,
+): Promise<{
+  schedules: PalEnrollmentSchedule[]
+  classDays: PalClassDay[]
+  existing: PalWeeklyConfiguration[]
+  completions: PalDailyLogCompletion[]
+}> {
+  const periodKey = palPeriodKeyForActivityDay(periodStart)
+  const periodEnd = addCalendarDays(periodStart, 4)
+
+  const [enrollmentResult, configurationResult, completionResult] = await Promise.all([
+    loadPagedRows<EnrollmentRow>(() =>
+      supabase
+        .from('classroom_enrollments')
+        .select(
+          'id, student_id, classroom_id, created_at, classrooms!inner(start_date,end_date,archived_at)',
+        ),
+    PAGE_SIZE),
+    loadPagedRows<ConfigurationRow>(() =>
+      supabase
+        .from('pal_daily_log_week_configurations')
+        .select('id, student_id, period_key, config_version, period_status, eligible_days')
+        .eq('period_key', periodKey),
+    PAGE_SIZE),
+    loadPagedRows<CompletionRow>(() =>
+      supabase
+        .from('pal_event_outbox')
+        .select('id, student_id, payload')
+        .eq('event_type', 'daily_log.completed')
+        .contains('payload', { metadata: { period_key: periodKey } }),
+    PAGE_SIZE),
+  ])
+
+  const firstError = enrollmentResult.error
+    ?? configurationResult.error
+    ?? completionResult.error
+  if (firstError) {
+    throw new Error(`Failed to load Pal weekly configuration inputs: ${firstError.message}`)
+  }
+
+  const schedules = enrollmentResult.rows.flatMap((row) => {
+    const classroom = Array.isArray(row.classrooms)
+      ? row.classrooms[0]
+      : row.classrooms
+    if (!classroom) return []
+    return [{
+      studentId: row.student_id,
+      classroomId: row.classroom_id,
+      enrolledAt: row.created_at,
+      classroomStart: classroom.start_date,
+      classroomEnd: classroom.end_date,
+      archivedAt: classroom.archived_at,
+    }]
+  })
+
+  const classroomIds = [...new Set(schedules.map((schedule) => schedule.classroomId))]
+  const classDayRows: ClassDayRow[] = []
+  for (const classroomIdChunk of chunkValues(classroomIds, 50)) {
+    const classDayResult = await loadPagedRows<ClassDayRow>(() =>
+      supabase
+        .from('class_days')
+        .select('id, classroom_id, date, is_class_day')
+        .in('classroom_id', classroomIdChunk)
+        .gte('date', periodStart)
+        .lte('date', periodEnd)
+        .eq('is_class_day', true),
+    PAGE_SIZE)
+    if (classDayResult.error) {
+      throw new Error(`Failed to load Pal class days: ${classDayResult.error.message}`)
+    }
+    classDayRows.push(...classDayResult.rows)
+  }
+
+  return {
+    schedules,
+    classDays: classDayRows
+      .map((row) => ({ classroomId: row.classroom_id, date: row.date })),
+    existing: configurationResult.rows.map((row) => ({
+      studentId: row.student_id,
+      periodKey: row.period_key,
+      configVersion: row.config_version,
+      periodStatus: row.period_status,
+      eligibleDays: row.eligible_days,
+    })),
+    completions: completionResult.rows.flatMap((row) => {
+      const activityDay = row.payload?.metadata?.activity_day
+      return typeof activityDay === 'string'
+        ? [{ studentId: row.student_id, activityDay }]
+        : []
+    }),
+  }
+}
+
+async function syncPeriod(input: {
+  supabase: SupabaseLike
+  periodStart: string
+  periodStatus: 'open' | 'closed'
+  createIfMissing: boolean
+  configuredAt: Date
+}): Promise<number> {
+  const periodInputs = await loadPeriodInputs(input.supabase, input.periodStart)
+  const revisions = planPalWeeklyConfigurationRevisions({
+    periodStart: input.periodStart,
+    periodStatus: input.periodStatus,
+    createIfMissing: input.createIfMissing,
+    ...periodInputs,
+  })
+
+  for (const revision of revisions) {
+    const event = buildDailyLogWeekConfiguredEvent({
+      learnerId: revision.studentId,
+      occurredAt: input.configuredAt,
+      periodKey: revision.periodKey,
+      configVersion: revision.configVersion,
+      periodStatus: revision.periodStatus,
+      eligibleDays: revision.eligibleDays,
+    })
+    const { error } = await input.supabase.rpc(
+      'record_pal_daily_log_week_configuration_atomic',
+      {
+        p_student_id: revision.studentId,
+        p_period_key: revision.periodKey,
+        p_config_version: revision.configVersion,
+        p_period_status: revision.periodStatus,
+        p_eligible_days: revision.eligibleDays,
+        p_configured_at: input.configuredAt.toISOString(),
+        p_pal_event: event,
+      },
+    )
+    if (error) {
+      throw new Error(`Failed to record Pal weekly configuration: ${error.message}`)
+    }
+  }
+
+  return revisions.length
+}
+
+export async function syncPalWeeklyConfigurations(input: {
+  supabase?: SupabaseLike
+  now?: Date
+} = {}): Promise<{ status: 'disabled' | 'ok'; configured: number; closed: number }> {
+  if (!isPalEnabled()) {
+    return { status: 'disabled', configured: 0, closed: 0 }
+  }
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const now = input.now ?? new Date()
+  const activityDay = formatDateInToronto(now)
+  const currentPeriodStart = palPeriodKeyForActivityDay(activityDay)
+    .replace(/^pika-week-/, '')
+  const previousPeriodStart = addCalendarDays(currentPeriodStart, -7)
+
+  const closed = await syncPeriod({
+    supabase,
+    periodStart: previousPeriodStart,
+    periodStatus: 'closed',
+    createIfMissing: false,
+    configuredAt: now,
+  })
+  const configured = await syncPeriod({
+    supabase,
+    periodStart: currentPeriodStart,
+    periodStatus: 'open',
+    createIfMissing: true,
+    configuredAt: now,
+  })
+
+  return { status: 'ok', configured, closed }
+}

--- a/src/lib/validations/pal.ts
+++ b/src/lib/validations/pal.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const palOutboxRequeueRequestSchema = z.object({
+  outbox_id: z.string().uuid(),
+}).strict()

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2893,6 +2893,102 @@ export type Database = {
           },
         ]
       }
+      pal_daily_log_week_configurations: {
+        Row: {
+          config_version: number
+          configured_at: string
+          created_at: string
+          eligible_days: number
+          id: string
+          period_key: string
+          period_status: string
+          student_id: string
+        }
+        Insert: {
+          config_version: number
+          configured_at: string
+          created_at?: string
+          eligible_days: number
+          id?: string
+          period_key: string
+          period_status: string
+          student_id: string
+        }
+        Update: {
+          config_version?: number
+          configured_at?: string
+          created_at?: string
+          eligible_days?: number
+          id?: string
+          period_key?: string
+          period_status?: string
+          student_id?: string
+        }
+        Relationships: []
+      }
+      pal_event_outbox: {
+        Row: {
+          attempts: number
+          created_at: string
+          delivered_at: string | null
+          event_type: string
+          id: string
+          idempotency_key: string
+          last_attempt_at: string | null
+          last_error_code: string | null
+          last_error_detail: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          payload: Json
+          source_id: string
+          source_kind: string
+          status: string
+          student_id: string
+          updated_at: string
+        }
+        Insert: {
+          attempts?: number
+          created_at?: string
+          delivered_at?: string | null
+          event_type: string
+          id?: string
+          idempotency_key: string
+          last_attempt_at?: string | null
+          last_error_code?: string | null
+          last_error_detail?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          payload: Json
+          source_id: string
+          source_kind: string
+          status?: string
+          student_id: string
+          updated_at?: string
+        }
+        Update: {
+          attempts?: number
+          created_at?: string
+          delivered_at?: string | null
+          event_type?: string
+          id?: string
+          idempotency_key?: string
+          last_attempt_at?: string | null
+          last_error_code?: string | null
+          last_error_detail?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          next_attempt_at?: string
+          payload?: Json
+          source_id?: string
+          source_kind?: string
+          status?: string
+          student_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       report_card_rows: {
         Row: {
           created_at: string
@@ -4222,6 +4318,35 @@ export type Database = {
           storage_path: string
         }[]
       }
+      claim_pal_event_outbox: {
+        Args: { p_lease_seconds?: number; p_limit?: number }
+        Returns: {
+          attempts: number
+          created_at: string
+          delivered_at: string | null
+          event_type: string
+          id: string
+          idempotency_key: string
+          last_attempt_at: string | null
+          last_error_code: string | null
+          last_error_detail: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          payload: Json
+          source_id: string
+          source_kind: string
+          status: string
+          student_id: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "pal_event_outbox"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       claim_test_ai_grading_run: {
         Args: {
           p_lease_seconds?: number
@@ -4455,10 +4580,15 @@ export type Database = {
         Args: { p_extract_id: string; p_lease_token: string }
         Returns: boolean
       }
+      complete_pal_event_outbox: {
+        Args: { p_lease_token: string; p_outbox_id: string }
+        Returns: boolean
+      }
       complete_test_document_snapshot_storage_cleanup: {
         Args: { p_cleanup_id: string; p_lease_token: string }
         Returns: boolean
       }
+      count_pal_event_outbox_ready: { Args: never; Returns: number }
       create_assignment_ai_grading_run_atomic: {
         Args: {
           p_assignment_id: string
@@ -4505,6 +4635,23 @@ export type Database = {
           isOneToOne: true
           isSetofReturn: false
         }
+      }
+      create_assignment_doc_with_pal_event_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_pal_event: Json
+          p_student_id: string
+          p_viewed_at: string
+        }
+        Returns: Json
+      }
+      create_classroom_enrollment_with_pal_event_atomic: {
+        Args: {
+          p_classroom_id: string
+          p_pal_event: Json
+          p_student_id: string
+        }
+        Returns: Json
       }
       create_course_blueprint_atomic: {
         Args: {
@@ -4558,6 +4705,40 @@ export type Database = {
       enqueue_assignment_artifact_storage_cleanup_path: {
         Args: { p_delay_seconds?: number; p_storage_path: string }
         Returns: boolean
+      }
+      enqueue_pal_event: {
+        Args: {
+          p_event: Json
+          p_source_id: string
+          p_source_kind: string
+          p_student_id: string
+        }
+        Returns: {
+          attempts: number
+          created_at: string
+          delivered_at: string | null
+          event_type: string
+          id: string
+          idempotency_key: string
+          last_attempt_at: string | null
+          last_error_code: string | null
+          last_error_detail: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          next_attempt_at: string
+          payload: Json
+          source_id: string
+          source_kind: string
+          status: string
+          student_id: string
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "pal_event_outbox"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
       enqueue_test_document_snapshot_storage_cleanup_path: {
         Args: { p_delay_seconds?: number; p_storage_path: string }
@@ -4628,6 +4809,15 @@ export type Database = {
           p_error_code: string
           p_extract_id: string
           p_lease_token: string
+        }
+        Returns: boolean
+      }
+      fail_pal_event_outbox: {
+        Args: {
+          p_error_code: string
+          p_error_detail: string
+          p_lease_token: string
+          p_outbox_id: string
         }
         Returns: boolean
       }
@@ -4760,6 +4950,18 @@ export type Database = {
         Args: { p_operation_id: string; p_row: Json; p_table_name: string }
         Returns: Json
       }
+      record_pal_daily_log_week_configuration_atomic: {
+        Args: {
+          p_config_version: number
+          p_configured_at: string
+          p_eligible_days: number
+          p_pal_event: Json
+          p_period_key: string
+          p_period_status: string
+          p_student_id: string
+        }
+        Returns: Json
+      }
       remove_classroom_roster_entries_atomic: {
         Args: { p_classroom_id: string; p_roster_ids: string[] }
         Returns: Json
@@ -4829,6 +5031,10 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      requeue_pal_event_outbox: {
+        Args: { p_outbox_id: string }
+        Returns: boolean
+      }
       resolve_classroom_archive_resource_classroom_id: {
         Args: { p_row_id: string; p_table_name: string }
         Returns: string
@@ -4840,6 +5046,16 @@ export type Database = {
           p_table_name: string
         }
         Returns: string
+      }
+      retry_pal_event_outbox: {
+        Args: {
+          p_error_code: string
+          p_error_detail: string
+          p_lease_token: string
+          p_next_attempt_at: string
+          p_outbox_id: string
+        }
+        Returns: boolean
       }
       return_assignment_docs_atomic: {
         Args: {
@@ -5071,6 +5287,18 @@ export type Database = {
         }
         Returns: Json
       }
+      submit_assignment_doc_with_pal_event_atomic: {
+        Args: {
+          p_assignment_id: string
+          p_char_count: number
+          p_content: Json
+          p_expected_updated_at: string
+          p_pal_event: Json
+          p_student_id: string
+          p_word_count: number
+        }
+        Returns: Json
+      }
       submit_test_attempt_atomic: {
         Args: {
           p_responses: Json
@@ -5151,6 +5379,21 @@ export type Database = {
           p_source_entry_count: number
           p_suggested_agent: string
           p_title: string
+        }
+        Returns: Json
+      }
+      upsert_student_entry_with_pal_event_atomic: {
+        Args: {
+          p_classroom_id: string
+          p_date: string
+          p_expected_version?: number
+          p_minutes_reported?: number
+          p_mood?: string
+          p_on_time: boolean
+          p_pal_event: Json
+          p_rich_content: Json
+          p_student_id: string
+          p_text: string
         }
         Returns: Json
       }

--- a/src/vendor/pal-contract/README.md
+++ b/src/vendor/pal-contract/README.md
@@ -1,8 +1,8 @@
 # Vendored Pal event contract
 
 This directory copies `packages/contract/src` from the Pal repository at commit
-`db9f22e22cbf971744bea7a78a8306f2ae787d65` (the contract landed by Pal PR
-#35).
+`cd9fc872b646b8c91551fd44f9b4b36725ab0fe4` (the contract landed by Pal PR
+#35 and was hardened on Pal PR #39).
 
 The only Pika-local adaptation removes the `.js` suffix from three relative
 imports so Next.js resolves the vendored TypeScript source during its production

--- a/src/vendor/pal-contract/README.md
+++ b/src/vendor/pal-contract/README.md
@@ -1,0 +1,18 @@
+# Vendored Pal event contract
+
+This directory copies `packages/contract/src` from the Pal repository at commit
+`db9f22e22cbf971744bea7a78a8306f2ae787d65` (the contract landed by Pal PR
+#35).
+
+The only Pika-local adaptation removes the `.js` suffix from three relative
+imports so Next.js resolves the vendored TypeScript source during its production
+build. Contract types, constants, and validation behavior are unchanged.
+
+Pika vendors this small, dependency-free package during the pilot so its
+producer tests execute the same validator as Pal ingest without waiting for a
+published package. The matching JSON compatibility fixtures live at
+`tests/fixtures/pal-contract-v1`.
+
+Do not change contract behavior locally. Change it in Pal first, then replace
+this directory and the fixtures together, reapply the import-suffix adaptation,
+and record the new Pal commit here.

--- a/src/vendor/pal-contract/index.ts
+++ b/src/vendor/pal-contract/index.ts
@@ -1,0 +1,5 @@
+// @pal/contract — the wire contract between an integration and Pal's ingest API.
+//
+// Versions are namespaced so more than one can be supported at once during a
+// rollout. Pal must accept a version before any producer emits it.
+export * as v1 from "./v1/index";

--- a/src/vendor/pal-contract/v1/index.ts
+++ b/src/vendor/pal-contract/v1/index.ts
@@ -1,0 +1,20 @@
+export {
+  SCHEMA_VERSION,
+  V1_ERRORS,
+  V1_EVENT_TYPES,
+  type ClassroomJoinedEvent,
+  type DailyLogCompletedEvent,
+  type DailyLogWeekConfiguredEvent,
+  type LearningItemCompletedEvent,
+  type LearningItemViewedEvent,
+  type OpaqueToken,
+  type PeriodKey,
+  type SessionStartedEvent,
+  type V1Envelope,
+  type V1Error,
+  type V1EventType,
+  type V1Metadata,
+  type V1ValidationResult,
+} from "./types";
+
+export { isV1Payload, validateV1Event } from "./validate";

--- a/src/vendor/pal-contract/v1/types.ts
+++ b/src/vendor/pal-contract/v1/types.ts
@@ -106,6 +106,7 @@ export const V1_ERRORS = [
   "invalid_idempotency_key",
   "invalid_learner_id",
   "invalid_occurred_at",
+  "invalid_envelope",
   "invalid_metadata",
 ] as const;
 

--- a/src/vendor/pal-contract/v1/types.ts
+++ b/src/vendor/pal-contract/v1/types.ts
@@ -1,0 +1,116 @@
+// Version 1 of the integration event contract.
+//
+// This file is the machine-readable form of the "Canonical version 1 contract"
+// section of docs/pika-signal-adapter.md. Where the two disagree, this file is
+// correct and the doc is a bug.
+//
+// An integration (Pika first, ClassOS later) asserts a privacy-safe *fact* by
+// delivering an *event*. The distinction matters: an event is one delivery and
+// may be a duplicate; the fact is what it asserts. Pal deduplicates events into
+// qualified facts before any achievement rule sees them.
+
+export const SCHEMA_VERSION = 1 as const;
+
+// The six facts an integration may assert in version 1. Adding a name here is
+// additive (no consumer expects it yet) and does NOT bump SCHEMA_VERSION — see
+// the versioning policy in this package's README.
+export const V1_EVENT_TYPES = [
+  "platform.session.started",
+  "classroom.joined",
+  "daily_log_week.configured",
+  "daily_log.completed",
+  "learning_item.viewed",
+  "learning_item.completed",
+] as const;
+
+export type V1EventType = (typeof V1_EVENT_TYPES)[number];
+
+// Pal never derives the academic calendar from delivery time, so the producer
+// names the week the behavior belongs to.
+export type PeriodKey = string;
+
+// An opaque, integration-scoped token. Reversible only with the producer's
+// private mapping — never a raw Pika user, classroom, or assignment id.
+export type OpaqueToken = string;
+
+export type V1Metadata = {
+  // A genuine authenticated learner session. Pal derives "first login"; the
+  // producer does not claim it.
+  "platform.session.started": Record<string, never>;
+
+  // A newly created enrolment. Revisiting an existing enrolment is not a join.
+  "classroom.joined": {
+    classroom_token: OpaqueToken;
+  };
+
+  // How many daily-log opportunities the learner actually had that week.
+  // Sent automatically for every active learner, including zero-opportunity
+  // weeks, so Pal can tell "no opportunity" from "missed it".
+  "daily_log_week.configured": {
+    period_key: PeriodKey;
+    config_version: number;
+    period_status: "open" | "closed";
+    eligible_days: number;
+  };
+
+  // At least one qualifying log on that date. One fact per learner/date, even
+  // when the learner logged in several classrooms.
+  "daily_log.completed": {
+    period_key: PeriodKey;
+    activity_day: string;
+  };
+
+  // The first genuine learner-initiated open of an item. Background fetches,
+  // preloads, and later reopens do not qualify.
+  "learning_item.viewed": {
+    item_token: OpaqueToken;
+    kind: "assignment";
+    period_key: PeriodKey;
+    timing: "within_24h_of_release" | "later";
+  };
+
+  // The first authoritative valid completion. Unsubmit/resubmit does not
+  // produce a second version 1 fact.
+  "learning_item.completed": {
+    item_token: OpaqueToken;
+    kind: "assignment";
+    period_key: PeriodKey;
+    timing: "on_time" | "late";
+  };
+};
+
+export type V1Envelope<T extends V1EventType = V1EventType> = {
+  schema_version: typeof SCHEMA_VERSION;
+  idempotency_key: string;
+  learner_id: OpaqueToken;
+  event_type: T;
+  occurred_at: string;
+  metadata: V1Metadata[T];
+};
+
+// Convenience aliases for producers building one specific fact.
+export type SessionStartedEvent = V1Envelope<"platform.session.started">;
+export type ClassroomJoinedEvent = V1Envelope<"classroom.joined">;
+export type DailyLogWeekConfiguredEvent = V1Envelope<"daily_log_week.configured">;
+export type DailyLogCompletedEvent = V1Envelope<"daily_log.completed">;
+export type LearningItemViewedEvent = V1Envelope<"learning_item.viewed">;
+export type LearningItemCompletedEvent = V1Envelope<"learning_item.completed">;
+
+// Rejection reasons. These are the `error` values Pal returns with a 422, so
+// producers can branch on them without parsing prose. All of them are
+// non-retryable: the same payload will always fail the same way.
+export const V1_ERRORS = [
+  "unsupported_schema_version",
+  "missing_required_fields",
+  "unknown_event_type",
+  "invalid_idempotency_key",
+  "invalid_learner_id",
+  "invalid_occurred_at",
+  "invalid_metadata",
+] as const;
+
+export type V1Error = (typeof V1_ERRORS)[number];
+
+export type V1ValidationResult =
+  | { ok: true; event: V1Envelope }
+  | { ok: false; error: V1Error; detail: string };

--- a/src/vendor/pal-contract/v1/validate.ts
+++ b/src/vendor/pal-contract/v1/validate.ts
@@ -35,6 +35,14 @@ const RFC_3339_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$/;
 const CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/;
 
 const EVENT_TYPES = new Set<string>(V1_EVENT_TYPES);
+const ENVELOPE_KEYS = [
+  "schema_version",
+  "idempotency_key",
+  "learner_id",
+  "event_type",
+  "occurred_at",
+  "metadata",
+] as const;
 
 function fail(error: V1Error, detail: string): V1ValidationResult {
   return { ok: false, error, detail };
@@ -144,6 +152,16 @@ export function validateV1Event(payload: unknown): V1ValidationResult {
     return fail("missing_required_fields", "payload must be a JSON object");
   }
 
+  const unexpectedEnvelopeKeys = Object.keys(payload).filter(
+    (key) => !ENVELOPE_KEYS.includes(key as (typeof ENVELOPE_KEYS)[number])
+  );
+  if (unexpectedEnvelopeKeys.length > 0) {
+    return fail(
+      "invalid_envelope",
+      `version 1 does not allow envelope keys: ${unexpectedEnvelopeKeys.join(", ")}`
+    );
+  }
+
   // Version first. An unsupported version means the rest of the shape is not
   // ours to interpret, and the producer should stop retrying rather than
   // reformat the body.
@@ -212,7 +230,20 @@ export function validateV1Event(payload: unknown): V1ValidationResult {
     return fail("invalid_metadata", problem);
   }
 
-  return { ok: true, event: payload as V1Envelope };
+  // Return a freshly closed envelope as defense in depth. Even if this
+  // validator is later changed to tolerate an input detail, an accepted value
+  // cannot forward fields outside the versioned privacy contract.
+  return {
+    ok: true,
+    event: {
+      schema_version: SCHEMA_VERSION,
+      idempotency_key: key,
+      learner_id: payload.learner_id,
+      event_type: eventType,
+      occurred_at: payload.occurred_at,
+      metadata: payload.metadata,
+    } as V1Envelope,
+  };
 }
 
 /** True when a payload declares a version this package can validate. */

--- a/src/vendor/pal-contract/v1/validate.ts
+++ b/src/vendor/pal-contract/v1/validate.ts
@@ -1,0 +1,221 @@
+// Zero-dependency validation for the version 1 event contract.
+//
+// Deliberately no schema library. This package is imported by producers (Pika's
+// adapter) as well as by Pal's ingest, and a validation dependency here becomes
+// a version conflict in someone else's app. The v1 contract is small and closed
+// — six event types, flat metadata, no nesting — so hand-rolling costs less than
+// it costs to share a dependency across two repos.
+//
+// What this file deliberately does NOT check:
+//
+//   * Whether `occurred_at` is in the future. That needs a clock, and a clock
+//     makes the validator impure and untestable without freezing time. Ingest
+//     owns that check — see the CLOCK_SKEW_MS note in the events route.
+//   * Whether `idempotency_key` has been seen before. That needs storage and is
+//     scoped per integration.
+//   * Whether the asserted fact is true. Only the producer can know that.
+
+import {
+  SCHEMA_VERSION,
+  V1_EVENT_TYPES,
+  type V1Envelope,
+  type V1Error,
+  type V1EventType,
+  type V1ValidationResult,
+} from "./types";
+
+// RFC 3986 unreserved characters. Tokens travel in URLs and log lines, so the
+// contract keeps them free of anything needing escaping.
+const URL_SAFE = /^[A-Za-z0-9._~-]+$/;
+
+// RFC 3339 with a required UTC designator. Producers classify in the classroom's
+// authoritative timezone and convert; Pal stores instants, never local time.
+const RFC_3339_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$/;
+
+const CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+const EVENT_TYPES = new Set<string>(V1_EVENT_TYPES);
+
+function fail(error: V1Error, detail: string): V1ValidationResult {
+  return { ok: false, error, detail };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+
+function isToken(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 1 &&
+    value.length <= maxLength &&
+    URL_SAFE.test(value)
+  );
+}
+
+// A calendar day that actually exists. `2026-02-30` matches the shape but is
+// not a date, and a producer that emits one has a timezone bug worth surfacing
+// rather than silently storing.
+function isCalendarDay(value: unknown): value is string {
+  if (typeof value !== "string" || !CALENDAR_DAY.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+type MetadataCheck = (metadata: Record<string, unknown>) => string | null;
+
+// Exactly the keys listed for each event type, and nothing else. Rejecting
+// unknown keys is what keeps a well-meaning producer from quietly widening the
+// privacy surface by attaching an assignment title "just for debugging".
+const METADATA_RULES: Record<V1EventType, { keys: string[]; check: MetadataCheck }> = {
+  "platform.session.started": {
+    keys: [],
+    check: () => null,
+  },
+
+  "classroom.joined": {
+    keys: ["classroom_token"],
+    check: (m) =>
+      isToken(m.classroom_token, 128) ? null : "classroom_token must be 1-128 URL-safe characters",
+  },
+
+  "daily_log_week.configured": {
+    keys: ["period_key", "config_version", "period_status", "eligible_days"],
+    check: (m) => {
+      if (!isToken(m.period_key, 64)) return "period_key must be 1-64 URL-safe characters";
+      if (!isInteger(m.config_version) || m.config_version < 1)
+        return "config_version must be an integer >= 1";
+      if (m.period_status !== "open" && m.period_status !== "closed")
+        return "period_status must be 'open' or 'closed'";
+      // Version 1 models a Monday-Friday daily-log week.
+      if (!isInteger(m.eligible_days) || m.eligible_days < 0 || m.eligible_days > 5)
+        return "eligible_days must be an integer 0-5";
+      return null;
+    },
+  },
+
+  "daily_log.completed": {
+    keys: ["period_key", "activity_day"],
+    check: (m) => {
+      if (!isToken(m.period_key, 64)) return "period_key must be 1-64 URL-safe characters";
+      if (!isCalendarDay(m.activity_day)) return "activity_day must be a real YYYY-MM-DD date";
+      return null;
+    },
+  },
+
+  "learning_item.viewed": {
+    keys: ["item_token", "kind", "period_key", "timing"],
+    check: (m) => {
+      if (!isToken(m.item_token, 128)) return "item_token must be 1-128 URL-safe characters";
+      if (m.kind !== "assignment") return "kind must be 'assignment' in version 1";
+      if (!isToken(m.period_key, 64)) return "period_key must be 1-64 URL-safe characters";
+      if (m.timing !== "within_24h_of_release" && m.timing !== "later")
+        return "timing must be 'within_24h_of_release' or 'later'";
+      return null;
+    },
+  },
+
+  "learning_item.completed": {
+    keys: ["item_token", "kind", "period_key", "timing"],
+    check: (m) => {
+      if (!isToken(m.item_token, 128)) return "item_token must be 1-128 URL-safe characters";
+      if (m.kind !== "assignment") return "kind must be 'assignment' in version 1";
+      if (!isToken(m.period_key, 64)) return "period_key must be 1-64 URL-safe characters";
+      if (m.timing !== "on_time" && m.timing !== "late")
+        return "timing must be 'on_time' or 'late'";
+      return null;
+    },
+  },
+};
+
+/**
+ * Validate an unknown payload against version 1 of the event contract.
+ *
+ * Returns a discriminated union rather than throwing, because both callers want
+ * the failure as a value: ingest turns it into a 422 body, and a producer's
+ * outbox marks the record non-retryable and moves on.
+ */
+export function validateV1Event(payload: unknown): V1ValidationResult {
+  if (!isPlainObject(payload)) {
+    return fail("missing_required_fields", "payload must be a JSON object");
+  }
+
+  // Version first. An unsupported version means the rest of the shape is not
+  // ours to interpret, and the producer should stop retrying rather than
+  // reformat the body.
+  if (payload.schema_version !== SCHEMA_VERSION) {
+    return fail(
+      "unsupported_schema_version",
+      `schema_version must be ${SCHEMA_VERSION}, received ${JSON.stringify(payload.schema_version)}`
+    );
+  }
+
+  for (const field of ["idempotency_key", "learner_id", "event_type", "occurred_at"]) {
+    if (payload[field] === undefined || payload[field] === null) {
+      return fail("missing_required_fields", `${field} is required`);
+    }
+  }
+
+  // Not URL-safe-constrained: the contract allows readable prefixes like
+  // "pika:assignment:<token>". The embedded tokens still have to be opaque, but
+  // that is the producer's guarantee and not something Pal can verify.
+  const key = payload.idempotency_key;
+  if (typeof key !== "string" || key.length < 1 || key.length > 200) {
+    return fail("invalid_idempotency_key", "idempotency_key must be a string of 1-200 characters");
+  }
+
+  if (!isToken(payload.learner_id, 128)) {
+    return fail("invalid_learner_id", "learner_id must be 1-128 URL-safe characters");
+  }
+
+  if (typeof payload.event_type !== "string" || !EVENT_TYPES.has(payload.event_type)) {
+    return fail(
+      "unknown_event_type",
+      `event_type must be one of: ${V1_EVENT_TYPES.join(", ")}`
+    );
+  }
+  const eventType = payload.event_type as V1EventType;
+
+  if (typeof payload.occurred_at !== "string" || !RFC_3339_UTC.test(payload.occurred_at)) {
+    return fail("invalid_occurred_at", "occurred_at must be an RFC 3339 UTC timestamp");
+  }
+  if (Number.isNaN(Date.parse(payload.occurred_at))) {
+    return fail("invalid_occurred_at", "occurred_at is not a real instant");
+  }
+
+  if (!isPlainObject(payload.metadata)) {
+    return fail("invalid_metadata", "metadata must be a JSON object");
+  }
+
+  const rule = METADATA_RULES[eventType];
+  const present = Object.keys(payload.metadata);
+
+  const unexpected = present.filter((k) => !rule.keys.includes(k));
+  if (unexpected.length > 0) {
+    return fail(
+      "invalid_metadata",
+      `${eventType} does not allow metadata keys: ${unexpected.join(", ")}`
+    );
+  }
+
+  const missing = rule.keys.filter((k) => !present.includes(k));
+  if (missing.length > 0) {
+    return fail("invalid_metadata", `${eventType} requires metadata keys: ${missing.join(", ")}`);
+  }
+
+  const problem = rule.check(payload.metadata);
+  if (problem !== null) {
+    return fail("invalid_metadata", problem);
+  }
+
+  return { ok: true, event: payload as V1Envelope };
+}
+
+/** True when a payload declares a version this package can validate. */
+export function isV1Payload(payload: unknown): boolean {
+  return isPlainObject(payload) && payload.schema_version === SCHEMA_VERSION;
+}

--- a/supabase/migrations/111_pal_pilot_transactional_outbox.sql
+++ b/supabase/migrations/111_pal_pilot_transactional_outbox.sql
@@ -1,0 +1,787 @@
+-- Pal achievement pilot: durable, privacy-safe delivery outbox.
+--
+-- Pika remains the academic source of truth. These tables are an internal
+-- delivery ledger; only the JSON payload crosses the Pal boundary.
+
+create table public.pal_event_outbox (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  student_id uuid not null,
+  event_type text not null,
+  source_kind text not null,
+  source_id text not null,
+  payload jsonb not null,
+  status text not null default 'pending',
+  attempts integer not null default 0,
+  next_attempt_at timestamptz not null default now(),
+  lease_token uuid,
+  lease_expires_at timestamptz,
+  last_attempt_at timestamptz,
+  delivered_at timestamptz,
+  last_error_code text,
+  last_error_detail text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint pal_event_outbox_event_type_check check (
+    event_type in (
+      'platform.session.started',
+      'classroom.joined',
+      'daily_log_week.configured',
+      'daily_log.completed',
+      'learning_item.viewed',
+      'learning_item.completed'
+    )
+  ),
+  constraint pal_event_outbox_status_check check (
+    status in ('pending', 'processing', 'delivered', 'non_retryable')
+  ),
+  constraint pal_event_outbox_attempts_check check (attempts >= 0),
+  constraint pal_event_outbox_payload_check check (
+    jsonb_typeof(payload) = 'object'
+    and payload->>'idempotency_key' = idempotency_key
+    and payload->>'event_type' = event_type
+    and payload->>'schema_version' = '1'
+    and jsonb_typeof(payload->'metadata') = 'object'
+  )
+);
+
+create index pal_event_outbox_delivery_idx
+  on public.pal_event_outbox (next_attempt_at, created_at)
+  where status in ('pending', 'processing');
+
+create index pal_event_outbox_student_created_idx
+  on public.pal_event_outbox (student_id, created_at desc);
+
+create table public.pal_daily_log_week_configurations (
+  id uuid primary key default gen_random_uuid(),
+  student_id uuid not null,
+  period_key text not null,
+  config_version integer not null,
+  period_status text not null,
+  eligible_days integer not null,
+  configured_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  constraint pal_daily_log_week_config_version_check check (config_version >= 1),
+  constraint pal_daily_log_week_period_status_check check (
+    period_status in ('open', 'closed')
+  ),
+  constraint pal_daily_log_week_eligible_days_check check (
+    eligible_days between 0 and 5
+  ),
+  unique (student_id, period_key, config_version)
+);
+
+create index pal_daily_log_week_latest_idx
+  on public.pal_daily_log_week_configurations (
+    student_id,
+    period_key,
+    config_version desc
+  );
+
+alter table public.pal_event_outbox enable row level security;
+alter table public.pal_daily_log_week_configurations enable row level security;
+
+revoke all on table public.pal_event_outbox from public, anon, authenticated;
+revoke all on table public.pal_daily_log_week_configurations from public, anon, authenticated;
+grant select, insert, update on table public.pal_event_outbox to service_role;
+grant select, insert on table public.pal_daily_log_week_configurations to service_role;
+
+create or replace function private.enqueue_pal_event(
+  p_student_id uuid,
+  p_source_kind text,
+  p_source_id text,
+  p_event jsonb
+)
+returns public.pal_event_outbox
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_outbox public.pal_event_outbox;
+  v_idempotency_key text;
+  v_event_type text;
+begin
+  if p_event is null then
+    return null;
+  end if;
+
+  v_idempotency_key := p_event->>'idempotency_key';
+  v_event_type := p_event->>'event_type';
+
+  if p_student_id is null
+    or nullif(btrim(p_source_kind), '') is null
+    or nullif(btrim(p_source_id), '') is null
+    or nullif(v_idempotency_key, '') is null
+    or length(v_idempotency_key) > 200
+    or nullif(p_event->>'learner_id', '') is null
+    or nullif(p_event->>'occurred_at', '') is null
+    or jsonb_typeof(p_event->'metadata') <> 'object'
+    or p_event->>'schema_version' <> '1'
+    or v_event_type not in (
+      'platform.session.started',
+      'classroom.joined',
+      'daily_log_week.configured',
+      'daily_log.completed',
+      'learning_item.viewed',
+      'learning_item.completed'
+    ) then
+    raise exception 'Invalid Pal v1 outbox event' using errcode = '22023';
+  end if;
+
+  insert into public.pal_event_outbox (
+    idempotency_key,
+    student_id,
+    event_type,
+    source_kind,
+    source_id,
+    payload
+  ) values (
+    v_idempotency_key,
+    p_student_id,
+    v_event_type,
+    p_source_kind,
+    p_source_id,
+    p_event
+  )
+  on conflict (idempotency_key) do nothing
+  returning * into v_outbox;
+
+  if not found then
+    select * into v_outbox
+    from public.pal_event_outbox
+    where idempotency_key = v_idempotency_key;
+  end if;
+
+  return v_outbox;
+end;
+$$;
+
+create or replace function public.enqueue_pal_event(
+  p_student_id uuid,
+  p_source_kind text,
+  p_source_id text,
+  p_event jsonb
+)
+returns public.pal_event_outbox
+language sql
+security definer
+set search_path = public, private
+as $$
+  select private.enqueue_pal_event(
+    p_student_id,
+    p_source_kind,
+    p_source_id,
+    p_event
+  );
+$$;
+
+create or replace function public.create_classroom_enrollment_with_pal_event_atomic(
+  p_classroom_id uuid,
+  p_student_id uuid,
+  p_pal_event jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_enrollment public.classroom_enrollments;
+  v_created boolean := false;
+begin
+  if p_classroom_id is null or p_student_id is null then
+    raise exception 'Invalid classroom enrollment request' using errcode = '22023';
+  end if;
+
+  insert into public.classroom_enrollments (classroom_id, student_id)
+  values (p_classroom_id, p_student_id)
+  on conflict (classroom_id, student_id) do nothing
+  returning * into v_enrollment;
+
+  if found then
+    v_created := true;
+    perform private.enqueue_pal_event(
+      p_student_id,
+      'classroom_enrollment',
+      p_classroom_id::text,
+      p_pal_event
+    );
+  else
+    select * into v_enrollment
+    from public.classroom_enrollments
+    where classroom_id = p_classroom_id and student_id = p_student_id;
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'created', v_created,
+    'enrollment', to_jsonb(v_enrollment)
+  );
+end;
+$$;
+
+create or replace function public.upsert_student_entry_with_pal_event_atomic(
+  p_student_id uuid,
+  p_classroom_id uuid,
+  p_date date,
+  p_text text,
+  p_rich_content jsonb,
+  p_minutes_reported integer,
+  p_mood text,
+  p_on_time boolean,
+  p_pal_event jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_entry public.entries;
+  v_created boolean := false;
+begin
+  if p_student_id is null
+    or p_classroom_id is null
+    or p_date is null
+    or p_text is null
+    or p_rich_content is null
+    or p_on_time is null then
+    raise exception 'Invalid student entry request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'pal_daily_log:' || p_student_id::text || ':' || p_classroom_id::text || ':' || p_date::text,
+      0
+    )
+  );
+
+  select * into v_entry
+  from public.entries
+  where student_id = p_student_id
+    and classroom_id = p_classroom_id
+    and date = p_date
+  for update;
+
+  if found then
+    update public.entries
+    set text = p_text,
+        rich_content = p_rich_content,
+        minutes_reported = p_minutes_reported,
+        mood = p_mood,
+        on_time = p_on_time,
+        version = coalesce(version, 1) + 1
+    where id = v_entry.id
+    returning * into v_entry;
+  else
+    insert into public.entries (
+      student_id,
+      classroom_id,
+      date,
+      text,
+      rich_content,
+      minutes_reported,
+      mood,
+      on_time
+    ) values (
+      p_student_id,
+      p_classroom_id,
+      p_date,
+      p_text,
+      p_rich_content,
+      p_minutes_reported,
+      p_mood,
+      p_on_time
+    )
+    returning * into v_entry;
+    v_created := true;
+  end if;
+
+  perform private.enqueue_pal_event(
+    p_student_id,
+    'daily_log',
+    p_date::text,
+    p_pal_event
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'created', v_created,
+    'entry', to_jsonb(v_entry)
+  );
+end;
+$$;
+
+create or replace function public.create_assignment_doc_with_pal_event_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid,
+  p_viewed_at timestamptz,
+  p_pal_event jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_doc public.assignment_docs;
+  v_created boolean := false;
+begin
+  if p_assignment_id is null or p_student_id is null or p_viewed_at is null then
+    raise exception 'Invalid assignment view request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'pal_assignment_view:' || p_assignment_id::text || ':' || p_student_id::text,
+      0
+    )
+  );
+
+  select * into v_doc
+  from public.assignment_docs
+  where assignment_id = p_assignment_id and student_id = p_student_id
+  for update;
+
+  if not found then
+    insert into public.assignment_docs (
+      assignment_id,
+      student_id,
+      content,
+      repo_url,
+      github_username,
+      is_submitted,
+      submitted_at,
+      viewed_at
+    ) values (
+      p_assignment_id,
+      p_student_id,
+      '{"type":"doc","content":[]}'::jsonb,
+      null,
+      null,
+      false,
+      null,
+      p_viewed_at
+    )
+    returning * into v_doc;
+    v_created := true;
+
+    perform private.enqueue_pal_event(
+      p_student_id,
+      'assignment_first_view',
+      p_assignment_id::text,
+      p_pal_event
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'created', v_created,
+    'doc', to_jsonb(v_doc)
+  );
+end;
+$$;
+
+create or replace function public.submit_assignment_doc_with_pal_event_atomic(
+  p_assignment_id uuid,
+  p_student_id uuid,
+  p_content jsonb,
+  p_expected_updated_at timestamptz,
+  p_word_count integer,
+  p_char_count integer,
+  p_pal_event jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_doc public.assignment_docs;
+  v_history public.assignment_doc_history;
+begin
+  if p_assignment_id is null or p_student_id is null or p_content is null
+    or p_expected_updated_at is null then
+    raise exception 'Invalid assignment document submission request' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('assignment_submission:' || p_assignment_id::text, 0)
+  );
+
+  select * into v_doc
+  from public.assignment_docs
+  where assignment_id = p_assignment_id and student_id = p_student_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false, 'status', 400, 'error_code', 'assignment_doc_missing',
+      'error', 'No work to submit. Please save your work first.'
+    );
+  end if;
+
+  if v_doc.is_submitted then
+    if v_doc.content = p_content then
+      select * into v_history
+      from public.assignment_doc_history
+      where assignment_doc_id = v_doc.id
+        and trigger = 'submit'
+        and created_at >= coalesce(v_doc.submitted_at, '-infinity'::timestamptz)
+        and patch is null
+        and snapshot = v_doc.content
+      order by created_at desc, id desc
+      limit 1;
+
+      if not found then
+        insert into public.assignment_doc_history (
+          assignment_doc_id, patch, snapshot, word_count, char_count,
+          paste_word_count, keystroke_count, trigger, created_at
+        ) values (
+          v_doc.id, null, v_doc.content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+          0, 0, 'submit', clock_timestamp()
+        ) returning * into v_history;
+      end if;
+
+      return jsonb_build_object(
+        'ok', true, 'idempotent', true, 'doc', to_jsonb(v_doc),
+        'history_entry', to_jsonb(v_history)
+      );
+    end if;
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_submitted',
+      'error', 'This assignment is already submitted and cannot be changed.'
+    );
+  end if;
+
+  if v_doc.updated_at <> p_expected_updated_at then
+    return jsonb_build_object(
+      'ok', false, 'status', 409, 'error_code', 'assignment_doc_revision_conflict',
+      'error', 'Your saved draft changed before submission. Review it and try again.'
+    );
+  end if;
+
+  perform private.validate_assignment_submission_requirements(v_doc);
+
+  update public.assignment_docs
+  set content = p_content,
+      is_submitted = true,
+      submitted_at = clock_timestamp()
+  where id = v_doc.id and is_submitted is false
+  returning * into v_doc;
+
+  insert into public.assignment_doc_history (
+    assignment_doc_id, patch, snapshot, word_count, char_count,
+    paste_word_count, keystroke_count, trigger, created_at
+  ) values (
+    v_doc.id, null, p_content, coalesce(p_word_count, 0), coalesce(p_char_count, 0),
+    0, 0, 'submit', clock_timestamp()
+  ) returning * into v_history;
+
+  perform private.enqueue_pal_event(
+    p_student_id,
+    'assignment_first_completion',
+    p_assignment_id::text,
+    p_pal_event
+  );
+
+  return jsonb_build_object(
+    'ok', true, 'idempotent', false, 'doc', to_jsonb(v_doc), 'history_entry', to_jsonb(v_history)
+  );
+end;
+$$;
+
+create or replace function public.record_pal_daily_log_week_configuration_atomic(
+  p_student_id uuid,
+  p_period_key text,
+  p_config_version integer,
+  p_period_status text,
+  p_eligible_days integer,
+  p_configured_at timestamptz,
+  p_pal_event jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  v_existing public.pal_daily_log_week_configurations;
+  v_previous public.pal_daily_log_week_configurations;
+begin
+  if p_student_id is null
+    or nullif(btrim(p_period_key), '') is null
+    or p_config_version < 1
+    or p_period_status not in ('open', 'closed')
+    or p_eligible_days not between 0 and 5
+    or p_configured_at is null then
+    raise exception 'Invalid Pal weekly configuration' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'pal_daily_log_week:' || p_student_id::text || ':' || p_period_key,
+      0
+    )
+  );
+
+  select * into v_existing
+  from public.pal_daily_log_week_configurations
+  where student_id = p_student_id
+    and period_key = p_period_key
+    and config_version = p_config_version;
+
+  if found then
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'configuration', to_jsonb(v_existing)
+    );
+  end if;
+
+  select * into v_previous
+  from public.pal_daily_log_week_configurations
+  where student_id = p_student_id and period_key = p_period_key
+  order by config_version desc
+  limit 1
+  for update;
+
+  if found and v_previous.period_status = 'closed' then
+    raise exception 'Pal weekly configuration is already closed' using errcode = '23514';
+  end if;
+
+  if found and p_config_version <> v_previous.config_version + 1 then
+    raise exception 'Pal weekly configuration version must be monotonic' using errcode = '23514';
+  end if;
+
+  if not found and p_config_version <> 1 then
+    raise exception 'First Pal weekly configuration version must be 1' using errcode = '23514';
+  end if;
+
+  insert into public.pal_daily_log_week_configurations (
+    student_id,
+    period_key,
+    config_version,
+    period_status,
+    eligible_days,
+    configured_at
+  ) values (
+    p_student_id,
+    p_period_key,
+    p_config_version,
+    p_period_status,
+    p_eligible_days,
+    p_configured_at
+  )
+  returning * into v_existing;
+
+  perform private.enqueue_pal_event(
+    p_student_id,
+    'daily_log_week_configuration',
+    p_period_key || ':' || p_config_version::text,
+    p_pal_event
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'configuration', to_jsonb(v_existing)
+  );
+end;
+$$;
+
+create or replace function public.claim_pal_event_outbox(
+  p_limit integer default 25,
+  p_lease_seconds integer default 60
+)
+returns setof public.pal_event_outbox
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_limit not between 1 and 100 or p_lease_seconds not between 10 and 600 then
+    raise exception 'Invalid Pal outbox claim options' using errcode = '22023';
+  end if;
+
+  return query
+  with candidates as (
+    select id
+    from public.pal_event_outbox
+    where (
+      status = 'pending' and next_attempt_at <= now()
+    ) or (
+      status = 'processing' and lease_expires_at <= now()
+    )
+    order by next_attempt_at, created_at
+    limit p_limit
+    for update skip locked
+  )
+  update public.pal_event_outbox outbox
+  set status = 'processing',
+      attempts = outbox.attempts + 1,
+      lease_token = gen_random_uuid(),
+      lease_expires_at = now() + make_interval(secs => p_lease_seconds),
+      last_attempt_at = now(),
+      updated_at = now()
+  from candidates
+  where outbox.id = candidates.id
+  returning outbox.*;
+end;
+$$;
+
+create or replace function public.complete_pal_event_outbox(
+  p_outbox_id uuid,
+  p_lease_token uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.pal_event_outbox
+  set status = 'delivered',
+      delivered_at = now(),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = null,
+      last_error_detail = null,
+      updated_at = now()
+  where id = p_outbox_id
+    and status = 'processing'
+    and lease_token = p_lease_token;
+  return found;
+end;
+$$;
+
+create or replace function public.retry_pal_event_outbox(
+  p_outbox_id uuid,
+  p_lease_token uuid,
+  p_next_attempt_at timestamptz,
+  p_error_code text,
+  p_error_detail text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.pal_event_outbox
+  set status = 'pending',
+      next_attempt_at = greatest(p_next_attempt_at, now()),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = left(nullif(p_error_code, ''), 100),
+      last_error_detail = left(nullif(p_error_detail, ''), 500),
+      updated_at = now()
+  where id = p_outbox_id
+    and status = 'processing'
+    and lease_token = p_lease_token;
+  return found;
+end;
+$$;
+
+create or replace function public.fail_pal_event_outbox(
+  p_outbox_id uuid,
+  p_lease_token uuid,
+  p_error_code text,
+  p_error_detail text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.pal_event_outbox
+  set status = 'non_retryable',
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = left(nullif(p_error_code, ''), 100),
+      last_error_detail = left(nullif(p_error_detail, ''), 500),
+      updated_at = now()
+  where id = p_outbox_id
+    and status = 'processing'
+    and lease_token = p_lease_token;
+  return found;
+end;
+$$;
+
+create or replace function public.requeue_pal_event_outbox(
+  p_outbox_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.pal_event_outbox
+  set status = 'pending',
+      next_attempt_at = now(),
+      lease_token = null,
+      lease_expires_at = null,
+      last_error_code = null,
+      last_error_detail = null,
+      updated_at = now()
+  where id = p_outbox_id
+    and status = 'non_retryable';
+  return found;
+end;
+$$;
+
+revoke all on function private.enqueue_pal_event(uuid, text, text, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.enqueue_pal_event(uuid, text, text, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.submit_assignment_doc_with_pal_event_atomic(uuid, uuid, jsonb, timestamptz, integer, integer, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.record_pal_daily_log_week_configuration_atomic(uuid, text, integer, text, integer, timestamptz, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.claim_pal_event_outbox(integer, integer)
+  from public, anon, authenticated;
+revoke all on function public.complete_pal_event_outbox(uuid, uuid)
+  from public, anon, authenticated;
+revoke all on function public.retry_pal_event_outbox(uuid, uuid, timestamptz, text, text)
+  from public, anon, authenticated;
+revoke all on function public.fail_pal_event_outbox(uuid, uuid, text, text)
+  from public, anon, authenticated;
+revoke all on function public.requeue_pal_event_outbox(uuid)
+  from public, anon, authenticated;
+
+grant execute on function public.enqueue_pal_event(uuid, text, text, jsonb)
+  to service_role;
+grant execute on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
+  to service_role;
+grant execute on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, jsonb)
+  to service_role;
+grant execute on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
+  to service_role;
+grant execute on function public.submit_assignment_doc_with_pal_event_atomic(uuid, uuid, jsonb, timestamptz, integer, integer, jsonb)
+  to service_role;
+grant execute on function public.record_pal_daily_log_week_configuration_atomic(uuid, text, integer, text, integer, timestamptz, jsonb)
+  to service_role;
+grant execute on function public.claim_pal_event_outbox(integer, integer)
+  to service_role;
+grant execute on function public.complete_pal_event_outbox(uuid, uuid)
+  to service_role;
+grant execute on function public.retry_pal_event_outbox(uuid, uuid, timestamptz, text, text)
+  to service_role;
+grant execute on function public.fail_pal_event_outbox(uuid, uuid, text, text)
+  to service_role;
+grant execute on function public.requeue_pal_event_outbox(uuid)
+  to service_role;
+
+comment on table public.pal_event_outbox is
+  'Internal Pika delivery ledger for privacy-safe Pal facts; payload is the only outbound data.';
+comment on table public.pal_daily_log_week_configurations is
+  'Pika-owned learner/week opportunity revisions used to reconcile Weekly Rhythm facts.';

--- a/supabase/migrations/111_pal_pilot_transactional_outbox.sql
+++ b/supabase/migrations/111_pal_pilot_transactional_outbox.sql
@@ -230,6 +230,7 @@ create or replace function public.upsert_student_entry_with_pal_event_atomic(
   p_minutes_reported integer,
   p_mood text,
   p_on_time boolean,
+  p_expected_version integer,
   p_pal_event jsonb
 )
 returns jsonb
@@ -265,6 +266,16 @@ begin
   for update;
 
   if found then
+    if p_expected_version is not null
+      and coalesce(v_entry.version, 1) <> p_expected_version then
+      return jsonb_build_object(
+        'ok', false,
+        'status', 409,
+        'error', 'Entry has been updated elsewhere',
+        'entry', to_jsonb(v_entry)
+      );
+    end if;
+
     update public.entries
     set text = p_text,
         rich_content = p_rich_content,
@@ -275,6 +286,15 @@ begin
     where id = v_entry.id
     returning * into v_entry;
   else
+    if p_expected_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'status', 409,
+        'error', 'Entry has been updated elsewhere',
+        'entry', null
+      );
+    end if;
+
     insert into public.entries (
       student_id,
       classroom_id,
@@ -631,6 +651,22 @@ begin
 end;
 $$;
 
+create or replace function public.count_pal_event_outbox_ready()
+returns bigint
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select count(*)
+  from public.pal_event_outbox
+  where (
+    status = 'pending' and next_attempt_at <= now()
+  ) or (
+    status = 'processing' and lease_expires_at <= now()
+  );
+$$;
+
 create or replace function public.complete_pal_event_outbox(
   p_outbox_id uuid,
   p_lease_token uuid
@@ -739,7 +775,7 @@ revoke all on function public.enqueue_pal_event(uuid, text, text, jsonb)
   from public, anon, authenticated;
 revoke all on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
   from public, anon, authenticated;
-revoke all on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, jsonb)
+revoke all on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, integer, jsonb)
   from public, anon, authenticated;
 revoke all on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
   from public, anon, authenticated;
@@ -748,6 +784,8 @@ revoke all on function public.submit_assignment_doc_with_pal_event_atomic(uuid, 
 revoke all on function public.record_pal_daily_log_week_configuration_atomic(uuid, text, integer, text, integer, timestamptz, jsonb)
   from public, anon, authenticated;
 revoke all on function public.claim_pal_event_outbox(integer, integer)
+  from public, anon, authenticated;
+revoke all on function public.count_pal_event_outbox_ready()
   from public, anon, authenticated;
 revoke all on function public.complete_pal_event_outbox(uuid, uuid)
   from public, anon, authenticated;
@@ -762,7 +800,7 @@ grant execute on function public.enqueue_pal_event(uuid, text, text, jsonb)
   to service_role;
 grant execute on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
   to service_role;
-grant execute on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, jsonb)
+grant execute on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, integer, jsonb)
   to service_role;
 grant execute on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
   to service_role;
@@ -771,6 +809,8 @@ grant execute on function public.submit_assignment_doc_with_pal_event_atomic(uui
 grant execute on function public.record_pal_daily_log_week_configuration_atomic(uuid, text, integer, text, integer, timestamptz, jsonb)
   to service_role;
 grant execute on function public.claim_pal_event_outbox(integer, integer)
+  to service_role;
+grant execute on function public.count_pal_event_outbox_ready()
   to service_role;
 grant execute on function public.complete_pal_event_outbox(uuid, uuid)
   to service_role;

--- a/supabase/migrations/111_pal_pilot_transactional_outbox.sql
+++ b/supabase/migrations/111_pal_pilot_transactional_outbox.sql
@@ -227,11 +227,11 @@ create or replace function public.upsert_student_entry_with_pal_event_atomic(
   p_date date,
   p_text text,
   p_rich_content jsonb,
-  p_minutes_reported integer,
-  p_mood text,
   p_on_time boolean,
-  p_expected_version integer,
-  p_pal_event jsonb
+  p_pal_event jsonb,
+  p_minutes_reported integer default null,
+  p_mood text default null,
+  p_expected_version integer default null
 )
 returns jsonb
 language plpgsql
@@ -775,7 +775,7 @@ revoke all on function public.enqueue_pal_event(uuid, text, text, jsonb)
   from public, anon, authenticated;
 revoke all on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
   from public, anon, authenticated;
-revoke all on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, integer, jsonb)
+revoke all on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, boolean, jsonb, integer, text, integer)
   from public, anon, authenticated;
 revoke all on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
   from public, anon, authenticated;
@@ -800,7 +800,7 @@ grant execute on function public.enqueue_pal_event(uuid, text, text, jsonb)
   to service_role;
 grant execute on function public.create_classroom_enrollment_with_pal_event_atomic(uuid, uuid, jsonb)
   to service_role;
-grant execute on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, integer, text, boolean, integer, jsonb)
+grant execute on function public.upsert_student_entry_with_pal_event_atomic(uuid, uuid, date, text, jsonb, boolean, jsonb, integer, text, integer)
   to service_role;
 grant execute on function public.create_assignment_doc_with_pal_event_atomic(uuid, uuid, timestamptz, jsonb)
   to service_role;

--- a/tests/api/cron/pal-outbox.test.ts
+++ b/tests/api/cron/pal-outbox.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockDeliverPalOutboxBatch,
+  mockLoadPalOutboxStatus,
+  mockRequeuePalOutboxEvent,
+} = vi.hoisted(() => ({
+  mockDeliverPalOutboxBatch: vi.fn(),
+  mockLoadPalOutboxStatus: vi.fn(),
+  mockRequeuePalOutboxEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/server/pal-outbox', () => ({
+  deliverPalOutboxBatch: mockDeliverPalOutboxBatch,
+}))
+vi.mock('@/lib/server/pal-operations', () => ({
+  loadPalOutboxStatus: mockLoadPalOutboxStatus,
+  requeuePalOutboxEvent: mockRequeuePalOutboxEvent,
+}))
+
+import { GET, PATCH, POST } from '@/app/api/cron/pal-outbox/route'
+
+describe('POST /api/cron/pal-outbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('CRON_SECRET', 'cron-secret')
+    mockDeliverPalOutboxBatch.mockResolvedValue({
+      status: 'ok',
+      claimed: 1,
+      delivered: 1,
+      retrying: 0,
+      nonRetryable: 0,
+    })
+    mockLoadPalOutboxStatus.mockResolvedValue({
+      enabled: true,
+      counts: { pending: 2, processing: 0, delivered: 8, non_retryable: 1 },
+      exceptions: [],
+    })
+  })
+
+  it('requires cron authentication', async () => {
+    const response = await POST(new Request('http://localhost/api/cron/pal-outbox', {
+      method: 'POST',
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(401)
+    expect(mockDeliverPalOutboxBatch).not.toHaveBeenCalled()
+  })
+
+  it('runs one bounded delivery batch', async () => {
+    const response = await POST(new Request('http://localhost/api/cron/pal-outbox', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer cron-secret' },
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ delivered: 1 })
+    expect(mockDeliverPalOutboxBatch).toHaveBeenCalledOnce()
+  })
+
+  it('returns privacy-safe adapter status under the same credential', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/pal-outbox', {
+      headers: { Authorization: 'Bearer cron-secret' },
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      counts: { pending: 2, non_retryable: 1 },
+    })
+  })
+
+  it('requeues a selected non-retryable event', async () => {
+    mockRequeuePalOutboxEvent.mockResolvedValue(true)
+    const response = await PATCH(new Request('http://localhost/api/cron/pal-outbox', {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer cron-secret' },
+      body: JSON.stringify({
+        outbox_id: '10000000-0000-4000-8000-000000000001',
+      }),
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    expect(mockRequeuePalOutboxEvent).toHaveBeenCalledWith({
+      outboxId: '10000000-0000-4000-8000-000000000001',
+    })
+  })
+})

--- a/tests/api/cron/pal-sync.test.ts
+++ b/tests/api/cron/pal-sync.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockDeliverPalOutboxBatch, mockSyncPalWeeklyConfigurations } = vi.hoisted(() => ({
+  mockDeliverPalOutboxBatch: vi.fn(),
+  mockSyncPalWeeklyConfigurations: vi.fn(),
+}))
+
+vi.mock('@/lib/server/pal-outbox', () => ({
+  deliverPalOutboxBatch: mockDeliverPalOutboxBatch,
+}))
+vi.mock('@/lib/server/pal-weekly-config', () => ({
+  syncPalWeeklyConfigurations: mockSyncPalWeeklyConfigurations,
+}))
+
+import { GET } from '@/app/api/cron/pal-sync/route'
+
+describe('GET /api/cron/pal-sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('CRON_SECRET', 'cron-secret')
+    mockSyncPalWeeklyConfigurations.mockResolvedValue({
+      status: 'ok',
+      configured: 2,
+      closed: 1,
+    })
+    mockDeliverPalOutboxBatch.mockResolvedValue({
+      status: 'ok',
+      claimed: 3,
+      delivered: 3,
+      retrying: 0,
+      nonRetryable: 0,
+    })
+  })
+
+  it('requires cron authentication', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/pal-sync') as any, {
+      params: Promise.resolve({}),
+    })
+
+    expect(response.status).toBe(401)
+    expect(mockSyncPalWeeklyConfigurations).not.toHaveBeenCalled()
+  })
+
+  it('reconciles weekly opportunities before draining the delivery outbox', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/pal-sync', {
+      headers: { Authorization: 'Bearer cron-secret' },
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      weekly: { status: 'ok', configured: 2, closed: 1 },
+      delivery: {
+        status: 'ok',
+        claimed: 3,
+        delivered: 3,
+        retrying: 0,
+        nonRetryable: 0,
+      },
+    })
+    expect(mockSyncPalWeeklyConfigurations.mock.invocationCallOrder[0])
+      .toBeLessThan(mockDeliverPalOutboxBatch.mock.invocationCallOrder[0])
+  })
+
+  it('still drains the delivery outbox when weekly reconciliation fails', async () => {
+    mockSyncPalWeeklyConfigurations.mockRejectedValue(new Error('weekly unavailable'))
+
+    const response = await GET(new Request('http://localhost/api/cron/pal-sync', {
+      headers: { Authorization: 'Bearer cron-secret' },
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: 'partial',
+      weekly: { status: 'error', error: 'weekly_sync_failed' },
+      delivery: {
+        status: 'ok',
+        claimed: 3,
+        delivered: 3,
+        retrying: 0,
+        nonRetryable: 0,
+      },
+    })
+    expect(mockDeliverPalOutboxBatch).toHaveBeenCalledOnce()
+  })
+
+  it('reports a partial run when delivery fails after weekly reconciliation', async () => {
+    mockDeliverPalOutboxBatch.mockRejectedValue(new Error('delivery unavailable'))
+
+    const response = await GET(new Request('http://localhost/api/cron/pal-sync', {
+      headers: { Authorization: 'Bearer cron-secret' },
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: 'partial',
+      weekly: { status: 'ok', configured: 2, closed: 1 },
+      delivery: { status: 'error', error: 'outbox_delivery_failed' },
+    })
+  })
+})

--- a/tests/api/cron/pal-sync.test.ts
+++ b/tests/api/cron/pal-sync.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockDeliverPalOutboxBatch, mockSyncPalWeeklyConfigurations } = vi.hoisted(() => ({
-  mockDeliverPalOutboxBatch: vi.fn(),
+const { mockDrainPalOutbox, mockSyncPalWeeklyConfigurations } = vi.hoisted(() => ({
+  mockDrainPalOutbox: vi.fn(),
   mockSyncPalWeeklyConfigurations: vi.fn(),
 }))
 
 vi.mock('@/lib/server/pal-outbox', () => ({
-  deliverPalOutboxBatch: mockDeliverPalOutboxBatch,
+  drainPalOutbox: mockDrainPalOutbox,
 }))
 vi.mock('@/lib/server/pal-weekly-config', () => ({
   syncPalWeeklyConfigurations: mockSyncPalWeeklyConfigurations,
@@ -22,13 +22,18 @@ describe('GET /api/cron/pal-sync', () => {
       status: 'ok',
       configured: 2,
       closed: 1,
+      catchUpPeriods: 1,
+      remainingCatchUp: false,
     })
-    mockDeliverPalOutboxBatch.mockResolvedValue({
+    mockDrainPalOutbox.mockResolvedValue({
       status: 'ok',
       claimed: 3,
       delivered: 3,
       retrying: 0,
       nonRetryable: 0,
+      batches: 1,
+      remainingReady: 0,
+      stoppedReason: 'drained',
     })
   })
 
@@ -49,17 +54,26 @@ describe('GET /api/cron/pal-sync', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
       status: 'ok',
-      weekly: { status: 'ok', configured: 2, closed: 1 },
+      weekly: {
+        status: 'ok',
+        configured: 2,
+        closed: 1,
+        catchUpPeriods: 1,
+        remainingCatchUp: false,
+      },
       delivery: {
         status: 'ok',
         claimed: 3,
         delivered: 3,
         retrying: 0,
         nonRetryable: 0,
+        batches: 1,
+        remainingReady: 0,
+        stoppedReason: 'drained',
       },
     })
     expect(mockSyncPalWeeklyConfigurations.mock.invocationCallOrder[0])
-      .toBeLessThan(mockDeliverPalOutboxBatch.mock.invocationCallOrder[0])
+      .toBeLessThan(mockDrainPalOutbox.mock.invocationCallOrder[0])
   })
 
   it('still drains the delivery outbox when weekly reconciliation fails', async () => {
@@ -79,13 +93,16 @@ describe('GET /api/cron/pal-sync', () => {
         delivered: 3,
         retrying: 0,
         nonRetryable: 0,
+        batches: 1,
+        remainingReady: 0,
+        stoppedReason: 'drained',
       },
     })
-    expect(mockDeliverPalOutboxBatch).toHaveBeenCalledOnce()
+    expect(mockDrainPalOutbox).toHaveBeenCalledOnce()
   })
 
   it('reports a partial run when delivery fails after weekly reconciliation', async () => {
-    mockDeliverPalOutboxBatch.mockRejectedValue(new Error('delivery unavailable'))
+    mockDrainPalOutbox.mockRejectedValue(new Error('delivery unavailable'))
 
     const response = await GET(new Request('http://localhost/api/cron/pal-sync', {
       headers: { Authorization: 'Bearer cron-secret' },
@@ -94,7 +111,13 @@ describe('GET /api/cron/pal-sync', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
       status: 'partial',
-      weekly: { status: 'ok', configured: 2, closed: 1 },
+      weekly: {
+        status: 'ok',
+        configured: 2,
+        closed: 1,
+        catchUpPeriods: 1,
+        remainingCatchUp: false,
+      },
       delivery: { status: 'error', error: 'outbox_delivery_failed' },
     })
   })

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -871,6 +871,82 @@ describe('POST /api/student/entries', () => {
       expect(data.error).toBe('Failed to create entry')
     })
 
+    it('preserves omitted mood and minutes on a Pal-enabled POST update', async () => {
+      vi.stubEnv('PAL_ENABLED', 'true')
+      vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+      vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+      vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
+
+      const mockRpc = vi.fn().mockResolvedValue({
+        data: {
+          ok: true,
+          created: false,
+          entry: {
+            id: 'entry-1',
+            version: 2,
+            text: 'Updated reflection',
+            minutes_reported: 30,
+            mood: '😊',
+          },
+        },
+        error: null,
+      })
+      ;(mockSupabaseClient as any).rpc = mockRpc
+      ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+        if (table === 'class_days') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({
+                data: { is_class_day: true },
+                error: null,
+              }),
+            })),
+          }
+        }
+        if (table === 'entries') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'entry-1',
+                  version: 1,
+                  minutes_reported: 30,
+                  mood: '😊',
+                },
+                error: null,
+              }),
+            })),
+          }
+        }
+      })
+
+      const response = await POST(new NextRequest(
+        'http://localhost:3000/api/student/entries',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            classroom_id: 'classroom-1',
+            date: '2024-10-15',
+            text: 'Updated reflection',
+          }),
+        },
+      ))
+
+      expect(response.status).toBe(200)
+      expect(mockRpc).toHaveBeenCalledWith(
+        'upsert_student_entry_with_pal_event_atomic',
+        expect.objectContaining({
+          p_minutes_reported: 30,
+          p_mood: '😊',
+          p_pal_event: expect.objectContaining({
+            event_type: 'daily_log.completed',
+          }),
+        }),
+      )
+    })
+
     it('should return 500 when updating entry fails', async () => {
       const mockFrom = vi.fn((table: string) => {
         if (table === 'classroom_enrollments') {
@@ -943,8 +1019,8 @@ describe('PATCH /api/student/entries', () => {
   it('atomically creates the first autosaved log with its Pal fact', async () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     const content: TiptapContent = {
       type: 'doc',
@@ -1026,8 +1102,8 @@ describe('PATCH /api/student/entries', () => {
   it('atomically saves an empty autosave without emitting a completion fact', async () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     const content: TiptapContent = {
       type: 'doc',
@@ -1093,8 +1169,8 @@ describe('PATCH /api/student/entries', () => {
   it('atomically emits the fact when an existing empty autosave gains content', async () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     const emptyContent: TiptapContent = {
       type: 'doc',
@@ -1143,6 +1219,8 @@ describe('PATCH /api/student/entries', () => {
                 version: 1,
                 text: '',
                 rich_content: emptyContent,
+                minutes_reported: 45,
+                mood: '🙂',
               },
               error: null,
             }),
@@ -1169,6 +1247,8 @@ describe('PATCH /api/student/entries', () => {
       'upsert_student_entry_with_pal_event_atomic',
       expect.objectContaining({
         p_expected_version: 1,
+        p_minutes_reported: 45,
+        p_mood: '🙂',
         p_pal_event: expect.objectContaining({
           event_type: 'daily_log.completed',
         }),

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -3,7 +3,7 @@
  * Tests student journal entry creation and retrieval
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, POST, PATCH } from '@/app/api/student/entries/route'
 import { NextRequest } from 'next/server'
 import { mockAuthenticationError } from '../setup'
@@ -40,6 +40,11 @@ vi.mock('@/lib/server/classrooms', () => ({
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  delete (mockSupabaseClient as any).rpc
+})
 
 describe('GET /api/student/entries', () => {
   beforeEach(() => {
@@ -933,6 +938,89 @@ describe('POST /api/student/entries', () => {
 describe('PATCH /api/student/entries', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('atomically creates the first autosaved log with its Pal fact', async () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [{
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'First autosaved log' }],
+      }],
+    }
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        created: true,
+        entry: {
+          id: 'entry-1',
+          version: 1,
+          text: 'First autosaved log',
+          rich_content: content,
+        },
+      },
+      error: null,
+    })
+    ;(mockSupabaseClient as any).rpc = mockRpc
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { is_class_day: true },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' },
+            }),
+          })),
+        }
+      }
+    })
+
+    const response = await PATCH(new NextRequest(
+      'http://localhost:3000/api/student/entries',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          classroom_id: 'classroom-1',
+          date: '2024-10-15',
+          version: 1,
+          rich_content: content,
+        }),
+      },
+    ))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      entry: { id: 'entry-1' },
+    })
+    expect(mockRpc).toHaveBeenCalledWith(
+      'upsert_student_entry_with_pal_event_atomic',
+      expect.objectContaining({
+        p_student_id: 'student-1',
+        p_classroom_id: 'classroom-1',
+        p_date: '2024-10-15',
+        p_pal_event: expect.objectContaining({
+          event_type: 'daily_log.completed',
+          metadata: expect.objectContaining({ activity_day: '2024-10-15' }),
+        }),
+      }),
+    )
   })
 
   it('should apply patch and increment version', async () => {

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -1023,6 +1023,159 @@ describe('PATCH /api/student/entries', () => {
     )
   })
 
+  it('atomically saves an empty autosave without emitting a completion fact', async () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    }
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        created: true,
+        entry: { id: 'entry-empty', version: 1, text: '', rich_content: content },
+      },
+      error: null,
+    })
+    ;(mockSupabaseClient as any).rpc = mockRpc
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { is_class_day: true },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' },
+            }),
+          })),
+        }
+      }
+    })
+
+    const response = await PATCH(new NextRequest(
+      'http://localhost:3000/api/student/entries',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          classroom_id: 'classroom-1',
+          date: '2024-10-15',
+          version: 1,
+          rich_content: content,
+        }),
+      },
+    ))
+
+    expect(response.status).toBe(200)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'upsert_student_entry_with_pal_event_atomic',
+      expect.objectContaining({
+        p_expected_version: null,
+        p_pal_event: null,
+      }),
+    )
+  })
+
+  it('atomically emits the fact when an existing empty autosave gains content', async () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    const emptyContent: TiptapContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    }
+    const nextContent: TiptapContent = {
+      type: 'doc',
+      content: [{
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Now this qualifies' }],
+      }],
+    }
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        created: false,
+        entry: {
+          id: 'entry-1',
+          version: 2,
+          text: 'Now this qualifies',
+          rich_content: nextContent,
+        },
+      },
+      error: null,
+    })
+    ;(mockSupabaseClient as any).rpc = mockRpc
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { is_class_day: true },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'entry-1',
+                version: 1,
+                text: '',
+                rich_content: emptyContent,
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+    })
+
+    const response = await PATCH(new NextRequest(
+      'http://localhost:3000/api/student/entries',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          classroom_id: 'classroom-1',
+          date: '2024-10-15',
+          version: 1,
+          rich_content: nextContent,
+        }),
+      },
+    ))
+
+    expect(response.status).toBe(200)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'upsert_student_entry_with_pal_event_atomic',
+      expect.objectContaining({
+        p_expected_version: 1,
+        p_pal_event: expect.objectContaining({
+          event_type: 'daily_log.completed',
+        }),
+      }),
+    )
+  })
+
   it('should apply patch and increment version', async () => {
     const baseContent: TiptapContent = {
       type: 'doc',

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -1084,10 +1084,10 @@ describe('PATCH /api/student/entries', () => {
     expect(mockRpc).toHaveBeenCalledWith(
       'upsert_student_entry_with_pal_event_atomic',
       expect.objectContaining({
-        p_expected_version: null,
         p_pal_event: null,
       }),
     )
+    expect(mockRpc.mock.calls[0][1]).not.toHaveProperty('p_expected_version')
   })
 
   it('atomically emits the fact when an existing empty autosave gains content', async () => {

--- a/tests/api/student/pal-read-token.test.ts
+++ b/tests/api/student/pal-read-token.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockMintPalReadToken, mockRequireRole } = vi.hoisted(() => ({
+  mockMintPalReadToken: vi.fn(),
+  mockRequireRole: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: mockRequireRole }))
+vi.mock('@/lib/server/pal-read-token', () => ({
+  mintPalReadToken: mockMintPalReadToken,
+}))
+
+import { POST } from '@/app/api/student/pal/read-token/route'
+
+describe('POST /api/student/pal/read-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('PAL_ENABLED', 'true')
+    mockRequireRole.mockResolvedValue({ id: 'student-1', role: 'student' })
+    mockMintPalReadToken.mockResolvedValue({
+      token: 'short-lived-token',
+      expires_at: '2026-09-16T18:25:00.000Z',
+    })
+  })
+
+  it('returns a no-store learner-scoped read token', async () => {
+    const response = await POST(new Request('http://localhost/api/student/pal/read-token', {
+      method: 'POST',
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(mockMintPalReadToken).toHaveBeenCalledWith({ studentId: 'student-1' })
+  })
+
+  it('does not expose the endpoint while the pilot is disabled', async () => {
+    vi.stubEnv('PAL_ENABLED', 'false')
+    const response = await POST(new Request('http://localhost/api/student/pal/read-token', {
+      method: 'POST',
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(404)
+    expect(mockMintPalReadToken).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/student/pal-read-token.test.ts
+++ b/tests/api/student/pal-read-token.test.ts
@@ -16,6 +16,9 @@ describe('POST /api/student/pal/read-token', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     mockRequireRole.mockResolvedValue({ id: 'student-1', role: 'student' })
     mockMintPalReadToken.mockResolvedValue({
       token: 'short-lived-token',
@@ -40,6 +43,16 @@ describe('POST /api/student/pal/read-token', () => {
     }) as any, { params: Promise.resolve({}) })
 
     expect(response.status).toBe(404)
+    expect(mockMintPalReadToken).not.toHaveBeenCalled()
+  })
+
+  it('fails closed before minting when enabled configuration is incomplete', async () => {
+    vi.stubEnv('PAL_INTEGRATION_SECRET', '')
+    const response = await POST(new Request('http://localhost/api/student/pal/read-token', {
+      method: 'POST',
+    }) as any, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(500)
     expect(mockMintPalReadToken).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -95,11 +95,16 @@ vi.mock('@/components/layout', async () => {
     ThreePanelShell: ({ children }: any) => <div>{children}</div>,
     LeftSidebar: ({ children }: any) => <div>{children}</div>,
     MainContent: ({ children }: any) => <main>{children}</main>,
-    NavItems: ({ onTabChange }: any) => (
+    NavItems: ({ onTabChange, palEnabled }: any) => (
       <nav>
         <button type="button" onClick={() => onTabChange('attendance')}>
           Go Daily
         </button>
+        {palEnabled ? (
+          <button type="button" onClick={() => onTabChange('achievements')}>
+            Go Achievements
+          </button>
+        ) : null}
         <button type="button" onClick={() => onTabChange('assignments')}>
           Go Classwork
         </button>
@@ -322,6 +327,13 @@ vi.mock('@/app/classrooms/[classroomId]/StudentTestsTab', () => ({
     return <div />
   },
 }))
+vi.mock('@/app/classrooms/[classroomId]/StudentAchievementsTab', () => ({
+  StudentAchievementsTab: ({ embedUrl, isActive }: any) => (
+    <div data-testid="student-achievements">
+      {isActive ? 'active' : 'inactive'}:{embedUrl}
+    </div>
+  ),
+}))
 vi.mock('@/components/StudentLogHistory', () => ({
   StudentLogHistory: () => <div />,
 }))
@@ -374,6 +386,8 @@ function renderStudentClient(options?: {
   classroom?: Classroom
   initialTab?: string
   initialSearchParams?: Record<string, string | undefined>
+  palEnabled?: boolean
+  palEmbedUrl?: string | null
 }) {
   const targetClassroom = options?.classroom ?? classroom
   const initialTab = options?.initialTab ?? 'today'
@@ -387,6 +401,8 @@ function renderStudentClient(options?: {
         teacherClassrooms={[]}
         initialTab={initialTab}
         initialSearchParams={initialSearchParams}
+        palEnabled={options?.palEnabled}
+        palEmbedUrl={options?.palEmbedUrl}
       />
     </MarkdownPreferenceProvider>,
   )
@@ -432,6 +448,20 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
         isActive: true,
       })
     })
+  })
+
+  it('mounts the Pal achievements destination only when enabled for a student', async () => {
+    renderStudentClient({
+      initialTab: 'today',
+      initialSearchParams: { tab: 'today' },
+      palEnabled: true,
+      palEmbedUrl: 'https://pal.example/embed/roadmap',
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go Achievements' }))
+    expect(await screen.findByTestId('student-achievements')).toHaveTextContent(
+      'active:https://pal.example/embed/roadmap',
+    )
   })
 
   it('updates the app shell classroom theme when settings saves classroom changes', async () => {

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -91,6 +91,33 @@ describe('NavItems notification dots', () => {
     expect(screen.queryByRole('link', { name: 'Quizzes' })).toBeNull()
   })
 
+  it('shows the learner achievements destination only when the Pal pilot is enabled', () => {
+    const { rerender } = render(
+      <NavItems
+        classroomId="classroom-1"
+        role="student"
+        activeTab="today"
+        onTabChange={vi.fn()}
+        updateSearchParams={vi.fn()}
+        palEnabled={false}
+      />
+    )
+    expect(screen.queryByRole('link', { name: 'Achievements' })).toBeNull()
+
+    rerender(
+      <NavItems
+        classroomId="classroom-1"
+        role="student"
+        activeTab="achievements"
+        onTabChange={vi.fn()}
+        updateSearchParams={vi.fn()}
+        palEnabled
+      />
+    )
+    expect(screen.getByRole('link', { name: 'Achievements' }))
+      .toHaveAttribute('aria-current', 'page')
+  })
+
   it('uses dot path for student assignments nav item', () => {
     mockNotifications = baseNotifications({ unviewedAssignmentsCount: 2 })
     renderNav('student', 'assignments')

--- a/tests/components/StudentAchievementsTab.test.tsx
+++ b/tests/components/StudentAchievementsTab.test.tsx
@@ -1,0 +1,165 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { StudentAchievementsTab } from '@/app/classrooms/[classroomId]/StudentAchievementsTab'
+
+describe('StudentAchievementsTab', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('dark')
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('shows a bounded unavailable state when no Pal embed is configured', () => {
+    render(<StudentAchievementsTab embedUrl={null} isActive />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Achievements are unavailable')
+    expect(screen.queryByTitle('Pal achievements roadmap')).toBeNull()
+  })
+
+  it('hands a short-lived token only to the exact iframe origin and nonce', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'nonce-1' })
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({
+        token: 'short-lived-token',
+        expires_at: '2026-09-16T18:25:00.000Z',
+      }))))
+    render(
+      <StudentAchievementsTab
+        embedUrl="https://pal.example.test/embed/roadmap"
+        isActive
+      />,
+    )
+
+    const frame = await screen.findByTitle('Pal achievements roadmap')
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage')
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://attacker.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.ready', nonce: 'nonce-1' },
+      }))
+    })
+    expect(fetch).not.toHaveBeenCalled()
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://pal.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.ready', nonce: 'nonce-1' },
+      }))
+    })
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      '/api/student/pal/read-token',
+      expect.objectContaining({ method: 'POST' }),
+    ))
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'pal.embed.authenticate',
+        nonce: 'nonce-1',
+        token: 'short-lived-token',
+        theme: 'light',
+      },
+      'https://pal.example.test',
+    ))
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://pal.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.authenticated', nonce: 'nonce-1' },
+      }))
+    })
+    await waitFor(() =>
+      expect(screen.queryByText('Loading achievements')).not.toBeInTheDocument())
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'pal.embed.appearance',
+        nonce: 'nonce-1',
+        theme: 'light',
+      },
+      'https://pal.example.test',
+    ))
+  })
+
+  it('notifies an authenticated Pal frame when Pika changes theme', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'nonce-1' })
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({
+        token: 'short-lived-token',
+        expires_at: '2026-09-16T18:25:00.000Z',
+      }))))
+    render(
+      <StudentAchievementsTab
+        embedUrl="https://pal.example.test/embed/roadmap"
+        isActive
+      />,
+    )
+
+    const frame = await screen.findByTitle('Pal achievements roadmap')
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage')
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://pal.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.ready', nonce: 'nonce-1' },
+      }))
+    })
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'pal.embed.authenticate' }),
+      'https://pal.example.test',
+    ))
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://pal.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.authenticated', nonce: 'nonce-1' },
+      }))
+    })
+
+    act(() => {
+      document.documentElement.classList.add('dark')
+    })
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'pal.embed.appearance',
+        nonce: 'nonce-1',
+        theme: 'dark',
+      },
+      'https://pal.example.test',
+    ))
+    document.documentElement.classList.remove('dark')
+  })
+
+  it('offers a retry without navigating away when authentication fails', async () => {
+    vi.stubGlobal('crypto', { randomUUID: vi.fn()
+      .mockReturnValueOnce('nonce-1')
+      .mockReturnValueOnce('nonce-2') })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    render(
+      <StudentAchievementsTab
+        embedUrl="https://pal.example.test/embed/roadmap"
+        isActive
+      />,
+    )
+
+    const frame = await screen.findByTitle('Pal achievements roadmap')
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://pal.example.test',
+        source: frame.contentWindow,
+        data: { type: 'pal.embed.ready', nonce: 'nonce-1' },
+      }))
+    })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Achievements are temporarily unavailable',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await waitFor(() =>
+      expect(screen.getByTitle('Pal achievements roadmap'))
+        .toHaveAttribute('src', expect.stringContaining('nonce-2')))
+  })
+})

--- a/tests/fixtures/pal-contract-v1/invalid/activity-day-not-a-real-date.json
+++ b/tests/fixtures/pal-contract-v1/invalid/activity-day-not-a-real-date.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log:log-7e2a9c4b21",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log.completed",
+  "occurred_at": "2026-02-28T18:20:00Z",
+  "metadata": {
+    "period_key": "2026-winter-week-08",
+    "activity_day": "2026-02-30"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/config-version-zero.json
+++ b/tests/fixtures/pal-contract-v1/invalid/config-version-zero.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log-week:cfg-5c8a1d9e32",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log_week.configured",
+  "occurred_at": "2026-09-14T11:00:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "config_version": 0,
+    "period_status": "open",
+    "eligible_days": 3
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/derived-event-type.json
+++ b/tests/fixtures/pal-contract-v1/invalid/derived-event-type.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:forged:level-up-1",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "level_up",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {}
+}

--- a/tests/fixtures/pal-contract-v1/invalid/eligible-days-out-of-range.json
+++ b/tests/fixtures/pal-contract-v1/invalid/eligible-days-out-of-range.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log-week:cfg-5c8a1d9e31",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log_week.configured",
+  "occurred_at": "2026-09-14T11:00:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "config_version": 1,
+    "period_status": "open",
+    "eligible_days": 7
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-debug-object.json
+++ b/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-debug-object.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:enrolment:enr-2b7e4c1a",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "classroom.joined",
+  "occurred_at": "2026-09-14T13:04:47Z",
+  "metadata": {
+    "classroom_token": "cls-4a7b2e9f"
+  },
+  "debug": {
+    "request_id": "trace-123"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-email.json
+++ b/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-email.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:enrolment:enr-2b7e4c1a",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "classroom.joined",
+  "occurred_at": "2026-09-14T13:04:47Z",
+  "metadata": {
+    "classroom_token": "cls-4a7b2e9f"
+  },
+  "email": "learner@example.com"
+}

--- a/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-raw-student-id.json
+++ b/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-raw-student-id.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:enrolment:enr-2b7e4c1a",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "classroom.joined",
+  "occurred_at": "2026-09-14T13:04:47Z",
+  "metadata": {
+    "classroom_token": "cls-4a7b2e9f"
+  },
+  "student_id": "raw-database-id"
+}

--- a/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-title.json
+++ b/tests/fixtures/pal-contract-v1/invalid/envelope-leaks-title.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:enrolment:enr-2b7e4c1a",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "classroom.joined",
+  "occurred_at": "2026-09-14T13:04:47Z",
+  "metadata": {
+    "classroom_token": "cls-4a7b2e9f"
+  },
+  "title": "Period 2 Biology"
+}

--- a/tests/fixtures/pal-contract-v1/invalid/kind-not-allowed-in-v1.json
+++ b/tests/fixtures/pal-contract-v1/invalid/kind-not-allowed-in-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:quiz:itm-6f0a2d81:completed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "item_token": "itm-6f0a2d81",
+    "kind": "quiz",
+    "period_key": "2026-fall-week-03",
+    "timing": "on_time"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/legacy-event-type.json
+++ b/tests/fixtures/pal-contract-v1/invalid/legacy-event-type.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika-assignment-abc123",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "assignment.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "on_time": true
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/manifest.json
+++ b/tests/fixtures/pal-contract-v1/invalid/manifest.json
@@ -17,6 +17,22 @@
       "error": "invalid_metadata",
       "why": "Version 1 models a Monday-Friday week, so 7 eligible days cannot be true."
     },
+    "envelope-leaks-debug-object.json": {
+      "error": "invalid_envelope",
+      "why": "Nested debugging context is outside the closed event envelope and may carry accidental personal data."
+    },
+    "envelope-leaks-email.json": {
+      "error": "invalid_envelope",
+      "why": "A raw email must be rejected even when it is outside metadata; the entire event envelope is privacy-allow-listed."
+    },
+    "envelope-leaks-raw-student-id.json": {
+      "error": "invalid_envelope",
+      "why": "A producer cannot attach its internal learner identifier beside the pseudonymous learner_id."
+    },
+    "envelope-leaks-title.json": {
+      "error": "invalid_envelope",
+      "why": "Human-readable classroom or assignment titles are not part of the event envelope."
+    },
     "kind-not-allowed-in-v1.json": {
       "error": "invalid_metadata",
       "why": "Only 'assignment' is defined in version 1. Widening the enum is a contract change, not a payload choice."

--- a/tests/fixtures/pal-contract-v1/invalid/manifest.json
+++ b/tests/fixtures/pal-contract-v1/invalid/manifest.json
@@ -1,0 +1,57 @@
+{
+  "$comment": "Each fixture in this directory must be rejected with the listed error. Producers can use these to prove their adapter never emits a payload Pal will refuse; Pal uses them to prove ingest refuses one.",
+  "cases": {
+    "activity-day-not-a-real-date.json": {
+      "error": "invalid_metadata",
+      "why": "2026-02-30 has the right shape but is not a date, which usually means a timezone bug upstream."
+    },
+    "config-version-zero.json": {
+      "error": "invalid_metadata",
+      "why": "config_version is monotonic and 1-based; 0 would sort below every real revision."
+    },
+    "derived-event-type.json": {
+      "error": "unknown_event_type",
+      "why": "Engine-derived events are never ingestable. An integration that could POST level_up could grant its own levels."
+    },
+    "eligible-days-out-of-range.json": {
+      "error": "invalid_metadata",
+      "why": "Version 1 models a Monday-Friday week, so 7 eligible days cannot be true."
+    },
+    "kind-not-allowed-in-v1.json": {
+      "error": "invalid_metadata",
+      "why": "Only 'assignment' is defined in version 1. Widening the enum is a contract change, not a payload choice."
+    },
+    "legacy-event-type.json": {
+      "error": "unknown_event_type",
+      "why": "The prototype's assignment.completed is not part of the v1 vocabulary; it reaches ingest on the legacy path instead."
+    },
+    "metadata-leaks-assignment-title.json": {
+      "error": "invalid_metadata",
+      "why": "The privacy boundary is enforced by rejecting unknown keys, not by trusting producers to omit them."
+    },
+    "missing-period-key.json": {
+      "error": "invalid_metadata",
+      "why": "Without period_key Pal would have to infer the academic week from delivery time, which is exactly what the contract forbids."
+    },
+    "occurred-at-local-time.json": {
+      "error": "invalid_occurred_at",
+      "why": "occurred_at is an absolute instant. Offsets are rejected so no consumer has to guess a timezone."
+    },
+    "raw-learner-email.json": {
+      "error": "invalid_learner_id",
+      "why": "learner_id must be a pseudonymous token. An email is both non-URL-safe and a privacy violation."
+    },
+    "session-started-with-metadata.json": {
+      "error": "invalid_metadata",
+      "why": "platform.session.started carries no metadata, so an IP address cannot ride along with it."
+    },
+    "timing-enum-not-allowed.json": {
+      "error": "invalid_metadata",
+      "why": "'excused' is an academic state Pika owns; it is not a completion timing Pal can interpret."
+    },
+    "unsupported-schema-version.json": {
+      "error": "unsupported_schema_version",
+      "why": "Pal must ship support for a version before a producer emits it. This failure is not retryable."
+    }
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/metadata-leaks-assignment-title.json
+++ b/tests/fixtures/pal-contract-v1/invalid/metadata-leaks-assignment-title.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-91c3f7a2:completed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "item_token": "itm-91c3f7a2",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "on_time",
+    "assignment_title": "Unit 3 Reflection"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/missing-period-key.json
+++ b/tests/fixtures/pal-contract-v1/invalid/missing-period-key.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-91c3f7a2:viewed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.viewed",
+  "occurred_at": "2026-09-15T09:41:03Z",
+  "metadata": {
+    "item_token": "itm-91c3f7a2",
+    "kind": "assignment",
+    "timing": "within_24h_of_release"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/occurred-at-local-time.json
+++ b/tests/fixtures/pal-contract-v1/invalid/occurred-at-local-time.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log:log-7e2a9c4b20",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log.completed",
+  "occurred_at": "2026-09-16T14:20:00-04:00",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "activity_day": "2026-09-16"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/raw-learner-email.json
+++ b/tests/fixtures/pal-contract-v1/invalid/raw-learner-email.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:session:ses-6d1f9a3c72b48e06",
+  "learner_id": "student@example.school",
+  "event_type": "platform.session.started",
+  "occurred_at": "2026-09-14T13:02:11Z",
+  "metadata": {}
+}

--- a/tests/fixtures/pal-contract-v1/invalid/session-started-with-metadata.json
+++ b/tests/fixtures/pal-contract-v1/invalid/session-started-with-metadata.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:session:ses-6d1f9a3c72b48e05",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "platform.session.started",
+  "occurred_at": "2026-09-14T13:02:11Z",
+  "metadata": {
+    "ip_address": "203.0.113.14"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/timing-enum-not-allowed.json
+++ b/tests/fixtures/pal-contract-v1/invalid/timing-enum-not-allowed.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-91c3f7a2:completed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "item_token": "itm-91c3f7a2",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "excused"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/invalid/unsupported-schema-version.json
+++ b/tests/fixtures/pal-contract-v1/invalid/unsupported-schema-version.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "idempotency_key": "pika:daily-log:log-7e2a9c4b19",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "activity_day": "2026-09-16"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/classroom-joined.json
+++ b/tests/fixtures/pal-contract-v1/valid/classroom-joined.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:enrolment:enr-2b7e4c1a",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "classroom.joined",
+  "occurred_at": "2026-09-14T13:04:47Z",
+  "metadata": {
+    "classroom_token": "cls-4a7b2e9f"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/daily-log-completed.json
+++ b/tests/fixtures/pal-contract-v1/valid/daily-log-completed.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log:log-7e2a9c4b18",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "activity_day": "2026-09-16"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured-closed.json
+++ b/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured-closed.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log-week:cfg-5c8a1d9e30",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log_week.configured",
+  "occurred_at": "2026-09-21T11:00:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "config_version": 3,
+    "period_status": "closed",
+    "eligible_days": 3
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured-zero-days.json
+++ b/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured-zero-days.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log-week:cfg-0b3f7a1c94",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log_week.configured",
+  "occurred_at": "2026-12-21T11:00:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-16",
+    "config_version": 1,
+    "period_status": "open",
+    "eligible_days": 0
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured.json
+++ b/tests/fixtures/pal-contract-v1/valid/daily-log-week-configured.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:daily-log-week:cfg-5c8a1d9e2f",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "daily_log_week.configured",
+  "occurred_at": "2026-09-14T11:00:00Z",
+  "metadata": {
+    "period_key": "2026-fall-week-03",
+    "config_version": 2,
+    "period_status": "open",
+    "eligible_days": 3
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/learning-item-completed-late.json
+++ b/tests/fixtures/pal-contract-v1/valid/learning-item-completed-late.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-3d8b5e07:completed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.completed",
+  "occurred_at": "2026-09-22T02:47:19Z",
+  "metadata": {
+    "item_token": "itm-3d8b5e07",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "late"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/learning-item-completed-on-time.json
+++ b/tests/fixtures/pal-contract-v1/valid/learning-item-completed-on-time.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-91c3f7a2:completed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.completed",
+  "occurred_at": "2026-09-16T18:20:00Z",
+  "metadata": {
+    "item_token": "itm-91c3f7a2",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "on_time"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/learning-item-viewed-early.json
+++ b/tests/fixtures/pal-contract-v1/valid/learning-item-viewed-early.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-91c3f7a2:viewed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.viewed",
+  "occurred_at": "2026-09-15T09:41:03Z",
+  "metadata": {
+    "item_token": "itm-91c3f7a2",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "within_24h_of_release"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/learning-item-viewed-later.json
+++ b/tests/fixtures/pal-contract-v1/valid/learning-item-viewed-later.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:assignment:itm-3d8b5e07:viewed",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "learning_item.viewed",
+  "occurred_at": "2026-09-19T21:12:55Z",
+  "metadata": {
+    "item_token": "itm-3d8b5e07",
+    "kind": "assignment",
+    "period_key": "2026-fall-week-03",
+    "timing": "later"
+  }
+}

--- a/tests/fixtures/pal-contract-v1/valid/platform-session-started.json
+++ b/tests/fixtures/pal-contract-v1/valid/platform-session-started.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "idempotency_key": "pika:session:ses-6d1f9a3c72b48e05",
+  "learner_id": "lrn-8f2c1a9b4e7d3056",
+  "event_type": "platform.session.started",
+  "occurred_at": "2026-09-14T13:02:11Z",
+  "metadata": {}
+}

--- a/tests/lib/server/assignment-doc-submissions-atomic.test.ts
+++ b/tests/lib/server/assignment-doc-submissions-atomic.test.ts
@@ -4,6 +4,7 @@ import {
   submitAssignmentDocAtomic,
   unsubmitAssignmentDocAtomic,
 } from '@/lib/server/assignment-doc-submissions'
+import { buildLearningItemCompletedEvent } from '@/lib/server/pal-events'
 
 const beforeContent = {
   type: 'doc',
@@ -164,6 +165,39 @@ describe('atomic assignment document operations', () => {
       p_word_count: 1,
       p_char_count: 5,
     }))
+  })
+
+  it('uses the Pal-aware atomic submit RPC when a completion fact is supplied', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        idempotent: false,
+        doc: makeDoc({ is_submitted: true, submitted_at: '2026-07-16T12:02:00.000Z' }),
+        history_entry: null,
+      },
+      error: null,
+    })
+    const palEvent = buildLearningItemCompletedEvent({
+      learnerId: 'student-1',
+      itemId: 'assignment-1',
+      dueAt: '2026-07-16T13:00:00.000Z',
+      occurredAt: new Date('2026-07-16T12:02:00.000Z'),
+      pseudonymSecret: 'test-pseudonym-secret',
+    })
+
+    await submitAssignmentDocAtomic({
+      supabase: { rpc },
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      content: afterContent,
+      expectedUpdatedAt: '2026-07-16T12:01:00.000Z',
+      palEvent,
+    })
+
+    expect(rpc).toHaveBeenCalledWith(
+      'submit_assignment_doc_with_pal_event_atomic',
+      expect.objectContaining({ p_pal_event: palEvent }),
+    )
   })
 
   it('accepts production-shaped authenticity flags from every mutation RPC', async () => {

--- a/tests/lib/server/assignment-doc-submissions-atomic.test.ts
+++ b/tests/lib/server/assignment-doc-submissions-atomic.test.ts
@@ -182,7 +182,7 @@ describe('atomic assignment document operations', () => {
       itemId: 'assignment-1',
       dueAt: '2026-07-16T13:00:00.000Z',
       occurredAt: new Date('2026-07-16T12:02:00.000Z'),
-      pseudonymSecret: 'test-pseudonym-secret',
+      pseudonymSecret: 'test-pseudonym-secret-32-characters-long',
     })
 
     await submitAssignmentDocAtomic({

--- a/tests/lib/server/pal-config.test.ts
+++ b/tests/lib/server/pal-config.test.ts
@@ -17,8 +17,8 @@ describe('Pal pilot configuration', () => {
 
     vi.stubEnv('PAL_ENABLED', ' TRUE ')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     expect(isPalEnabled()).toBe(true)
 
     vi.stubEnv('PAL_ENABLED', 'false')
@@ -27,20 +27,20 @@ describe('Pal pilot configuration', () => {
 
   it('loads server-only connection settings when configured', () => {
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(requirePalEnvironment()).toEqual({
       apiUrl: 'https://pal.example.test',
-      integrationSecret: 'integration-secret',
-      pseudonymSecret: 'pseudonym-secret',
+      integrationSecret: 'integration-secret-32-characters-long',
+      pseudonymSecret: 'pseudonym-secret-32-characters-long',
     })
   })
 
   it('fails closed when an enabled adapter is missing required settings', () => {
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
     vi.stubEnv('PAL_INTEGRATION_SECRET', '')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(() => requirePalEnvironment()).toThrow(
       'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
@@ -55,16 +55,36 @@ describe('Pal pilot configuration', () => {
   })
 
   it('allows event pseudonymization without loading delivery configuration', () => {
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
-    expect(requirePalPseudonymSecret()).toBe('pseudonym-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
+    expect(requirePalPseudonymSecret()).toBe('pseudonym-secret-32-characters-long')
+  })
+
+  it('rejects weak or shared integration secrets at the enabled boundary', () => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'too-short')
+    vi.stubEnv(
+      'PAL_PSEUDONYM_SECRET',
+      'pseudonym-secret-32-characters-long-32-characters-long',
+    )
+    expect(() => requirePalEnvironment()).toThrow('at least 32 characters')
+
+    vi.stubEnv(
+      'PAL_INTEGRATION_SECRET',
+      'shared-secret-value-that-is-long-enough',
+    )
+    vi.stubEnv(
+      'PAL_PSEUDONYM_SECRET',
+      'shared-secret-value-that-is-long-enough',
+    )
+    expect(() => requirePalEnvironment()).toThrow('must be distinct')
   })
 
   it.each(['pal.example.test', 'ftp://pal.example.test'])(
     'rejects an invalid Pal API URL: %s',
     (apiUrl) => {
       vi.stubEnv('PAL_API_URL', apiUrl)
-      vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-      vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+      vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+      vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
       expect(() => requirePalEnvironment()).toThrow()
     },
@@ -73,8 +93,8 @@ describe('Pal pilot configuration', () => {
   it('exposes only the chrome-free public embed URL to the learner page', () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(getPalEmbedUrl()).toBe('https://pal.example.test/embed/roadmap')
   })
@@ -86,8 +106,8 @@ describe('Pal pilot configuration', () => {
     'https://pal.example.test/#embed',
   ])('rejects a URL that is not an origin: %s', (apiUrl) => {
     vi.stubEnv('PAL_API_URL', apiUrl)
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(() => requirePalEnvironment()).toThrow(
       'PAL_API_URL must contain only an origin',
@@ -97,8 +117,8 @@ describe('Pal pilot configuration', () => {
   it('rejects production HTTP origins', () => {
     vi.stubEnv('NODE_ENV', 'production')
     vi.stubEnv('PAL_API_URL', 'http://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(() => requirePalEnvironment()).toThrow(
       'PAL_API_URL must use HTTPS',
@@ -108,8 +128,8 @@ describe('Pal pilot configuration', () => {
   it('allows loopback HTTP only outside production', () => {
     vi.stubEnv('NODE_ENV', 'test')
     vi.stubEnv('PAL_API_URL', 'http://localhost:3100/')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
 
     expect(requirePalEnvironment().apiUrl).toBe('http://localhost:3100')
   })

--- a/tests/lib/server/pal-config.test.ts
+++ b/tests/lib/server/pal-config.test.ts
@@ -4,6 +4,7 @@ import {
   getPalEmbedUrl,
   isPalEnabled,
   requirePalEnvironment,
+  requirePalPseudonymSecret,
 } from '@/lib/server/pal-config'
 
 describe('Pal pilot configuration', () => {
@@ -15,6 +16,9 @@ describe('Pal pilot configuration', () => {
     expect(isPalEnabled()).toBe(false)
 
     vi.stubEnv('PAL_ENABLED', ' TRUE ')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
     expect(isPalEnabled()).toBe(true)
 
     vi.stubEnv('PAL_ENABLED', 'false')
@@ -43,6 +47,18 @@ describe('Pal pilot configuration', () => {
     )
   })
 
+  it('fails at the feature gate when enabled configuration is incomplete', () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    expect(() => isPalEnabled()).toThrow(
+      'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
+    )
+  })
+
+  it('allows event pseudonymization without loading delivery configuration', () => {
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    expect(requirePalPseudonymSecret()).toBe('pseudonym-secret')
+  })
+
   it.each(['pal.example.test', 'ftp://pal.example.test'])(
     'rejects an invalid Pal API URL: %s',
     (apiUrl) => {
@@ -50,23 +66,51 @@ describe('Pal pilot configuration', () => {
       vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
       vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
 
-      expect(() => requirePalEnvironment()).toThrow(
-        'PAL_API_URL must be a valid http or https URL',
-      )
+      expect(() => requirePalEnvironment()).toThrow()
     },
   )
 
   it('exposes only the chrome-free public embed URL to the learner page', () => {
     vi.stubEnv('PAL_ENABLED', 'true')
-    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/api/')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
 
     expect(getPalEmbedUrl()).toBe('https://pal.example.test/embed/roadmap')
   })
 
-  it('does not expose an embed URL for an invalid origin', () => {
-    vi.stubEnv('PAL_ENABLED', 'true')
-    vi.stubEnv('PAL_API_URL', 'javascript:alert(1)')
+  it.each([
+    'https://user:pass@pal.example.test',
+    'https://pal.example.test/api',
+    'https://pal.example.test/?tenant=pika',
+    'https://pal.example.test/#embed',
+  ])('rejects a URL that is not an origin: %s', (apiUrl) => {
+    vi.stubEnv('PAL_API_URL', apiUrl)
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
 
-    expect(getPalEmbedUrl()).toBeNull()
+    expect(() => requirePalEnvironment()).toThrow(
+      'PAL_API_URL must contain only an origin',
+    )
+  })
+
+  it('rejects production HTTP origins', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('PAL_API_URL', 'http://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    expect(() => requirePalEnvironment()).toThrow(
+      'PAL_API_URL must use HTTPS',
+    )
+  })
+
+  it('allows loopback HTTP only outside production', () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('PAL_API_URL', 'http://localhost:3100/')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    expect(requirePalEnvironment().apiUrl).toBe('http://localhost:3100')
   })
 })

--- a/tests/lib/server/pal-config.test.ts
+++ b/tests/lib/server/pal-config.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getPalEmbedUrl,
+  isPalEnabled,
+  requirePalEnvironment,
+} from '@/lib/server/pal-config'
+
+describe('Pal pilot configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('is disabled unless the single environment flag is explicitly true', () => {
+    expect(isPalEnabled()).toBe(false)
+
+    vi.stubEnv('PAL_ENABLED', ' TRUE ')
+    expect(isPalEnabled()).toBe(true)
+
+    vi.stubEnv('PAL_ENABLED', 'false')
+    expect(isPalEnabled()).toBe(false)
+  })
+
+  it('loads server-only connection settings when configured', () => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    expect(requirePalEnvironment()).toEqual({
+      apiUrl: 'https://pal.example.test',
+      integrationSecret: 'integration-secret',
+      pseudonymSecret: 'pseudonym-secret',
+    })
+  })
+
+  it('fails closed when an enabled adapter is missing required settings', () => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', '')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+    expect(() => requirePalEnvironment()).toThrow(
+      'PAL_ENABLED requires PAL_API_URL, PAL_INTEGRATION_SECRET, and PAL_PSEUDONYM_SECRET',
+    )
+  })
+
+  it.each(['pal.example.test', 'ftp://pal.example.test'])(
+    'rejects an invalid Pal API URL: %s',
+    (apiUrl) => {
+      vi.stubEnv('PAL_API_URL', apiUrl)
+      vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+      vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+
+      expect(() => requirePalEnvironment()).toThrow(
+        'PAL_API_URL must be a valid http or https URL',
+      )
+    },
+  )
+
+  it('exposes only the chrome-free public embed URL to the learner page', () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/api/')
+
+    expect(getPalEmbedUrl()).toBe('https://pal.example.test/embed/roadmap')
+  })
+
+  it('does not expose an embed URL for an invalid origin', () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'javascript:alert(1)')
+
+    expect(getPalEmbedUrl()).toBeNull()
+  })
+})

--- a/tests/lib/server/pal-contract.test.ts
+++ b/tests/lib/server/pal-contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { v1 } from '@/vendor/pal-contract'
+
+const fixtureRoot = resolve(process.cwd(), 'tests/fixtures/pal-contract-v1')
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+describe('vendored Pal v1 contract', () => {
+  it('accepts every canonical valid fixture', () => {
+    const fixtureNames = readdirSync(resolve(fixtureRoot, 'valid')).sort()
+
+    for (const fixtureName of fixtureNames) {
+      const result = v1.validateV1Event(
+        readJson(resolve(fixtureRoot, 'valid', fixtureName)),
+      )
+      expect(result, fixtureName).toMatchObject({ ok: true })
+    }
+  })
+
+  it('rejects every canonical invalid fixture with the canonical error', () => {
+    const manifest = readJson(
+      resolve(fixtureRoot, 'invalid', 'manifest.json'),
+    ) as { cases: Record<string, { error: v1.V1Error }> }
+
+    for (const [fixtureName, fixture] of Object.entries(manifest.cases)) {
+      const result = v1.validateV1Event(
+        readJson(resolve(fixtureRoot, 'invalid', fixtureName)),
+      )
+      expect(result, fixtureName).toMatchObject({
+        ok: false,
+        error: fixture.error,
+      })
+    }
+  })
+})

--- a/tests/lib/server/pal-events.test.ts
+++ b/tests/lib/server/pal-events.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildClassroomJoinedEvent,
+  buildDailyLogCompletedEvent,
+  buildDailyLogWeekConfiguredEvent,
+  buildLearningItemCompletedEvent,
+  buildLearningItemViewedEvent,
+  buildSessionStartedEvent,
+  palPeriodKeyForActivityDay,
+  pseudonymizePalRef,
+} from '@/lib/server/pal-events'
+import { v1 } from '@/vendor/pal-contract'
+
+const secret = 'pal-pilot-test-secret'
+
+describe('Pika Pal v1 event builder', () => {
+  it('makes stable, opaque, URL-safe tokens with domain separation', () => {
+    const learner = pseudonymizePalRef('learner', 'raw-uuid', secret)
+
+    expect(learner).toBe(pseudonymizePalRef('learner', 'raw-uuid', secret))
+    expect(learner).not.toContain('raw-uuid')
+    expect(learner).toMatch(/^[A-Za-z0-9._~-]+$/)
+    expect(learner).not.toBe(pseudonymizePalRef('item', 'raw-uuid', secret))
+  })
+
+  it('uses the Toronto calendar week anchored to Monday', () => {
+    expect(palPeriodKeyForActivityDay('2026-09-14')).toBe('pika-week-2026-09-14')
+    expect(palPeriodKeyForActivityDay('2026-09-20')).toBe('pika-week-2026-09-14')
+    expect(palPeriodKeyForActivityDay('2026-09-21')).toBe('pika-week-2026-09-21')
+  })
+
+  it('builds all six canonical facts accepted by Pal', () => {
+    const occurredAt = new Date('2026-09-16T18:20:00.000Z')
+    const common = { learnerId: 'learner-uuid', occurredAt, pseudonymSecret: secret }
+    const events = [
+      buildSessionStartedEvent({ ...common, sessionId: 'session-uuid' }),
+      buildClassroomJoinedEvent({ ...common, classroomId: 'classroom-uuid' }),
+      buildDailyLogWeekConfiguredEvent({
+        ...common,
+        periodKey: 'pika-week-2026-09-14',
+        configVersion: 1,
+        periodStatus: 'open',
+        eligibleDays: 3,
+      }),
+      buildDailyLogCompletedEvent({ ...common, activityDay: '2026-09-16' }),
+      buildLearningItemViewedEvent({
+        ...common,
+        itemId: 'assignment-uuid',
+        releasedAt: '2026-09-16T12:00:00.000Z',
+      }),
+      buildLearningItemCompletedEvent({
+        ...common,
+        itemId: 'assignment-uuid',
+        dueAt: '2026-09-17T03:59:00.000Z',
+      }),
+    ]
+
+    expect(events.map((event) => event.event_type)).toEqual(v1.V1_EVENT_TYPES)
+    for (const event of events) {
+      expect(v1.validateV1Event(event)).toMatchObject({ ok: true })
+      expect(JSON.stringify(event)).not.toContain('learner-uuid')
+      expect(JSON.stringify(event)).not.toContain('assignment-uuid')
+      expect(JSON.stringify(event)).not.toContain('classroom-uuid')
+    }
+  })
+
+  it('deduplicates daily logs across classrooms at learner and activity-day scope', () => {
+    const common = {
+      learnerId: 'learner-uuid',
+      occurredAt: new Date('2026-09-16T18:20:00.000Z'),
+      activityDay: '2026-09-16',
+      pseudonymSecret: secret,
+    }
+
+    expect(buildDailyLogCompletedEvent(common).idempotency_key).toBe(
+      buildDailyLogCompletedEvent(common).idempotency_key,
+    )
+  })
+
+  it('classifies item timing in Pika without sending release or due timestamps', () => {
+    const common = {
+      learnerId: 'learner-uuid',
+      itemId: 'assignment-uuid',
+      pseudonymSecret: secret,
+    }
+    const early = buildLearningItemViewedEvent({
+      ...common,
+      occurredAt: new Date('2026-09-16T12:30:00.000Z'),
+      releasedAt: '2026-09-16T12:00:00.000Z',
+    })
+    const later = buildLearningItemViewedEvent({
+      ...common,
+      occurredAt: new Date('2026-09-18T12:30:00.000Z'),
+      releasedAt: '2026-09-16T12:00:00.000Z',
+    })
+    const onTime = buildLearningItemCompletedEvent({
+      ...common,
+      occurredAt: new Date('2026-09-17T03:59:00.000Z'),
+      dueAt: '2026-09-17T03:59:00.000Z',
+    })
+    const late = buildLearningItemCompletedEvent({
+      ...common,
+      occurredAt: new Date('2026-09-17T04:00:00.000Z'),
+      dueAt: '2026-09-17T03:59:00.000Z',
+    })
+
+    expect(early.metadata.timing).toBe('within_24h_of_release')
+    expect(later.metadata.timing).toBe('later')
+    expect(onTime.metadata.timing).toBe('on_time')
+    expect(late.metadata.timing).toBe('late')
+    expect(JSON.stringify([early, later, onTime, late])).not.toMatch(/released_at|due_at/)
+  })
+})

--- a/tests/lib/server/pal-events.test.ts
+++ b/tests/lib/server/pal-events.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/server/pal-events'
 import { v1 } from '@/vendor/pal-contract'
 
-const secret = 'pal-pilot-test-secret'
+const secret = 'pal-pilot-test-secret-32-characters-long'
 
 describe('Pika Pal v1 event builder', () => {
   it('makes stable, opaque, URL-safe tokens with domain separation', () => {
@@ -22,6 +22,11 @@ describe('Pika Pal v1 event builder', () => {
     expect(learner).not.toContain('raw-uuid')
     expect(learner).toMatch(/^[A-Za-z0-9._~-]+$/)
     expect(learner).not.toBe(pseudonymizePalRef('item', 'raw-uuid', secret))
+  })
+
+  it('rejects a weak explicit pseudonym secret', () => {
+    expect(() => pseudonymizePalRef('learner', 'raw-uuid', 'too-short'))
+      .toThrow('at least 32 characters')
   })
 
   it('uses the Toronto calendar week anchored to Monday', () => {

--- a/tests/lib/server/pal-events.test.ts
+++ b/tests/lib/server/pal-events.test.ts
@@ -104,11 +104,19 @@ describe('Pika Pal v1 event builder', () => {
       occurredAt: new Date('2026-09-17T04:00:00.000Z'),
       dueAt: '2026-09-17T03:59:00.000Z',
     })
+    const noDeadline = buildLearningItemCompletedEvent({
+      ...common,
+      occurredAt: new Date('2026-09-17T04:00:00.000Z'),
+      dueAt: null,
+    })
 
     expect(early.metadata.timing).toBe('within_24h_of_release')
     expect(later.metadata.timing).toBe('later')
     expect(onTime.metadata.timing).toBe('on_time')
     expect(late.metadata.timing).toBe('late')
-    expect(JSON.stringify([early, later, onTime, late])).not.toMatch(/released_at|due_at/)
+    expect(noDeadline.metadata.timing).toBe('on_time')
+    expect(JSON.stringify([early, later, onTime, late, noDeadline])).not.toMatch(
+      /released_at|due_at/,
+    )
   })
 })

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -15,7 +15,7 @@ const event = buildSessionStartedEvent({
   learnerId: studentId,
   sessionId: 'session-1',
   occurredAt,
-  pseudonymSecret: 'test-pseudonym-secret',
+  pseudonymSecret: 'test-pseudonym-secret-32-characters-long',
 })
 
 function buildSupabase(rows: unknown[] = []) {
@@ -43,8 +43,8 @@ describe('Pal outbox adapter', () => {
   beforeEach(() => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'pal-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'test-pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'pal-integration-secret-32-characters')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'test-pseudonym-secret-32-characters-long')
   })
 
   afterEach(() => {
@@ -109,7 +109,7 @@ describe('Pal outbox adapter', () => {
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
-          Authorization: 'Bearer pal-secret',
+          Authorization: 'Bearer pal-integration-secret-32-characters',
         }),
         body: JSON.stringify(event),
       }),
@@ -208,8 +208,27 @@ describe('Pal outbox adapter', () => {
     })
   })
 
+  it('releases a claimed row without contacting Pal after the worker deadline', async () => {
+    const supabase = buildSupabase([claimedRow()])
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+      deadlineAtMs: 1_000,
+      clock: () => 1_000,
+    })).resolves.toMatchObject({ retrying: 1 })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(supabase.calls.at(-1)).toMatchObject({
+      name: 'retry_pal_event_outbox',
+      args: { p_error_code: 'worker_deadline' },
+    })
+  })
+
   it('drains more than one class-day of events and reports no ready backlog', async () => {
-    const batchSizes = [50, 50, 20]
+    const batchSizes = [20, 20, 20, 20, 20, 20, 0]
     let claim = 0
     const rpc = vi.fn(async (name: string, args?: Record<string, unknown>) => {
       if (name === 'claim_pal_event_outbox') {
@@ -238,7 +257,7 @@ describe('Pal outbox adapter', () => {
     })).resolves.toMatchObject({
       claimed: 120,
       delivered: 120,
-      batches: 3,
+      batches: 7,
       remainingReady: 0,
       stoppedReason: 'drained',
     })

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildSessionStartedEvent } from '@/lib/server/pal-events'
 import {
   deliverPalOutboxBatch,
+  drainPalOutbox,
   enqueueStandalonePalEvent,
 } from '@/lib/server/pal-outbox'
 
@@ -167,6 +168,26 @@ describe('Pal outbox adapter', () => {
     })
   })
 
+  it('quarantines envelope privacy violations without contacting Pal', async () => {
+    const supabase = buildSupabase([claimedRow({
+      ...event,
+      email: 'learner@example.com',
+    })])
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({ nonRetryable: 1 })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(supabase.calls.at(-1)).toMatchObject({
+      name: 'fail_pal_event_outbox',
+      args: { p_error_code: 'invalid_envelope' },
+    })
+  })
+
   it('quarantines permanent HTTP failures for operator reconciliation', async () => {
     const supabase = buildSupabase([claimedRow()])
     const fetchImpl = vi.fn<typeof fetch>(async () =>
@@ -185,5 +206,43 @@ describe('Pal outbox adapter', () => {
         p_error_detail: 'Pal returned HTTP 422',
       },
     })
+  })
+
+  it('drains more than one class-day of events and reports no ready backlog', async () => {
+    const batchSizes = [50, 50, 20]
+    let claim = 0
+    const rpc = vi.fn(async (name: string, args?: Record<string, unknown>) => {
+      if (name === 'claim_pal_event_outbox') {
+        const count = batchSizes[claim++] ?? 0
+        return {
+          data: Array.from({ length: count }, (_, index) => ({
+            id: `${String(claim).padStart(8, '0')}-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+            payload: event,
+            attempts: 1,
+            lease_token: `${String(claim + 100).padStart(8, '0')}-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+          })),
+          error: null,
+        }
+      }
+      if (name === 'count_pal_event_outbox_ready') {
+        return { data: 0, error: null }
+      }
+      return { data: true, error: null }
+    })
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }))
+
+    await expect(drainPalOutbox({
+      supabase: { rpc },
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({
+      claimed: 120,
+      delivered: 120,
+      batches: 3,
+      remainingReady: 0,
+      stoppedReason: 'drained',
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(120)
+    expect(rpc).toHaveBeenCalledWith('count_pal_event_outbox_ready')
   })
 })

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildSessionStartedEvent } from '@/lib/server/pal-events'
+import {
+  deliverPalOutboxBatch,
+  enqueueStandalonePalEvent,
+} from '@/lib/server/pal-outbox'
+
+const studentId = '10000000-0000-4000-8000-000000000001'
+const rowId = '20000000-0000-4000-8000-000000000001'
+const leaseToken = '30000000-0000-4000-8000-000000000001'
+const occurredAt = new Date('2026-09-16T18:20:00.000Z')
+const event = buildSessionStartedEvent({
+  learnerId: studentId,
+  sessionId: 'session-1',
+  occurredAt,
+  pseudonymSecret: 'test-pseudonym-secret',
+})
+
+function buildSupabase(rows: unknown[] = []) {
+  const calls: Array<{ name: string; args: Record<string, unknown> }> = []
+  const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
+    calls.push({ name, args })
+    if (name === 'claim_pal_event_outbox') {
+      return { data: rows, error: null }
+    }
+    return { data: true, error: null }
+  })
+  return { client: { rpc }, calls }
+}
+
+function claimedRow(payload: unknown = event, attempts = 1) {
+  return {
+    id: rowId,
+    payload,
+    attempts,
+    lease_token: leaseToken,
+  }
+}
+
+describe('Pal outbox adapter', () => {
+  beforeEach(() => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'pal-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'test-pseudonym-secret')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('does not touch the outbox while the pilot flag is disabled', async () => {
+    vi.stubEnv('PAL_ENABLED', 'false')
+    const supabase = buildSupabase()
+
+    await expect(enqueueStandalonePalEvent({
+      studentId,
+      sourceKind: 'session',
+      sourceId: 'session-1',
+      event,
+      supabase: supabase.client,
+    })).resolves.toBe('disabled')
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+    })).resolves.toMatchObject({ status: 'disabled', claimed: 0 })
+    expect(supabase.client.rpc).not.toHaveBeenCalled()
+  })
+
+  it('enqueues a validated standalone session fact', async () => {
+    const supabase = buildSupabase()
+
+    await expect(enqueueStandalonePalEvent({
+      studentId,
+      sourceKind: 'authenticated_session',
+      sourceId: 'session-1',
+      event,
+      supabase: supabase.client,
+    })).resolves.toBe('enqueued')
+
+    expect(supabase.calls).toEqual([{
+      name: 'enqueue_pal_event',
+      args: expect.objectContaining({
+        p_student_id: studentId,
+        p_event: event,
+      }),
+    }])
+  })
+
+  it('delivers a claimed fact with bearer authentication and completes its lease', async () => {
+    const supabase = buildSupabase([claimedRow()])
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify({ status: 'processed' }), { status: 200 }))
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({
+      claimed: 1,
+      delivered: 1,
+      retrying: 0,
+      nonRetryable: 0,
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://pal.example.test/api/v1/events',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer pal-secret',
+        }),
+        body: JSON.stringify(event),
+      }),
+    )
+    expect(supabase.calls.at(-1)).toEqual({
+      name: 'complete_pal_event_outbox',
+      args: {
+        p_outbox_id: rowId,
+        p_lease_token: leaseToken,
+      },
+    })
+  })
+
+  it('retries network and server failures with bounded exponential delay', async () => {
+    const supabase = buildSupabase([claimedRow(event, 3)])
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 503 }))
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({ retrying: 1 })
+
+    expect(supabase.calls.at(-1)).toEqual({
+      name: 'retry_pal_event_outbox',
+      args: {
+        p_outbox_id: rowId,
+        p_lease_token: leaseToken,
+        p_next_attempt_at: '2026-09-16T18:22:00.000Z',
+        p_error_code: 'http_503',
+        p_error_detail: 'Pal returned HTTP 503',
+      },
+    })
+  })
+
+  it('quarantines contract-invalid payloads without contacting Pal', async () => {
+    const supabase = buildSupabase([claimedRow({ ...event, schema_version: 2 })])
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({ nonRetryable: 1 })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(supabase.calls.at(-1)).toEqual({
+      name: 'fail_pal_event_outbox',
+      args: {
+        p_outbox_id: rowId,
+        p_lease_token: leaseToken,
+        p_error_code: 'unsupported_schema_version',
+        p_error_detail: 'Pika outbox payload failed the pinned Pal v1 validator',
+      },
+    })
+  })
+
+  it('quarantines permanent HTTP failures for operator reconciliation', async () => {
+    const supabase = buildSupabase([claimedRow()])
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      new Response(null, { status: 422 }))
+
+    await expect(deliverPalOutboxBatch({
+      supabase: supabase.client,
+      fetchImpl,
+      now: occurredAt,
+    })).resolves.toMatchObject({ nonRetryable: 1 })
+
+    expect(supabase.calls.at(-1)).toMatchObject({
+      name: 'fail_pal_event_outbox',
+      args: {
+        p_error_code: 'http_422',
+        p_error_detail: 'Pal returned HTTP 422',
+      },
+    })
+  })
+})

--- a/tests/lib/server/pal-read-token.test.ts
+++ b/tests/lib/server/pal-read-token.test.ts
@@ -24,6 +24,7 @@ describe('Pal learner read token', () => {
     await expect(mintPalReadToken({
       studentId: 'raw-student-id',
       fetchImpl,
+      now: new Date('2026-09-16T18:20:00.000Z'),
     })).resolves.toEqual({
       token: 'short-lived-token',
       expires_at: '2026-09-16T18:25:00.000Z',
@@ -36,5 +37,40 @@ describe('Pal learner read token', () => {
         }),
       }),
     )
+  })
+
+  it.each([
+    ['2026-09-16T18:20:00.000Z', 'expired'],
+    ['2026-09-16T18:31:00.000Z', 'maximum TTL'],
+  ])('rejects an unsafe expiry at %s', async (expiresAt, message) => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      token: 'unsafe-token',
+      expires_at: expiresAt,
+    })))
+
+    await expect(mintPalReadToken({
+      studentId: 'student-id',
+      fetchImpl,
+      now: new Date('2026-09-16T18:20:00.000Z'),
+    })).rejects.toThrow(message)
+  })
+
+  it('rejects malformed token responses', async () => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      token: '',
+      expires_at: 'not-a-date',
+    })))
+
+    await expect(mintPalReadToken({
+      studentId: 'student-id',
+      fetchImpl,
+      now: new Date('2026-09-16T18:20:00.000Z'),
+    })).rejects.toThrow()
   })
 })

--- a/tests/lib/server/pal-read-token.test.ts
+++ b/tests/lib/server/pal-read-token.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { mintPalReadToken } from '@/lib/server/pal-read-token'
+
+describe('Pal learner read token', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('mints a short-lived token without sending a raw Pika learner id', async () => {
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const body = String(init?.body)
+      expect(body).not.toContain('raw-student-id')
+      expect(JSON.parse(body)).toEqual({
+        learner_id: expect.stringMatching(/^pika-learner-/),
+      })
+      return new Response(JSON.stringify({
+        token: 'short-lived-token',
+        expires_at: '2026-09-16T18:25:00.000Z',
+      }))
+    })
+
+    await expect(mintPalReadToken({
+      studentId: 'raw-student-id',
+      fetchImpl,
+    })).resolves.toEqual({
+      token: 'short-lived-token',
+      expires_at: '2026-09-16T18:25:00.000Z',
+    })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://pal.example.test/api/v1/integration/read-token',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer integration-secret',
+        }),
+      }),
+    )
+  })
+})

--- a/tests/lib/server/pal-read-token.test.ts
+++ b/tests/lib/server/pal-read-token.test.ts
@@ -7,8 +7,8 @@ describe('Pal learner read token', () => {
 
   it('mints a short-lived token without sending a raw Pika learner id', async () => {
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test/')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
       const body = String(init?.body)
       expect(body).not.toContain('raw-student-id')
@@ -33,7 +33,7 @@ describe('Pal learner read token', () => {
       'https://pal.example.test/api/v1/integration/read-token',
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer integration-secret',
+          Authorization: 'Bearer integration-secret-32-characters-long',
         }),
       }),
     )
@@ -44,8 +44,8 @@ describe('Pal learner read token', () => {
     ['2026-09-16T18:31:00.000Z', 'maximum TTL'],
   ])('rejects an unsafe expiry at %s', async (expiresAt, message) => {
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
       token: 'unsafe-token',
       expires_at: expiresAt,
@@ -60,8 +60,8 @@ describe('Pal learner read token', () => {
 
   it('rejects malformed token responses', async () => {
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
       token: '',
       expires_at: 'not-a-date',

--- a/tests/lib/server/pal-signals.test.ts
+++ b/tests/lib/server/pal-signals.test.ts
@@ -30,8 +30,8 @@ describe('Pal session signal', () => {
   it('records one privacy-safe fact for an authenticated learner session', async () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     mockEnqueueStandalonePalEvent.mockResolvedValue('enqueued')
 
     await recordPalAuthenticatedSession({
@@ -55,8 +55,8 @@ describe('Pal session signal', () => {
   it('never blocks login when the adapter cannot record the session', async () => {
     vi.stubEnv('PAL_ENABLED', 'true')
     vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
-    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
-    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret-32-characters-long')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret-32-characters-long')
     mockEnqueueStandalonePalEvent.mockRejectedValue(new Error('outbox unavailable'))
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 

--- a/tests/lib/server/pal-signals.test.ts
+++ b/tests/lib/server/pal-signals.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockEnqueueStandalonePalEvent } = vi.hoisted(() => ({
+  mockEnqueueStandalonePalEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/server/pal-outbox', () => ({
+  enqueueStandalonePalEvent: mockEnqueueStandalonePalEvent,
+}))
+
+import { recordPalAuthenticatedSession } from '@/lib/server/pal-signals'
+
+describe('Pal session signal', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+  })
+
+  it('does nothing while the pilot is disabled', async () => {
+    vi.stubEnv('PAL_ENABLED', 'false')
+
+    await recordPalAuthenticatedSession({
+      studentId: 'student-1',
+      sessionId: 'session-1',
+    })
+
+    expect(mockEnqueueStandalonePalEvent).not.toHaveBeenCalled()
+  })
+
+  it('records one privacy-safe fact for an authenticated learner session', async () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    mockEnqueueStandalonePalEvent.mockResolvedValue('enqueued')
+
+    await recordPalAuthenticatedSession({
+      studentId: 'student-1',
+      sessionId: 'session-1',
+      occurredAt: new Date('2026-09-16T18:20:00.000Z'),
+    })
+
+    expect(mockEnqueueStandalonePalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        studentId: 'student-1',
+        sourceKind: 'authenticated_session',
+        sourceId: 'session-1',
+        event: expect.objectContaining({
+          event_type: 'platform.session.started',
+        }),
+      }),
+    )
+  })
+
+  it('never blocks login when the adapter cannot record the session', async () => {
+    vi.stubEnv('PAL_ENABLED', 'true')
+    vi.stubEnv('PAL_API_URL', 'https://pal.example.test')
+    vi.stubEnv('PAL_INTEGRATION_SECRET', 'integration-secret')
+    vi.stubEnv('PAL_PSEUDONYM_SECRET', 'pseudonym-secret')
+    mockEnqueueStandalonePalEvent.mockRejectedValue(new Error('outbox unavailable'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(recordPalAuthenticatedSession({
+      studentId: 'student-1',
+      sessionId: 'session-1',
+    })).resolves.toBeUndefined()
+    expect(consoleError).toHaveBeenCalled()
+  })
+})

--- a/tests/lib/server/pal-source-writes.test.ts
+++ b/tests/lib/server/pal-source-writes.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createAssignmentDocWithPalEvent,
+  createClassroomEnrollmentWithPalEvent,
+  upsertStudentEntryWithPalEvent,
+} from '@/lib/server/pal-source-writes'
+import {
+  buildClassroomJoinedEvent,
+  buildDailyLogCompletedEvent,
+  buildLearningItemViewedEvent,
+} from '@/lib/server/pal-events'
+
+const occurredAt = new Date('2026-09-16T18:20:00.000Z')
+const pseudonymSecret = 'test-pseudonym-secret'
+const studentId = 'student-1'
+
+function clientFor(result: unknown) {
+  return {
+    rpc: vi.fn().mockResolvedValue({ data: result, error: null }),
+  }
+}
+
+describe('Pal transactional source writes', () => {
+  it('creates enrolment and classroom.joined in one RPC', async () => {
+    const supabase = clientFor({
+      ok: true,
+      created: true,
+      enrollment: { id: 'enrollment-1' },
+    })
+    const event = buildClassroomJoinedEvent({
+      learnerId: studentId,
+      classroomId: 'classroom-1',
+      occurredAt,
+      pseudonymSecret,
+    })
+
+    await createClassroomEnrollmentWithPalEvent({
+      supabase,
+      classroomId: 'classroom-1',
+      studentId,
+      event,
+    })
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'create_classroom_enrollment_with_pal_event_atomic',
+      expect.objectContaining({ p_pal_event: event }),
+    )
+  })
+
+  it('saves the log and learner/date completion fact in one RPC', async () => {
+    const supabase = clientFor({
+      ok: true,
+      created: false,
+      entry: { id: 'entry-1' },
+    })
+    const event = buildDailyLogCompletedEvent({
+      learnerId: studentId,
+      activityDay: '2026-09-16',
+      occurredAt,
+      pseudonymSecret,
+    })
+
+    await upsertStudentEntryWithPalEvent({
+      supabase,
+      studentId,
+      classroomId: 'classroom-1',
+      date: '2026-09-16',
+      text: 'Reflection',
+      richContent: { type: 'doc', content: [] },
+      onTime: true,
+      event,
+    })
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'upsert_student_entry_with_pal_event_atomic',
+      expect.objectContaining({ p_pal_event: event }),
+    )
+  })
+
+  it('creates the first assignment doc and first-view fact in one RPC', async () => {
+    const supabase = clientFor({
+      ok: true,
+      created: true,
+      doc: { id: 'doc-1' },
+    })
+    const event = buildLearningItemViewedEvent({
+      learnerId: studentId,
+      itemId: 'assignment-1',
+      releasedAt: '2026-09-16T12:00:00.000Z',
+      occurredAt,
+      pseudonymSecret,
+    })
+
+    await createAssignmentDocWithPalEvent({
+      supabase,
+      assignmentId: 'assignment-1',
+      studentId,
+      viewedAt: occurredAt.toISOString(),
+      event,
+    })
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'create_assignment_doc_with_pal_event_atomic',
+      expect.objectContaining({ p_pal_event: event }),
+    )
+  })
+})

--- a/tests/lib/server/pal-source-writes.test.ts
+++ b/tests/lib/server/pal-source-writes.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/server/pal-events'
 
 const occurredAt = new Date('2026-09-16T18:20:00.000Z')
-const pseudonymSecret = 'test-pseudonym-secret'
+const pseudonymSecret = 'test-pseudonym-secret-32-characters-long'
 const studentId = 'student-1'
 
 function clientFor(result: unknown) {

--- a/tests/lib/server/pal-source-writes.test.ts
+++ b/tests/lib/server/pal-source-writes.test.ts
@@ -69,12 +69,16 @@ describe('Pal transactional source writes', () => {
       text: 'Reflection',
       richContent: { type: 'doc', content: [] },
       onTime: true,
+      expectedVersion: 4,
       event,
     })
 
     expect(supabase.rpc).toHaveBeenCalledWith(
       'upsert_student_entry_with_pal_event_atomic',
-      expect.objectContaining({ p_pal_event: event }),
+      expect.objectContaining({
+        p_expected_version: 4,
+        p_pal_event: event,
+      }),
     )
   })
 

--- a/tests/lib/server/pal-weekly-config.test.ts
+++ b/tests/lib/server/pal-weekly-config.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  MAX_PAL_WEEKLY_CATCH_UP_PERIODS,
+  palWeeklyCatchUpPeriodStarts,
   planPalWeeklyConfigurationRevisions,
   type PalClassDay,
   type PalEnrollmentSchedule,
@@ -28,6 +30,26 @@ function classDays(
 }
 
 describe('Pal Weekly Rhythm source configuration', () => {
+  it('enumerates every missed open week before the current period', () => {
+    expect(palWeeklyCatchUpPeriodStarts({
+      oldestOpenPeriodStart: '2026-08-24',
+      currentPeriodStart: '2026-09-14',
+    })).toEqual({
+      periods: ['2026-08-24', '2026-08-31', '2026-09-07'],
+      remaining: false,
+    })
+  })
+
+  it('bounds catch-up work and reports when another run is needed', () => {
+    const catchUp = palWeeklyCatchUpPeriodStarts({
+      oldestOpenPeriodStart: '2026-01-05',
+      currentPeriodStart: '2026-09-14',
+    })
+
+    expect(catchUp.periods).toHaveLength(MAX_PAL_WEEKLY_CATCH_UP_PERIODS)
+    expect(catchUp.remaining).toBe(true)
+  })
+
   it('reports the actual short-week opportunity count instead of assuming five days', () => {
     const revisions = planPalWeeklyConfigurationRevisions({
       periodStart,

--- a/tests/lib/server/pal-weekly-config.test.ts
+++ b/tests/lib/server/pal-weekly-config.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  planPalWeeklyConfigurationRevisions,
+  type PalClassDay,
+  type PalEnrollmentSchedule,
+} from '@/lib/server/pal-weekly-config'
+
+const periodStart = '2026-09-14'
+
+function schedule(overrides: Partial<PalEnrollmentSchedule> = {}): PalEnrollmentSchedule {
+  return {
+    studentId: 'student-1',
+    classroomId: 'classroom-1',
+    enrolledAt: '2026-09-01T12:00:00.000Z',
+    classroomStart: '2026-09-01',
+    classroomEnd: '2026-12-18',
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
+function classDays(
+  dates: string[],
+  classroomId = 'classroom-1',
+): PalClassDay[] {
+  return dates.map((date) => ({ classroomId, date }))
+}
+
+describe('Pal Weekly Rhythm source configuration', () => {
+  it('reports the actual short-week opportunity count instead of assuming five days', () => {
+    const revisions = planPalWeeklyConfigurationRevisions({
+      periodStart,
+      periodStatus: 'open',
+      createIfMissing: true,
+      schedules: [schedule()],
+      classDays: classDays(['2026-09-14', '2026-09-16', '2026-09-18']),
+      existing: [],
+      completions: [],
+    })
+
+    expect(revisions).toEqual([expect.objectContaining({
+      periodKey: 'pika-week-2026-09-14',
+      configVersion: 1,
+      eligibleDays: 3,
+      periodStatus: 'open',
+    })])
+  })
+
+  it('unions opportunities across classrooms without counting a date twice', () => {
+    const revisions = planPalWeeklyConfigurationRevisions({
+      periodStart,
+      periodStatus: 'open',
+      createIfMissing: true,
+      schedules: [
+        schedule(),
+        schedule({ classroomId: 'classroom-2' }),
+      ],
+      classDays: [
+        ...classDays(['2026-09-14', '2026-09-16']),
+        ...classDays(['2026-09-14', '2026-09-17'], 'classroom-2'),
+      ],
+      existing: [],
+      completions: [],
+    })
+
+    expect(revisions[0].eligibleDays).toBe(3)
+  })
+
+  it('excludes days before enrolment and on or after classroom archive', () => {
+    const revisions = planPalWeeklyConfigurationRevisions({
+      periodStart,
+      periodStatus: 'open',
+      createIfMissing: true,
+      schedules: [schedule({
+        enrolledAt: '2026-09-16T13:00:00.000Z',
+        archivedAt: '2026-09-18T13:00:00.000Z',
+      })],
+      classDays: classDays([
+        '2026-09-14',
+        '2026-09-15',
+        '2026-09-16',
+        '2026-09-17',
+        '2026-09-18',
+      ]),
+      existing: [],
+      completions: [],
+    })
+
+    expect(revisions[0].eligibleDays).toBe(2)
+  })
+
+  it('never revises eligible days below already-emitted completion dates', () => {
+    const revisions = planPalWeeklyConfigurationRevisions({
+      periodStart,
+      periodStatus: 'open',
+      createIfMissing: true,
+      schedules: [],
+      classDays: [],
+      existing: [{
+        studentId: 'student-1',
+        periodKey: 'pika-week-2026-09-14',
+        configVersion: 1,
+        periodStatus: 'open',
+        eligibleDays: 4,
+      }],
+      completions: [
+        { studentId: 'student-1', activityDay: '2026-09-14' },
+        { studentId: 'student-1', activityDay: '2026-09-16' },
+      ],
+    })
+
+    expect(revisions).toEqual([expect.objectContaining({
+      configVersion: 2,
+      eligibleDays: 2,
+    })])
+  })
+
+  it('emits only genuine revisions and closes each week once', () => {
+    const existing = [{
+      studentId: 'student-1',
+      periodKey: 'pika-week-2026-09-14',
+      configVersion: 2,
+      periodStatus: 'open' as const,
+      eligibleDays: 3,
+    }]
+    const inputs = {
+      periodStart,
+      createIfMissing: true,
+      schedules: [schedule()],
+      classDays: classDays(['2026-09-14', '2026-09-16', '2026-09-18']),
+      existing,
+      completions: [],
+    }
+
+    expect(planPalWeeklyConfigurationRevisions({
+      ...inputs,
+      periodStatus: 'open',
+    })).toEqual([])
+    expect(planPalWeeklyConfigurationRevisions({
+      ...inputs,
+      periodStatus: 'closed',
+    })).toEqual([expect.objectContaining({
+      configVersion: 3,
+      periodStatus: 'closed',
+    })])
+  })
+})

--- a/tests/unit/attendance.test.ts
+++ b/tests/unit/attendance.test.ts
@@ -3,6 +3,7 @@ import {
   computeAttendanceStatusForStudent,
   computeAttendanceRecords,
   entryHasContent,
+  hasQualifyingDailyLogContent,
   getAttendanceIcon,
   getAttendanceLabel,
   getAttendanceDotClass,
@@ -10,6 +11,17 @@ import {
 import type { ClassDay, Entry } from '@/types'
 
 describe('attendance utilities', () => {
+  it.each(['', ' ', '\n\t'])(
+    'does not treat whitespace-only text as a qualifying daily log: %j',
+    (text) => {
+      expect(hasQualifyingDailyLogContent(text)).toBe(false)
+    },
+  )
+
+  it('uses the attendance content predicate as the Pal qualification boundary', () => {
+    expect(hasQualifyingDailyLogContent('A real reflection')).toBe(true)
+  })
+
   const classDays: ClassDay[] = [
     { id: '1', course_code: 'GLD2O', date: '2024-09-01', is_class_day: true, prompt_text: null },
     { id: '2', course_code: 'GLD2O', date: '2024-09-02', is_class_day: true, prompt_text: null },

--- a/tests/unit/pal-pilot-outbox-migration.test.ts
+++ b/tests/unit/pal-pilot-outbox-migration.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/111_pal_pilot_transactional_outbox.sql'),
+  'utf8',
+).toLowerCase()
+
+describe('Pal pilot transactional outbox migration', () => {
+  it('creates a private, durable outbox with idempotency and retry state', () => {
+    expect(migration).toContain('create table public.pal_event_outbox')
+    expect(migration).toContain('idempotency_key text not null unique')
+    expect(migration).toContain("'pending', 'processing', 'delivered', 'non_retryable'")
+    expect(migration).toContain('for update skip locked')
+    expect(migration).toContain('lease_token uuid')
+  })
+
+  it('keeps every learner action and its event in one database transaction', () => {
+    for (const functionName of [
+      'create_classroom_enrollment_with_pal_event_atomic',
+      'upsert_student_entry_with_pal_event_atomic',
+      'create_assignment_doc_with_pal_event_atomic',
+      'submit_assignment_doc_with_pal_event_atomic',
+      'record_pal_daily_log_week_configuration_atomic',
+    ]) {
+      const start = migration.indexOf(`function public.${functionName}`)
+      expect(start, functionName).toBeGreaterThan(-1)
+      const body = migration.slice(start, migration.indexOf('$$;', start) + 3)
+      expect(body, functionName).toContain('private.enqueue_pal_event')
+    }
+  })
+
+  it('prevents browser roles from reading or invoking the adapter ledger', () => {
+    expect(migration).toContain('alter table public.pal_event_outbox enable row level security')
+    expect(migration).toContain(
+      'revoke all on table public.pal_event_outbox from public, anon, authenticated',
+    )
+    expect(migration).toMatch(
+      /revoke all on function public\.enqueue_pal_event[\s\S]+from public, anon, authenticated/,
+    )
+    expect(migration).toMatch(
+      /grant execute on function public\.enqueue_pal_event[\s\S]+to service_role/,
+    )
+    expect(migration).toContain(
+      'grant execute on function public.claim_pal_event_outbox(integer, integer)\n  to service_role',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.requeue_pal_event_outbox(uuid)\n  to service_role',
+    )
+  })
+
+  it('stores monotonic weekly opportunity revisions and terminal closure', () => {
+    expect(migration).toContain('create table public.pal_daily_log_week_configurations')
+    expect(migration).toContain('pal weekly configuration version must be monotonic')
+    expect(migration).toContain('pal weekly configuration is already closed')
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
   },
   "crons": [
     {
+      "path": "/api/cron/pal-sync",
+      "schedule": "30 5 * * *"
+    },
+    {
       "path": "/api/cron/nightly-log-summaries",
       "schedule": "0 6 * * *"
     },


### PR DESCRIPTION
## Summary

- add the disabled-by-default Pika-to-Pal achievements pilot with privacy-safe facts, transactional source writes/outbox, bounded weekly recovery, and learner read-token minting
- add student Achievements navigation behind `PAL_ENABLED` while keeping the iframe as a disabled interim prototype
- confirm the native `@pal/widget` boundary and include the already-reviewed 36-property Pika theme adapter from PR #953
- draft unapplied migration 111 and its CI-generated Supabase types

## Hardening completed

- rebased cleanly onto current `main`; migration 111 has no sequence collision
- pin the closed Pal v1 privacy contract at Pal commit `cd9fc872b646b8c91551fd44f9b4b36725ab0fe4`; both envelope and metadata reject unknown fields
- fail closed when enabled configuration is missing or unsafe; require an HTTPS origin and distinct secrets of at least 32 characters
- reject expired or overlong read tokens
- emit only qualifying daily-log facts and preserve mood, minutes, and optimistic versions in enabled POST/PATCH paths
- remove silent authoritative event-builder fallbacks
- recover up to 12 missed weekly periods per run
- drain up to 10 batches of 20 rows with concurrency 10, a shared execution deadline, 60-second leases, and ready-backlog reporting
- replace new Pal persistence `any` boundaries with generated service-role client types

## Safety and rollout state

- `PAL_ENABLED` remains false by default
- migration 111 has not been applied locally or to any hosted target
- outbound facts exclude raw IDs, names, titles, work, grades, deadlines, and teacher-maintained catalogs
- the current iframe is not the rollout target and must not be enabled

## Verification

Exact head `67eee3ba` is green:

- Test & Build, including 3,891 tests, TypeScript, lint, architecture, and production build
- clean ephemeral Supabase replay, generated-type drift check, concurrency/integrity contracts, and archive recovery rehearsal
- teacher/student browser experience matrix
- UI import and no-`dark:` policy checks
- Pika audit and focused 101-test security/operability review suite
- independent security/privacy/migration and architecture/operability reviews: clean after remediation

## Dependencies before enablement

1. Review and publish `@pal/widget` from Pal PR #39.
2. Import the package contract directly and delete the temporary vendored manifest.
3. Replace `StudentAchievementsTab` iframe code with the native provider and three surfaces.
4. Run the authenticated student visual matrix and duplicate/retry/out-of-order vertical slice against Pal.
5. Obtain one-time human authorization to apply migration 111 to the named target.
