### PR TITLE
Fix Blueprint capture with submitted requirements

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15526,3 +15526,33 @@
 
 **Remaining:**
 - After the lower stack lands and PR 911 is retargeted to `main`, require exact-head GitHub Actions and the repository's external approval before merge.
+
+<!-- pika-session-log-archive-batch:41254a35a1c50266b214cfd9ec89752ebb2a4e357dcc47e4d69168936566d732 -->
+## 2026-07-22 — Hardened Daily and attendance read states
+
+**Risk profile:** workspace-state
+
+**Model recommendation:** GPT-5.6 Terra (high) - this slice crosses shared classroom schedule state, cached student work, teacher history selection, and asynchronous retry boundaries.
+
+**Completed:**
+- Added an explicit class-schedule error and snapshot contract. Cold failures block with retry; failed refreshes retain the last valid teacher/student workspace with a compact retry warning.
+- Added explicit student Daily entry and teacher selected-student history failures, retry behavior, and persistent cached-snapshot recovery without replacing usable data with false empty states.
+- Prevented previous-classroom Daily content from painting during classroom switches and prevented stale load-more responses from appending one student's logs to another student's history.
+- Announced student Daily save status through a polite atomic live region and exposed save failures as alerts.
+- Preserved the existing class-wide teacher table and student journal composition. Mobile workspace redesign and Gradex remained out of scope.
+
+**Validation:**
+- Focused Daily/Attendance and classroom integration suites (5 files / 72 tests)
+- Full repository suite before the final provider-scope remediation (407 files / 3,670 tests); exact-head PR CI is required
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit and composite-widget accessibility checklist
+- Playwright experience matrix (18 cases across both roles, desktop/mobile, light/dark)
+- Exact failure/stale-state screenshots for teacher and student; no horizontal overflow at 390px
+- Three independent review passes; five findings fixed in two remediation batches; the first remediation re-reviews are clean and the final provider-scope re-review is pending
+
+**Remaining:**
+- Require exact-head PR CI and repository approval before merge.
+- Defer Daily/Attendance mobile history/table modes until the later mobile UX phase; continue Phase 3 with Tests desktop/accessibility while Gradex remains separately owned.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,35 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-22 — Hardened Daily and attendance read states
-
-**Risk profile:** workspace-state
-
-**Model recommendation:** GPT-5.6 Terra (high) - this slice crosses shared classroom schedule state, cached student work, teacher history selection, and asynchronous retry boundaries.
-
-**Completed:**
-- Added an explicit class-schedule error and snapshot contract. Cold failures block with retry; failed refreshes retain the last valid teacher/student workspace with a compact retry warning.
-- Added explicit student Daily entry and teacher selected-student history failures, retry behavior, and persistent cached-snapshot recovery without replacing usable data with false empty states.
-- Prevented previous-classroom Daily content from painting during classroom switches and prevented stale load-more responses from appending one student's logs to another student's history.
-- Announced student Daily save status through a polite atomic live region and exposed save failures as alerts.
-- Preserved the existing class-wide teacher table and student journal composition. Mobile workspace redesign and Gradex remained out of scope.
-
-**Validation:**
-- Focused Daily/Attendance and classroom integration suites (5 files / 72 tests)
-- Full repository suite before the final provider-scope remediation (407 files / 3,670 tests); exact-head PR CI is required
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (623 modules / 0 allowances)
-- `pnpm build`
-- Pika changed-file audit and composite-widget accessibility checklist
-- Playwright experience matrix (18 cases across both roles, desktop/mobile, light/dark)
-- Exact failure/stale-state screenshots for teacher and student; no horizontal overflow at 390px
-- Three independent review passes; five findings fixed in two remediation batches; the first remediation re-reviews are clean and the final provider-scope re-review is pending
-
-**Remaining:**
-- Require exact-head PR CI and repository approval before merge.
-- Defer Daily/Attendance mobile history/table modes until the later mobile UX phase; continue Phase 3 with Tests desktop/accessibility while Gradex remains separately owned.
-
 ## 2026-07-22 — Scoped Daily history across student switches
 
 **Risk profile:** none
@@ -1365,3 +1336,35 @@ application invariants.
 - The rebuilt local database contains no users or seed data. Recover prior data
   only through a separately planned selective restore; a full restore would
   reintroduce the old migration history.
+
+## 2026-07-28 — Submitted-requirement Blueprint capture fix
+
+**Risk profile:** runtime-platform — submitted-work integrity trigger and
+service-role Blueprint capture.
+
+**Completed:**
+- Diagnosed the production Codepet Labs capture failure as migration 099's
+  requirement guard rejecting migration 112's stable identity-only update
+  after assignment documents had been submitted.
+- Added migration 113, which permits only service-role, transaction-marked
+  updates where the three Blueprint lineage columns are the sole differences.
+  Requirement ownership and pedagogical fields remain immutable.
+- Added safe RPC diagnostics that log the database error code without database
+  message, detail, or row content.
+- Expanded the live versioned-Blueprint database contract to capture an
+  assignment with one link requirement and four submitted documents, prove the
+  documents remain byte-for-byte unchanged, verify lineage mapping, reject a
+  forged authenticated marker, and reject service-role content changes.
+
+**Validation:**
+- Full Vitest suite: 452 files / 3,936 tests.
+- Live local PostgreSQL contract passed twice consecutively with exact fixture
+  cleanup.
+- Production build, generated database types, lint, Bash syntax, focused
+  migration/server tests, migration numbering, Pika audit, and diff checks
+  passed.
+
+**Remaining:**
+- Publish and review the fix PR.
+- Applying migration 113 to production requires a fresh one-time authorization
+  naming production and migration 113; no production mutation was performed.

--- a/scripts/check-versioned-course-blueprint-database.sh
+++ b/scripts/check-versioned-course-blueprint-database.sh
@@ -14,6 +14,10 @@ fi
 
 TEACHER_ID='81000000-0000-4000-8000-000000000001'
 CASCADE_TEACHER_ID='81000000-0000-4000-8000-000000000002'
+STUDENT_ONE_ID='81000000-0000-4000-8000-000000000011'
+STUDENT_TWO_ID='81000000-0000-4000-8000-000000000012'
+STUDENT_THREE_ID='81000000-0000-4000-8000-000000000013'
+STUDENT_FOUR_ID='81000000-0000-4000-8000-000000000014'
 BLUEPRINT_ID='82000000-0000-4000-8000-000000000001'
 CASCADE_BLUEPRINT_ID='82000000-0000-4000-8000-000000000002'
 CLASSROOM_ID='83000000-0000-4000-8000-000000000001'
@@ -32,8 +36,17 @@ cleanup() {
   if [[ -n "$RESULT_ONE" ]]; then rm -f "$RESULT_ONE"; fi
   if [[ -n "$RESULT_TWO" ]]; then rm -f "$RESULT_TWO"; fi
   run_psql -c "
+    delete from public.classrooms
+    where id = '$CLASSROOM_ID'::uuid;
     delete from public.users
-    where id in ('$TEACHER_ID'::uuid, '$CASCADE_TEACHER_ID'::uuid);
+    where id in (
+      '$TEACHER_ID'::uuid,
+      '$CASCADE_TEACHER_ID'::uuid,
+      '$STUDENT_ONE_ID'::uuid,
+      '$STUDENT_TWO_ID'::uuid,
+      '$STUDENT_THREE_ID'::uuid,
+      '$STUDENT_FOUR_ID'::uuid
+    );
   " >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -42,7 +55,11 @@ cleanup
 run_psql <<SQL >/dev/null
 insert into public.users (id, email, role) values
   ('$TEACHER_ID', 'versioned-blueprint-contract@example.test', 'teacher'),
-  ('$CASCADE_TEACHER_ID', 'versioned-blueprint-cascade@example.test', 'teacher');
+  ('$CASCADE_TEACHER_ID', 'versioned-blueprint-cascade@example.test', 'teacher'),
+  ('$STUDENT_ONE_ID', 'versioned-blueprint-student-1@example.test', 'student'),
+  ('$STUDENT_TWO_ID', 'versioned-blueprint-student-2@example.test', 'student'),
+  ('$STUDENT_THREE_ID', 'versioned-blueprint-student-3@example.test', 'student'),
+  ('$STUDENT_FOUR_ID', 'versioned-blueprint-student-4@example.test', 'student');
 
 insert into public.course_blueprints (id, teacher_id, title) values
   ('$BLUEPRINT_ID', '$TEACHER_ID', 'Versioned Blueprint'),
@@ -347,6 +364,220 @@ begin
   ) then
     raise exception 'Repository proposal unpublished a planned site';
   end if;
+end
+\$contract\$;
+
+do \$contract\$
+declare
+  v_assignment_id constant uuid := '86000000-0000-4000-8000-000000000001';
+  v_requirement_id constant uuid := '87000000-0000-4000-8000-000000000001';
+  v_assignment_artifact_id constant uuid := '88000000-0000-4000-8000-000000000001';
+  v_requirement_artifact_id constant uuid := '89000000-0000-4000-8000-000000000001';
+  v_operation_id constant uuid := '85000000-0000-4000-8000-000000000010';
+  v_source_revision bigint;
+  v_result jsonb;
+  v_plan jsonb;
+  v_docs_before jsonb;
+  v_docs_after jsonb;
+  v_requirement_before jsonb;
+  v_requirement_after jsonb;
+  v_student_id uuid;
+  v_doc_updated_at timestamptz;
+  v_content jsonb;
+begin
+  insert into public.assignments (
+    id, classroom_id, title, description, instructions_markdown, due_at,
+    created_by, position, is_draft, released_at, track_authenticity,
+    points_possible, gradebook_weight, include_in_final
+  ) values (
+    v_assignment_id, '$CLASSROOM_ID', 'Submitted Blueprint assignment',
+    'Student-bearing capture contract', 'Submit the repository link.',
+    '2026-09-15T23:59:00-04:00'::timestamptz, '$TEACHER_ID', 0, false,
+    now(), false, 20, 10, true
+  );
+
+  insert into public.assignment_submission_requirements (
+    id, assignment_id, type, label, instructions, required, position,
+    validation_policy_json
+  ) values (
+    v_requirement_id, v_assignment_id, 'repo_link', 'Repository link',
+    'Paste the repository URL.', false, 0, '{"provider":"github"}'::jsonb
+  );
+
+  foreach v_student_id in array array[
+    '$STUDENT_ONE_ID'::uuid,
+    '$STUDENT_TWO_ID'::uuid,
+    '$STUDENT_THREE_ID'::uuid,
+    '$STUDENT_FOUR_ID'::uuid
+  ]
+  loop
+    v_content := jsonb_build_object(
+      'type', 'doc',
+      'content', jsonb_build_array(jsonb_build_object(
+        'type', 'paragraph',
+        'content', jsonb_build_array(jsonb_build_object(
+          'type', 'text',
+          'text', 'Submitted work ' || v_student_id::text
+        ))
+      ))
+    );
+    insert into public.assignment_docs (
+      assignment_id, student_id, content, is_submitted
+    ) values (
+      v_assignment_id, v_student_id, v_content, false
+    )
+    returning updated_at into v_doc_updated_at;
+
+    v_result := public.submit_assignment_doc_atomic(
+      v_assignment_id,
+      v_student_id,
+      v_content,
+      v_doc_updated_at,
+      2,
+      50
+    );
+    if not coalesce((v_result->>'ok')::boolean, false) then
+      raise exception 'Could not create submitted Blueprint fixture: %', v_result;
+    end if;
+  end loop;
+
+  select blueprint_source_revision
+  into v_source_revision
+  from public.classrooms
+  where id = '$CLASSROOM_ID';
+
+  select jsonb_agg(to_jsonb(doc) order by doc.id)
+  into v_docs_before
+  from public.assignment_docs doc
+  where doc.assignment_id = v_assignment_id;
+
+  select to_jsonb(requirement)
+  into v_requirement_before
+  from public.assignment_submission_requirements requirement
+  where requirement.id = v_requirement_id;
+
+  v_plan := jsonb_build_object(
+    'blueprint', jsonb_build_object(
+      'title', 'Submitted Requirement Capture',
+      'subject', '',
+      'grade_level', '',
+      'course_code', '',
+      'term_template', '',
+      'overview_markdown', '',
+      'outline_markdown', '',
+      'resources_markdown', '',
+      'gradebook_use_weights', false,
+      'gradebook_assignments_weight', 70,
+      'gradebook_tests_weight', 30,
+      'planned_site_slug', null,
+      'planned_site_published', false,
+      'planned_site_config', '{}'::jsonb
+    ),
+    'assignments', jsonb_build_array(jsonb_build_object(
+      'artifact_id', v_assignment_artifact_id,
+      'title', 'Submitted Blueprint assignment',
+      'instructions_markdown', 'Submit the repository link.',
+      'submission_requirements_json', jsonb_build_array(jsonb_build_object(
+        'id', v_requirement_artifact_id,
+        'type', 'repo_link',
+        'label', 'Repository link',
+        'instructions', 'Paste the repository URL.',
+        'required', false,
+        'position', 0,
+        'validation_policy_json', '{"provider":"github"}'::jsonb
+      )),
+      'default_due_days', 0,
+      'default_due_time', '23:59',
+      'points_possible', 20,
+      'gradebook_weight', 10,
+      'include_in_final', true,
+      'is_draft', true,
+      'track_authenticity', false,
+      'position', 0
+    )),
+    'assessments', '[]'::jsonb,
+    'lesson_templates', '[]'::jsonb,
+    'materials', '[]'::jsonb,
+    'surveys', '[]'::jsonb,
+    'manifest_version', '3',
+    'source_package_exported_at', null
+  );
+
+  perform set_config('request.jwt.claim.role', 'service_role', true);
+  v_result := public.create_course_blueprint_atomic_v2(
+    v_operation_id,
+    '$TEACHER_ID',
+    'capture',
+    repeat('6', 64),
+    '$CLASSROOM_ID',
+    v_source_revision,
+    v_plan
+  );
+  if not coalesce((v_result->>'ok')::boolean, false) then
+    raise exception 'Submitted-requirement Blueprint capture failed: %', v_result;
+  end if;
+
+  select jsonb_agg(to_jsonb(doc) order by doc.id)
+  into v_docs_after
+  from public.assignment_docs doc
+  where doc.assignment_id = v_assignment_id;
+  if v_docs_after is distinct from v_docs_before then
+    raise exception 'Blueprint capture changed submitted assignment documents';
+  end if;
+
+  select to_jsonb(requirement)
+  into v_requirement_after
+  from public.assignment_submission_requirements requirement
+  where requirement.id = v_requirement_id;
+  if (
+    v_requirement_after - array[
+      'artifact_id',
+      'source_artifact_id',
+      'source_blueprint_version_id',
+      'updated_at'
+    ]::text[]
+  ) is distinct from (
+    v_requirement_before - array[
+      'artifact_id',
+      'source_artifact_id',
+      'source_blueprint_version_id',
+      'updated_at'
+    ]::text[]
+  ) then
+    raise exception 'Blueprint capture changed requirement definition content';
+  end if;
+  if v_requirement_after->>'artifact_id' <> v_requirement_artifact_id::text
+    or v_requirement_after->>'source_artifact_id' <> v_requirement_artifact_id::text
+  then
+    raise exception 'Blueprint capture did not attach stable requirement identity';
+  end if;
+
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+  begin
+    perform set_config('pika.identity_mapping', 'on', true);
+    update public.assignment_submission_requirements
+    set source_artifact_id = null
+    where id = v_requirement_id;
+    raise exception 'Authenticated identity marker bypassed submitted-work immutability';
+  exception when check_violation then
+    if sqlerrm not like '%assignment_requirements_submitted_documents_immutable%' then
+      raise;
+    end if;
+  end;
+
+  perform set_config('request.jwt.claim.role', 'service_role', true);
+  begin
+    perform set_config('pika.identity_mapping', 'on', true);
+    update public.assignment_submission_requirements
+    set label = 'Forbidden content change'
+    where id = v_requirement_id;
+    raise exception 'Identity mapping accepted a pedagogical requirement change';
+  exception when check_violation then
+    if sqlerrm not like '%assignment_requirements_submitted_documents_immutable%' then
+      raise;
+    end if;
+  end;
+  perform set_config('pika.identity_mapping', 'off', true);
 end
 \$contract\$;
 

--- a/src/lib/server/course-blueprint-operations.ts
+++ b/src/lib/server/course-blueprint-operations.ts
@@ -466,6 +466,12 @@ async function executeBlueprintOperation(
   const { data, error } = await supabase.rpc(rpcName, args)
 
   if (error) {
+    console.error('[blueprint-operation-rpc-error]', JSON.stringify({
+      operation_id: operationId,
+      operation_type: operationType,
+      rpc_name: rpcName,
+      database_error_code: error.code ?? 'unknown',
+    }))
     const result: BlueprintOperationResult = isMissingBlueprintOperationRpcError(error)
       ? {
           ok: false,

--- a/supabase/migrations/113_allow_submitted_requirement_identity_mapping.sql
+++ b/supabase/migrations/113_allow_submitted_requirement_identity_mapping.sql
@@ -1,0 +1,103 @@
+-- Allow trusted Blueprint capture to attach stable lineage to requirement
+-- definitions without weakening submitted-work immutability.
+
+create or replace function public.guard_assignment_submission_requirement_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_assignment_id uuid;
+  v_artifact_id uuid;
+  v_doc_id uuid;
+begin
+  if public.is_classroom_archive_maintenance_mode('restore')
+    or public.is_classroom_archive_maintenance_mode('compaction') then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  if tg_op = 'UPDATE' and old.assignment_id <> new.assignment_id then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_requirement_move_forbidden';
+  end if;
+
+  -- The v2 Blueprint RPC is service-role-only and sets this transaction-local
+  -- marker while it maps stable artifact identity. Permit only lineage columns
+  -- to differ; all pedagogical fields, ownership, timestamps, and row identity
+  -- must remain unchanged. Requiring the JWT role prevents callers from
+  -- bypassing the guard by setting the custom GUC themselves.
+  if tg_op = 'UPDATE'
+    and current_setting('pika.identity_mapping', true) = 'on'
+    and auth.role() = 'service_role'
+    and (
+      to_jsonb(new) - array[
+        'artifact_id',
+        'source_artifact_id',
+        'source_blueprint_version_id'
+      ]::text[]
+    ) = (
+      to_jsonb(old) - array[
+        'artifact_id',
+        'source_artifact_id',
+        'source_blueprint_version_id'
+      ]::text[]
+    )
+  then
+    return new;
+  end if;
+
+  v_assignment_id := case when tg_op = 'DELETE' then old.assignment_id else new.assignment_id end;
+
+  -- Parent assignment cascades are destructive operations, not requirement edits.
+  if tg_op = 'DELETE' and not exists (
+    select 1 from public.assignments where id = v_assignment_id
+  ) then
+    return old;
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended('assignment_submission:' || v_assignment_id::text, 0));
+
+  if tg_op = 'DELETE' then
+    for v_artifact_id in
+      select artifact.id
+      from public.assignment_submission_artifacts artifact
+      where artifact.requirement_id = old.id
+      order by artifact.id
+      for update
+    loop
+      null;
+    end loop;
+  end if;
+
+  for v_doc_id in
+    select doc.id
+    from public.assignment_docs doc
+    where doc.assignment_id = v_assignment_id
+    order by doc.id
+    for update
+  loop
+    null;
+  end loop;
+
+  if exists (
+    select 1
+    from public.assignment_docs
+    where assignment_id = v_assignment_id
+      and is_submitted is true
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'assignment_requirements_submitted_documents_immutable';
+  end if;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+revoke all on function public.guard_assignment_submission_requirement_mutation()
+  from public, anon, authenticated, service_role;
+
+comment on function public.guard_assignment_submission_requirement_mutation() is
+  'Locks requirement definitions after submission, except service-role Blueprint lineage-only mapping.';

--- a/tests/lib/server/course-blueprint-operations.test.ts
+++ b/tests/lib/server/course-blueprint-operations.test.ts
@@ -181,6 +181,43 @@ describe('atomic blueprint operation contracts', () => {
     }))
   })
 
+  it('logs the safe database error code when an atomic RPC fails', async () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const supabase = {
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: {
+          code: '23514',
+          message: 'sensitive database detail',
+          details: 'sensitive row detail',
+        },
+      }),
+    }
+
+    await createCourseBlueprintAtomic({
+      supabase,
+      operationId,
+      teacherId: '30000000-0000-4000-8000-000000000020',
+      operationType: 'capture',
+      sourceClassroomId: '40000000-0000-4000-8000-000000000020',
+      expectedSourceRevision: 12,
+      plan: createPlan(),
+    })
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[blueprint-operation-rpc-error]',
+      JSON.stringify({
+        operation_id: operationId,
+        operation_type: 'capture',
+        rpc_name: 'create_course_blueprint_atomic_v2',
+        database_error_code: '23514',
+      }),
+    )
+    expect(errorSpy.mock.calls.flat().join(' ')).not.toContain('sensitive database detail')
+    expect(errorSpy.mock.calls.flat().join(' ')).not.toContain('sensitive row detail')
+  })
+
   it('passes the source revision into capture without making it part of the write plan', async () => {
     vi.spyOn(console, 'info').mockImplementation(() => {})
     const supabase = {

--- a/tests/unit/blueprint-submitted-requirement-identity-migration.test.ts
+++ b/tests/unit/blueprint-submitted-requirement-identity-migration.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/113_allow_submitted_requirement_identity_mapping.sql',
+  ),
+  'utf8',
+).toLowerCase()
+
+describe('submitted assignment requirement identity migration', () => {
+  it('allows only service-role Blueprint identity mapping to bypass submission immutability', () => {
+    expect(migration).toContain(
+      'create or replace function public.guard_assignment_submission_requirement_mutation()',
+    )
+    expect(migration).toContain("current_setting('pika.identity_mapping', true) = 'on'")
+    expect(migration).toContain("auth.role() = 'service_role'")
+    expect(migration).toContain("tg_op = 'update'")
+    expect(migration).toContain("'artifact_id'")
+    expect(migration).toContain("'source_artifact_id'")
+    expect(migration).toContain("'source_blueprint_version_id'")
+    expect(migration).toContain('to_jsonb(new)')
+    expect(migration).toContain('to_jsonb(old)')
+  })
+
+  it('retains the submitted-document lock for every non-lineage mutation', () => {
+    expect(migration).toContain('assignment_requirement_move_forbidden')
+    expect(migration).toContain('assignment_requirements_submitted_documents_immutable')
+    expect(migration).toContain('from public.assignment_docs')
+    expect(migration).toContain('for update')
+    expect(migration).toContain(
+      'revoke all on function public.guard_assignment_submission_requirement_mutation()',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- allow migration 112 Blueprint capture to map requirement lineage after student submissions
- keep the exception service-role-only and lineage-only
- preserve all submitted documents and requirement content
- log only the safe database error code for failed Blueprint RPCs

## Verification
- full Vitest suite: 452 files / 3,936 tests
- versioned Blueprint PostgreSQL contract passed twice consecutively
- production build
- generated database type parity
- lint, Bash syntax, migration numbering, Pika audit, diff checks

## Rollout
Migration 113 is not applied to production by this PR. Production application requires a separate one-time authorization naming production and migration 113.