### PR TITLE
Add minimal guidance design contract

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15556,3 +15556,28 @@
 **Remaining:**
 - Require exact-head PR CI and repository approval before merge.
 - Defer Daily/Attendance mobile history/table modes until the later mobile UX phase; continue Phase 3 with Tests desktop/accessibility while Gradex remains separately owned.
+
+<!-- pika-session-log-archive-batch:e0e0b6b8c2908e9ac39ea0411d74612b15a0fa119b5360e7d1eb59f46771bbab -->
+## 2026-07-22 — Scoped Daily history across student switches
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5.6 Terra (high) - the fix is narrow, but correctness depends on React commit and effect ordering across student identity changes.
+
+**Completed:**
+- Remounted only the selected-student history state when the classroom/student scope changes, preventing the prior student's entries from committing beneath the next student's inspector heading.
+- Initialized each scoped history view from that student's preview so the privacy fix does not introduce a false empty-state flash.
+- Added a layout-effect regression test that observes the transition commit before passive effects run.
+- Preserved the existing teacher Daily table and inspector UI; no student, mobile, schema, migration, or production behavior changed.
+
+**Validation:**
+- `pnpm test` (407 files / 3,672 tests)
+- Focused Daily history and attendance suites (2 files / 25 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- Pika changed-file audit
+- Teacher Daily desktop screenshots after sequential student selection in light and dark themes; no horizontal overflow
+
+**Remaining:**
+- Require independent rereview and exact-head PR CI before merge.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,30 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-22 — Scoped Daily history across student switches
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5.6 Terra (high) - the fix is narrow, but correctness depends on React commit and effect ordering across student identity changes.
-
-**Completed:**
-- Remounted only the selected-student history state when the classroom/student scope changes, preventing the prior student's entries from committing beneath the next student's inspector heading.
-- Initialized each scoped history view from that student's preview so the privacy fix does not introduce a false empty-state flash.
-- Added a layout-effect regression test that observes the transition commit before passive effects run.
-- Preserved the existing teacher Daily table and inspector UI; no student, mobile, schema, migration, or production behavior changed.
-
-**Validation:**
-- `pnpm test` (407 files / 3,672 tests)
-- Focused Daily history and attendance suites (2 files / 25 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (623 modules / 0 allowances)
-- Pika changed-file audit
-- Teacher Daily desktop screenshots after sequential student selection in light and dark themes; no horizontal overflow
-
-**Remaining:**
-- Require independent rereview and exact-head PR CI before merge.
-
 ## 2026-07-22 — Backported student classwork test isolation
 
 **Risk profile:** none
@@ -1368,3 +1344,20 @@ service-role Blueprint capture.
 - Publish and review the fix PR.
 - Applying migration 113 to production requires a fresh one-time authorization
   naming production and migration 113; no production mutation was performed.
+
+## 2026-07-29 — Minimal guidance design contract
+
+**Risk profile:** none — documentation-only design guidance.
+
+**Completed:**
+- Added a canonical content-and-guidance contract to `DESIGN.md`.
+- Established minimal default screens, contextual optional help, dismissible
+  first-visit orientation, short search placeholders, and narrow exceptions for
+  persistent explanatory copy.
+
+**Validation:**
+- Markdown diff review and `git diff --check`.
+
+**Remaining:**
+- Apply the contract incrementally when Blueprint and other product surfaces
+  are deliberately revised.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -69,6 +69,19 @@ Pika already has a substantial visual foundation. New work should refine the
 current product rather than introduce a broad visual redesign without evidence
 and explicit product approval.
 
+### Content and guidance
+
+- Default screens show headings, labels, state, and actions. Do not add
+  instructional paragraphs when the interface is self-evident.
+- Put optional explanation in contextual help, such as a tooltip or help
+  affordance, instead of permanent page copy.
+- Use a dismissible one-time first-visit message when a workflow needs longer
+  orientation.
+- Keep placeholders short. Search placeholders use one or two words and do not
+  enumerate searchable fields.
+- Reserve persistent explanatory copy for risk, irreversible effects, errors,
+  recovery, or important data boundaries.
+
 ### Observed visual language
 
 Current executable owners and representative recorded teacher, student,


### PR DESCRIPTION
## Summary

- add a canonical minimal-by-default content rule to Pika design guidance
- move optional orientation into contextual help or a dismissible first-visit message
- reserve persistent explanatory copy for consequential states and data boundaries

## Why

Blueprint UX review showed that self-evident pages were accumulating permanent instructional copy. This establishes a durable product-wide rule while preserving necessary safety, error, recovery, and boundary explanations.

## Validation

- pnpm check:design-policy
- node scripts/trim-session-log.mjs --check
- git diff --check