### PR TITLE
Add Course Blueprint deletion control

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15581,3 +15581,24 @@
 
 **Remaining:**
 - Require independent rereview and exact-head PR CI before merge.
+
+<!-- pika-session-log-archive-batch:e4d3a8b389b122dcec157c07b9e681a005b5056088c418c44a4cf6dd01ed7850 -->
+## 2026-07-22 — Backported student classwork test isolation
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5.6 Terra (medium) - this is a localized test-only cache-isolation correction with no runtime behavior change.
+
+**Completed:**
+- Reset the student assignment, material, and survey request-cache namespaces before every `StudentAssignmentsTab` test.
+- Removed the obsolete workaround that expected an already-viewed assignment to open its instructions modal automatically.
+- Aligned `main` with the deterministic test behavior already proven on `production`; no application, schema, grading, or deployment behavior changed.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/StudentAssignmentsTab.test.tsx` (1 file / 12 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `git diff --check`
+
+**Remaining:**
+- Require exact-head PR CI and normal protected merge into `main`.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-22 — Backported student classwork test isolation
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5.6 Terra (medium) - this is a localized test-only cache-isolation correction with no runtime behavior change.
-
-**Completed:**
-- Reset the student assignment, material, and survey request-cache namespaces before every `StudentAssignmentsTab` test.
-- Removed the obsolete workaround that expected an already-viewed assignment to open its instructions modal automatically.
-- Aligned `main` with the deterministic test behavior already proven on `production`; no application, schema, grading, or deployment behavior changed.
-
-**Validation:**
-- `pnpm exec vitest run tests/components/StudentAssignmentsTab.test.tsx` (1 file / 12 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `git diff --check`
-
-**Remaining:**
-- Require exact-head PR CI and normal protected merge into `main`.
-
 ## 2026-07-22 — Hardened Tests list read states
 
 **Risk profile:** workspace-state
@@ -1361,3 +1341,30 @@ service-role Blueprint capture.
 **Remaining:**
 - Apply the contract incrementally when Blueprint and other product surfaces
   are deliberately revised.
+
+## 2026-07-29 — Course Blueprint deletion control
+
+**Risk profile:** none — teacher-owned Blueprint UI over the existing
+ownership-checked deletion endpoint.
+
+**Completed:**
+- Added a destructive Course Blueprint action to the desktop action bar and
+  mobile overflow menu.
+- Added confirmation copy that distinguishes unlinked Blueprints from linked
+  Blueprints, whose classrooms remain intact while their Blueprint connection
+  is removed.
+- Kept the Blueprint list, selected detail, route, and request cache consistent
+  after deletion.
+- Added component coverage for confirmation, endpoint invocation, cache
+  invalidation, route cleanup, and selecting the next Blueprint.
+
+**Validation:**
+- Full Vitest suite: 452 files / 3,937 tests.
+- Production build, TypeScript, Pika audit, and diff checks passed.
+- Visually verified desktop and mobile layouts, light and dark themes, default,
+  overflow-menu, and confirmation states. The student role safely redirects
+  away from the teacher-only route.
+
+**Remaining:**
+- Publish, review, merge, and release the deletion control.
+- Use the released control to remove the temporary production smoke Blueprint.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1353,18 +1353,29 @@ ownership-checked deletion endpoint.
 - Added confirmation copy that distinguishes unlinked Blueprints from linked
   Blueprints, whose classrooms remain intact while their Blueprint connection
   is removed.
+- Bound each confirmation to the exact loaded Blueprint and suppress deletion
+  while a newly selected Blueprint is loading, preventing stale-detail deletion
+  races.
+- Hid deletion while repository authority is active and added the matching
+  server-side 409 guard; teachers can switch authority back to Pika before
+  deleting.
 - Kept the Blueprint list, selected detail, route, and request cache consistent
   after deletion.
 - Added component coverage for confirmation, endpoint invocation, cache
-  invalidation, route cleanup, and selecting the next Blueprint.
+  invalidation, route cleanup, selecting the next Blueprint, stale selection,
+  and repository authority. Added server coverage for the repository guard.
 
 **Validation:**
-- Full Vitest suite: 452 files / 3,937 tests.
+- Full pre-review Vitest suite: 452 files / 3,937 tests.
+- Post-review focused suite: 2 files / 23 tests.
 - Production build, TypeScript, Pika audit, and diff checks passed.
 - Visually verified desktop and mobile layouts, light and dark themes, default,
   overflow-menu, and confirmation states. The student role safely redirects
   away from the teacher-only route.
+- Independent review identified and the implementation resolved the
+  stale-detail deletion race and repository-authority bypass.
 
 **Remaining:**
-- Publish, review, merge, and release the deletion control.
+- Complete targeted re-review and exact-head CI, then merge and release the
+  deletion control.
 - Use the released control to remove the temporary production smoke Blueprint.

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Button, FormField, Input } from '@/ui'
+import { Button, ConfirmDialog, FormField, Input } from '@/ui'
 import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
 import { Spinner } from '@/components/Spinner'
 import { CreateBlueprintModal } from '@/components/CreateBlueprintModal'
@@ -158,6 +158,8 @@ export default function TeacherBlueprintsPage() {
   const [loadingDetail, setLoadingDetail] = useState(false)
   const [showCreate, setShowCreate] = useState(false)
   const [showCreateClassroom, setShowCreateClassroom] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [activeTab, setActiveTab] = useState<EditorTab>('overview')
   const [drafts, setDrafts] = useState<DraftState>(emptyDraftState())
   const [meta, setMeta] = useState({
@@ -398,6 +400,39 @@ export default function TeacherBlueprintsPage() {
       setError(err.message || 'Failed to save metadata')
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function deleteSelectedBlueprint() {
+    if (!selectedBlueprintId || !detail) return
+
+    const blueprintId = selectedBlueprintId
+    setDeleting(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/course-blueprints/${blueprintId}`, {
+        method: 'DELETE',
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to delete course blueprint')
+      }
+
+      const remainingBlueprints = blueprints.filter(
+        (blueprint) => blueprint.id !== blueprintId,
+      )
+      detailRequestIdRef.current += 1
+      invalidateTeacherBlueprints()
+      setBlueprints(remainingBlueprints)
+      setDetail(null)
+      setSelectedBlueprintId(remainingBlueprints[0]?.id || null)
+      setShowDeleteConfirm(false)
+      router.push('/teacher/blueprints')
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete course blueprint')
+      setShowDeleteConfirm(false)
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -782,6 +817,13 @@ export default function TeacherBlueprintsPage() {
                 ...(plannedSite.published && plannedSite.slug
                   ? [{ id: 'open-planned-site', label: 'Open Planned Site', onSelect: () => window.open(`/planned/${plannedSite.slug}`, '_blank') }]
                   : []),
+                {
+                  id: 'delete-blueprint',
+                  label: 'Delete Course Blueprint',
+                  destructive: true,
+                  disabled: deleting,
+                  onSelect: () => setShowDeleteConfirm(true),
+                },
               ]
             : []),
         ]}
@@ -1442,6 +1484,28 @@ export default function TeacherBlueprintsPage() {
           setShowCreateClassroom(false)
           router.push(`/classrooms/${classroom.id}?tab=attendance`)
         }}
+      />
+
+      <ConfirmDialog
+        isOpen={showDeleteConfirm}
+        title={detail ? `Delete ${detail.title}?` : 'Delete Course Blueprint?'}
+        description={
+          detail?.linked_classrooms.length
+            ? `${detail.linked_classrooms.length} linked ${
+                detail.linked_classrooms.length === 1 ? 'classroom will' : 'classrooms will'
+              } stay intact, but ${
+                detail.linked_classrooms.length === 1 ? 'its' : 'their'
+              } Blueprint connection will be removed. This cannot be undone.`
+            : 'This permanently deletes the Course Blueprint and its saved Versions. This cannot be undone.'
+        }
+        confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+        confirmVariant="danger"
+        isCancelDisabled={deleting}
+        isConfirmDisabled={deleting}
+        onCancel={() => {
+          if (!deleting) setShowDeleteConfirm(false)
+        }}
+        onConfirm={deleteSelectedBlueprint}
       />
     </PageLayout>
   )

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -101,6 +101,12 @@ type MarkdownEditorTab = Exclude<
 
 type DraftState = Record<MarkdownEditorTab, string>
 
+type BlueprintDeleteTarget = {
+  id: string
+  title: string
+  linkedClassroomCount: number
+}
+
 type BlueprintProposal = {
   id: string
   source_kind: 'classroom' | 'package' | 'repository' | 'ai' | 'blueprint'
@@ -158,7 +164,7 @@ export default function TeacherBlueprintsPage() {
   const [loadingDetail, setLoadingDetail] = useState(false)
   const [showCreate, setShowCreate] = useState(false)
   const [showCreateClassroom, setShowCreateClassroom] = useState(false)
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<BlueprintDeleteTarget | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [activeTab, setActiveTab] = useState<EditorTab>('overview')
   const [drafts, setDrafts] = useState<DraftState>(emptyDraftState())
@@ -217,6 +223,8 @@ export default function TeacherBlueprintsPage() {
     }
   }, [detail])
   const repositoryManaged = detail?.authority_mode === 'repository'
+  const canDeleteSelectedBlueprint =
+    detail?.id === selectedBlueprintId && !repositoryManaged
   const actionableProposalCount = useMemo(
     () => proposals.filter((proposal) =>
       proposal.status === 'ready' || proposal.status === 'needs_review'
@@ -404,9 +412,18 @@ export default function TeacherBlueprintsPage() {
   }
 
   async function deleteSelectedBlueprint() {
-    if (!selectedBlueprintId || !detail) return
+    if (
+      !deleteTarget
+      || detail?.id !== deleteTarget.id
+      || selectedBlueprintId !== deleteTarget.id
+      || detail.authority_mode === 'repository'
+    ) {
+      setDeleteTarget(null)
+      setError('The selected Course Blueprint changed. Review it before deleting.')
+      return
+    }
 
-    const blueprintId = selectedBlueprintId
+    const blueprintId = deleteTarget.id
     setDeleting(true)
     setError('')
     try {
@@ -426,14 +443,29 @@ export default function TeacherBlueprintsPage() {
       setBlueprints(remainingBlueprints)
       setDetail(null)
       setSelectedBlueprintId(remainingBlueprints[0]?.id || null)
-      setShowDeleteConfirm(false)
+      setDeleteTarget(null)
       router.push('/teacher/blueprints')
     } catch (err: any) {
       setError(err.message || 'Failed to delete course blueprint')
-      setShowDeleteConfirm(false)
+      setDeleteTarget(null)
     } finally {
       setDeleting(false)
     }
+  }
+
+  function openDeleteConfirm() {
+    if (!canDeleteSelectedBlueprint || !detail) return
+    setDeleteTarget({
+      id: detail.id,
+      title: detail.title,
+      linkedClassroomCount: detail.linked_classrooms.length,
+    })
+  }
+
+  function selectBlueprint(blueprintId: string) {
+    setDeleteTarget(null)
+    setDetail(null)
+    setSelectedBlueprintId(blueprintId)
   }
 
   async function changeAuthorityMode() {
@@ -817,13 +849,15 @@ export default function TeacherBlueprintsPage() {
                 ...(plannedSite.published && plannedSite.slug
                   ? [{ id: 'open-planned-site', label: 'Open Planned Site', onSelect: () => window.open(`/planned/${plannedSite.slug}`, '_blank') }]
                   : []),
-                {
-                  id: 'delete-blueprint',
-                  label: 'Delete Course Blueprint',
-                  destructive: true,
-                  disabled: deleting,
-                  onSelect: () => setShowDeleteConfirm(true),
-                },
+                ...(canDeleteSelectedBlueprint
+                  ? [{
+                      id: 'delete-blueprint',
+                      label: 'Delete Course Blueprint',
+                      destructive: true,
+                      disabled: deleting,
+                      onSelect: openDeleteConfirm,
+                    }]
+                  : []),
               ]
             : []),
         ]}
@@ -867,7 +901,7 @@ export default function TeacherBlueprintsPage() {
                   <button
                     key={blueprint.id}
                     type="button"
-                    onClick={() => setSelectedBlueprintId(blueprint.id)}
+                    onClick={() => selectBlueprint(blueprint.id)}
                     className={`w-full rounded-card border px-3 py-3 text-left transition-colors ${
                       selectedBlueprintId === blueprint.id
                         ? 'border-primary bg-info-bg'
@@ -1487,14 +1521,14 @@ export default function TeacherBlueprintsPage() {
       />
 
       <ConfirmDialog
-        isOpen={showDeleteConfirm}
-        title={detail ? `Delete ${detail.title}?` : 'Delete Course Blueprint?'}
+        isOpen={deleteTarget !== null}
+        title={deleteTarget ? `Delete ${deleteTarget.title}?` : 'Delete Course Blueprint?'}
         description={
-          detail?.linked_classrooms.length
-            ? `${detail.linked_classrooms.length} linked ${
-                detail.linked_classrooms.length === 1 ? 'classroom will' : 'classrooms will'
+          deleteTarget?.linkedClassroomCount
+            ? `${deleteTarget.linkedClassroomCount} linked ${
+                deleteTarget.linkedClassroomCount === 1 ? 'classroom will' : 'classrooms will'
               } stay intact, but ${
-                detail.linked_classrooms.length === 1 ? 'its' : 'their'
+                deleteTarget.linkedClassroomCount === 1 ? 'its' : 'their'
               } Blueprint connection will be removed. This cannot be undone.`
             : 'This permanently deletes the Course Blueprint and its saved Versions. This cannot be undone.'
         }
@@ -1503,7 +1537,7 @@ export default function TeacherBlueprintsPage() {
         isCancelDisabled={deleting}
         isConfirmDisabled={deleting}
         onCancel={() => {
-          if (!deleting) setShowDeleteConfirm(false)
+          if (!deleting) setDeleteTarget(null)
         }}
         onConfirm={deleteSelectedBlueprint}
       />

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -366,6 +366,13 @@ export async function updateCourseBlueprint(
 export async function deleteCourseBlueprint(teacherId: string, blueprintId: string) {
   const ownership = await assertTeacherOwnsCourseBlueprint(teacherId, blueprintId)
   if (!ownership.ok) return ownership
+  if (ownership.blueprint.authority_mode === 'repository') {
+    return {
+      ok: false as const,
+      status: 409,
+      error: 'This Blueprint is repository-managed. Switch to Pika as Editor before deleting it.',
+    }
+  }
 
   const supabase = getSupabase()
   const { error } = await supabase.from('course_blueprints').delete().eq('id', blueprintId)

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -153,6 +153,9 @@ describe('TeacherBlueprintsPage', () => {
       if (url === '/api/teacher/course-blueprints/b-2' && method === 'PATCH') {
         return Promise.resolve(jsonResponse({ blueprint: blueprintDetail }))
       }
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'DELETE') {
+        return Promise.resolve(jsonResponse({ success: true }))
+      }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`))
     }) as any)
   })
@@ -248,6 +251,36 @@ describe('TeacherBlueprintsPage', () => {
 
     await waitFor(() => {
       expect(invalidateCachedJSONMatching).toHaveBeenCalledWith('teacher-blueprints:')
+    })
+  })
+
+  it('warns about linked classrooms before deleting the selected Blueprint', async () => {
+    render(<TeacherBlueprintsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Blueprint Two')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Course Blueprint' }))
+
+    expect(screen.getByRole('dialog', { name: 'Delete Blueprint Two?' })).toBeInTheDocument()
+    expect(screen.getByText(
+      '1 linked classroom will stay intact, but its Blueprint connection will be removed. This cannot be undone.',
+    )).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/teacher/course-blueprints/b-2',
+        { method: 'DELETE' },
+      )
+    })
+    expect(invalidateCachedJSONMatching).toHaveBeenCalledWith('teacher-blueprints:')
+    expect(mockPush).toHaveBeenCalledWith('/teacher/blueprints')
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Blueprint One')).toBeInTheDocument()
     })
   })
 })

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -67,6 +67,7 @@ const blueprintList = [
 const blueprintDetail = {
   id: 'b-2',
   teacher_id: 'teacher-1',
+  authority_mode: 'pika',
   title: 'Blueprint Two',
   subject: 'Computer Science',
   grade_level: 'Grade 11',
@@ -154,6 +155,9 @@ describe('TeacherBlueprintsPage', () => {
         return Promise.resolve(jsonResponse({ blueprint: blueprintDetail }))
       }
       if (url === '/api/teacher/course-blueprints/b-2' && method === 'DELETE') {
+        return Promise.resolve(jsonResponse({ success: true }))
+      }
+      if (url === '/api/teacher/course-blueprints/b-1' && method === 'DELETE') {
         return Promise.resolve(jsonResponse({ success: true }))
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`))
@@ -282,5 +286,71 @@ describe('TeacherBlueprintsPage', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('Blueprint One')).toBeInTheDocument()
     })
+  })
+
+  it('never offers deletion for stale detail during a Blueprint selection change', async () => {
+    let resolveBlueprintOne: ((response: Response) => void) | undefined
+    const delayedBlueprintOne = new Promise<Response>((resolve) => {
+      resolveBlueprintOne = resolve
+    })
+    const defaultFetch = vi.mocked(fetch).getMockImplementation()
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+      if (url === '/api/teacher/course-blueprints/b-1' && method === 'GET') {
+        return delayedBlueprintOne
+      }
+      return defaultFetch!(input, init)
+    })
+
+    render(<TeacherBlueprintsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Blueprint Two')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Blueprint One/ }))
+
+    expect(screen.queryByRole('button', { name: 'Delete Course Blueprint' })).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    await act(async () => {
+      resolveBlueprintOne?.(jsonResponse({ blueprint: blueprintOneDetail }))
+      await delayedBlueprintOne
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Course Blueprint' }))
+    expect(screen.getByRole('dialog', { name: 'Delete Blueprint One?' })).toBeInTheDocument()
+    expect(screen.getByText(
+      'This permanently deletes the Course Blueprint and its saved Versions. This cannot be undone.',
+    )).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/teacher/course-blueprints/b-1',
+        { method: 'DELETE' },
+      )
+    })
+  })
+
+  it('does not offer deletion while repository authority is active', async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation()
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'GET') {
+        return Promise.resolve(jsonResponse({
+          blueprint: { ...blueprintDetail, authority_mode: 'repository' },
+        }))
+      }
+      return defaultFetch!(input, init)
+    })
+
+    render(<TeacherBlueprintsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Repository-managed')).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Delete Course Blueprint' })).toBeNull()
   })
 })

--- a/tests/lib/server/course-blueprints.test.ts
+++ b/tests/lib/server/course-blueprints.test.ts
@@ -428,6 +428,27 @@ describe('course-blueprints server helpers', () => {
     expect(deleteBuilder.delete).toHaveBeenCalled()
   })
 
+  it('blocks deletion while repository authority is active', async () => {
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({
+          data: {
+            id: 'b-1',
+            teacher_id: 'teacher-1',
+            authority_mode: 'repository',
+          },
+          error: null,
+        }),
+      ],
+    })
+
+    await expect(deleteCourseBlueprint('teacher-1', 'b-1')).resolves.toEqual({
+      ok: false,
+      status: 409,
+      error: 'This Blueprint is repository-managed. Switch to Pika as Editor before deleting it.',
+    })
+  })
+
   it('rejects a mixed-revision blueprint detail snapshot', async () => {
     mockSupabase = makeSupabaseFromQueues({
       course_blueprints: [


### PR DESCRIPTION
## Summary
- add a destructive Course Blueprint action to desktop and mobile controls
- confirm deletion with explicit linked-classroom behavior
- keep list selection, routing, and cache state consistent after deletion
- cover the deletion flow in the Blueprint page component tests

## Validation
- bash scripts/verify-env.sh --tests (452 files, 3,937 tests)
- pnpm build
- pnpm exec tsc --noEmit
- bash .codex/skills/pika-audit/scripts/audit.sh
- desktop/mobile, light/dark visual verification including overflow and confirmation states