### PR TITLE
Reuse archived classrooms through Course Blueprints

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15633,3 +15633,24 @@
 **Remaining:**
 - Require targeted remediation review and exact-head PR CI before merge.
 - Continue Tests with authoring/grading mode separation; defer mobile navigation and Gradex to their separately owned phases.
+
+<!-- pika-session-log-archive-batch:1d4a8a3a3f21343cdba541ef596c78ee067b028840c0db789273c841e7b0078e -->
+## 2026-07-22 — Added canonical grading architecture guide
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5.6 Terra (medium) - this is a documentation-only reconciliation of implemented grading boundaries and contracts.
+
+**Completed:**
+- Added one canonical guide covering grading layers, assignment/test/repository-review flows, versioning, sanitization, atomic persistence, teacher-review evals, calibration limits, and the Pika/Gradex boundary.
+- Routed grading work to the guide from the AI instruction table and core architecture.
+- Updated current context to reflect verified migrations through 104.
+- Documented current implementation separately from future Gradex and paid replay work; no runtime, schema, provider, grading, or deployment behavior changed.
+
+**Validation:**
+- Verified referenced source paths and relative documentation links.
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`
+
+**Remaining:**
+- Require exact-head PR CI and normal protected merge into `main`.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15602,3 +15602,34 @@
 
 **Remaining:**
 - Require exact-head PR CI and normal protected merge into `main`.
+
+<!-- pika-session-log-archive-batch:e3fddc5f00fa3d63e47815776933b28930f4634c7857ec22b5a005b7274e69c9 -->
+## 2026-07-22 — Hardened Tests list read states
+
+**Risk profile:** workspace-state
+
+**Model recommendation:** GPT-5.6 Terra (high) - the slice crosses cached teacher/student lists, controlled workspace URLs, classroom transitions, and asynchronous retry boundaries.
+
+**Completed:**
+- Added explicit teacher and student Tests list loading, cold-error, successful-empty, and failed-refresh contracts with retry controls.
+- Preserved the last valid list when refresh fails, rejected non-successful student list responses, and replaced one-off refresh cache keys with canonical invalidation.
+- Scoped rendered list snapshots and errors to the active classroom so another classroom's tests cannot paint during navigation.
+- Kept controlled teacher test URLs intact until a successful list snapshot proves the selected test is invalid.
+- Resolved independent review feedback by moving focus from a replaced Retry button to a stable named Tests region for both failed and successful retries.
+- Preserved the existing desktop list-first composition. Mobile UX, Gradex, schema, migrations, and production state were unchanged.
+
+**Validation:**
+- Focused teacher/student Tests list suites (3 files / 110 tests)
+- Full repository suite before the focus-only remediation (407 files / 3,680 tests); exact-head PR CI is required
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (623 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit and composite-widget accessibility checklist
+- Playwright desktop matrix for both roles in light/dark across normal, cold-error, and preserved-refresh-error states (12 captures; no horizontal overflow)
+- Post-remediation teacher/student desktop light/dark captures (4 captures; no layout change or horizontal overflow)
+- `git diff --check`
+
+**Remaining:**
+- Require targeted remediation review and exact-head PR CI before merge.
+- Continue Tests with authoring/grading mode separation; defer mobile navigation and Gradex to their separately owned phases.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,26 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-22 — Added canonical grading architecture guide
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5.6 Terra (medium) - this is a documentation-only reconciliation of implemented grading boundaries and contracts.
-
-**Completed:**
-- Added one canonical guide covering grading layers, assignment/test/repository-review flows, versioning, sanitization, atomic persistence, teacher-review evals, calibration limits, and the Pika/Gradex boundary.
-- Routed grading work to the guide from the AI instruction table and core architecture.
-- Updated current context to reflect verified migrations through 104.
-- Documented current implementation separately from future Gradex and paid replay work; no runtime, schema, provider, grading, or deployment behavior changed.
-
-**Validation:**
-- Verified referenced source paths and relative documentation links.
-- `node scripts/trim-session-log.mjs --check`
-- `git diff --check`
-
-**Remaining:**
-- Require exact-head PR CI and normal protected merge into `main`.
-
 ## 2026-07-23 — Separated Tests authoring from grading
 
 **Risk profile:** none
@@ -1381,3 +1361,33 @@ ownership-checked deletion endpoint.
 - Publish for independent review and exact-head CI before merge.
 - A later slice can replace the advanced Classroom Updates conflict handoff
   with a more guided normal-user reconciliation surface.
+
+## 2026-07-29 — Archived classroom Use again review remediation
+
+**Risk profile:** high — concurrent Blueprint graph creation and archived
+classroom lineage.
+
+**Completed:**
+- Added migration 114 with a classroom-row transaction fence so unlinked
+  archived capture and lineage linking commit together; concurrent or
+  crash/retry requests reuse one linked Blueprint.
+- Added an archive-specific proposal finalizer that locks and rechecks the hot
+  archive before changing the Blueprint, then saves the resulting immutable
+  Version and advances source provenance in the same transaction.
+- Made simultaneous classroom and Draft changes require review even when both
+  sides independently reached matching current content.
+- Replaced current-calendar lesson inference with persisted lesson artifact
+  lineage, preventing overflow templates from becoming false deletions after
+  calendar edits.
+- Included reusable public-site visibility defaults in capture, comparison,
+  suggestions, and promotion while excluding operational slug/publication
+  state.
+
+**Validation:**
+- Focused suites: 6 files / 57 tests.
+- Full Vitest suite: 455 files / 3,956 tests.
+- TypeScript, lint, production build, migration contract, and diff checks pass.
+
+**Remaining:**
+- Run Pika audit, complete targeted re-review and exact-head CI.
+- Migration 114 requires explicit target authorization before application.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,36 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-22 — Hardened Tests list read states
-
-**Risk profile:** workspace-state
-
-**Model recommendation:** GPT-5.6 Terra (high) - the slice crosses cached teacher/student lists, controlled workspace URLs, classroom transitions, and asynchronous retry boundaries.
-
-**Completed:**
-- Added explicit teacher and student Tests list loading, cold-error, successful-empty, and failed-refresh contracts with retry controls.
-- Preserved the last valid list when refresh fails, rejected non-successful student list responses, and replaced one-off refresh cache keys with canonical invalidation.
-- Scoped rendered list snapshots and errors to the active classroom so another classroom's tests cannot paint during navigation.
-- Kept controlled teacher test URLs intact until a successful list snapshot proves the selected test is invalid.
-- Resolved independent review feedback by moving focus from a replaced Retry button to a stable named Tests region for both failed and successful retries.
-- Preserved the existing desktop list-first composition. Mobile UX, Gradex, schema, migrations, and production state were unchanged.
-
-**Validation:**
-- Focused teacher/student Tests list suites (3 files / 110 tests)
-- Full repository suite before the focus-only remediation (407 files / 3,680 tests); exact-head PR CI is required
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (623 modules / 0 allowances)
-- `pnpm build`
-- Pika changed-file audit and composite-widget accessibility checklist
-- Playwright desktop matrix for both roles in light/dark across normal, cold-error, and preserved-refresh-error states (12 captures; no horizontal overflow)
-- Post-remediation teacher/student desktop light/dark captures (4 captures; no layout change or horizontal overflow)
-- `git diff --check`
-
-**Remaining:**
-- Require targeted remediation review and exact-head PR CI before merge.
-- Continue Tests with authoring/grading mode separation; defer mobile navigation and Gradex to their separately owned phases.
-
 ## 2026-07-22 — Added canonical grading architecture guide
 
 **Risk profile:** none
@@ -1379,3 +1349,35 @@ ownership-checked deletion endpoint.
 - Complete targeted re-review and exact-head CI, then merge and release the
   deletion control.
 - Use the released control to remove the temporary production smoke Blueprint.
+
+## 2026-07-29 — Archived classroom Use again foundation
+
+**Risk profile:** reusable course lineage and archived-classroom UX.
+
+**Completed:**
+- Added a compact **Use again** action to hot archived classroom cards while
+  preserving the separate Restore action and cold-archive recovery boundary.
+- Compared reusable classroom content with its exact source Blueprint Version
+  and current Draft, normalizing expected instantiation transformations.
+- Reused the current Draft when safe, promoted classroom-only changes through
+  the atomic proposal path, and routed concurrent classroom/Draft changes to
+  review without silently choosing a side.
+- Created and linked a Pika-managed Blueprint copy for legacy archived
+  classrooms with no lineage; no student or runtime data enters the copy.
+- Opened normal classroom creation with the prepared Blueprint selected and
+  added a direct review handoff to Classroom Updates.
+- Documented the archive and Blueprint-version contracts for the flow.
+
+**Validation:**
+- Full Vitest suite: 454 files / 3,948 tests.
+- Focused final suites: 5 files / 50 tests, plus copy-only Blueprint coverage.
+- TypeScript, lint, production build, Pika audit, and diff checks.
+- Playwright teacher matrix: desktop/mobile and light/dark for the archived
+  card and conflict dialog. Student classrooms were checked and are unaffected.
+- Composite-widget checklist reviewed; existing ConfirmDialog keyboard/focus
+  behavior and semantic roles are covered, with no manual follow-up.
+
+**Remaining:**
+- Publish for independent review and exact-head CI before merge.
+- A later slice can replace the advanced Classroom Updates conflict handoff
+  with a more guided normal-user reconciliation surface.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1382,11 +1382,19 @@ classroom lineage.
 - Included reusable public-site visibility defaults in capture, comparison,
   suggestions, and promotion while excluding operational slug/publication
   state.
+- Completed root and nested artifact lineage mapping for both initial archived
+  capture and later promotion, including exact source Version IDs.
+- Made initial Version hashing match Pika's recursive canonical JSON and pass
+  the canonical result digest from TypeScript for promoted Versions.
+- Regenerated the Supabase function contracts for all migration 114 RPCs and
+  internal helpers after CI applied the migration successfully.
 
 **Validation:**
 - Focused suites: 6 files / 57 tests.
 - Full Vitest suite: 455 files / 3,956 tests.
 - TypeScript, lint, production build, migration contract, and diff checks pass.
+- Post-review lineage/digest suites: 6 files / 47 tests; TypeScript and lint
+  pass.
 
 **Remaining:**
 - Run Pika audit, complete targeted re-review and exact-head CI.

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -313,11 +313,15 @@ The teacher Archived view combines two representations without pretending they h
 semantics:
 
 - `archived_hot` classrooms remain ordinary classroom rows and retain open and restore controls.
+  **Use again** prepares reusable course content through the Course Blueprint workflow, then opens
+  normal classroom creation. It never copies students, submissions, grades, attendance, or other
+  runtime history.
   Permanent removal is not available through the classroom route or teacher UI; future hot-data
   removal must run only through the verified compaction state machine.
 - `archived_cold` classrooms are listed from teacher-scoped `classroom_cold_tombstones` metadata as
   **Stored archive** rows. Their submissions, grades, and files are not queryable through the normal
-  classroom routes until the archive is restored to `archived_hot`.
+  classroom routes until the archive is restored to `archived_hot`; **Use again** is therefore
+  unavailable while the classroom remains cold.
 
 `GET /api/teacher/classrooms?archived=true` returns both lists. The cold list is validated against
 the shared classroom-lifecycle Zod contract. During a backward-compatible rollout, a missing

--- a/docs/guidance/classroom-lifecycle-archives.md
+++ b/docs/guidance/classroom-lifecycle-archives.md
@@ -315,7 +315,8 @@ semantics:
 - `archived_hot` classrooms remain ordinary classroom rows and retain open and restore controls.
   **Use again** prepares reusable course content through the Course Blueprint workflow, then opens
   normal classroom creation. It never copies students, submissions, grades, attendance, or other
-  runtime history.
+  runtime history. Blueprint capture/linking and classroom-only promotion are classroom-locked
+  transactions that recheck `archived_at`, ownership, lineage, and structural revision.
   Permanent removal is not available through the classroom route or teacher UI; future hot-data
   removal must run only through the verified compaction state machine.
 - `archived_cold` classrooms are listed from teacher-scoped `classroom_cold_tombstones` metadata as

--- a/docs/guidance/course-blueprint-identity-versioning.md
+++ b/docs/guidance/course-blueprint-identity-versioning.md
@@ -147,6 +147,14 @@ with both its source Version and the current Blueprint Draft:
 - if the classroom has no Blueprint lineage, create and link a Pika-managed
   Blueprint copy without including runtime or student data.
 
+Unlinked capture and lineage linking are one classroom-locked transaction, so
+concurrent requests reuse one winner and cannot leave an orphan Blueprint.
+Classroom-only promotion rechecks that the classroom is still hot-archived in
+the same transaction, saves the resulting Version, and advances the archived
+classroom's source provenance. Lesson comparison uses persisted artifact
+lineage rather than the current calendar size. Reusable public-site visibility
+defaults participate in the comparison; slugs and publication state do not.
+
 The action always creates a new classroom through normal Blueprint
 instantiation. It never restores or clones the archived classroom record.
 

--- a/docs/guidance/course-blueprint-identity-versioning.md
+++ b/docs/guidance/course-blueprint-identity-versioning.md
@@ -135,6 +135,21 @@ Version. A classroom always records the exact Version it used.
 The portable package format version is independent of a teacher's Blueprint
 version number.
 
+### Archived Classroom Reuse
+
+For a hot archived classroom, **Use again** compares its reusable projection
+with both its source Version and the current Blueprint Draft:
+
+- if the classroom still matches its source Version, use the current Draft;
+- if only the classroom changed, submit and atomically apply those reusable
+  changes before classroom creation;
+- if the classroom and Draft both changed, require review; and
+- if the classroom has no Blueprint lineage, create and link a Pika-managed
+  Blueprint copy without including runtime or student data.
+
+The action always creates a new classroom through normal Blueprint
+instantiation. It never restores or clones the archived classroom record.
+
 ## Classroom Provenance
 
 Instantiation preserves lineage at every reusable artifact boundary:

--- a/src/app/api/teacher/classrooms/[id]/use-again/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/use-again/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { prepareArchivedClassroomReuse } from '@/lib/server/archived-classroom-reuse'
+import { resolveBlueprintOperationId } from '@/lib/server/course-blueprint-operations'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const POST = withErrorHandler(
+  'PostTeacherArchivedClassroomUseAgain',
+  async (request, context) => {
+    const user = await requireRole('teacher')
+    const { id } = await context.params
+    const result = await prepareArchivedClassroomReuse({
+      teacherId: user.id,
+      classroomId: id,
+      operationId: resolveBlueprintOperationId(
+        request.headers.get('idempotency-key'),
+      ),
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+    return NextResponse.json(result)
+  },
+)

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -34,6 +34,7 @@ import {
   fetchTeacherClassrooms,
   invalidateTeacherClassrooms,
 } from '@/lib/teacher-classrooms-client'
+import { invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
 import { getClassroomThemeDefinition, getClassroomThemeStyle } from '@/lib/classroom-theme'
 
 interface Props {
@@ -48,17 +49,26 @@ type PendingAction =
   | { mode: 'restore-cold'; archive: ClassroomColdArchiveSummary }
   | null
 
+type ReuseReview = {
+  classroomTitle: string
+  reviewUrl: string
+} | null
+
 export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const router = useRouter()
   const pathname = usePathname()
   const lastPathRef = useRef(pathname)
   const coldRestoreOperationIdsRef = useRef(new Map<string, string>())
+  const reuseOperationIdsRef = useRef(new Map<string, string>())
   const [activeClassrooms, setActiveClassrooms] = useState<Classroom[]>(initialClassrooms)
   const [archivedClassrooms, setArchivedClassrooms] = useState<Classroom[]>([])
   const [coldArchives, setColdArchives] = useState<ClassroomColdArchiveSummary[]>([])
   const [coldArchiveRestoreEnabled, setColdArchiveRestoreEnabled] = useState(false)
   const [view, setView] = useState<ViewMode>('active')
   const [showCreate, setShowCreate] = useState(false)
+  const [reuseBlueprintId, setReuseBlueprintId] = useState<string | null>(null)
+  const [reuseReview, setReuseReview] = useState<ReuseReview>(null)
+  const [reusingClassroomId, setReusingClassroomId] = useState<string | null>(null)
   const [isEditingClassrooms, setIsEditingClassrooms] = useState(false)
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
   const [isProcessing, setIsProcessing] = useState(false)
@@ -296,6 +306,49 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     }
   }
 
+  async function prepareArchivedClassroomAgain(classroom: Classroom) {
+    let operationId = reuseOperationIdsRef.current.get(classroom.id)
+    if (!operationId) {
+      operationId = crypto.randomUUID()
+      reuseOperationIdsRef.current.set(classroom.id, operationId)
+    }
+
+    setReusingClassroomId(classroom.id)
+    setError('')
+    try {
+      const response = await fetch(
+        `/api/teacher/classrooms/${classroom.id}/use-again`,
+        {
+          method: 'POST',
+          headers: { 'Idempotency-Key': operationId },
+        },
+      )
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to prepare this course')
+      }
+      if (data.status === 'review_required') {
+        setReuseReview({
+          classroomTitle: classroom.title,
+          reviewUrl: data.review_url,
+        })
+        return
+      }
+      if (data.status !== 'ready' || typeof data.blueprint_id !== 'string') {
+        throw new Error('Failed to prepare this course')
+      }
+
+      reuseOperationIdsRef.current.delete(classroom.id)
+      invalidateTeacherBlueprints()
+      setReuseBlueprintId(data.blueprint_id)
+      setShowCreate(true)
+    } catch (err: any) {
+      setError(err.message || 'Failed to prepare this course')
+    } finally {
+      setReusingClassroomId(null)
+    }
+  }
+
   async function handleConfirmAction() {
     if (!pendingAction) return
 
@@ -467,13 +520,26 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                           </div>
                         )}
                       </button>
-                      <div className="flex items-center lg:justify-end">
+                      <div className="flex items-center gap-2 lg:justify-end">
+                        <Button
+                          type="button"
+                          variant="primary"
+                          size="xs"
+                          onClick={() => prepareArchivedClassroomAgain(c)}
+                          loading={reusingClassroomId === c.id}
+                          disabled={
+                            openingClassroomId !== null
+                            || (reusingClassroomId !== null && reusingClassroomId !== c.id)
+                          }
+                        >
+                          {reusingClassroomId === c.id ? 'Preparing' : 'Use again'}
+                        </Button>
                         <Button
                           type="button"
                           variant="surface"
                           size="xs"
                           onClick={() => setPendingAction({ mode: 'restore-hot', classroom: c })}
-                          disabled={openingClassroomId !== null}
+                          disabled={openingClassroomId !== null || reusingClassroomId !== null}
                         >
                           Restore
                         </Button>
@@ -558,9 +624,14 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
       <CreateClassroomModal
         isOpen={showCreate}
-        onClose={() => setShowCreate(false)}
+        initialBlueprintId={reuseBlueprintId}
+        onClose={() => {
+          setShowCreate(false)
+          setReuseBlueprintId(null)
+        }}
         onSuccess={(created) => {
           setShowCreate(false)
+          setReuseBlueprintId(null)
           setActiveClassrooms((prev) => [created, ...prev])
           openClassroom(created)
         }}
@@ -576,6 +647,21 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         isCancelDisabled={isProcessing}
         onCancel={() => (isProcessing ? null : setPendingAction(null))}
         onConfirm={handleConfirmAction}
+      />
+
+      <ConfirmDialog
+        isOpen={reuseReview !== null}
+        title={`Review changes to ${reuseReview?.classroomTitle || 'this course'}?`}
+        description="Both versions changed. Review which course changes to keep."
+        confirmLabel="Review changes"
+        cancelLabel="Cancel"
+        onCancel={() => setReuseReview(null)}
+        onConfirm={() => {
+          if (!reuseReview) return
+          reuseOperationIdsRef.current.clear()
+          router.push(reuseReview.reviewUrl)
+          setReuseReview(null)
+        }}
       />
     </PageLayout>
   )

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button, ConfirmDialog, FormField, Input } from '@/ui'
 import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
@@ -211,6 +211,8 @@ export default function TeacherBlueprintsPage() {
   selectedBlueprintIdRef.current = selectedBlueprintId
   const preferredBlueprintId = searchParams.get('blueprint')
   const fromClassroomId = searchParams.get('fromClassroom')
+  const reviewClassroomId = searchParams.get('reviewClassroom')
+  const openedReviewClassroomRef = useRef<string | null>(null)
 
   const counts = useMemo(() => {
     if (!detail) return null
@@ -654,7 +656,9 @@ export default function TeacherBlueprintsPage() {
     }
   }
 
-  async function loadMergeSuggestions(classroomId = mergeClassroomId) {
+  const loadMergeSuggestions = useCallback(async (
+    classroomId = mergeClassroomId,
+  ) => {
     if (!selectedBlueprintId || !classroomId) return
     setMergeLoading(true)
     setError('')
@@ -676,7 +680,33 @@ export default function TeacherBlueprintsPage() {
     } finally {
       setMergeLoading(false)
     }
-  }
+  }, [mergeClassroomId, selectedBlueprintId])
+
+  useEffect(() => {
+    if (
+      !reviewClassroomId
+      || !preferredBlueprintId
+      || selectedBlueprintId !== preferredBlueprintId
+      || detail?.id !== preferredBlueprintId
+      || !detail.linked_classrooms.some(
+        (classroom) => classroom.id === reviewClassroomId,
+      )
+      || openedReviewClassroomRef.current === reviewClassroomId
+    ) {
+      return
+    }
+
+    openedReviewClassroomRef.current = reviewClassroomId
+    setMergeClassroomId(reviewClassroomId)
+    setActiveTab('sync')
+    loadMergeSuggestions(reviewClassroomId)
+  }, [
+    detail,
+    loadMergeSuggestions,
+    preferredBlueprintId,
+    reviewClassroomId,
+    selectedBlueprintId,
+  ])
 
   async function applyMergeSuggestions() {
     if (!selectedBlueprintId || !mergeClassroomId || !mergeSuggestions) return

--- a/src/lib/server/archived-classroom-reuse.ts
+++ b/src/lib/server/archived-classroom-reuse.ts
@@ -4,7 +4,7 @@ import {
   hashCanonicalJson,
 } from '@/lib/server/course-blueprint-versions'
 import {
-  applyPersistedCourseBlueprintProposal,
+  applyArchivedClassroomCourseBlueprintProposal,
   buildClassroomCourseBlueprintSnapshot,
 } from '@/lib/server/course-blueprint-proposals'
 import {
@@ -18,7 +18,6 @@ import {
 import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 import { loadClassroomBlueprintSource } from '@/lib/server/classroom-blueprint-source'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { COURSE_BLUEPRINT_PACKAGE_VERSION } from '@/lib/course-blueprint-package'
 
 type ReusableArea =
   | 'overview'
@@ -30,6 +29,7 @@ type ReusableArea =
   | 'materials'
   | 'surveys'
   | 'grading'
+  | 'site-visibility'
 
 type ArchivedClassroomReuseReady = {
   ok: true
@@ -58,7 +58,7 @@ function withoutDraftRevision(snapshot: CourseBlueprintSnapshot) {
 
 function normalizeVersionForClassroom(
   snapshot: CourseBlueprintSnapshot,
-  classDayCount: number,
+  appliedLessonArtifactIds: ReadonlySet<string>,
 ): CourseBlueprintSnapshot {
   return {
     ...structuredClone(snapshot),
@@ -71,7 +71,9 @@ function normalizeVersionForClassroom(
       ...assessment,
       points_possible: assessment.points_possible ?? 100,
     })),
-    lesson_templates: snapshot.lesson_templates.slice(0, classDayCount),
+    lesson_templates: snapshot.lesson_templates.filter((lesson) =>
+      appliedLessonArtifactIds.has(lesson.artifact_id),
+    ),
   }
 }
 
@@ -79,6 +81,7 @@ function classroomReusableContent(snapshot: CourseBlueprintSnapshot) {
   return {
     sections: snapshot.sections,
     grading: snapshot.grading,
+    planned_site: { config: snapshot.planned_site.config },
     assignments: snapshot.assignments,
     assessments: snapshot.assessments,
     lesson_templates: snapshot.lesson_templates,
@@ -91,15 +94,11 @@ export function classifyArchivedClassroomReuseSnapshots(args: {
   baseVersion: CourseBlueprintSnapshot
   currentBlueprint: CourseBlueprintSnapshot
   currentClassroom: CourseBlueprintSnapshot
-  classDayCount: number
+  appliedLessonArtifactIds: ReadonlySet<string>
 }) {
   const classroomBaseline = normalizeVersionForClassroom(
     args.baseVersion,
-    args.classDayCount,
-  )
-  const currentBlueprintForClassroom = normalizeVersionForClassroom(
-    args.currentBlueprint,
-    args.classDayCount,
+    args.appliedLessonArtifactIds,
   )
   const blueprintChanged =
     hashCanonicalJson(withoutDraftRevision(args.baseVersion))
@@ -107,16 +106,24 @@ export function classifyArchivedClassroomReuseSnapshots(args: {
   const classroomChanged =
     hashCanonicalJson(classroomReusableContent(classroomBaseline))
     !== hashCanonicalJson(classroomReusableContent(args.currentClassroom))
-  const currentCourseMatchesClassroom =
-    hashCanonicalJson(classroomReusableContent(currentBlueprintForClassroom))
-    === hashCanonicalJson(classroomReusableContent(args.currentClassroom))
 
   return {
     blueprintChanged,
     classroomChanged,
-    currentCourseMatchesClassroom,
     classroomBaseline,
   }
+}
+
+export function decideArchivedClassroomReuse(args: {
+  blueprintChanged: boolean
+  classroomChanged: boolean
+  authorityMode: 'pika' | 'repository'
+}): 'ready' | 'review' | 'promote' {
+  if (!args.classroomChanged) return 'ready'
+  if (args.blueprintChanged || args.authorityMode === 'repository') {
+    return 'review'
+  }
+  return 'promote'
 }
 
 function changedReusableAreas(
@@ -142,6 +149,9 @@ function changedReusableAreas(
   if (changed(blueprint.materials, classroom.materials)) areas.push('materials')
   if (changed(blueprint.surveys, classroom.surveys)) areas.push('surveys')
   if (changed(blueprint.grading, classroom.grading)) areas.push('grading')
+  if (changed(blueprint.planned_site.config, classroom.planned_site.config)) {
+    areas.push('site-visibility')
+  }
 
   return areas
 }
@@ -202,9 +212,11 @@ async function applyClassroomChanges(args: {
     }
   }
 
-  const applied = await applyPersistedCourseBlueprintProposal({
+  const applied = await applyArchivedClassroomCourseBlueprintProposal({
     supabase: getServiceRoleClient() as any,
     teacherId: args.teacherId,
+    classroomId: args.classroomId,
+    expectedClassroomRevision: args.classroomRevision,
     proposalId: proposalResult.proposal.id,
     candidate,
   })
@@ -250,34 +262,6 @@ export async function prepareArchivedClassroomReuse(args: {
       { operationId: args.operationId, copyOnly: true },
     )
     if (!created.ok) return created
-
-    const linked = await getServiceRoleClient()
-      .from('classrooms')
-      .update({
-        source_blueprint_id: created.blueprint.id,
-        source_blueprint_origin: {
-          blueprint_id: created.blueprint.id,
-          blueprint_title: created.blueprint.title,
-          blueprint_content_revision: created.blueprint.content_revision,
-          package_manifest_version: COURSE_BLUEPRINT_PACKAGE_VERSION,
-          package_exported_at: new Date().toISOString(),
-          operation_id: created.operation_id,
-        },
-      })
-      .eq('id', args.classroomId)
-      .eq('teacher_id', args.teacherId)
-      .eq('blueprint_source_revision', source.classroom.blueprint_source_revision)
-      .not('archived_at', 'is', null)
-      .is('source_blueprint_id', null)
-      .select('id')
-      .maybeSingle()
-    if (linked.error || !linked.data) {
-      return {
-        ok: false,
-        status: 409,
-        error: 'The archived classroom changed while preparing this course; retry',
-      }
-    }
     return {
       ok: true,
       status: 'ready',
@@ -316,7 +300,6 @@ export async function prepareArchivedClassroomReuse(args: {
       args.classroomId,
     )
     if (!suggestions.ok) return suggestions
-    if (suggestions.suggestionSet.suggestions.length === 0) return ready()
 
     const sourceRevision =
       source.classroom.source_blueprint_origin?.blueprint_content_revision
@@ -326,6 +309,7 @@ export async function prepareArchivedClassroomReuse(args: {
     ) {
       return review()
     }
+    if (suggestions.suggestionSet.suggestions.length === 0) return ready()
 
     const areas = suggestions.suggestionSet.suggestions
       .map((suggestion) => suggestion.area)
@@ -343,7 +327,7 @@ export async function prepareArchivedClassroomReuse(args: {
   }
 
   const supabase = getServiceRoleClient()
-  const [versionResult, classDaysResult] = await Promise.all([
+  const [versionResult, lessonProvenanceResult] = await Promise.all([
     supabase
       .from('course_blueprint_versions')
       .select('course_blueprint_id,source_draft_revision,snapshot_json')
@@ -351,13 +335,14 @@ export async function prepareArchivedClassroomReuse(args: {
       .eq('course_blueprint_id', blueprint.id)
       .single(),
     supabase
-      .from('class_days')
-      .select('id', { count: 'exact', head: true })
-      .eq('classroom_id', args.classroomId),
+      .from('lesson_plans')
+      .select('source_artifact_id')
+      .eq('classroom_id', args.classroomId)
+      .not('source_artifact_id', 'is', null),
   ])
   if (versionResult.error || !versionResult.data) return review()
-  if (classDaysResult.error) {
-    return { ok: false, status: 500, error: 'Failed to inspect classroom calendar' }
+  if (lessonProvenanceResult.error) {
+    return { ok: false, status: 500, error: 'Failed to inspect lesson provenance' }
   }
 
   const baseVersion =
@@ -373,21 +358,21 @@ export async function prepareArchivedClassroomReuse(args: {
     baseVersion,
     currentBlueprint,
     currentClassroom,
-    classDayCount: classDaysResult.count ?? 0,
+    appliedLessonArtifactIds: new Set(
+      (lessonProvenanceResult.data || [])
+        .map((lesson) => lesson.source_artifact_id)
+        .filter((id): id is string => typeof id === 'string'),
+    ),
   })
 
-  if (
-    !classification.classroomChanged
-    || classification.currentCourseMatchesClassroom
-  ) {
-    return ready()
-  }
-  if (
-    classification.blueprintChanged
-    || blueprint.authority_mode === 'repository'
-  ) {
-    return review()
-  }
+  const decision = decideArchivedClassroomReuse({
+    blueprintChanged: classification.blueprintChanged,
+    classroomChanged: classification.classroomChanged,
+    authorityMode:
+      blueprint.authority_mode === 'repository' ? 'repository' : 'pika',
+  })
+  if (decision === 'ready') return ready()
+  if (decision === 'review') return review()
 
   const areas = changedReusableAreas(
     classification.classroomBaseline,

--- a/src/lib/server/archived-classroom-reuse.ts
+++ b/src/lib/server/archived-classroom-reuse.ts
@@ -1,0 +1,406 @@
+import type { CourseBlueprintSnapshot } from '@/lib/server/course-blueprint-versions'
+import {
+  buildCourseBlueprintSnapshot,
+  hashCanonicalJson,
+} from '@/lib/server/course-blueprint-versions'
+import {
+  applyPersistedCourseBlueprintProposal,
+  buildClassroomCourseBlueprintSnapshot,
+} from '@/lib/server/course-blueprint-proposals'
+import {
+  createCourseBlueprintFromClassroom,
+  getCourseBlueprintDetail,
+} from '@/lib/server/course-blueprints'
+import {
+  applyBlueprintMergeSuggestions,
+  getBlueprintMergeSuggestionSet,
+} from '@/lib/server/course-sites'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { loadClassroomBlueprintSource } from '@/lib/server/classroom-blueprint-source'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { COURSE_BLUEPRINT_PACKAGE_VERSION } from '@/lib/course-blueprint-package'
+
+type ReusableArea =
+  | 'overview'
+  | 'outline'
+  | 'resources'
+  | 'assignments'
+  | 'tests'
+  | 'lesson-plans'
+  | 'materials'
+  | 'surveys'
+  | 'grading'
+
+type ArchivedClassroomReuseReady = {
+  ok: true
+  status: 'ready'
+  blueprint_id: string
+  blueprint_title: string
+}
+
+type ArchivedClassroomReuseReview = {
+  ok: true
+  status: 'review_required'
+  blueprint_id: string
+  blueprint_title: string
+  review_url: string
+}
+
+export type ArchivedClassroomReuseResult =
+  | ArchivedClassroomReuseReady
+  | ArchivedClassroomReuseReview
+  | { ok: false; status: number; error: string }
+
+function withoutDraftRevision(snapshot: CourseBlueprintSnapshot) {
+  const { draft_revision: _draftRevision, ...content } = snapshot
+  return content
+}
+
+function normalizeVersionForClassroom(
+  snapshot: CourseBlueprintSnapshot,
+  classDayCount: number,
+): CourseBlueprintSnapshot {
+  return {
+    ...structuredClone(snapshot),
+    assignments: snapshot.assignments.map((assignment) => ({
+      ...assignment,
+      is_draft: true,
+      points_possible: assignment.points_possible ?? 30,
+    })),
+    assessments: snapshot.assessments.map((assessment) => ({
+      ...assessment,
+      points_possible: assessment.points_possible ?? 100,
+    })),
+    lesson_templates: snapshot.lesson_templates.slice(0, classDayCount),
+  }
+}
+
+function classroomReusableContent(snapshot: CourseBlueprintSnapshot) {
+  return {
+    sections: snapshot.sections,
+    grading: snapshot.grading,
+    assignments: snapshot.assignments,
+    assessments: snapshot.assessments,
+    lesson_templates: snapshot.lesson_templates,
+    materials: snapshot.materials,
+    surveys: snapshot.surveys,
+  }
+}
+
+export function classifyArchivedClassroomReuseSnapshots(args: {
+  baseVersion: CourseBlueprintSnapshot
+  currentBlueprint: CourseBlueprintSnapshot
+  currentClassroom: CourseBlueprintSnapshot
+  classDayCount: number
+}) {
+  const classroomBaseline = normalizeVersionForClassroom(
+    args.baseVersion,
+    args.classDayCount,
+  )
+  const currentBlueprintForClassroom = normalizeVersionForClassroom(
+    args.currentBlueprint,
+    args.classDayCount,
+  )
+  const blueprintChanged =
+    hashCanonicalJson(withoutDraftRevision(args.baseVersion))
+    !== hashCanonicalJson(withoutDraftRevision(args.currentBlueprint))
+  const classroomChanged =
+    hashCanonicalJson(classroomReusableContent(classroomBaseline))
+    !== hashCanonicalJson(classroomReusableContent(args.currentClassroom))
+  const currentCourseMatchesClassroom =
+    hashCanonicalJson(classroomReusableContent(currentBlueprintForClassroom))
+    === hashCanonicalJson(classroomReusableContent(args.currentClassroom))
+
+  return {
+    blueprintChanged,
+    classroomChanged,
+    currentCourseMatchesClassroom,
+    classroomBaseline,
+  }
+}
+
+function changedReusableAreas(
+  blueprint: CourseBlueprintSnapshot,
+  classroom: CourseBlueprintSnapshot,
+): ReusableArea[] {
+  const changed = (left: unknown, right: unknown) =>
+    hashCanonicalJson(left) !== hashCanonicalJson(right)
+  const areas: ReusableArea[] = []
+
+  if (changed(blueprint.sections.overview_markdown, classroom.sections.overview_markdown)) {
+    areas.push('overview')
+  }
+  if (changed(blueprint.sections.outline_markdown, classroom.sections.outline_markdown)) {
+    areas.push('outline')
+  }
+  if (changed(blueprint.sections.resources_markdown, classroom.sections.resources_markdown)) {
+    areas.push('resources')
+  }
+  if (changed(blueprint.assignments, classroom.assignments)) areas.push('assignments')
+  if (changed(blueprint.assessments, classroom.assessments)) areas.push('tests')
+  if (changed(blueprint.lesson_templates, classroom.lesson_templates)) areas.push('lesson-plans')
+  if (changed(blueprint.materials, classroom.materials)) areas.push('materials')
+  if (changed(blueprint.surveys, classroom.surveys)) areas.push('surveys')
+  if (changed(blueprint.grading, classroom.grading)) areas.push('grading')
+
+  return areas
+}
+
+function reviewResult(args: {
+  blueprintId: string
+  blueprintTitle: string
+  classroomId: string
+}): ArchivedClassroomReuseReview {
+  return {
+    ok: true,
+    status: 'review_required',
+    blueprint_id: args.blueprintId,
+    blueprint_title: args.blueprintTitle,
+    review_url:
+      `/teacher/blueprints?blueprint=${encodeURIComponent(args.blueprintId)}`
+      + `&reviewClassroom=${encodeURIComponent(args.classroomId)}`,
+  }
+}
+
+async function applyClassroomChanges(args: {
+  teacherId: string
+  blueprintId: string
+  classroomId: string
+  blueprintRevision: number
+  classroomRevision: number
+  areas: ReusableArea[]
+}): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  const proposalResult = await applyBlueprintMergeSuggestions(
+    args.teacherId,
+    args.blueprintId,
+    args.classroomId,
+    args.areas,
+    {
+      expectedBlueprintRevision: args.blueprintRevision,
+      expectedClassroomRevision: args.classroomRevision,
+    },
+  )
+  if (!proposalResult.ok) return proposalResult
+  if (
+    proposalResult.proposal.status !== 'ready'
+    && proposalResult.proposal.status !== 'needs_review'
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'Course changes need review before this classroom can be used again',
+    }
+  }
+
+  const candidate = proposalResult.proposal.diff_json
+    .candidate_snapshot as CourseBlueprintSnapshot | undefined
+  if (!candidate) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'Course changes need review before this classroom can be used again',
+    }
+  }
+
+  const applied = await applyPersistedCourseBlueprintProposal({
+    supabase: getServiceRoleClient() as any,
+    teacherId: args.teacherId,
+    proposalId: proposalResult.proposal.id,
+    candidate,
+  })
+  if (!applied.ok) return applied
+  if (applied.proposal.status !== 'applied') {
+    return {
+      ok: false,
+      status: 409,
+      error: 'Course changes need review before this classroom can be used again',
+    }
+  }
+  return { ok: true }
+}
+
+export async function prepareArchivedClassroomReuse(args: {
+  teacherId: string
+  classroomId: string
+  operationId: string
+}): Promise<ArchivedClassroomReuseResult> {
+  const access = await assertTeacherOwnsClassroom(args.teacherId, args.classroomId)
+  if (!access.ok) return access
+  if (!access.classroom.archived_at) {
+    return {
+      ok: false,
+      status: 409,
+      error: 'Only archived classrooms can be used again',
+    }
+  }
+
+  const sourceResult = await loadClassroomBlueprintSource(
+    args.teacherId,
+    args.classroomId,
+    { lessonTemplateTitleMode: 'generic' },
+  )
+  if (!sourceResult.ok) return sourceResult
+  const source = sourceResult.source
+
+  if (!source.classroom.source_blueprint_id) {
+    const created = await createCourseBlueprintFromClassroom(
+      args.teacherId,
+      args.classroomId,
+      { title: source.classroom.title },
+      { operationId: args.operationId, copyOnly: true },
+    )
+    if (!created.ok) return created
+
+    const linked = await getServiceRoleClient()
+      .from('classrooms')
+      .update({
+        source_blueprint_id: created.blueprint.id,
+        source_blueprint_origin: {
+          blueprint_id: created.blueprint.id,
+          blueprint_title: created.blueprint.title,
+          blueprint_content_revision: created.blueprint.content_revision,
+          package_manifest_version: COURSE_BLUEPRINT_PACKAGE_VERSION,
+          package_exported_at: new Date().toISOString(),
+          operation_id: created.operation_id,
+        },
+      })
+      .eq('id', args.classroomId)
+      .eq('teacher_id', args.teacherId)
+      .eq('blueprint_source_revision', source.classroom.blueprint_source_revision)
+      .not('archived_at', 'is', null)
+      .is('source_blueprint_id', null)
+      .select('id')
+      .maybeSingle()
+    if (linked.error || !linked.data) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'The archived classroom changed while preparing this course; retry',
+      }
+    }
+    return {
+      ok: true,
+      status: 'ready',
+      blueprint_id: created.blueprint.id,
+      blueprint_title: created.blueprint.title,
+    }
+  }
+
+  const blueprintId = source.classroom.source_blueprint_id
+  const blueprintResult = await getCourseBlueprintDetail(args.teacherId, blueprintId)
+  if (!blueprintResult.detail) {
+    return {
+      ok: false,
+      status: blueprintResult.status || 500,
+      error: blueprintResult.error || 'Failed to load Course Blueprint',
+    }
+  }
+  const blueprint = blueprintResult.detail
+  const ready = (): ArchivedClassroomReuseReady => ({
+    ok: true,
+    status: 'ready',
+    blueprint_id: blueprint.id,
+    blueprint_title: blueprint.title,
+  })
+  const review = () => reviewResult({
+    blueprintId: blueprint.id,
+    blueprintTitle: blueprint.title,
+    classroomId: args.classroomId,
+  })
+
+  const sourceVersionId = source.classroom.source_blueprint_version_id
+  if (!sourceVersionId) {
+    const suggestions = await getBlueprintMergeSuggestionSet(
+      args.teacherId,
+      blueprint.id,
+      args.classroomId,
+    )
+    if (!suggestions.ok) return suggestions
+    if (suggestions.suggestionSet.suggestions.length === 0) return ready()
+
+    const sourceRevision =
+      source.classroom.source_blueprint_origin?.blueprint_content_revision
+    if (
+      sourceRevision !== blueprint.content_revision
+      || blueprint.authority_mode === 'repository'
+    ) {
+      return review()
+    }
+
+    const areas = suggestions.suggestionSet.suggestions
+      .map((suggestion) => suggestion.area)
+      .filter((area): area is ReusableArea => area !== 'announcements')
+    if (areas.length === 0) return ready()
+    const applied = await applyClassroomChanges({
+      teacherId: args.teacherId,
+      blueprintId: blueprint.id,
+      classroomId: args.classroomId,
+      blueprintRevision: blueprint.content_revision,
+      classroomRevision: source.classroom.blueprint_source_revision,
+      areas,
+    })
+    return applied.ok ? ready() : applied.status === 409 ? review() : applied
+  }
+
+  const supabase = getServiceRoleClient()
+  const [versionResult, classDaysResult] = await Promise.all([
+    supabase
+      .from('course_blueprint_versions')
+      .select('course_blueprint_id,source_draft_revision,snapshot_json')
+      .eq('id', sourceVersionId)
+      .eq('course_blueprint_id', blueprint.id)
+      .single(),
+    supabase
+      .from('class_days')
+      .select('id', { count: 'exact', head: true })
+      .eq('classroom_id', args.classroomId),
+  ])
+  if (versionResult.error || !versionResult.data) return review()
+  if (classDaysResult.error) {
+    return { ok: false, status: 500, error: 'Failed to inspect classroom calendar' }
+  }
+
+  const baseVersion =
+    versionResult.data.snapshot_json as unknown as CourseBlueprintSnapshot
+  const currentBlueprint = buildCourseBlueprintSnapshot(blueprint)
+  const currentClassroom = buildClassroomCourseBlueprintSnapshot({
+    source,
+    blueprintId: blueprint.id,
+    blueprintRevision: Number(versionResult.data.source_draft_revision),
+    candidate: baseVersion,
+  })
+  const classification = classifyArchivedClassroomReuseSnapshots({
+    baseVersion,
+    currentBlueprint,
+    currentClassroom,
+    classDayCount: classDaysResult.count ?? 0,
+  })
+
+  if (
+    !classification.classroomChanged
+    || classification.currentCourseMatchesClassroom
+  ) {
+    return ready()
+  }
+  if (
+    classification.blueprintChanged
+    || blueprint.authority_mode === 'repository'
+  ) {
+    return review()
+  }
+
+  const areas = changedReusableAreas(
+    classification.classroomBaseline,
+    currentClassroom,
+  )
+  if (areas.length === 0) return ready()
+  const applied = await applyClassroomChanges({
+    teacherId: args.teacherId,
+    blueprintId: blueprint.id,
+    classroomId: args.classroomId,
+    blueprintRevision: blueprint.content_revision,
+    classroomRevision: source.classroom.blueprint_source_revision,
+    areas,
+  })
+  return applied.ok ? ready() : applied.status === 409 ? review() : applied
+}

--- a/src/lib/server/archived-classroom-reuse.ts
+++ b/src/lib/server/archived-classroom-reuse.ts
@@ -51,9 +51,12 @@ export type ArchivedClassroomReuseResult =
   | ArchivedClassroomReuseReview
   | { ok: false; status: number; error: string }
 
-function withoutDraftRevision(snapshot: CourseBlueprintSnapshot) {
+function reusableBlueprintContent(snapshot: CourseBlueprintSnapshot) {
   const { draft_revision: _draftRevision, ...content } = snapshot
-  return content
+  return {
+    ...content,
+    planned_site: { config: snapshot.planned_site.config },
+  }
 }
 
 function normalizeVersionForClassroom(
@@ -101,8 +104,8 @@ export function classifyArchivedClassroomReuseSnapshots(args: {
     args.appliedLessonArtifactIds,
   )
   const blueprintChanged =
-    hashCanonicalJson(withoutDraftRevision(args.baseVersion))
-    !== hashCanonicalJson(withoutDraftRevision(args.currentBlueprint))
+    hashCanonicalJson(reusableBlueprintContent(args.baseVersion))
+    !== hashCanonicalJson(reusableBlueprintContent(args.currentBlueprint))
   const classroomChanged =
     hashCanonicalJson(classroomReusableContent(classroomBaseline))
     !== hashCanonicalJson(classroomReusableContent(args.currentClassroom))

--- a/src/lib/server/course-blueprint-operations.ts
+++ b/src/lib/server/course-blueprint-operations.ts
@@ -403,6 +403,7 @@ export type BlueprintOperationResult = z.infer<typeof blueprintOperationResultSc
 
 type BlueprintRpcName =
   | 'create_course_blueprint_atomic_v2'
+  | 'create_archived_classroom_blueprint_atomic'
   | 'instantiate_course_blueprint_atomic_v2'
 type SupabaseRpcClient = Pick<SupabaseClient<any>, 'rpc'>
 
@@ -548,6 +549,41 @@ export async function createCourseBlueprintAtomic(args: {
     },
     args.operationId,
     args.operationType,
+  )
+}
+
+export async function createArchivedClassroomBlueprintAtomic(args: {
+  supabase: SupabaseRpcClient
+  operationId: string
+  teacherId: string
+  sourceClassroomId: string
+  expectedSourceRevision: number
+  plan: CreateBlueprintWritePlan
+}): Promise<BlueprintOperationResult> {
+  const plan = createBlueprintWritePlanSchema.parse(args.plan)
+  const expectedSourceRevision = z.number().int().positive().parse(
+    args.expectedSourceRevision,
+  )
+  const requestSha256 = hashBlueprintOperationRequest({
+    operation_type: 'archived_reuse',
+    source_classroom_id: args.sourceClassroomId,
+    expected_source_revision: expectedSourceRevision,
+    plan,
+  })
+
+  return executeBlueprintOperation(
+    args.supabase,
+    'create_archived_classroom_blueprint_atomic',
+    {
+      p_operation_id: args.operationId,
+      p_teacher_id: args.teacherId,
+      p_request_sha256: requestSha256,
+      p_source_classroom_id: args.sourceClassroomId,
+      p_expected_source_revision: expectedSourceRevision,
+      p_plan: parseDatabaseJson(plan),
+    },
+    args.operationId,
+    'import',
   )
 }
 

--- a/src/lib/server/course-blueprint-proposals.ts
+++ b/src/lib/server/course-blueprint-proposals.ts
@@ -633,6 +633,64 @@ export async function applyPersistedCourseBlueprintProposal(args: {
     : { ok: false, status: 500, error: 'Blueprint proposal transaction returned an invalid response' }
 }
 
+export async function applyArchivedClassroomCourseBlueprintProposal(args: {
+  supabase: Pick<SupabaseClient<any>, 'rpc'>
+  teacherId: string
+  classroomId: string
+  expectedClassroomRevision: number
+  proposalId: string
+  candidate: CourseBlueprintSnapshot
+}): Promise<
+  | { ok: true; proposal: CourseBlueprintProposalRecord }
+  | { ok: false; status: number; error: string }
+> {
+  const candidateSha256 = hashCourseBlueprintSnapshot(args.candidate)
+  const { data, error } = await args.supabase.rpc(
+    'apply_archived_classroom_blueprint_proposal_atomic',
+    {
+      p_teacher_id: args.teacherId,
+      p_classroom_id: uuidSchema.parse(args.classroomId),
+      p_expected_classroom_revision: args.expectedClassroomRevision,
+      p_proposal_id: uuidSchema.parse(args.proposalId),
+      p_candidate_snapshot: parseDatabaseJson(args.candidate),
+      p_candidate_sha256: candidateSha256,
+    },
+  )
+
+  if (error) {
+    const missing = error.code === '42883'
+      || error.code === 'PGRST202'
+      || (error.message || '').includes(
+        'apply_archived_classroom_blueprint_proposal_atomic',
+      )
+    return {
+      ok: false,
+      status:
+        missing
+          ? 503
+          : error.code === '40001' || error.code === '55000'
+            ? 409
+            : 500,
+      error: missing
+        ? 'Archived classroom reuse requires migration 114 to be applied'
+        : error.code === '40001'
+          ? 'The archived classroom changed; review the course again'
+          : error.code === '55000'
+            ? 'Proposal source does not match the selected Blueprint authority'
+            : 'Failed to apply archived classroom changes',
+    }
+  }
+
+  const parsed = parseProposalRpcResult(data)
+  return parsed.success
+    ? { ok: true, proposal: parsed.data }
+    : {
+        ok: false,
+        status: 500,
+        error: 'Archived classroom proposal transaction returned an invalid response',
+      }
+}
+
 export function serializeCourseBlueprintProposalCandidate(
   candidate: CourseBlueprintSnapshot
 ): string {

--- a/src/lib/server/course-blueprint-proposals.ts
+++ b/src/lib/server/course-blueprint-proposals.ts
@@ -645,6 +645,11 @@ export async function applyArchivedClassroomCourseBlueprintProposal(args: {
   | { ok: false; status: number; error: string }
 > {
   const candidateSha256 = hashCourseBlueprintSnapshot(args.candidate)
+  const resultSnapshot = {
+    ...structuredClone(args.candidate),
+    draft_revision: args.candidate.draft_revision + 1,
+  }
+  const resultSnapshotSha256 = hashCourseBlueprintSnapshot(resultSnapshot)
   const { data, error } = await args.supabase.rpc(
     'apply_archived_classroom_blueprint_proposal_atomic',
     {
@@ -654,6 +659,7 @@ export async function applyArchivedClassroomCourseBlueprintProposal(args: {
       p_proposal_id: uuidSchema.parse(args.proposalId),
       p_candidate_snapshot: parseDatabaseJson(args.candidate),
       p_candidate_sha256: candidateSha256,
+      p_result_snapshot_sha256: resultSnapshotSha256,
     },
   )
 

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -1,6 +1,9 @@
 import { getServiceRoleClient } from '@/lib/supabase'
 import { loadClassroomBlueprintSource } from '@/lib/server/classroom-blueprint-source'
-import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+import {
+  assertTeacherCanMutateClassroom,
+  assertTeacherOwnsClassroom,
+} from '@/lib/server/classrooms'
 import {
   COURSE_BLUEPRINT_PACKAGE_VERSION,
   buildCourseBlueprintExportBundle,
@@ -48,6 +51,7 @@ type BlueprintOwnershipResult =
 
 type BlueprintOperationOptions = {
   operationId?: string
+  copyOnly?: boolean
 }
 
 function getSupabase() {
@@ -1119,7 +1123,9 @@ export async function createCourseBlueprintFromClassroom(
   input: { title?: string },
   options: BlueprintOperationOptions = {},
 ) {
-  const classroomAccess = await assertTeacherCanMutateClassroom(teacherId, classroomId)
+  const classroomAccess = options.copyOnly
+    ? await assertTeacherOwnsClassroom(teacherId, classroomId)
+    : await assertTeacherCanMutateClassroom(teacherId, classroomId)
   if (!classroomAccess.ok) return classroomAccess
 
   const sourceResult = await loadClassroomBlueprintSource(teacherId, classroomId, {
@@ -1168,9 +1174,11 @@ export async function createCourseBlueprintFromClassroom(
     supabase,
     operationId,
     teacherId,
-    operationType: 'capture',
-    sourceClassroomId: classroomId,
-    expectedSourceRevision: source.classroom.blueprint_source_revision ?? 1,
+    operationType: options.copyOnly ? 'import' : 'capture',
+    sourceClassroomId: options.copyOnly ? null : classroomId,
+    expectedSourceRevision: options.copyOnly
+      ? undefined
+      : source.classroom.blueprint_source_revision ?? 1,
     plan,
   })
   if (!operation.ok) return operation

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -35,6 +35,7 @@ import { stripTestDocumentSnapshots } from '@/lib/test-documents'
 import {
   buildCreateBlueprintWritePlan,
   buildInstantiateBlueprintWritePlan,
+  createArchivedClassroomBlueprintAtomic,
   createCourseBlueprintAtomic,
   instantiateCourseBlueprintAtomic,
   resolveBlueprintOperationId,
@@ -1152,7 +1153,9 @@ export async function createCourseBlueprintFromClassroom(
       gradebook_tests_weight: source.grading?.tests_weight ?? 30,
       planned_site_slug: null,
       planned_site_published: false,
-      planned_site_config: DEFAULT_PLANNED_COURSE_SITE_CONFIG,
+      planned_site_config: normalizePlannedCourseSiteConfig(
+        source.classroom.actual_site_config,
+      ),
     },
     assignments: source.assignments.map((assignment) => ({
       ...assignment,
@@ -1170,17 +1173,26 @@ export async function createCourseBlueprintFromClassroom(
     surveys: source.surveys || [],
     manifestVersion: COURSE_BLUEPRINT_PACKAGE_VERSION,
   })
-  const operation = await createCourseBlueprintAtomic({
-    supabase,
-    operationId,
-    teacherId,
-    operationType: options.copyOnly ? 'import' : 'capture',
-    sourceClassroomId: options.copyOnly ? null : classroomId,
-    expectedSourceRevision: options.copyOnly
-      ? undefined
-      : source.classroom.blueprint_source_revision ?? 1,
-    plan,
-  })
+  const expectedSourceRevision =
+    source.classroom.blueprint_source_revision ?? 1
+  const operation = options.copyOnly
+    ? await createArchivedClassroomBlueprintAtomic({
+        supabase,
+        operationId,
+        teacherId,
+        sourceClassroomId: classroomId,
+        expectedSourceRevision,
+        plan,
+      })
+    : await createCourseBlueprintAtomic({
+        supabase,
+        operationId,
+        teacherId,
+        operationType: 'capture',
+        sourceClassroomId: classroomId,
+        expectedSourceRevision,
+        plan,
+      })
   if (!operation.ok) return operation
   if (!operation.blueprint_id) {
     return { ok: false as const, status: 500, error: 'Atomic classroom capture returned no blueprint id' }

--- a/src/lib/server/course-sites.ts
+++ b/src/lib/server/course-sites.ts
@@ -570,6 +570,32 @@ export async function getBlueprintMergeSuggestionSet(
     })
   }
 
+  const currentSiteVisibility = normalizePlannedCourseSiteConfig(
+    blueprint.planned_site_config,
+  )
+  const sourceSiteVisibility = normalizePlannedCourseSiteConfig(
+    source.classroom.actual_site_config,
+  )
+  if (
+    JSON.stringify(currentSiteVisibility)
+    !== JSON.stringify(sourceSiteVisibility)
+  ) {
+    const visibleCount = (config: typeof currentSiteVisibility) =>
+      Object.values(config).filter(Boolean).length
+    suggestions.push({
+      area: 'site-visibility',
+      title: 'Site visibility',
+      summary: 'Classroom site visibility differs from the Blueprint defaults.',
+      items: [{
+        key: 'site-visibility',
+        label: 'Reusable page defaults',
+        operation: 'update',
+        current_summary: `${visibleCount(currentSiteVisibility)} sections visible`,
+        proposed_summary: `${visibleCount(sourceSiteVisibility)} sections visible`,
+      }],
+    })
+  }
+
   return {
     ok: true,
     suggestionSet: {
@@ -598,6 +624,7 @@ export async function applyBlueprintMergeSuggestions(
     | 'materials'
     | 'surveys'
     | 'grading'
+    | 'site-visibility'
   >,
   expected: {
     expectedBlueprintRevision: number
@@ -743,6 +770,11 @@ export async function applyBlueprintMergeSuggestions(
     candidateDetail.gradebook_use_weights = sourceGrading.use_weights
     candidateDetail.gradebook_assignments_weight = sourceGrading.assignments_weight
     candidateDetail.gradebook_tests_weight = sourceGrading.tests_weight
+  }
+  if (areas.includes('site-visibility')) {
+    candidateDetail.planned_site_config = normalizePlannedCourseSiteConfig(
+      source.classroom.actual_site_config,
+    )
   }
 
   let base

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -4599,6 +4599,48 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      apply_archived_classroom_blueprint_proposal_atomic: {
+        Args: {
+          p_candidate_sha256: string
+          p_candidate_snapshot: Json
+          p_classroom_id: string
+          p_expected_classroom_revision: number
+          p_proposal_id: string
+          p_result_snapshot_sha256: string
+          p_teacher_id: string
+        }
+        Returns: {
+          applied_at: string | null
+          applied_blueprint_revision: number | null
+          applied_classroom_revision: number | null
+          base_blueprint_revision: number
+          base_blueprint_version_id: string | null
+          base_classroom_revision: number | null
+          course_blueprint_id: string
+          created_at: string
+          diff_json: Json
+          id: string
+          idempotency_key: string
+          operations_json: Json
+          payload_schema_version: number
+          rejected_at: string | null
+          request_sha256: string
+          source_classroom_id: string | null
+          source_kind: string
+          status: string
+          target_classroom_id: string | null
+          target_kind: string
+          teacher_id: string
+          updated_at: string
+          validation_errors: Json
+        }
+        SetofOptions: {
+          from: "*"
+          to: "course_blueprint_change_proposals"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       apply_course_blueprint_classroom_proposal_atomic: {
         Args: {
           p_classroom_plan: Json
@@ -4676,6 +4718,14 @@ export type Database = {
           isOneToOne: true
           isSetofReturn: false
         }
+      }
+      archived_classroom_blueprint_snapshot_from_plan: {
+        Args: {
+          p_blueprint_id: string
+          p_draft_revision: number
+          p_plan: Json
+        }
+        Returns: Json
       }
       begin_classroom_archive_compaction: {
         Args: {
@@ -5180,6 +5230,21 @@ export type Database = {
         Returns: boolean
       }
       count_pal_event_outbox_ready: { Args: never; Returns: number }
+      course_blueprint_canonical_jsonb_text: {
+        Args: { p_value: Json }
+        Returns: string
+      }
+      create_archived_classroom_blueprint_atomic: {
+        Args: {
+          p_expected_source_revision: number
+          p_operation_id: string
+          p_plan: Json
+          p_request_sha256: string
+          p_source_classroom_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
       create_assignment_ai_grading_run_atomic: {
         Args: {
           p_assignment_id: string

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -4720,11 +4720,7 @@ export type Database = {
         }
       }
       archived_classroom_blueprint_snapshot_from_plan: {
-        Args: {
-          p_blueprint_id: string
-          p_draft_revision: number
-          p_plan: Json
-        }
+        Args: { p_blueprint_id: string; p_draft_revision: number; p_plan: Json }
         Returns: Json
       }
       begin_classroom_archive_compaction: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1224,6 +1224,7 @@ export type BlueprintMergeSuggestionArea =
   | 'materials'
   | 'surveys'
   | 'grading'
+  | 'site-visibility'
   | 'announcements'
 
 export type BlueprintMergeSuggestionOperation = 'add' | 'update' | 'remove'

--- a/supabase/migrations/114_atomic_archived_classroom_blueprint_reuse.sql
+++ b/supabase/migrations/114_atomic_archived_classroom_blueprint_reuse.sql
@@ -2,6 +2,218 @@
 -- durable fence: concurrent requests serialize on it, and only the first may
 -- create and link a Blueprint.
 
+-- Match hashCanonicalJson: recursively sort object keys and emit minified JSON
+-- without altering whitespace inside string values.
+create or replace function public.course_blueprint_canonical_jsonb_text(
+  p_value jsonb
+)
+returns text
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  v_result text;
+begin
+  case jsonb_typeof(p_value)
+    when 'object' then
+      select '{' || coalesce(
+        string_agg(
+          to_jsonb(entry.key)::text || ':'
+            || public.course_blueprint_canonical_jsonb_text(entry.value),
+          ','
+          order by entry.key
+        ),
+        ''
+      ) || '}'
+      into v_result
+      from jsonb_each(p_value) entry;
+    when 'array' then
+      select '[' || coalesce(
+        string_agg(
+          public.course_blueprint_canonical_jsonb_text(item.value),
+          ','
+          order by item.ordinality
+        ),
+        ''
+      ) || ']'
+      into v_result
+      from jsonb_array_elements(p_value)
+        with ordinality as item(value, ordinality);
+    else
+      v_result := p_value::text;
+  end case;
+  return v_result;
+end;
+$$;
+
+revoke all on function public.course_blueprint_canonical_jsonb_text(jsonb)
+  from public, anon, authenticated;
+grant execute on function public.course_blueprint_canonical_jsonb_text(jsonb)
+  to service_role;
+
+create or replace function public.archived_classroom_blueprint_snapshot_from_plan(
+  p_blueprint_id uuid,
+  p_draft_revision bigint,
+  p_plan jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = ''
+as $$
+  select jsonb_build_object(
+    'schema_version', 2,
+    'blueprint_id', p_blueprint_id,
+    'draft_revision', p_draft_revision,
+    'metadata', jsonb_build_object(
+      'title', p_plan->'blueprint'->>'title',
+      'subject', coalesce(p_plan->'blueprint'->>'subject', ''),
+      'grade_level', coalesce(p_plan->'blueprint'->>'grade_level', ''),
+      'course_code', coalesce(p_plan->'blueprint'->>'course_code', ''),
+      'term_template', coalesce(p_plan->'blueprint'->>'term_template', '')
+    ),
+    'sections', jsonb_build_object(
+      'overview_markdown',
+        coalesce(p_plan->'blueprint'->>'overview_markdown', ''),
+      'outline_markdown',
+        coalesce(p_plan->'blueprint'->>'outline_markdown', ''),
+      'resources_markdown',
+        coalesce(p_plan->'blueprint'->>'resources_markdown', '')
+    ),
+    'grading', jsonb_build_object(
+      'use_weights',
+        coalesce((p_plan->'blueprint'->>'gradebook_use_weights')::boolean, false),
+      'assignments_weight',
+        coalesce((p_plan->'blueprint'->>'gradebook_assignments_weight')::integer, 70),
+      'tests_weight',
+        coalesce((p_plan->'blueprint'->>'gradebook_tests_weight')::integer, 30)
+    ),
+    'planned_site', jsonb_build_object(
+      'slug', nullif(p_plan->'blueprint'->>'planned_site_slug', ''),
+      'published',
+        coalesce((p_plan->'blueprint'->>'planned_site_published')::boolean, false),
+      'config',
+        coalesce(p_plan->'blueprint'->'planned_site_config', '{}'::jsonb)
+    ),
+    'assignments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'artifact_id', item.value->>'artifact_id',
+          'title', item.value->>'title',
+          'instructions_markdown',
+            coalesce(item.value->>'instructions_markdown', ''),
+          'submission_requirements',
+            coalesce(item.value->'submission_requirements_json', '[]'::jsonb),
+          'default_due_days',
+            coalesce((item.value->>'default_due_days')::integer, 0),
+          'default_due_time',
+            coalesce(item.value->>'default_due_time', '23:59'),
+          'points_possible', item.value->'points_possible',
+          'gradebook_weight',
+            coalesce((item.value->>'gradebook_weight')::integer, 10),
+          'include_in_final',
+            coalesce((item.value->>'include_in_final')::boolean, true),
+          'is_draft', true,
+          'track_authenticity',
+            coalesce((item.value->>'track_authenticity')::boolean, false),
+          'position', coalesce((item.value->>'position')::integer, 0)
+        )
+        order by item.ordinality
+      )
+      from jsonb_array_elements(coalesce(p_plan->'assignments', '[]'::jsonb))
+        with ordinality as item(value, ordinality)
+    ), '[]'::jsonb),
+    'assessments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'artifact_id', item.value->>'artifact_id',
+          'assessment_type', 'test',
+          'title', item.value->>'title',
+          'content', coalesce(item.value->'content', '{}'::jsonb),
+          'documents', coalesce(item.value->'documents', '[]'::jsonb),
+          'points_possible', item.value->'points_possible',
+          'gradebook_weight',
+            coalesce((item.value->>'gradebook_weight')::integer, 10),
+          'include_in_final',
+            coalesce((item.value->>'include_in_final')::boolean, true),
+          'position', coalesce((item.value->>'position')::integer, 0)
+        )
+        order by item.ordinality
+      )
+      from jsonb_array_elements(coalesce(p_plan->'assessments', '[]'::jsonb))
+        with ordinality as item(value, ordinality)
+    ), '[]'::jsonb),
+    'lesson_templates', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'artifact_id', item.value->>'artifact_id',
+          'title', coalesce(item.value->>'title', ''),
+          'content_markdown', coalesce(item.value->>'content_markdown', ''),
+          'position', coalesce((item.value->>'position')::integer, 0)
+        )
+        order by item.ordinality
+      )
+      from jsonb_array_elements(
+        coalesce(p_plan->'lesson_templates', '[]'::jsonb)
+      ) with ordinality as item(value, ordinality)
+    ), '[]'::jsonb),
+    'materials', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'artifact_id', item.value->>'artifact_id',
+          'title', item.value->>'title',
+          'content_markdown', coalesce(item.value->>'content_markdown', ''),
+          'position', coalesce((item.value->>'position')::integer, 0)
+        )
+        order by item.ordinality
+      )
+      from jsonb_array_elements(coalesce(p_plan->'materials', '[]'::jsonb))
+        with ordinality as item(value, ordinality)
+    ), '[]'::jsonb),
+    'surveys', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'artifact_id', item.value->>'artifact_id',
+          'title', item.value->>'title',
+          'show_results',
+            coalesce((item.value->>'show_results')::boolean, true),
+          'dynamic_responses',
+            coalesce((item.value->>'dynamic_responses')::boolean, false),
+          'questions', coalesce((
+            select jsonb_agg(
+              (question.value - 'id')
+                || jsonb_build_object(
+                  'artifact_id',
+                  question.value->>'id'
+                )
+              order by question.ordinality
+            )
+            from jsonb_array_elements(
+              coalesce(item.value->'questions_json', '[]'::jsonb)
+            ) with ordinality as question(value, ordinality)
+          ), '[]'::jsonb),
+          'position', coalesce((item.value->>'position')::integer, 0)
+        )
+        order by item.ordinality
+      )
+      from jsonb_array_elements(coalesce(p_plan->'surveys', '[]'::jsonb))
+        with ordinality as item(value, ordinality)
+    ), '[]'::jsonb)
+  );
+$$;
+
+revoke all on function public.archived_classroom_blueprint_snapshot_from_plan(
+  uuid,
+  bigint,
+  jsonb
+) from public, anon, authenticated;
+grant execute on function public.archived_classroom_blueprint_snapshot_from_plan(
+  uuid,
+  bigint,
+  jsonb
+) to service_role;
+
 create or replace function public.create_archived_classroom_blueprint_atomic(
   p_operation_id uuid,
   p_teacher_id uuid,
@@ -20,6 +232,14 @@ declare
   v_result jsonb;
   v_blueprint_id uuid;
   v_blueprint_revision bigint;
+  v_version public.course_blueprint_versions;
+  v_version_snapshot jsonb;
+  v_version_sha256 text;
+  v_item jsonb;
+  v_child jsonb;
+  v_parent_id uuid;
+  v_position integer;
+  v_updated integer;
 begin
   select *
   into v_classroom
@@ -113,13 +333,262 @@ begin
   v_blueprint_id := (v_result->>'blueprint_id')::uuid;
   v_blueprint_revision := (v_result->>'result_content_revision')::bigint;
 
+  perform set_config('pika.identity_mapping', 'on', true);
+
+  for v_item in
+    select value from jsonb_array_elements(
+      coalesce(p_plan->'assignments', '[]'::jsonb)
+    )
+  loop
+    v_position := coalesce((v_item->>'position')::integer, 0);
+    update public.assignments
+    set
+      artifact_id = (v_item->>'artifact_id')::uuid,
+      source_artifact_id = (v_item->>'artifact_id')::uuid
+    where classroom_id = p_source_classroom_id
+      and blueprint_archived_at is null
+      and position = v_position
+    returning id into v_parent_id;
+    if not found then
+      raise exception 'Archived assignment identity mapping failed'
+        using errcode = '22023';
+    end if;
+
+    for v_child in
+      select value from jsonb_array_elements(
+        coalesce(v_item->'submission_requirements_json', '[]'::jsonb)
+      )
+    loop
+      update public.assignment_submission_requirements
+      set
+        artifact_id = (v_child->>'id')::uuid,
+        source_artifact_id = (v_child->>'id')::uuid
+      where assignment_id = v_parent_id
+        and position = coalesce((v_child->>'position')::integer, 0);
+      get diagnostics v_updated = row_count;
+      if v_updated <> 1 then
+        raise exception 'Archived assignment requirement identity mapping failed'
+          using errcode = '22023';
+      end if;
+    end loop;
+  end loop;
+
+  for v_item in
+    select value from jsonb_array_elements(
+      coalesce(p_plan->'assessments', '[]'::jsonb)
+    )
+  loop
+    v_position := coalesce((v_item->>'position')::integer, 0);
+    update public.tests
+    set
+      artifact_id = (v_item->>'artifact_id')::uuid,
+      source_artifact_id = (v_item->>'artifact_id')::uuid
+    where classroom_id = p_source_classroom_id
+      and blueprint_archived_at is null
+      and position = v_position
+    returning id into v_parent_id;
+    if not found then
+      raise exception 'Archived Test identity mapping failed'
+        using errcode = '22023';
+    end if;
+
+    for v_child in
+      select value from jsonb_array_elements(
+        coalesce(v_item->'content'->'questions', '[]'::jsonb)
+      )
+    loop
+      update public.test_questions
+      set
+        artifact_id = (v_child->>'id')::uuid,
+        source_artifact_id = (v_child->>'id')::uuid
+      where test_id = v_parent_id
+        and position = coalesce((v_child->>'position')::integer, 0);
+      get diagnostics v_updated = row_count;
+      if v_updated <> 1 then
+        raise exception 'Archived Test question identity mapping failed'
+          using errcode = '22023';
+      end if;
+    end loop;
+  end loop;
+
+  for v_item in
+    select value from jsonb_array_elements(
+      coalesce(p_plan->'lesson_templates', '[]'::jsonb)
+    )
+  loop
+    v_position := coalesce((v_item->>'position')::integer, 0);
+    update public.lesson_plans
+    set
+      artifact_id = (v_item->>'artifact_id')::uuid,
+      source_artifact_id = (v_item->>'artifact_id')::uuid
+    where id = (
+      select lesson.id
+      from public.lesson_plans lesson
+      where lesson.classroom_id = p_source_classroom_id
+        and lesson.blueprint_archived_at is null
+      order by lesson.date, lesson.id
+      offset v_position
+      limit 1
+    );
+    get diagnostics v_updated = row_count;
+    if v_updated <> 1 then
+      raise exception 'Archived lesson identity mapping failed'
+        using errcode = '22023';
+    end if;
+  end loop;
+
+  for v_item in
+    select value from jsonb_array_elements(
+      coalesce(p_plan->'materials', '[]'::jsonb)
+    )
+  loop
+    update public.classwork_materials
+    set
+      artifact_id = (v_item->>'artifact_id')::uuid,
+      source_artifact_id = (v_item->>'artifact_id')::uuid
+    where classroom_id = p_source_classroom_id
+      and blueprint_archived_at is null
+      and position = coalesce((v_item->>'position')::integer, 0);
+    get diagnostics v_updated = row_count;
+    if v_updated <> 1 then
+      raise exception 'Archived material identity mapping failed'
+        using errcode = '22023';
+    end if;
+  end loop;
+
+  for v_item in
+    select value from jsonb_array_elements(
+      coalesce(p_plan->'surveys', '[]'::jsonb)
+    )
+  loop
+    update public.surveys
+    set
+      artifact_id = (v_item->>'artifact_id')::uuid,
+      source_artifact_id = (v_item->>'artifact_id')::uuid
+    where classroom_id = p_source_classroom_id
+      and blueprint_archived_at is null
+      and position = coalesce((v_item->>'position')::integer, 0)
+    returning id into v_parent_id;
+    if not found then
+      raise exception 'Archived survey identity mapping failed'
+        using errcode = '22023';
+    end if;
+
+    for v_child in
+      select value from jsonb_array_elements(
+        coalesce(v_item->'questions_json', '[]'::jsonb)
+      )
+    loop
+      update public.survey_questions
+      set
+        artifact_id = (v_child->>'id')::uuid,
+        source_artifact_id = (v_child->>'id')::uuid
+      where survey_id = v_parent_id
+        and position = coalesce((v_child->>'position')::integer, 0);
+      get diagnostics v_updated = row_count;
+      if v_updated <> 1 then
+        raise exception 'Archived survey question identity mapping failed'
+          using errcode = '22023';
+      end if;
+    end loop;
+  end loop;
+
+  v_version_snapshot :=
+    public.archived_classroom_blueprint_snapshot_from_plan(
+      v_blueprint_id,
+      v_blueprint_revision,
+      p_plan
+    );
+  v_version_sha256 := encode(
+    extensions.digest(
+      convert_to(
+        public.course_blueprint_canonical_jsonb_text(v_version_snapshot),
+        'UTF8'
+      ),
+      'sha256'
+    ),
+    'hex'
+  );
+  select *
+  into v_version
+  from public.save_course_blueprint_version_atomic(
+    p_teacher_id,
+    v_blueprint_id,
+    v_blueprint_revision,
+    2,
+    v_version_snapshot,
+    v_version_sha256,
+    'classroom',
+    jsonb_build_object(
+      'classroom_id', p_source_classroom_id,
+      'operation_id', p_operation_id,
+      'reuse_source', 'archived_classroom'
+    )
+  );
+
+  update public.assignments
+  set source_blueprint_version_id = v_version.id
+  where classroom_id = p_source_classroom_id
+    and blueprint_archived_at is null
+    and source_artifact_id is not null;
+  update public.assignment_submission_requirements requirement
+  set source_blueprint_version_id = v_version.id
+  where exists (
+    select 1
+    from public.assignments assignment
+    where assignment.id = requirement.assignment_id
+      and assignment.classroom_id = p_source_classroom_id
+      and assignment.blueprint_archived_at is null
+  ) and requirement.source_artifact_id is not null;
+  update public.tests
+  set source_blueprint_version_id = v_version.id
+  where classroom_id = p_source_classroom_id
+    and blueprint_archived_at is null
+    and source_artifact_id is not null;
+  update public.test_questions question
+  set source_blueprint_version_id = v_version.id
+  where exists (
+    select 1
+    from public.tests test
+    where test.id = question.test_id
+      and test.classroom_id = p_source_classroom_id
+      and test.blueprint_archived_at is null
+  ) and question.source_artifact_id is not null;
+  update public.lesson_plans
+  set source_blueprint_version_id = v_version.id
+  where classroom_id = p_source_classroom_id
+    and blueprint_archived_at is null
+    and source_artifact_id is not null;
+  update public.classwork_materials
+  set source_blueprint_version_id = v_version.id
+  where classroom_id = p_source_classroom_id
+    and blueprint_archived_at is null
+    and source_artifact_id is not null;
+  update public.surveys
+  set source_blueprint_version_id = v_version.id
+  where classroom_id = p_source_classroom_id
+    and blueprint_archived_at is null
+    and source_artifact_id is not null;
+  update public.survey_questions question
+  set source_blueprint_version_id = v_version.id
+  where exists (
+    select 1
+    from public.surveys survey
+    where survey.id = question.survey_id
+      and survey.classroom_id = p_source_classroom_id
+      and survey.blueprint_archived_at is null
+  ) and question.source_artifact_id is not null;
+
   update public.classrooms
   set
     source_blueprint_id = v_blueprint_id,
+    source_blueprint_version_id = v_version.id,
     source_blueprint_origin = jsonb_build_object(
       'blueprint_id', v_blueprint_id,
       'blueprint_title', p_plan->'blueprint'->>'title',
       'blueprint_content_revision', v_blueprint_revision,
+      'blueprint_version_id', v_version.id,
+      'blueprint_version_number', v_version.version_number,
       'package_manifest_version', p_plan->>'manifest_version',
       'package_exported_at', now(),
       'operation_id', p_operation_id,
@@ -127,13 +596,19 @@ begin
     )
   where id = p_source_classroom_id;
 
+  v_result := v_result || jsonb_build_object(
+    'source_blueprint_version_id',
+    v_version.id
+  );
   update public.course_blueprint_operations
   set
     source_classroom_id = p_source_classroom_id,
     result_classroom_id = p_source_classroom_id,
+    result = v_result,
     updated_at = now()
   where id = p_operation_id;
 
+  perform set_config('pika.identity_mapping', 'off', true);
   return v_result;
 end;
 $$;
@@ -164,7 +639,8 @@ create or replace function public.apply_archived_classroom_blueprint_proposal_at
   p_expected_classroom_revision bigint,
   p_proposal_id uuid,
   p_candidate_snapshot jsonb,
-  p_candidate_sha256 text
+  p_candidate_sha256 text,
+  p_result_snapshot_sha256 text
 )
 returns public.course_blueprint_change_proposals
 language plpgsql
@@ -176,8 +652,12 @@ declare
   v_proposal public.course_blueprint_change_proposals;
   v_version public.course_blueprint_versions;
   v_version_snapshot jsonb;
-  v_version_sha256 text;
 begin
+  if p_result_snapshot_sha256 !~ '^[a-f0-9]{64}$' then
+    raise exception 'Invalid result Blueprint Version digest'
+      using errcode = '22023';
+  end if;
+
   select *
   into v_classroom
   from public.classrooms
@@ -211,13 +691,6 @@ begin
       to_jsonb(v_proposal.applied_blueprint_revision),
       true
     );
-    v_version_sha256 := encode(
-      extensions.digest(
-        convert_to(v_version_snapshot::text, 'UTF8'),
-        'sha256'
-      ),
-      'hex'
-    );
     select *
     into v_version
     from public.save_course_blueprint_version_atomic(
@@ -226,13 +699,87 @@ begin
       v_proposal.applied_blueprint_revision,
       coalesce((v_version_snapshot->>'schema_version')::integer, 2),
       v_version_snapshot,
-      v_version_sha256,
+      p_result_snapshot_sha256,
       'classroom',
       jsonb_build_object(
         'classroom_id', p_classroom_id,
         'proposal_id', p_proposal_id,
         'reuse_source', 'archived_classroom'
       )
+    );
+
+    perform set_config('pika.identity_mapping', 'on', true);
+    update public.assignments
+    set
+      source_artifact_id = coalesce(source_artifact_id, artifact_id),
+      source_blueprint_version_id = v_version.id
+    where classroom_id = p_classroom_id
+      and blueprint_archived_at is null;
+    update public.assignment_submission_requirements requirement
+    set
+      source_artifact_id = coalesce(
+        requirement.source_artifact_id,
+        requirement.artifact_id
+      ),
+      source_blueprint_version_id = v_version.id
+    where exists (
+      select 1
+      from public.assignments assignment
+      where assignment.id = requirement.assignment_id
+        and assignment.classroom_id = p_classroom_id
+        and assignment.blueprint_archived_at is null
+    );
+    update public.tests
+    set
+      source_artifact_id = coalesce(source_artifact_id, artifact_id),
+      source_blueprint_version_id = v_version.id
+    where classroom_id = p_classroom_id
+      and blueprint_archived_at is null;
+    update public.test_questions question
+    set
+      source_artifact_id = coalesce(
+        question.source_artifact_id,
+        question.artifact_id
+      ),
+      source_blueprint_version_id = v_version.id
+    where exists (
+      select 1
+      from public.tests test
+      where test.id = question.test_id
+        and test.classroom_id = p_classroom_id
+        and test.blueprint_archived_at is null
+    );
+    update public.lesson_plans
+    set
+      source_artifact_id = coalesce(source_artifact_id, artifact_id),
+      source_blueprint_version_id = v_version.id
+    where classroom_id = p_classroom_id
+      and blueprint_archived_at is null;
+    update public.classwork_materials
+    set
+      source_artifact_id = coalesce(source_artifact_id, artifact_id),
+      source_blueprint_version_id = v_version.id
+    where classroom_id = p_classroom_id
+      and blueprint_archived_at is null;
+    update public.surveys
+    set
+      source_artifact_id = coalesce(source_artifact_id, artifact_id),
+      source_blueprint_version_id = v_version.id
+    where classroom_id = p_classroom_id
+      and blueprint_archived_at is null;
+    update public.survey_questions question
+    set
+      source_artifact_id = coalesce(
+        question.source_artifact_id,
+        question.artifact_id
+      ),
+      source_blueprint_version_id = v_version.id
+    where exists (
+      select 1
+      from public.surveys survey
+      where survey.id = question.survey_id
+        and survey.classroom_id = p_classroom_id
+        and survey.blueprint_archived_at is null
     );
 
     update public.classrooms
@@ -250,6 +797,7 @@ begin
           p_proposal_id
         )
     where id = p_classroom_id;
+    perform set_config('pika.identity_mapping', 'off', true);
   end if;
 
   return v_proposal;
@@ -262,6 +810,7 @@ revoke all on function public.apply_archived_classroom_blueprint_proposal_atomic
   bigint,
   uuid,
   jsonb,
+  text,
   text
 ) from public, anon, authenticated;
 grant execute on function public.apply_archived_classroom_blueprint_proposal_atomic(
@@ -270,5 +819,6 @@ grant execute on function public.apply_archived_classroom_blueprint_proposal_ato
   bigint,
   uuid,
   jsonb,
+  text,
   text
 ) to service_role;

--- a/supabase/migrations/114_atomic_archived_classroom_blueprint_reuse.sql
+++ b/supabase/migrations/114_atomic_archived_classroom_blueprint_reuse.sql
@@ -1,0 +1,274 @@
+-- Make archived-classroom reuse a single transaction. The classroom row is the
+-- durable fence: concurrent requests serialize on it, and only the first may
+-- create and link a Blueprint.
+
+create or replace function public.create_archived_classroom_blueprint_atomic(
+  p_operation_id uuid,
+  p_teacher_id uuid,
+  p_request_sha256 text,
+  p_source_classroom_id uuid,
+  p_expected_source_revision bigint,
+  p_plan jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_classroom public.classrooms;
+  v_result jsonb;
+  v_blueprint_id uuid;
+  v_blueprint_revision bigint;
+begin
+  select *
+  into v_classroom
+  from public.classrooms
+  where id = p_source_classroom_id
+    and teacher_id = p_teacher_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 404,
+      'operation_id', p_operation_id,
+      'operation_type', 'import',
+      'error_code', 'source_classroom_not_found',
+      'error', 'Archived classroom not found',
+      'retryable', false
+    );
+  end if;
+
+  if v_classroom.archived_at is null then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'operation_type', 'import',
+      'error_code', 'source_classroom_not_archived',
+      'error', 'Only archived classrooms can be used again',
+      'retryable', false
+    );
+  end if;
+
+  -- A distinct concurrent request that waited on this row reuses the winner.
+  -- No second Blueprint or operation row is created.
+  if v_classroom.source_blueprint_id is not null then
+    select content_revision
+    into v_blueprint_revision
+    from public.course_blueprints
+    where id = v_classroom.source_blueprint_id
+      and teacher_id = p_teacher_id;
+
+    if not found then
+      raise exception 'Archived classroom Blueprint lineage is invalid'
+        using errcode = '23503';
+    end if;
+
+    return jsonb_build_object(
+      'ok', true,
+      'status', 201,
+      'operation_id', p_operation_id,
+      'operation_type', 'import',
+      'replayed', true,
+      'blueprint_id', v_classroom.source_blueprint_id,
+      'source_revision', v_classroom.blueprint_source_revision,
+      'result_content_revision', v_blueprint_revision,
+      'counts', jsonb_build_object(
+        'assignments', 0,
+        'assessments', 0,
+        'lesson_templates', 0
+      )
+    );
+  end if;
+
+  if v_classroom.blueprint_source_revision <> p_expected_source_revision then
+    return jsonb_build_object(
+      'ok', false,
+      'status', 409,
+      'operation_id', p_operation_id,
+      'operation_type', 'import',
+      'error_code', 'source_classroom_changed',
+      'error', 'The archived classroom changed while preparing this course',
+      'retryable', true
+    );
+  end if;
+
+  -- The nested RPC participates in this transaction. Any failure after it
+  -- returns rolls back its Blueprint graph and operation-ledger write too.
+  v_result := public.create_course_blueprint_atomic_v2(
+    p_operation_id,
+    p_teacher_id,
+    'import',
+    p_request_sha256,
+    null,
+    null,
+    p_plan
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is false then
+    return v_result;
+  end if;
+
+  v_blueprint_id := (v_result->>'blueprint_id')::uuid;
+  v_blueprint_revision := (v_result->>'result_content_revision')::bigint;
+
+  update public.classrooms
+  set
+    source_blueprint_id = v_blueprint_id,
+    source_blueprint_origin = jsonb_build_object(
+      'blueprint_id', v_blueprint_id,
+      'blueprint_title', p_plan->'blueprint'->>'title',
+      'blueprint_content_revision', v_blueprint_revision,
+      'package_manifest_version', p_plan->>'manifest_version',
+      'package_exported_at', now(),
+      'operation_id', p_operation_id,
+      'reuse_source', 'archived_classroom'
+    )
+  where id = p_source_classroom_id;
+
+  update public.course_blueprint_operations
+  set
+    source_classroom_id = p_source_classroom_id,
+    result_classroom_id = p_source_classroom_id,
+    updated_at = now()
+  where id = p_operation_id;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.create_archived_classroom_blueprint_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid,
+  bigint,
+  jsonb
+) from public, anon, authenticated;
+grant execute on function public.create_archived_classroom_blueprint_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid,
+  bigint,
+  jsonb
+) to service_role;
+
+-- Promotion is also archive-specific. Lock and validate the hot archive in the
+-- same transaction as the existing proposal application so a concurrent
+-- Restore cannot turn this into an active-classroom write.
+create or replace function public.apply_archived_classroom_blueprint_proposal_atomic(
+  p_teacher_id uuid,
+  p_classroom_id uuid,
+  p_expected_classroom_revision bigint,
+  p_proposal_id uuid,
+  p_candidate_snapshot jsonb,
+  p_candidate_sha256 text
+)
+returns public.course_blueprint_change_proposals
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_classroom public.classrooms;
+  v_proposal public.course_blueprint_change_proposals;
+  v_version public.course_blueprint_versions;
+  v_version_snapshot jsonb;
+  v_version_sha256 text;
+begin
+  select *
+  into v_classroom
+  from public.classrooms
+  where id = p_classroom_id
+    and teacher_id = p_teacher_id
+  for update;
+
+  if not found then
+    raise exception 'Archived classroom not found' using errcode = 'P0002';
+  end if;
+  if v_classroom.archived_at is null
+    or v_classroom.blueprint_source_revision <> p_expected_classroom_revision
+  then
+    raise exception 'Archived classroom changed before Blueprint promotion'
+      using errcode = '40001';
+  end if;
+
+  select *
+  into v_proposal
+  from public.apply_course_blueprint_proposal_atomic(
+    p_teacher_id,
+    p_proposal_id,
+    p_candidate_snapshot,
+    p_candidate_sha256
+  );
+
+  if v_proposal.status = 'applied' then
+    v_version_snapshot := jsonb_set(
+      p_candidate_snapshot,
+      '{draft_revision}',
+      to_jsonb(v_proposal.applied_blueprint_revision),
+      true
+    );
+    v_version_sha256 := encode(
+      extensions.digest(
+        convert_to(v_version_snapshot::text, 'UTF8'),
+        'sha256'
+      ),
+      'hex'
+    );
+    select *
+    into v_version
+    from public.save_course_blueprint_version_atomic(
+      p_teacher_id,
+      v_proposal.course_blueprint_id,
+      v_proposal.applied_blueprint_revision,
+      coalesce((v_version_snapshot->>'schema_version')::integer, 2),
+      v_version_snapshot,
+      v_version_sha256,
+      'classroom',
+      jsonb_build_object(
+        'classroom_id', p_classroom_id,
+        'proposal_id', p_proposal_id,
+        'reuse_source', 'archived_classroom'
+      )
+    );
+
+    update public.classrooms
+    set
+      source_blueprint_version_id = v_version.id,
+      source_blueprint_origin = coalesce(source_blueprint_origin, '{}'::jsonb)
+        || jsonb_build_object(
+          'blueprint_content_revision',
+          v_proposal.applied_blueprint_revision,
+          'blueprint_version_id',
+          v_version.id,
+          'blueprint_version_number',
+          v_version.version_number,
+          'updated_from_proposal_id',
+          p_proposal_id
+        )
+    where id = p_classroom_id;
+  end if;
+
+  return v_proposal;
+end;
+$$;
+
+revoke all on function public.apply_archived_classroom_blueprint_proposal_atomic(
+  uuid,
+  uuid,
+  bigint,
+  uuid,
+  jsonb,
+  text
+) from public, anon, authenticated;
+grant execute on function public.apply_archived_classroom_blueprint_proposal_atomic(
+  uuid,
+  uuid,
+  bigint,
+  uuid,
+  jsonb,
+  text
+) to service_role;

--- a/tests/api/teacher/archived-classroom-use-again-route.test.ts
+++ b/tests/api/teacher/archived-classroom-use-again-route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/classrooms/[id]/use-again/route'
+
+const mockRequireRole = vi.fn()
+const mockPrepareArchivedClassroomReuse = vi.fn()
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: (...args: any[]) => mockRequireRole(...args),
+}))
+
+vi.mock('@/lib/server/archived-classroom-reuse', () => ({
+  prepareArchivedClassroomReuse: (...args: any[]) =>
+    mockPrepareArchivedClassroomReuse(...args),
+}))
+
+describe('archived classroom use-again route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRequireRole.mockResolvedValue({
+      id: '10000000-0000-4000-8000-000000000001',
+    })
+  })
+
+  it('prepares reuse with the caller idempotency key', async () => {
+    mockPrepareArchivedClassroomReuse.mockResolvedValue({
+      ok: true,
+      status: 'ready',
+      blueprint_id: '20000000-0000-4000-8000-000000000001',
+      blueprint_title: 'Course',
+    })
+
+    const response = await POST(
+      new NextRequest(
+        'http://localhost:3000/api/teacher/classrooms/30000000-0000-4000-8000-000000000001/use-again',
+        {
+          method: 'POST',
+          headers: {
+            'Idempotency-Key': '40000000-0000-4000-8000-000000000001',
+          },
+        },
+      ),
+      {
+        params: Promise.resolve({
+          id: '30000000-0000-4000-8000-000000000001',
+        }),
+      } as any,
+    )
+
+    expect(mockPrepareArchivedClassroomReuse).toHaveBeenCalledWith({
+      teacherId: '10000000-0000-4000-8000-000000000001',
+      classroomId: '30000000-0000-4000-8000-000000000001',
+      operationId: '40000000-0000-4000-8000-000000000001',
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      status: 'ready',
+      blueprint_id: '20000000-0000-4000-8000-000000000001',
+    }))
+  })
+})

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -157,6 +157,22 @@ describe('TeacherBlueprintsPage', () => {
       if (url === '/api/teacher/course-blueprints/b-2' && method === 'DELETE') {
         return Promise.resolve(jsonResponse({ success: true }))
       }
+      if (
+        url === '/api/teacher/course-blueprints/b-2/merge-suggestions?classroomId=c-9'
+        && method === 'GET'
+      ) {
+        return Promise.resolve(jsonResponse({
+          suggestion_set: {
+            classroom_id: 'c-9',
+            classroom_title: 'Semester 2',
+            classroom_revision: 2,
+            blueprint_id: 'b-2',
+            blueprint_revision: 4,
+            generated_at: '2026-07-29T00:00:00.000Z',
+            suggestions: [],
+          },
+        }))
+      }
       if (url === '/api/teacher/course-blueprints/b-1' && method === 'DELETE') {
         return Promise.resolve(jsonResponse({ success: true }))
       }
@@ -202,6 +218,23 @@ describe('TeacherBlueprintsPage', () => {
       expect.any(Function),
       20_000,
     )
+  })
+
+  it('opens classroom change review from the archived reuse handoff', async () => {
+    searchParamsMap = new Map([
+      ['blueprint', 'b-2'],
+      ['reviewClassroom', 'c-9'],
+    ])
+
+    render(<TeacherBlueprintsPage />)
+
+    expect(await screen.findByRole('button', {
+      name: 'Save Classroom Changes to Blueprint',
+    })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Semester 2')).toBeInTheDocument()
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      '/api/teacher/course-blueprints/b-2/merge-suggestions?classroomId=c-9',
+    ))
   })
 
   it('ignores stale detail responses after selecting a different blueprint', async () => {

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -11,6 +11,20 @@ import type { Classroom } from '@/types'
 
 const push = vi.hoisted(() => vi.fn())
 
+vi.mock('@/components/CreateClassroomModal', () => ({
+  CreateClassroomModal: ({
+    isOpen,
+    initialBlueprintId,
+  }: {
+    isOpen: boolean
+    initialBlueprintId?: string | null
+  }) => isOpen ? (
+    <div role="dialog" data-testid="create-classroom-modal">
+      Blueprint: {initialBlueprintId || 'none'}
+    </div>
+  ) : null,
+}))
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
   usePathname: () => '/classrooms',
@@ -116,7 +130,7 @@ describe('TeacherClassroomsIndex', () => {
     expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
   })
 
-  it('keeps archived classrooms restore-only and never issues classroom DELETE requests', async () => {
+  it('offers reuse and restore without ever issuing classroom DELETE requests', async () => {
     vi.mocked(fetchTeacherArchivedClassroomState).mockResolvedValueOnce({
       classrooms: [
         createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' }),
@@ -130,8 +144,89 @@ describe('TeacherClassroomsIndex', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
 
     expect(await screen.findByRole('button', { name: 'Restore' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use again' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false)
+  })
+
+  it('prepares an archived classroom and opens creation with its Blueprint selected', async () => {
+    const archived = createMockClassroom({
+      id: 'archived-1',
+      title: 'Archived',
+      archived_at: '2026-04-01T12:00:00Z',
+    })
+    vi.mocked(fetchTeacherArchivedClassroomState).mockResolvedValueOnce({
+      classrooms: [archived],
+      coldArchives: [],
+      coldArchiveRestoreEnabled: false,
+    })
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(
+      '10000000-0000-4000-8000-000000000001',
+    )
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        status: 'ready',
+        blueprint_id: '20000000-0000-4000-8000-000000000002',
+        blueprint_title: 'Reusable course',
+      }),
+    })
+
+    renderTeacherClassroomsIndex([])
+    fireEvent.click(screen.getByRole('button', { name: 'Organize classrooms' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Use again' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/api/teacher/classrooms/archived-1/use-again',
+      {
+        method: 'POST',
+        headers: {
+          'Idempotency-Key': '10000000-0000-4000-8000-000000000001',
+        },
+      },
+    ))
+    expect(await screen.findByTestId('create-classroom-modal')).toHaveTextContent(
+      'Blueprint: 20000000-0000-4000-8000-000000000002',
+    )
+  })
+
+  it('sends simultaneous classroom and Blueprint changes to review', async () => {
+    const archived = createMockClassroom({
+      id: 'archived-1',
+      title: 'Archived',
+      archived_at: '2026-04-01T12:00:00Z',
+    })
+    vi.mocked(fetchTeacherArchivedClassroomState).mockResolvedValueOnce({
+      classrooms: [archived],
+      coldArchives: [],
+      coldArchiveRestoreEnabled: false,
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        status: 'review_required',
+        blueprint_id: 'blueprint-1',
+        blueprint_title: 'Reusable course',
+        review_url: '/teacher/blueprints?blueprint=blueprint-1&reviewClassroom=archived-1',
+      }),
+    })
+
+    renderTeacherClassroomsIndex([])
+    fireEvent.click(screen.getByRole('button', { name: 'Organize classrooms' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Use again' }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(
+      'Both versions changed. Review which course changes to keep.',
+    )).toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Review changes' }))
+    expect(push).toHaveBeenCalledWith(
+      '/teacher/blueprints?blueprint=blueprint-1&reviewClassroom=archived-1',
+    )
   })
 
   it('hides the create button after the first classroom unless edit mode is enabled', async () => {

--- a/tests/lib/server/archived-classroom-reuse.test.ts
+++ b/tests/lib/server/archived-classroom-reuse.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   classifyArchivedClassroomReuseSnapshots,
+  decideArchivedClassroomReuse,
   prepareArchivedClassroomReuse,
 } from '@/lib/server/archived-classroom-reuse'
 
@@ -10,8 +11,7 @@ const mockCreateCourseBlueprintFromClassroom = vi.fn()
 const mockGetCourseBlueprintDetail = vi.fn()
 const mockGetBlueprintMergeSuggestionSet = vi.fn()
 const mockApplyBlueprintMergeSuggestions = vi.fn()
-const mockApplyPersistedCourseBlueprintProposal = vi.fn()
-const mockArchivedLinkMaybeSingle = vi.fn()
+const mockApplyArchivedClassroomCourseBlueprintProposal = vi.fn()
 
 vi.mock('@/lib/server/classrooms', () => ({
   assertTeacherOwnsClassroom: (...args: any[]) =>
@@ -41,20 +41,17 @@ vi.mock('@/lib/server/course-blueprint-proposals', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/server/course-blueprint-proposals')>()
   return {
     ...actual,
-    applyPersistedCourseBlueprintProposal: (...args: any[]) =>
-      mockApplyPersistedCourseBlueprintProposal(...args),
+    applyArchivedClassroomCourseBlueprintProposal: (...args: any[]) =>
+      mockApplyArchivedClassroomCourseBlueprintProposal(...args),
   }
 })
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => {
     const builder: Record<string, any> = {}
-    builder.update = vi.fn(() => builder)
     builder.eq = vi.fn(() => builder)
     builder.not = vi.fn(() => builder)
-    builder.is = vi.fn(() => builder)
     builder.select = vi.fn(() => builder)
-    builder.maybeSingle = (...args: any[]) => mockArchivedLinkMaybeSingle(...args)
     return {
       rpc: vi.fn(),
       from: vi.fn(() => builder),
@@ -129,10 +126,6 @@ describe('archived classroom reuse', () => {
         archived_at: '2026-07-01T00:00:00.000Z',
       },
     })
-    mockArchivedLinkMaybeSingle.mockResolvedValue({
-      data: { id: '30000000-0000-4000-8000-000000000001' },
-      error: null,
-    })
   })
 
   it('ignores expected classroom-instantiation transformations', () => {
@@ -194,7 +187,9 @@ describe('archived classroom reuse', () => {
       baseVersion: base,
       currentBlueprint: base,
       currentClassroom,
-      classDayCount: 1,
+      appliedLessonArtifactIds: new Set([
+        '60000000-0000-4000-8000-000000000001',
+      ]),
     })).toEqual(expect.objectContaining({
       blueprintChanged: false,
       classroomChanged: false,
@@ -215,7 +210,7 @@ describe('archived classroom reuse', () => {
       baseVersion: base,
       currentBlueprint: blueprintChanged,
       currentClassroom: base,
-      classDayCount: 0,
+      appliedLessonArtifactIds: new Set(),
     })).toEqual(expect.objectContaining({
       blueprintChanged: true,
       classroomChanged: false,
@@ -224,7 +219,7 @@ describe('archived classroom reuse', () => {
       baseVersion: base,
       currentBlueprint: base,
       currentClassroom: classroomChanged,
-      classDayCount: 0,
+      appliedLessonArtifactIds: new Set(),
     })).toEqual(expect.objectContaining({
       blueprintChanged: false,
       classroomChanged: true,
@@ -238,11 +233,75 @@ describe('archived classroom reuse', () => {
       baseVersion: base,
       currentBlueprint: matchingChanges,
       currentClassroom: matchingChanges,
-      classDayCount: 0,
+      appliedLessonArtifactIds: new Set(),
     })).toEqual(expect.objectContaining({
       blueprintChanged: true,
       classroomChanged: true,
-      currentCourseMatchesClassroom: true,
+    }))
+    expect(decideArchivedClassroomReuse({
+      blueprintChanged: true,
+      classroomChanged: true,
+      authorityMode: 'pika',
+    })).toBe('review')
+  })
+
+  it('uses persisted lesson lineage instead of the current calendar size', () => {
+    const appliedLessonId = '60000000-0000-4000-8000-000000000001'
+    const overflowLessonId = '60000000-0000-4000-8000-000000000002'
+    const base = snapshot({
+      lesson_templates: [
+        {
+          artifact_id: appliedLessonId,
+          title: 'Lesson 1',
+          content_markdown: 'Applied',
+          position: 0,
+        },
+        {
+          artifact_id: overflowLessonId,
+          title: 'Lesson 2',
+          content_markdown: 'Overflow',
+          position: 1,
+        },
+      ],
+    })
+    const classroom = snapshot({
+      lesson_templates: [base.lesson_templates[0]],
+    })
+
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: base,
+      currentClassroom: classroom,
+      appliedLessonArtifactIds: new Set([appliedLessonId]),
+    })).toEqual(expect.objectContaining({
+      classroomChanged: false,
+      classroomBaseline: expect.objectContaining({
+        lesson_templates: [base.lesson_templates[0]],
+      }),
+    }))
+  })
+
+  it('tracks reusable site visibility without comparing publication state', () => {
+    const base = snapshot()
+    const classroom = snapshot({
+      planned_site: {
+        slug: 'runtime-slug',
+        published: true,
+        config: {
+          ...base.planned_site.config,
+          tests: false,
+        },
+      },
+    })
+
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: base,
+      currentClassroom: classroom,
+      appliedLessonArtifactIds: new Set(),
+    })).toEqual(expect.objectContaining({
+      blueprintChanged: false,
+      classroomChanged: true,
     }))
   })
 
@@ -310,7 +369,7 @@ describe('archived classroom reuse', () => {
         diff_json: { candidate_snapshot: snapshot() },
       },
     })
-    mockApplyPersistedCourseBlueprintProposal.mockResolvedValue({
+    mockApplyArchivedClassroomCourseBlueprintProposal.mockResolvedValue({
       ok: true,
       proposal: { status: 'applied' },
     })
@@ -331,7 +390,12 @@ describe('archived classroom reuse', () => {
         expectedClassroomRevision: 2,
       },
     )
-    expect(mockApplyPersistedCourseBlueprintProposal).toHaveBeenCalledOnce()
+    expect(mockApplyArchivedClassroomCourseBlueprintProposal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classroomId: '30000000-0000-4000-8000-000000000001',
+        expectedClassroomRevision: 2,
+      }),
+    )
     expect(result).toEqual(expect.objectContaining({
       ok: true,
       status: 'ready',
@@ -374,5 +438,35 @@ describe('archived classroom reuse', () => {
         + '&reviewClassroom=30000000-0000-4000-8000-000000000001',
     })
     expect(mockApplyBlueprintMergeSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('requires review when both legacy sources reach matching content', async () => {
+    mockLoadClassroomBlueprintSource.mockResolvedValue({
+      ok: true,
+      source: legacySource(),
+    })
+    mockGetCourseBlueprintDetail.mockResolvedValue({
+      detail: {
+        id: '20000000-0000-4000-8000-000000000001',
+        title: 'Course',
+        content_revision: 5,
+        authority_mode: 'pika',
+      },
+    })
+    mockGetBlueprintMergeSuggestionSet.mockResolvedValue({
+      ok: true,
+      suggestionSet: { suggestions: [] },
+    })
+
+    const result = await prepareArchivedClassroomReuse({
+      teacherId: '10000000-0000-4000-8000-000000000001',
+      classroomId: '30000000-0000-4000-8000-000000000001',
+      operationId: '70000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'review_required',
+    }))
   })
 })

--- a/tests/lib/server/archived-classroom-reuse.test.ts
+++ b/tests/lib/server/archived-classroom-reuse.test.ts
@@ -283,6 +283,13 @@ describe('archived classroom reuse', () => {
 
   it('tracks reusable site visibility without comparing publication state', () => {
     const base = snapshot()
+    const operationalBlueprintChange = snapshot({
+      planned_site: {
+        ...base.planned_site,
+        slug: 'new-runtime-slug',
+        published: true,
+      },
+    })
     const classroom = snapshot({
       planned_site: {
         slug: 'runtime-slug',
@@ -296,7 +303,7 @@ describe('archived classroom reuse', () => {
 
     expect(classifyArchivedClassroomReuseSnapshots({
       baseVersion: base,
-      currentBlueprint: base,
+      currentBlueprint: operationalBlueprintChange,
       currentClassroom: classroom,
       appliedLessonArtifactIds: new Set(),
     })).toEqual(expect.objectContaining({

--- a/tests/lib/server/archived-classroom-reuse.test.ts
+++ b/tests/lib/server/archived-classroom-reuse.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  classifyArchivedClassroomReuseSnapshots,
+  prepareArchivedClassroomReuse,
+} from '@/lib/server/archived-classroom-reuse'
+
+const mockAssertTeacherOwnsClassroom = vi.fn()
+const mockLoadClassroomBlueprintSource = vi.fn()
+const mockCreateCourseBlueprintFromClassroom = vi.fn()
+const mockGetCourseBlueprintDetail = vi.fn()
+const mockGetBlueprintMergeSuggestionSet = vi.fn()
+const mockApplyBlueprintMergeSuggestions = vi.fn()
+const mockApplyPersistedCourseBlueprintProposal = vi.fn()
+const mockArchivedLinkMaybeSingle = vi.fn()
+
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherOwnsClassroom: (...args: any[]) =>
+    mockAssertTeacherOwnsClassroom(...args),
+}))
+
+vi.mock('@/lib/server/classroom-blueprint-source', () => ({
+  loadClassroomBlueprintSource: (...args: any[]) =>
+    mockLoadClassroomBlueprintSource(...args),
+}))
+
+vi.mock('@/lib/server/course-blueprints', () => ({
+  createCourseBlueprintFromClassroom: (...args: any[]) =>
+    mockCreateCourseBlueprintFromClassroom(...args),
+  getCourseBlueprintDetail: (...args: any[]) =>
+    mockGetCourseBlueprintDetail(...args),
+}))
+
+vi.mock('@/lib/server/course-sites', () => ({
+  getBlueprintMergeSuggestionSet: (...args: any[]) =>
+    mockGetBlueprintMergeSuggestionSet(...args),
+  applyBlueprintMergeSuggestions: (...args: any[]) =>
+    mockApplyBlueprintMergeSuggestions(...args),
+}))
+
+vi.mock('@/lib/server/course-blueprint-proposals', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/course-blueprint-proposals')>()
+  return {
+    ...actual,
+    applyPersistedCourseBlueprintProposal: (...args: any[]) =>
+      mockApplyPersistedCourseBlueprintProposal(...args),
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => {
+    const builder: Record<string, any> = {}
+    builder.update = vi.fn(() => builder)
+    builder.eq = vi.fn(() => builder)
+    builder.not = vi.fn(() => builder)
+    builder.is = vi.fn(() => builder)
+    builder.select = vi.fn(() => builder)
+    builder.maybeSingle = (...args: any[]) => mockArchivedLinkMaybeSingle(...args)
+    return {
+      rpc: vi.fn(),
+      from: vi.fn(() => builder),
+    }
+  }),
+}))
+
+function snapshot(overrides: Record<string, any> = {}) {
+  return {
+    schema_version: 2,
+    blueprint_id: '20000000-0000-4000-8000-000000000001',
+    draft_revision: 1,
+    metadata: {
+      title: 'Course',
+      subject: '',
+      grade_level: '',
+      course_code: '',
+      term_template: '',
+    },
+    sections: {
+      overview_markdown: 'Overview',
+      outline_markdown: 'Outline',
+      resources_markdown: 'Resources',
+    },
+    grading: {
+      use_weights: false,
+      assignments_weight: 70,
+      tests_weight: 30,
+    },
+    planned_site: {
+      slug: null,
+      published: false,
+      config: {
+        overview: true,
+        outline: true,
+        resources: true,
+        assignments: true,
+        tests: true,
+        lesson_plans: true,
+      },
+    },
+    assignments: [],
+    assessments: [],
+    lesson_templates: [],
+    materials: [],
+    surveys: [],
+    ...overrides,
+  } as any
+}
+
+function legacySource(overrides: Record<string, any> = {}) {
+  return {
+    classroom: {
+      id: '30000000-0000-4000-8000-000000000001',
+      title: 'Archived course',
+      source_blueprint_id: '20000000-0000-4000-8000-000000000001',
+      source_blueprint_version_id: null,
+      source_blueprint_origin: { blueprint_content_revision: 4 },
+      blueprint_source_revision: 2,
+      ...overrides,
+    },
+  }
+}
+
+describe('archived classroom reuse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAssertTeacherOwnsClassroom.mockResolvedValue({
+      ok: true,
+      classroom: {
+        id: '30000000-0000-4000-8000-000000000001',
+        archived_at: '2026-07-01T00:00:00.000Z',
+      },
+    })
+    mockArchivedLinkMaybeSingle.mockResolvedValue({
+      data: { id: '30000000-0000-4000-8000-000000000001' },
+      error: null,
+    })
+  })
+
+  it('ignores expected classroom-instantiation transformations', () => {
+    const base = snapshot({
+      assignments: [{
+        artifact_id: '40000000-0000-4000-8000-000000000001',
+        title: 'Assignment',
+        instructions_markdown: '',
+        submission_requirements: [],
+        default_due_days: 7,
+        default_due_time: '23:59',
+        points_possible: null,
+        gradebook_weight: 10,
+        include_in_final: true,
+        is_draft: false,
+        track_authenticity: false,
+        position: 0,
+      }],
+      assessments: [{
+        artifact_id: '50000000-0000-4000-8000-000000000001',
+        assessment_type: 'test',
+        title: 'Test',
+        content: { title: 'Test', show_results: false, questions: [] },
+        documents: [],
+        points_possible: null,
+        gradebook_weight: 10,
+        include_in_final: true,
+        position: 0,
+      }],
+      lesson_templates: [
+        {
+          artifact_id: '60000000-0000-4000-8000-000000000001',
+          title: 'Lesson 1',
+          content_markdown: '',
+          position: 0,
+        },
+        {
+          artifact_id: '60000000-0000-4000-8000-000000000002',
+          title: 'Overflow lesson',
+          content_markdown: '',
+          position: 1,
+        },
+      ],
+    })
+    const currentClassroom = snapshot({
+      assignments: [{
+        ...base.assignments[0],
+        points_possible: 30,
+        is_draft: true,
+      }],
+      assessments: [{
+        ...base.assessments[0],
+        points_possible: 100,
+      }],
+      lesson_templates: [base.lesson_templates[0]],
+    })
+
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: base,
+      currentClassroom,
+      classDayCount: 1,
+    })).toEqual(expect.objectContaining({
+      blueprintChanged: false,
+      classroomChanged: false,
+    }))
+  })
+
+  it('distinguishes Blueprint-only and classroom-only changes', () => {
+    const base = snapshot()
+    const blueprintChanged = snapshot({
+      draft_revision: 2,
+      metadata: { ...base.metadata, title: 'New title' },
+    })
+    const classroomChanged = snapshot({
+      sections: { ...base.sections, overview_markdown: 'Changed in class' },
+    })
+
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: blueprintChanged,
+      currentClassroom: base,
+      classDayCount: 0,
+    })).toEqual(expect.objectContaining({
+      blueprintChanged: true,
+      classroomChanged: false,
+    }))
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: base,
+      currentClassroom: classroomChanged,
+      classDayCount: 0,
+    })).toEqual(expect.objectContaining({
+      blueprintChanged: false,
+      classroomChanged: true,
+    }))
+
+    const matchingChanges = snapshot({
+      draft_revision: 2,
+      sections: { ...base.sections, overview_markdown: 'Same new content' },
+    })
+    expect(classifyArchivedClassroomReuseSnapshots({
+      baseVersion: base,
+      currentBlueprint: matchingChanges,
+      currentClassroom: matchingChanges,
+      classDayCount: 0,
+    })).toEqual(expect.objectContaining({
+      blueprintChanged: true,
+      classroomChanged: true,
+      currentCourseMatchesClassroom: true,
+    }))
+  })
+
+  it('creates a copy-only Blueprint for an unlinked archived classroom', async () => {
+    mockLoadClassroomBlueprintSource.mockResolvedValue({
+      ok: true,
+      source: legacySource({ source_blueprint_id: null }),
+    })
+    mockCreateCourseBlueprintFromClassroom.mockResolvedValue({
+      ok: true,
+      blueprint: {
+        id: '20000000-0000-4000-8000-000000000002',
+        title: 'Archived course',
+        content_revision: 1,
+      },
+      operation_id: '70000000-0000-4000-8000-000000000001',
+    })
+
+    const result = await prepareArchivedClassroomReuse({
+      teacherId: '10000000-0000-4000-8000-000000000001',
+      classroomId: '30000000-0000-4000-8000-000000000001',
+      operationId: '70000000-0000-4000-8000-000000000001',
+    })
+
+    expect(mockCreateCourseBlueprintFromClassroom).toHaveBeenCalledWith(
+      '10000000-0000-4000-8000-000000000001',
+      '30000000-0000-4000-8000-000000000001',
+      { title: 'Archived course' },
+      {
+        operationId: '70000000-0000-4000-8000-000000000001',
+        copyOnly: true,
+      },
+    )
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'ready',
+      blueprint_id: '20000000-0000-4000-8000-000000000002',
+    }))
+  })
+
+  it('atomically promotes legacy classroom-only changes before reuse', async () => {
+    mockLoadClassroomBlueprintSource.mockResolvedValue({
+      ok: true,
+      source: legacySource(),
+    })
+    mockGetCourseBlueprintDetail.mockResolvedValue({
+      detail: {
+        id: '20000000-0000-4000-8000-000000000001',
+        title: 'Course',
+        content_revision: 4,
+        authority_mode: 'pika',
+      },
+    })
+    mockGetBlueprintMergeSuggestionSet.mockResolvedValue({
+      ok: true,
+      suggestionSet: {
+        suggestions: [{ area: 'overview' }],
+      },
+    })
+    mockApplyBlueprintMergeSuggestions.mockResolvedValue({
+      ok: true,
+      proposal: {
+        id: '80000000-0000-4000-8000-000000000001',
+        status: 'needs_review',
+        diff_json: { candidate_snapshot: snapshot() },
+      },
+    })
+    mockApplyPersistedCourseBlueprintProposal.mockResolvedValue({
+      ok: true,
+      proposal: { status: 'applied' },
+    })
+
+    const result = await prepareArchivedClassroomReuse({
+      teacherId: '10000000-0000-4000-8000-000000000001',
+      classroomId: '30000000-0000-4000-8000-000000000001',
+      operationId: '70000000-0000-4000-8000-000000000001',
+    })
+
+    expect(mockApplyBlueprintMergeSuggestions).toHaveBeenCalledWith(
+      '10000000-0000-4000-8000-000000000001',
+      '20000000-0000-4000-8000-000000000001',
+      '30000000-0000-4000-8000-000000000001',
+      ['overview'],
+      {
+        expectedBlueprintRevision: 4,
+        expectedClassroomRevision: 2,
+      },
+    )
+    expect(mockApplyPersistedCourseBlueprintProposal).toHaveBeenCalledOnce()
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'ready',
+    }))
+  })
+
+  it('requires review when both legacy sources changed', async () => {
+    mockLoadClassroomBlueprintSource.mockResolvedValue({
+      ok: true,
+      source: legacySource(),
+    })
+    mockGetCourseBlueprintDetail.mockResolvedValue({
+      detail: {
+        id: '20000000-0000-4000-8000-000000000001',
+        title: 'Course',
+        content_revision: 5,
+        authority_mode: 'pika',
+      },
+    })
+    mockGetBlueprintMergeSuggestionSet.mockResolvedValue({
+      ok: true,
+      suggestionSet: {
+        suggestions: [{ area: 'overview' }],
+      },
+    })
+
+    const result = await prepareArchivedClassroomReuse({
+      teacherId: '10000000-0000-4000-8000-000000000001',
+      classroomId: '30000000-0000-4000-8000-000000000001',
+      operationId: '70000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      status: 'review_required',
+      blueprint_id: '20000000-0000-4000-8000-000000000001',
+      blueprint_title: 'Course',
+      review_url:
+        '/teacher/blueprints?blueprint=20000000-0000-4000-8000-000000000001'
+        + '&reviewClassroom=30000000-0000-4000-8000-000000000001',
+    })
+    expect(mockApplyBlueprintMergeSuggestions).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/server/course-blueprint-proposals.test.ts
+++ b/tests/lib/server/course-blueprint-proposals.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   applyPersistedClassroomBlueprintProposal,
+  applyArchivedClassroomCourseBlueprintProposal,
   buildClassroomCourseBlueprintSnapshot,
   countUntrackedClassroomBlueprintArtifacts,
   applyPersistedCourseBlueprintProposal,
@@ -11,6 +12,7 @@ import {
 } from '@/lib/server/course-blueprint-proposals'
 import { buildCourseBlueprintExportBundle } from '@/lib/course-blueprint-package'
 import type { CourseBlueprintSnapshot } from '@/lib/server/course-blueprint-versions'
+import { hashCourseBlueprintSnapshot } from '@/lib/server/course-blueprint-versions'
 import type { CourseBlueprintDetail } from '@/types'
 
 const base: CourseBlueprintSnapshot = {
@@ -259,6 +261,39 @@ describe('persisted course blueprint proposals', () => {
         p_proposal_id: proposalRow.id,
         p_candidate_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       })
+    )
+  })
+
+  it('supplies the canonical resulting Version digest for archived promotion', async () => {
+    const candidate = structuredClone(base)
+    candidate.sections.overview_markdown = 'Changed'
+    const appliedRow = {
+      ...proposalRow,
+      status: 'applied',
+      applied_blueprint_revision: 5,
+      applied_at: '2026-07-26T01:00:00.000Z',
+    }
+    const rpc = vi.fn().mockResolvedValue({ data: appliedRow, error: null })
+
+    const result = await applyArchivedClassroomCourseBlueprintProposal({
+      supabase: { rpc } as any,
+      teacherId: proposalRow.teacher_id,
+      classroomId: '50000000-0000-4000-8000-000000000000',
+      expectedClassroomRevision: 3,
+      proposalId: proposalRow.id,
+      candidate,
+    })
+
+    expect(result).toEqual(expect.objectContaining({ ok: true }))
+    expect(rpc).toHaveBeenCalledWith(
+      'apply_archived_classroom_blueprint_proposal_atomic',
+      expect.objectContaining({
+        p_candidate_sha256: hashCourseBlueprintSnapshot(candidate),
+        p_result_snapshot_sha256: hashCourseBlueprintSnapshot({
+          ...candidate,
+          draft_revision: 5,
+        }),
+      }),
     )
   })
 

--- a/tests/lib/server/course-blueprints.test.ts
+++ b/tests/lib/server/course-blueprints.test.ts
@@ -37,6 +37,7 @@ function makeSupabaseFromQueues(queues: Record<string, any[]>) {
 
 let mockSupabase: any
 const mockAssertTeacherCanMutateClassroom = vi.fn()
+const mockAssertTeacherOwnsClassroom = vi.fn()
 const mockLoadClassroomBlueprintSource = vi.fn()
 
 vi.mock('@/lib/supabase', () => ({
@@ -45,6 +46,7 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/server/classrooms', () => ({
   assertTeacherCanMutateClassroom: (...args: any[]) => mockAssertTeacherCanMutateClassroom(...args),
+  assertTeacherOwnsClassroom: (...args: any[]) => mockAssertTeacherOwnsClassroom(...args),
 }))
 
 vi.mock('@/lib/server/classroom-blueprint-source', () => ({
@@ -55,6 +57,7 @@ describe('course-blueprints server helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAssertTeacherCanMutateClassroom.mockReset()
+    mockAssertTeacherOwnsClassroom.mockReset()
     mockLoadClassroomBlueprintSource.mockReset()
   })
 
@@ -1060,6 +1063,105 @@ describe('course-blueprints server helpers', () => {
     expect(mockSupabase.from).not.toHaveBeenCalledWith('test_responses')
     expect(mockSupabase.from).not.toHaveBeenCalledWith('attendance')
     expect(mockSupabase.from).not.toHaveBeenCalledWith('announcements')
+  })
+
+  it('copies an archived classroom without asking the capture RPC to mutate it', async () => {
+    const operationId = '10000000-0000-4000-8000-000000000020'
+    const blueprintId = '20000000-0000-4000-8000-000000000020'
+    mockAssertTeacherOwnsClassroom.mockResolvedValue({
+      ok: true,
+      classroom: {
+        id: 'c-archived',
+        teacher_id: 'teacher-1',
+        archived_at: '2026-07-01T00:00:00.000Z',
+      },
+    })
+    mockLoadClassroomBlueprintSource.mockResolvedValue({
+      ok: true,
+      source: {
+        classroom: {
+          id: 'c-archived',
+          title: 'Archived course',
+          blueprint_source_revision: 9,
+          course_overview_markdown: '',
+          course_outline_markdown: '',
+        },
+        resources_markdown: '',
+        assignments: [],
+        tests: [],
+        lesson_templates: [],
+        materials: [],
+        surveys: [],
+      },
+    })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({
+          data: {
+            id: blueprintId,
+            teacher_id: 'teacher-1',
+            content_revision: 1,
+            title: 'Archived course',
+            overview_markdown: '',
+            outline_markdown: '',
+            resources_markdown: '',
+            planned_site_config: DEFAULT_PLANNED_COURSE_SITE_CONFIG,
+          },
+          error: null,
+        }),
+        makeQueryBuilder({ data: { content_revision: 1 }, error: null }),
+      ],
+      course_blueprint_assignments: [makeQueryBuilder({ data: [], error: null })],
+      course_blueprint_assessments: [makeQueryBuilder({ data: [], error: null })],
+      course_blueprint_lesson_templates: [makeQueryBuilder({ data: [], error: null })],
+      classrooms: [
+        makeQueryBuilder({
+          data: [{ id: 'c-archived', title: 'Archived course' }],
+          error: null,
+        }),
+      ],
+    })
+    mockSupabase.rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        status: 201,
+        operation_id: operationId,
+        operation_type: 'import',
+        replayed: false,
+        blueprint_id: blueprintId,
+        result_content_revision: 1,
+        counts: {
+          assignments: 0,
+          assessments: 0,
+          lesson_templates: 0,
+          materials: 0,
+          surveys: 0,
+        },
+      },
+      error: null,
+    })
+
+    const result = await createCourseBlueprintFromClassroom(
+      'teacher-1',
+      'c-archived',
+      {},
+      { operationId, copyOnly: true },
+    )
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      blueprint: expect.objectContaining({ id: blueprintId }),
+    }))
+    expect(mockAssertTeacherCanMutateClassroom).not.toHaveBeenCalled()
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'create_course_blueprint_atomic_v2',
+      expect.objectContaining({
+        p_operation_id: operationId,
+        p_operation_type: 'import',
+        p_source_classroom_id: null,
+        p_expected_source_revision: null,
+      }),
+    )
   })
 
   it('records classroom-link failure without a best-effort blueprint delete', async () => {

--- a/tests/lib/server/course-blueprints.test.ts
+++ b/tests/lib/server/course-blueprints.test.ts
@@ -1085,6 +1085,12 @@ describe('course-blueprints server helpers', () => {
           blueprint_source_revision: 9,
           course_overview_markdown: '',
           course_outline_markdown: '',
+          actual_site_config: {
+            ...DEFAULT_PLANNED_COURSE_SITE_CONFIG,
+            tests: false,
+            announcements: false,
+            lesson_plan_scope: 'all',
+          },
         },
         resources_markdown: '',
         assignments: [],
@@ -1154,12 +1160,19 @@ describe('course-blueprints server helpers', () => {
     }))
     expect(mockAssertTeacherCanMutateClassroom).not.toHaveBeenCalled()
     expect(mockSupabase.rpc).toHaveBeenCalledWith(
-      'create_course_blueprint_atomic_v2',
+      'create_archived_classroom_blueprint_atomic',
       expect.objectContaining({
         p_operation_id: operationId,
-        p_operation_type: 'import',
-        p_source_classroom_id: null,
-        p_expected_source_revision: null,
+        p_source_classroom_id: 'c-archived',
+        p_expected_source_revision: 9,
+        p_plan: expect.objectContaining({
+          blueprint: expect.objectContaining({
+            planned_site_config: {
+              ...DEFAULT_PLANNED_COURSE_SITE_CONFIG,
+              tests: false,
+            },
+          }),
+        }),
       }),
     )
   })

--- a/tests/lib/server/course-sites.test.ts
+++ b/tests/lib/server/course-sites.test.ts
@@ -104,7 +104,10 @@ vi.mock('@/lib/timezone', () => ({
   nowInToronto: vi.fn(() => new Date('2026-04-15T12:00:00Z')),
 }))
 
-function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
+function seedActualSiteSupabase(
+  sourceBlueprintId = 'b-1',
+  actualSiteConfig: Record<string, unknown> = { lesson_plan_scope: 'current_week' },
+) {
   mockSupabase = makeSupabaseFromQueues({
     classrooms: [
       makeQueryBuilder({
@@ -114,7 +117,7 @@ function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
           title: 'CS 11',
           actual_site_slug: 'cs11',
           actual_site_published: true,
-          actual_site_config: { lesson_plan_scope: 'current_week' },
+          actual_site_config: actualSiteConfig,
           blueprint_source_revision: 1,
           source_blueprint_id: sourceBlueprintId,
           course_overview_markdown: 'Actual overview',
@@ -127,7 +130,7 @@ function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
           id: 'c-1',
           teacher_id: 'teacher-1',
           title: 'CS 11',
-          actual_site_config: { lesson_plan_scope: 'current_week' },
+          actual_site_config: actualSiteConfig,
           blueprint_source_revision: 1,
           source_blueprint_id: sourceBlueprintId,
           course_overview_markdown: 'Actual overview',
@@ -316,7 +319,15 @@ describe('course-sites server helpers', () => {
       },
     })
 
-    seedActualSiteSupabase()
+    seedActualSiteSupabase('b-1', {
+      overview: true,
+      outline: true,
+      resources: true,
+      assignments: true,
+      tests: false,
+      lesson_plans: true,
+      lesson_plan_scope: 'current_week',
+    })
     const result = await getBlueprintMergeSuggestionSet('teacher-1', 'b-1', 'c-1')
     expect(result).toEqual(
       expect.objectContaining({
@@ -329,6 +340,7 @@ describe('course-sites server helpers', () => {
             expect.objectContaining({ area: 'assignments' }),
             expect.objectContaining({ area: 'tests' }),
             expect.objectContaining({ area: 'lesson-plans' }),
+            expect.objectContaining({ area: 'site-visibility' }),
           ]),
         }),
       })
@@ -343,7 +355,15 @@ describe('course-sites server helpers', () => {
   })
 
   it('turns selected classroom merge areas into a revision-bound proposal', async () => {
-    seedActualSiteSupabase()
+    seedActualSiteSupabase('b-1', {
+      overview: true,
+      outline: true,
+      resources: true,
+      assignments: true,
+      tests: false,
+      lesson_plans: true,
+      lesson_plan_scope: 'current_week',
+    })
     mockGetCourseBlueprintDetail.mockResolvedValue({
       detail: {
         id: 'b-1',
@@ -365,6 +385,7 @@ describe('course-sites server helpers', () => {
       'assignments',
       'tests',
       'lesson-plans',
+      'site-visibility',
     ], {
       expectedBlueprintRevision: 7,
       expectedClassroomRevision: 1,
@@ -380,6 +401,11 @@ describe('course-sites server helpers', () => {
       sourceClassroomId: 'c-1',
       baseClassroomRevision: 1,
     }))
+    expect(mockBuildBlueprintSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        planned_site_config: expect.objectContaining({ tests: false }),
+      }),
+    )
 
     expect(buildMarkdownSectionContent('Hello')).toEqual(
       expect.objectContaining({ type: 'doc' })

--- a/tests/unit/atomic-archived-classroom-blueprint-reuse-migration.test.ts
+++ b/tests/unit/atomic-archived-classroom-blueprint-reuse-migration.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/114_atomic_archived_classroom_blueprint_reuse.sql',
+  ),
+  'utf8',
+)
+
+describe('atomic archived classroom Blueprint reuse migration', () => {
+  it('serializes creation on the archived classroom and links in the transaction', () => {
+    expect(migration).toContain(
+      'create or replace function public.create_archived_classroom_blueprint_atomic(',
+    )
+    expect(migration).toMatch(
+      /from public\.classrooms[\s\S]{0,180}for update/,
+    )
+    expect(migration).toContain('if v_classroom.archived_at is null then')
+    expect(migration).toContain(
+      'if v_classroom.source_blueprint_id is not null then',
+    )
+    expect(migration).toContain(
+      'v_result := public.create_course_blueprint_atomic_v2(',
+    )
+    expect(migration).toMatch(
+      /create_course_blueprint_atomic_v2\([\s\S]{0,700}update public\.classrooms[\s\S]{0,220}source_blueprint_id = v_blueprint_id/,
+    )
+  })
+
+  it('replays the classroom-scoped winner without creating an orphan', () => {
+    expect(migration).toMatch(
+      /if v_classroom\.source_blueprint_id is not null then[\s\S]{0,900}'replayed', true/,
+    )
+    expect(migration).toContain(
+      "'reuse_source', 'archived_classroom'",
+    )
+    expect(migration).toContain(
+      'source_classroom_id = p_source_classroom_id',
+    )
+  })
+
+  it('locks and rechecks hot-archive state before promotion', () => {
+    expect(migration).toContain(
+      'create or replace function public.apply_archived_classroom_blueprint_proposal_atomic(',
+    )
+    expect(migration).toMatch(
+      /apply_archived_classroom_blueprint_proposal_atomic[\s\S]*from public\.classrooms[\s\S]{0,180}for update/,
+    )
+    expect(migration).toMatch(
+      /v_classroom\.archived_at is null[\s\S]{0,260}apply_course_blueprint_proposal_atomic/,
+    )
+    expect(migration).toContain(
+      'from public.save_course_blueprint_version_atomic(',
+    )
+    expect(migration).toMatch(
+      /save_course_blueprint_version_atomic\([\s\S]{0,900}source_blueprint_version_id = v_version\.id/,
+    )
+  })
+})

--- a/tests/unit/atomic-archived-classroom-blueprint-reuse-migration.test.ts
+++ b/tests/unit/atomic-archived-classroom-blueprint-reuse-migration.test.ts
@@ -25,8 +25,15 @@ describe('atomic archived classroom Blueprint reuse migration', () => {
     expect(migration).toContain(
       'v_result := public.create_course_blueprint_atomic_v2(',
     )
-    expect(migration).toMatch(
-      /create_course_blueprint_atomic_v2\([\s\S]{0,700}update public\.classrooms[\s\S]{0,220}source_blueprint_id = v_blueprint_id/,
+    expect(migration).toContain('source_blueprint_id = v_blueprint_id')
+    expect(migration).toContain(
+      'public.archived_classroom_blueprint_snapshot_from_plan(',
+    )
+    expect(migration).toContain(
+      'source_blueprint_version_id = v_version.id',
+    )
+    expect(migration).toContain(
+      "raise exception 'Archived lesson identity mapping failed'",
     )
   })
 
@@ -55,8 +62,21 @@ describe('atomic archived classroom Blueprint reuse migration', () => {
     expect(migration).toContain(
       'from public.save_course_blueprint_version_atomic(',
     )
+    expect(migration).toContain('p_result_snapshot_sha256')
     expect(migration).toMatch(
       /save_course_blueprint_version_atomic\([\s\S]{0,900}source_blueprint_version_id = v_version\.id/,
     )
+    expect(migration).toMatch(
+      /update public\.lesson_plans[\s\S]{0,220}source_artifact_id = coalesce\(source_artifact_id, artifact_id\)/,
+    )
+  })
+
+  it('hashes initial Versions with Pika canonical JSON rather than jsonb text', () => {
+    expect(migration).toContain(
+      'create or replace function public.course_blueprint_canonical_jsonb_text(',
+    )
+    expect(migration).toContain('order by entry.key')
+    expect(migration).toContain('order by item.ordinality')
+    expect(migration).not.toContain('convert_to(v_version_snapshot::text')
   })
 })


### PR DESCRIPTION
## Summary
- add a compact Use again action for hot archived classrooms
- reconcile the classroom against its source Blueprint Version and current Draft
- promote classroom-only reusable changes atomically, route true conflicts to review, and create lineage for legacy classrooms
- make archived capture/link and promotion concurrency-safe through migration 114
- preserve lesson artifact provenance and reusable public-site visibility defaults
- open normal classroom creation with the prepared Blueprint selected

## Validation
- full Vitest suite: 455 files / 3,956 tests
- focused remediation suites: 6 files / 57 tests
- TypeScript, lint, production build, Pika audit, migration contract, and diff checks
- desktop/mobile light/dark visual matrix for archived cards and conflict dialog
- composite-widget accessibility checklist reviewed; semantic dialog coverage present

## Boundaries
- hot archives only; cold archives must be restored first
- no students, submissions, grades, attendance, or runtime history enter a Blueprint
- reusable site visibility defaults are included; runtime slug/publication state is excluded
- Restore remains a separate action

## Rollout
- migration `114_atomic_archived_classroom_blueprint_reuse.sql` must be applied before the new endpoint is used
- migration application requires separate explicit target authorization
