### PR TITLE
Simplify prepared Blueprint classroom creation

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15704,3 +15704,36 @@
 **Validation:**
 - Focused Tests API/client/component suites (12 files / 208 tests)
 - Full repository suite (408 files / 3,674 tests)
+
+<!-- pika-session-log-archive-batch:c96e2b51f6b8f8807807abfaf6e228da757f373fc07eb4ffdcd6a54e872f7244 -->
+## 2026-07-23 — Hardened standalone test preview
+
+**Risk profile:** workspace-state, exam-mode, authorization, external-network, schema
+
+**Model recommendation:** GPT-5.6 Sol and Terra (high) - this slice crosses authorization, concurrent ownership, outbound document fetching, atomic persistence, focus, and the full-screen exam-mode shell.
+
+**Completed:**
+- Added route regressions for unauthenticated, non-teacher, non-owner, classroom/test mismatch, and authorized teacher access.
+- Made `testId` the preview-data owner and invalidated requests only at committed effect boundaries so abandoned concurrent renders cannot stall the active preview.
+- Hid old-owner content until the current preview finishes loading and ignored every late visible-state write from superseded requests.
+- Added A/B and suspended-render regressions proving preview B survives late A and committed A survives an abandoned B render.
+- Added named preview, document, and question regions plus keyboard focus transfer into an opened document and restoration to its trigger on close.
+- Revalidated the measured window fallback after blocked fullscreen/resize attempts and on later resize so non-maximized content relocks.
+- Added a DNS-resolving, address-pinned outbound fetch boundary that rejects private/reserved IPv4 and IPv6 targets, mixed DNS answers, and public-to-private redirects.
+- Added migration 105 for an atomic snapshot attach that locks test/classroom ownership, rejects archive/document/URL conflicts, preserves concurrent document changes, and returns the exact superseded snapshot for cleanup.
+- Switched snapshots to unique immutable storage paths and remove uncommitted or superseded objects after persistence outcomes.
+- Preserved the existing full-screen composition. Migration 105 was applied locally under one-time authorization and generated database types were refreshed; production, Gradex, and deferred mobile layout work were unchanged.
+
+**Validation:**
+- Focused preview, document sync, safe-fetch, migration, and existing editor suites (8 files / 77 tests)
+- Full repository suite (413 files / 3,712 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm check:architecture` (625 modules / 0 allowances)
+- `pnpm build`
+- Pika changed-file audit
+- `git diff --check`
+
+**Remaining:**
+- Require independent PR review and exact-head CI before merge.
+- Next retire unused component prop wrappers and the legacy test automation id; preserve database-shaped fields and the old `tab=quizzes` URL tombstone.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15686,3 +15686,21 @@
 **Remaining:**
 - Complete targeted independent rereview and exact-head PR CI.
 - Continue Tests with standalone preview authorization/framing, then student flag/save accessibility; keep mobile and Gradex deferred.
+
+<!-- pika-session-log-archive-batch:7330c944556cb96d53a3e9700b2784c150c12853dfc4b9d3e6915432306c67f0 -->
+## 2026-07-23 — Retired legacy Quiz API response aliases
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - the pass crosses student and teacher API producers, client normalizers, component consumers, and contract documentation.
+
+**Completed:**
+- Closed the internal Tests API compatibility window and removed legacy `quiz` / `quizzes` response aliases from active student and teacher Tests routes.
+- Removed quiz-key fallback reads and compatibility fixtures while preserving current `test` / `tests` handling for optional and error payloads.
+- Added route assertions and an architecture ratchet preventing the retired response helpers from returning.
+- Documented the cutoff, older-client risk, code-only rollback, and remaining database, archive, gradebook, package, component, URL, and automation compatibility boundaries.
+- Left schema, migrations, persisted `quiz_id` fields, archive v1 resources, gradebook tombstones, and course package compatibility unchanged.
+
+**Validation:**
+- Focused Tests API/client/component suites (12 files / 208 tests)
+- Full repository suite (408 files / 3,674 tests)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,38 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-23 — Hardened standalone test preview
-
-**Risk profile:** workspace-state, exam-mode, authorization, external-network, schema
-
-**Model recommendation:** GPT-5.6 Sol and Terra (high) - this slice crosses authorization, concurrent ownership, outbound document fetching, atomic persistence, focus, and the full-screen exam-mode shell.
-
-**Completed:**
-- Added route regressions for unauthenticated, non-teacher, non-owner, classroom/test mismatch, and authorized teacher access.
-- Made `testId` the preview-data owner and invalidated requests only at committed effect boundaries so abandoned concurrent renders cannot stall the active preview.
-- Hid old-owner content until the current preview finishes loading and ignored every late visible-state write from superseded requests.
-- Added A/B and suspended-render regressions proving preview B survives late A and committed A survives an abandoned B render.
-- Added named preview, document, and question regions plus keyboard focus transfer into an opened document and restoration to its trigger on close.
-- Revalidated the measured window fallback after blocked fullscreen/resize attempts and on later resize so non-maximized content relocks.
-- Added a DNS-resolving, address-pinned outbound fetch boundary that rejects private/reserved IPv4 and IPv6 targets, mixed DNS answers, and public-to-private redirects.
-- Added migration 105 for an atomic snapshot attach that locks test/classroom ownership, rejects archive/document/URL conflicts, preserves concurrent document changes, and returns the exact superseded snapshot for cleanup.
-- Switched snapshots to unique immutable storage paths and remove uncommitted or superseded objects after persistence outcomes.
-- Preserved the existing full-screen composition. Migration 105 was applied locally under one-time authorization and generated database types were refreshed; production, Gradex, and deferred mobile layout work were unchanged.
-
-**Validation:**
-- Focused preview, document sync, safe-fetch, migration, and existing editor suites (8 files / 77 tests)
-- Full repository suite (413 files / 3,712 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm check:architecture` (625 modules / 0 allowances)
-- `pnpm build`
-- Pika changed-file audit
-- `git diff --check`
-
-**Remaining:**
-- Require independent PR review and exact-head CI before merge.
-- Next retire unused component prop wrappers and the legacy test automation id; preserve database-shaped fields and the old `tab=quizzes` URL tombstone.
-
 ## 2026-07-23 — Retired legacy Quiz UI wrappers
 
 **Risk profile:** none
@@ -1405,3 +1373,24 @@ classroom lineage.
 
 **Remaining:**
 - Publish for independent review and exact-head CI before merge.
+
+## 2026-07-30 — Prepared Blueprint review remediation
+
+**Risk profile:** none — teacher-only wizard launch-state correction.
+
+**Completed:**
+- Fixed an independently reviewed race where the Blueprint-page classroom
+  action could open before async Blueprint detail loaded and lose its preset.
+- Snapshotted the selected Blueprint ID and title from the loaded Blueprint
+  list when the action is invoked, keeping the modal locked even if detail is
+  still pending or the page selection later changes.
+- Added a deferred-detail regression that failed on the reviewed implementation
+  and now proves the exact prepared Blueprint reaches classroom creation.
+
+**Validation:**
+- Focused Blueprint page, classroom wizard, archived reuse, and SplitButton
+  suites: 4 files / 50 tests.
+- TypeScript, lint, Pika audit, and diff checks pass.
+
+**Remaining:**
+- Complete targeted independent re-review and exact-head PR CI.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,23 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-23 — Retired legacy Quiz API response aliases
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5 Codex - the pass crosses student and teacher API producers, client normalizers, component consumers, and contract documentation.
-
-**Completed:**
-- Closed the internal Tests API compatibility window and removed legacy `quiz` / `quizzes` response aliases from active student and teacher Tests routes.
-- Removed quiz-key fallback reads and compatibility fixtures while preserving current `test` / `tests` handling for optional and error payloads.
-- Added route assertions and an architecture ratchet preventing the retired response helpers from returning.
-- Documented the cutoff, older-client risk, code-only rollback, and remaining database, archive, gradebook, package, component, URL, and automation compatibility boundaries.
-- Left schema, migrations, persisted `quiz_id` fields, archive v1 resources, gradebook tombstones, and course package compatibility unchanged.
-
-**Validation:**
-- Focused Tests API/client/component suites (12 files / 208 tests)
-- Full repository suite (408 files / 3,674 tests)
-
 ## 2026-07-23 — Hardened standalone test preview
 
 **Risk profile:** workspace-state, exam-mode, authorization, external-network, schema
@@ -1395,3 +1378,30 @@ classroom lineage.
 
 **Remaining:**
 - Publish the branch and confirm the real pull-request CI run on GitHub.
+
+## 2026-07-30 — Prepared Blueprint classroom wizard refinement
+
+**Risk profile:** none — teacher-only wizard copy and navigation.
+
+**Completed:**
+- Renamed the optional classroom creation path to **From course blueprint**.
+- Made **Use again** and Blueprint-page launches carry a fixed Blueprint
+  identity and title into classroom creation.
+- Skipped the redundant Blueprint picker for prepared launches and showed the
+  selected Course Blueprint as a concise read-only value on the Name step.
+- Kept normal classroom creation unchanged: primary Next creates a blank
+  classroom, while the split-menu path opens the Blueprint picker.
+- Added regression coverage for the prepared Name -> Calendar -> Name flow,
+  exact Blueprint instantiation, and the normal picker path.
+
+**Validation:**
+- Full Vitest suite passed, including SplitButton keyboard/focus coverage.
+- TypeScript, lint, architecture, design policy, UI policy, Pika audit, and
+  production build pass.
+- Playwright teacher verification passed on desktop/mobile and light/dark for
+  normal and prepared launches; student desktop/mobile views are unaffected.
+- Composite-widget checklist reviewed: keyboard behavior covered, semantic
+  roles/state covered by tests, and no manual follow-up remains.
+
+**Remaining:**
+- Publish for independent review and exact-head CI before merge.

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -66,7 +66,10 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const [coldArchiveRestoreEnabled, setColdArchiveRestoreEnabled] = useState(false)
   const [view, setView] = useState<ViewMode>('active')
   const [showCreate, setShowCreate] = useState(false)
-  const [reuseBlueprintId, setReuseBlueprintId] = useState<string | null>(null)
+  const [reuseBlueprint, setReuseBlueprint] = useState<{
+    id: string
+    title: string
+  } | null>(null)
   const [reuseReview, setReuseReview] = useState<ReuseReview>(null)
   const [reusingClassroomId, setReusingClassroomId] = useState<string | null>(null)
   const [isEditingClassrooms, setIsEditingClassrooms] = useState(false)
@@ -334,13 +337,20 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         })
         return
       }
-      if (data.status !== 'ready' || typeof data.blueprint_id !== 'string') {
+      if (
+        data.status !== 'ready'
+        || typeof data.blueprint_id !== 'string'
+        || typeof data.blueprint_title !== 'string'
+      ) {
         throw new Error('Failed to prepare this course')
       }
 
       reuseOperationIdsRef.current.delete(classroom.id)
       invalidateTeacherBlueprints()
-      setReuseBlueprintId(data.blueprint_id)
+      setReuseBlueprint({
+        id: data.blueprint_id,
+        title: data.blueprint_title,
+      })
       setShowCreate(true)
     } catch (err: any) {
       setError(err.message || 'Failed to prepare this course')
@@ -624,14 +634,14 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
       <CreateClassroomModal
         isOpen={showCreate}
-        initialBlueprintId={reuseBlueprintId}
+        presetBlueprint={reuseBlueprint}
         onClose={() => {
           setShowCreate(false)
-          setReuseBlueprintId(null)
+          setReuseBlueprint(null)
         }}
         onSuccess={(created) => {
           setShowCreate(false)
-          setReuseBlueprintId(null)
+          setReuseBlueprint(null)
           setActiveClassrooms((prev) => [created, ...prev])
           openClassroom(created)
         }}

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -163,7 +163,10 @@ export default function TeacherBlueprintsPage() {
   const [loadingList, setLoadingList] = useState(true)
   const [loadingDetail, setLoadingDetail] = useState(false)
   const [showCreate, setShowCreate] = useState(false)
-  const [showCreateClassroom, setShowCreateClassroom] = useState(false)
+  const [classroomBlueprintPreset, setClassroomBlueprintPreset] = useState<{
+    id: string
+    title: string
+  } | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<BlueprintDeleteTarget | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [activeTab, setActiveTab] = useState<EditorTab>('overview')
@@ -859,6 +862,16 @@ export default function TeacherBlueprintsPage() {
     }
   }
 
+  function openCreateClassroom() {
+    if (!selectedBlueprintId) return
+    const blueprint = blueprints.find((candidate) => candidate.id === selectedBlueprintId)
+    if (!blueprint) return
+    setClassroomBlueprintPreset({
+      id: blueprint.id,
+      title: blueprint.title,
+    })
+  }
+
   return (
     <PageLayout width="wide">
       <PageActionBar
@@ -874,7 +887,7 @@ export default function TeacherBlueprintsPage() {
           { id: 'import-package', label: 'Import Course Package', onSelect: () => importInputRef.current?.click() },
           ...(selectedBlueprintId
             ? [
-                { id: 'create-classroom', label: 'Use for Classroom', primary: true, onSelect: () => setShowCreateClassroom(true) },
+                { id: 'create-classroom', label: 'Use for Classroom', primary: true, onSelect: openCreateClassroom },
                 { id: 'export-package', label: 'Export Course Package', onSelect: handleExport },
                 ...(plannedSite.published && plannedSite.slug
                   ? [{ id: 'open-planned-site', label: 'Open Planned Site', onSelect: () => window.open(`/planned/${plannedSite.slug}`, '_blank') }]
@@ -1541,15 +1554,11 @@ export default function TeacherBlueprintsPage() {
       />
 
       <CreateClassroomModal
-        isOpen={showCreateClassroom}
-        onClose={() => setShowCreateClassroom(false)}
-        presetBlueprint={
-          detail?.id === selectedBlueprintId
-            ? { id: detail.id, title: detail.title }
-            : null
-        }
+        isOpen={classroomBlueprintPreset !== null}
+        onClose={() => setClassroomBlueprintPreset(null)}
+        presetBlueprint={classroomBlueprintPreset}
         onSuccess={(classroom) => {
-          setShowCreateClassroom(false)
+          setClassroomBlueprintPreset(null)
           router.push(`/classrooms/${classroom.id}?tab=attendance`)
         }}
       />

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -1543,7 +1543,11 @@ export default function TeacherBlueprintsPage() {
       <CreateClassroomModal
         isOpen={showCreateClassroom}
         onClose={() => setShowCreateClassroom(false)}
-        initialBlueprintId={selectedBlueprintId}
+        presetBlueprint={
+          detail?.id === selectedBlueprintId
+            ? { id: detail.id, title: detail.title }
+            : null
+        }
         onSuccess={(classroom) => {
           setShowCreateClassroom(false)
           router.push(`/classrooms/${classroom.id}?tab=attendance`)

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -18,15 +18,20 @@ interface CreateClassroomModalProps {
   isOpen: boolean
   onClose: () => void
   onSuccess: (classroom: any) => void
-  initialBlueprintId?: string | null
+  presetBlueprint?: {
+    id: string
+    title: string
+  } | null
 }
 
 export function CreateClassroomModal({
   isOpen,
   onClose,
   onSuccess,
-  initialBlueprintId = null,
+  presetBlueprint = null,
 }: CreateClassroomModalProps) {
+  const presetBlueprintId = presetBlueprint?.id || ''
+  const presetBlueprintTitle = presetBlueprint?.title || ''
   const startMonthId = useId()
   const endMonthId = useId()
   const importInputRef = useRef<HTMLInputElement | null>(null)
@@ -35,8 +40,8 @@ export function CreateClassroomModal({
   const [step, setStep] = useState<WizardStep>('name')
   const [title, setTitle] = useState('')
   const [availableBlueprints, setAvailableBlueprints] = useState<CourseBlueprint[]>([])
-  const [creationMode, setCreationMode] = useState<CreationMode>(initialBlueprintId ? 'blueprint' : 'blank')
-  const [selectedBlueprintId, setSelectedBlueprintId] = useState(initialBlueprintId || '')
+  const [creationMode, setCreationMode] = useState<CreationMode>(presetBlueprintId ? 'blueprint' : 'blank')
+  const [selectedBlueprintId, setSelectedBlueprintId] = useState(presetBlueprintId)
   const [calendarMode, setCalendarMode] = useState<CalendarMode>('preset')
   const [selectedSemester, setSelectedSemester] = useState<Semester>('semester1')
 
@@ -56,8 +61,12 @@ export function CreateClassroomModal({
     let isCurrent = true
     const loadGeneration = blueprintLoadGenerationRef.current + 1
     blueprintLoadGenerationRef.current = loadGeneration
-    setCreationMode(initialBlueprintId ? 'blueprint' : 'blank')
-    setSelectedBlueprintId(initialBlueprintId || '')
+    setCreationMode(presetBlueprintId ? 'blueprint' : 'blank')
+    setSelectedBlueprintId(presetBlueprintId)
+    if (presetBlueprintId) {
+      setAvailableBlueprints([])
+      return
+    }
     fetchTeacherBlueprints()
       .then((blueprints) => {
         if (isCurrent && blueprintLoadGenerationRef.current === loadGeneration) setAvailableBlueprints(blueprints)
@@ -68,7 +77,7 @@ export function CreateClassroomModal({
     return () => {
       isCurrent = false
     }
-  }, [initialBlueprintId, isOpen])
+  }, [isOpen, presetBlueprintId])
 
   function getSemesterYears() {
     const now = new Date()
@@ -100,16 +109,24 @@ export function CreateClassroomModal({
   function resetForm() {
     setStep('name')
     setTitle('')
-    setCreationMode(initialBlueprintId ? 'blueprint' : 'blank')
-    setSelectedBlueprintId(initialBlueprintId || '')
+    setCreationMode(presetBlueprintId ? 'blueprint' : 'blank')
+    setSelectedBlueprintId(presetBlueprintId)
     setCalendarMode('preset')
     setSelectedSemester('semester1')
     setError('')
   }
 
   function proceedFromName(nextMode: CreationMode) {
+    if (presetBlueprintId) {
+      setCreationMode('blueprint')
+      setSelectedBlueprintId(presetBlueprintId)
+      setStep('calendar')
+      setError('')
+      return
+    }
+
     setCreationMode(nextMode)
-    if (nextMode === 'blank' && !initialBlueprintId) {
+    if (nextMode === 'blank') {
       setSelectedBlueprintId('')
       setStep('calendar')
     } else {
@@ -249,7 +266,9 @@ export function CreateClassroomModal({
 
   const { semester1Year, semester2Year } = getSemesterYears()
   const progressSteps: WizardStep[] =
-    creationMode === 'blueprint' || step === 'blueprint'
+    presetBlueprintId
+      ? ['name', 'calendar']
+      : creationMode === 'blueprint' || step === 'blueprint'
       ? ['name', 'blueprint', 'calendar']
       : ['name', 'calendar']
   const canContinueFromBlueprintStep = !!selectedBlueprintId
@@ -301,6 +320,14 @@ export function CreateClassroomModal({
                 autoFocus
               />
             </FormField>
+            {presetBlueprintId ? (
+              <div className="mt-4">
+                <p className="text-sm text-text-muted">Course Blueprint</p>
+                <p className="mt-1 text-sm font-medium text-text-default">
+                  {presetBlueprintTitle}
+                </p>
+              </div>
+            ) : null}
           </div>
         )}
 
@@ -478,7 +505,13 @@ export function CreateClassroomModal({
               ? handleClose
               : () => {
                   if (step === 'calendar') {
-                    setStep(creationMode === 'blueprint' ? 'blueprint' : 'name')
+                    setStep(
+                      presetBlueprintId
+                        ? 'name'
+                        : creationMode === 'blueprint'
+                          ? 'blueprint'
+                          : 'name',
+                    )
                   } else {
                     setStep('name')
                   }
@@ -491,31 +524,42 @@ export function CreateClassroomModal({
           {step === 'name' ? 'Cancel' : 'Back'}
         </Button>
         {step === 'name' ? (
-          <SplitButton
-            label="Next"
-            onPrimaryClick={() => {
-              if (!title) return
-              proceedFromName(initialBlueprintId ? 'blueprint' : 'blank')
-            }}
-            options={[
-              {
-                id: 'from-blueprint',
-                label: 'From Course Blueprint',
-                onSelect: () => {
-                  if (!title) return
-                  proceedFromName('blueprint')
+          presetBlueprintId ? (
+            <Button
+              type="button"
+              onClick={() => proceedFromName('blueprint')}
+              disabled={isBusy || !title}
+              className="flex-1"
+            >
+              Next
+            </Button>
+          ) : (
+            <SplitButton
+              label="Next"
+              onPrimaryClick={() => {
+                if (!title) return
+                proceedFromName('blank')
+              }}
+              options={[
+                {
+                  id: 'from-blueprint',
+                  label: 'From course blueprint',
+                  onSelect: () => {
+                    if (!title) return
+                    proceedFromName('blueprint')
+                  },
                 },
-              },
-            ]}
-            disabled={isBusy || !title}
-            className="flex-1"
-            size="md"
-            toggleAriaLabel="Choose classroom creation path"
-            menuPlacement="up"
-            primaryButtonProps={{
-              className: 'min-w-0 flex-1 justify-center',
-            }}
-          />
+              ]}
+              disabled={isBusy || !title}
+              className="flex-1"
+              size="md"
+              toggleAriaLabel="Choose classroom creation path"
+              menuPlacement="up"
+              primaryButtonProps={{
+                className: 'min-w-0 flex-1 justify-center',
+              }}
+            />
+          )
         ) : step === 'blueprint' ? (
           <Button
             type="button"

--- a/tests/components/CreateClassroomModal.test.tsx
+++ b/tests/components/CreateClassroomModal.test.tsx
@@ -94,7 +94,7 @@ describe('CreateClassroomModal', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Choose classroom creation path' }))
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'From Course Blueprint' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'From course blueprint' }))
   }
 
   it('keeps the primary Next path as a blank-classroom flow', async () => {
@@ -114,7 +114,7 @@ describe('CreateClassroomModal', () => {
     expect(screen.queryByRole('combobox', { name: /course blueprint/i })).not.toBeInTheDocument()
   })
 
-  it('routes From Blueprint through a separate source step before calendar selection', async () => {
+  it('routes From course blueprint through a separate source step before calendar selection', async () => {
     renderModal()
 
     await openBlueprintSourceStep()
@@ -261,14 +261,27 @@ describe('CreateClassroomModal', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     })
 
-    renderModal({ initialBlueprintId: mockBlueprint.id, onSuccess })
+    renderModal({
+      presetBlueprint: { id: mockBlueprint.id, title: mockBlueprint.title },
+      onSuccess,
+    })
 
     fireEvent.change(getClassroomNameInput(), {
       target: { value: 'Computer Science 11 - Period 2' },
     })
 
+    expect(screen.getByText('Course Blueprint')).toBeInTheDocument()
+    expect(screen.getByText(mockBlueprint.title)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Choose classroom creation path' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /course blueprint/i })).not.toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
-    expect(await screen.findByRole('combobox', { name: /course blueprint/i })).toHaveValue(mockBlueprint.id)
+    expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /course blueprint/i })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(getClassroomNameInput()).toHaveValue('Computer Science 11 - Period 2')
+    expect(screen.getByText(mockBlueprint.title)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
     expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
@@ -285,8 +298,10 @@ describe('CreateClassroomModal', () => {
     expect(onSuccess).toHaveBeenCalledWith({ id: 'classroom-1', title: 'Computer Science 11 - Period 2' })
   })
 
-  it('preserves the preselected blueprint flow when launched from the blueprints page', async () => {
-    renderModal({ initialBlueprintId: mockBlueprint.id })
+  it('locks a preset blueprint when launched from the blueprints page', async () => {
+    renderModal({
+      presetBlueprint: { id: mockBlueprint.id, title: mockBlueprint.title },
+    })
 
     fireEvent.change(getClassroomNameInput(), {
       target: { value: 'Computer Science 11 - Period 2' },
@@ -294,8 +309,7 @@ describe('CreateClassroomModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
 
-    const blueprintSelect = await screen.findByRole('combobox', { name: /course blueprint/i })
-    expect(blueprintSelect).toHaveValue(mockBlueprint.id)
-    expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled()
+    expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /course blueprint/i })).not.toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -33,7 +33,17 @@ vi.mock('@/components/CreateBlueprintModal', () => ({
 }))
 
 vi.mock('@/components/CreateClassroomModal', () => ({
-  CreateClassroomModal: () => null,
+  CreateClassroomModal: ({
+    isOpen,
+    presetBlueprint,
+  }: {
+    isOpen: boolean
+    presetBlueprint?: { id: string; title: string } | null
+  }) => isOpen ? (
+    <div role="dialog" data-testid="create-classroom-modal">
+      Blueprint: {presetBlueprint?.id || 'none'} ({presetBlueprint?.title || 'untitled'})
+    </div>
+  ) : null,
 }))
 
 vi.mock('@/components/Spinner', () => ({
@@ -275,6 +285,35 @@ describe('TeacherBlueprintsPage', () => {
 
     expect(screen.getByDisplayValue('Blueprint One')).toBeInTheDocument()
     expect(screen.queryByDisplayValue('Blueprint Two')).toBeNull()
+  })
+
+  it('locks the selected Blueprint for classroom creation while detail is loading', async () => {
+    let resolveDelayedDetail: ((response: Response) => void) | undefined
+    const delayedDetail = new Promise<Response>((resolve) => {
+      resolveDelayedDetail = resolve
+    })
+    const defaultFetch = vi.mocked(fetch).getMockImplementation()
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'GET') {
+        return delayedDetail
+      }
+      return defaultFetch!(input, init)
+    })
+
+    render(<TeacherBlueprintsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Use for Classroom' }))
+
+    expect(await screen.findByTestId('create-classroom-modal')).toHaveTextContent(
+      'Blueprint: b-2 (Blueprint Two)',
+    )
+
+    await act(async () => {
+      resolveDelayedDetail?.(jsonResponse({ blueprint: blueprintDetail }))
+      await delayedDetail
+    })
   })
 
   it('invalidates blueprint caches before reloading after saving metadata', async () => {

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -14,13 +14,13 @@ const push = vi.hoisted(() => vi.fn())
 vi.mock('@/components/CreateClassroomModal', () => ({
   CreateClassroomModal: ({
     isOpen,
-    initialBlueprintId,
+    presetBlueprint,
   }: {
     isOpen: boolean
-    initialBlueprintId?: string | null
+    presetBlueprint?: { id: string; title: string } | null
   }) => isOpen ? (
     <div role="dialog" data-testid="create-classroom-modal">
-      Blueprint: {initialBlueprintId || 'none'}
+      Blueprint: {presetBlueprint?.id || 'none'} ({presetBlueprint?.title || 'untitled'})
     </div>
   ) : null,
 }))
@@ -188,7 +188,7 @@ describe('TeacherClassroomsIndex', () => {
       },
     ))
     expect(await screen.findByTestId('create-classroom-modal')).toHaveTextContent(
-      'Blueprint: 20000000-0000-4000-8000-000000000002',
+      'Blueprint: 20000000-0000-4000-8000-000000000002 (Reusable course)',
     )
   })
 


### PR DESCRIPTION
## Summary
- rename the optional creation path to From course blueprint
- lock prepared Blueprints for Use again and Blueprint-page launches
- skip the redundant Blueprint picker and show the selected Blueprint read-only

## Verification
- full Vitest suite
- focused wizard and SplitButton suites: 49 tests
- TypeScript, lint, architecture, design policy, UI policy, Pika audit
- production build
- Playwright teacher desktop/mobile light/dark; student views unaffected

## Accessibility
- composite-widget checklist reviewed
- keyboard/focus and semantic behavior covered by SplitButton and component tests