### PR TITLE
chore(workflow): guard commit prompt worktrees

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -15686,3 +15686,21 @@
 **Remaining:**
 - Complete targeted independent rereview and exact-head PR CI.
 - Continue Tests with standalone preview authorization/framing, then student flag/save accessibility; keep mobile and Gradex deferred.
+
+<!-- pika-session-log-archive-batch:d9261e45dbe0f937b55086cef991388438e8bc72bf26b66fc2588cc4ef1cc582 -->
+## 2026-07-23 — Retired legacy Quiz API response aliases
+
+**Risk profile:** none
+
+**Model recommendation:** GPT-5 Codex - the pass crosses student and teacher API producers, client normalizers, component consumers, and contract documentation.
+
+**Completed:**
+- Closed the internal Tests API compatibility window and removed legacy `quiz` / `quizzes` response aliases from active student and teacher Tests routes.
+- Removed quiz-key fallback reads and compatibility fixtures while preserving current `test` / `tests` handling for optional and error payloads.
+- Added route assertions and an architecture ratchet preventing the retired response helpers from returning.
+- Documented the cutoff, older-client risk, code-only rollback, and remaining database, archive, gradebook, package, component, URL, and automation compatibility boundaries.
+- Left schema, migrations, persisted `quiz_id` fields, archive v1 resources, gradebook tombstones, and course package compatibility unchanged.
+
+**Validation:**
+- Focused Tests API/client/component suites (12 files / 208 tests)
+- Full repository suite (408 files / 3,674 tests)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,23 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-07-23 — Retired legacy Quiz API response aliases
-
-**Risk profile:** none
-
-**Model recommendation:** GPT-5 Codex - the pass crosses student and teacher API producers, client normalizers, component consumers, and contract documentation.
-
-**Completed:**
-- Closed the internal Tests API compatibility window and removed legacy `quiz` / `quizzes` response aliases from active student and teacher Tests routes.
-- Removed quiz-key fallback reads and compatibility fixtures while preserving current `test` / `tests` handling for optional and error payloads.
-- Added route assertions and an architecture ratchet preventing the retired response helpers from returning.
-- Documented the cutoff, older-client risk, code-only rollback, and remaining database, archive, gradebook, package, component, URL, and automation compatibility boundaries.
-- Left schema, migrations, persisted `quiz_id` fields, archive v1 resources, gradebook tombstones, and course package compatibility unchanged.
-
-**Validation:**
-- Focused Tests API/client/component suites (12 files / 208 tests)
-- Full repository suite (408 files / 3,674 tests)
-
 ## 2026-07-23 — Hardened standalone test preview
 
 **Risk profile:** workspace-state, exam-mode, authorization, external-network, schema
@@ -1395,3 +1378,25 @@ classroom lineage.
 
 **Remaining:**
 - Publish the branch and confirm the real pull-request CI run on GitHub.
+
+## 2026-07-31 — Tightened commit prompt worktree guardrails
+
+**Risk profile:** none
+
+**Completed:**
+- Added the missing repo-root guard to the Codex `commit-and-pr` prompt so it
+  now resolves `git rev-parse --show-toplevel` and stops in the hub checkout at
+  `$HOME/Repos/pika` before any commit/push flow.
+- Extended the startup-doc regression suite to require both the Claude and
+  Codex commit prompts to include the canonical worktree safety checks:
+  repo-root resolution, hub-checkout stop, detached-HEAD stop, and no
+  force-push guidance.
+- Installed local dependencies in this app-managed worktree so the focused
+  startup-doc suite could run here.
+
+**Validation:**
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
+- `git diff --check`
+
+**Remaining:**
+- None.

--- a/.codex/prompts/commit-and-pr.md
+++ b/.codex/prompts/commit-and-pr.md
@@ -7,7 +7,7 @@ Use the dedicated-worktree rules from `docs/dev-workflow.md`. Task-specific safe
 - Use a conventional-commit message derived from the diff
 
 Steps:
-1. Confirm the current branch. If `git branch --show-current` is empty, stop because detached HEAD is not safe for commit/push/PR flow. Stop if the branch is `main` or `production`.
+1. Resolve the repo root with `git rev-parse --show-toplevel`. If it equals `$HOME/Repos/pika` (the hub), stop and ask me to create or open a worktree first. Confirm the current branch. If `git branch --show-current` is empty, stop because detached HEAD is not safe for commit/push/PR flow. Stop if the branch is `main` or `production`.
 2. Review `git diff --stat`, `git diff`, and recent commit style.
 3. Stage the intended files, generate a conventional-commit message, and commit.
 4. Push the branch, setting upstream if needed.

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -230,6 +230,19 @@ describe('AI startup docs', () => {
     }
   })
 
+  it('keeps commit prompts on the canonical worktree safety flow', () => {
+    const prompts = ['.claude/commands/commit-and-pr.md', '.codex/prompts/commit-and-pr.md']
+
+    for (const promptPath of prompts) {
+      const prompt = readRepoFile(promptPath)
+
+      expect(prompt).toContain('git rev-parse --show-toplevel')
+      expect(prompt).toContain('$HOME/Repos/pika')
+      expect(prompt).toContain('detached HEAD')
+      expect(prompt).toContain('Never force-push')
+    }
+  })
+
   it('documents orient-only startup for read-only work', () => {
     const files = ['.ai/START-HERE.md', '.claude/commands/session-start.md', '.codex/prompts/session-start.md']
 


### PR DESCRIPTION
## Summary
- add the hub-checkout guard to the Codex commit-and-PR prompt
- keep Claude and Codex commit prompt safety requirements aligned
- add focused regression coverage for worktree safety guidance

## Test plan
- pnpm vitest run tests/unit/ai-startup-docs.test.ts
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check