### PR TITLE
chore(workflow): add friction guardrails

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -6,7 +6,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.
 - Start each entry heading with a valid ISO date (`## YYYY-MM-DD ...`) so retention can identify the latest entries.
 - CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.
-- Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.
+- Use `node scripts/trim-session-log.mjs --check` to reject empty entries and verify the log is chronological and within the 60-entry cap.
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
@@ -298,8 +298,6 @@ classroom lineage.
 
 **Remaining:**
 - Publish the Pika branch and confirm exact-head review and CI.
-
-## 2026-08-01 — Native Pal learner experience
 
 ## 2026-08-02 — Built managed-storage ownership foundation
 
@@ -1190,3 +1188,17 @@ hot-archived Classroom with a student, assignment artifact, and test material.
 - Verified production already has the equivalent final schemas recorded as
   versions 118 and 119 under its separately authorized reconciliation history;
   this source correction performed no remote migration or state change.
+
+## 2026-08-07 — Add workflow-friction guardrails
+
+**Risk profile:** workspace-state.
+
+- Updated the E2E coverage and weekly simplification automations to create their
+  named task branch before edits when Codex starts them on a detached HEAD, and
+  to stop on any unexpected checkout state.
+- Added an explicit fallback for the workflow-friction review memory path while
+  retaining the configured hub project roots and report-only boundary.
+- Made session-log trim and check operations reject empty entries, removed the
+  existing empty duplicate heading, and added focused regression coverage.
+- Validation passed: focused trim/startup tests (51), full Vitest (468 files,
+  4,049 tests), lint, session-log check, TOML parsing, and diff checks.

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -42,7 +42,7 @@ All agents operate from exactly one current repo checkout/worktree.
 ## End of Session (MANDATORY)
 
 1. Append a concise session entry to `.ai/SESSION-LOG.md` with a valid ISO-date heading (`## YYYY-MM-DD ...`).
-2. Immediately run `node scripts/trim-session-log.mjs` in the same change. CI caps the log at 60; default trim keeps 40. Use `node scripts/trim-session-log.mjs --check` to verify heading dates, chronological order, and the cap.
+2. Immediately run `node scripts/trim-session-log.mjs` in the same change. CI caps the log at 60; default trim keeps 40. Use `node scripts/trim-session-log.mjs --check` for empty entries, heading dates, order, and the cap.
 3. Update `.ai/features.json` if anything changed:
    ```bash
    node scripts/features.mjs pass <feature-id>

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -64,7 +64,7 @@ function usage() {
     '',
     'Keeps the latest session entries, where each entry starts with a markdown "## " heading.',
     'Trimmed entries are appended to the archive file so history is preserved; pass --no-archive to discard them instead.',
-    'Use --check to fail when dated entries are out of order or the source has more entries than the check cap.',
+    'Use --check to fail when entries are empty, dated entries are out of order, or the source has more entries than the check cap.',
   ].join('\n')
 }
 
@@ -102,6 +102,18 @@ function assertDatedEntries(entries, source) {
     throw new Error(
       `${source} entry headings must start with a valid ISO date (YYYY-MM-DD); found: ${heading}`,
     )
+  }
+}
+
+function assertNonEmptyEntries(entries, source) {
+  const emptyEntry = entries.find((entry) => {
+    const [, ...bodyLines] = entry.split('\n')
+    return bodyLines.join('\n').trim().length === 0
+  })
+
+  if (emptyEntry) {
+    const heading = emptyEntry.split('\n', 1)[0]
+    throw new Error(`${source} entries must include content after the heading; found: ${heading}`)
   }
 }
 
@@ -147,7 +159,7 @@ function buildSessionLog(entries) {
     '- Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.',
     '- Start each entry heading with a valid ISO date (`## YYYY-MM-DD ...`) so retention can identify the latest entries.',
     '- CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.',
-    '- Use `node scripts/trim-session-log.mjs --check` to verify the log is chronological and within the 60-entry cap.',
+    '- Use `node scripts/trim-session-log.mjs --check` to reject empty entries and verify the log is chronological and within the 60-entry cap.',
     '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
     '- The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.',
     '- Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.',
@@ -199,6 +211,7 @@ function trimSessionLog({ keep, source, output, archive }) {
   }
 
   assertDatedEntries(entries, source)
+  assertNonEmptyEntries(entries, source)
   const orderedEntries = orderEntriesChronologically(entries)
   const retainedEntries = orderedEntries.slice(-keep)
   const removedEntries = orderedEntries.slice(0, orderedEntries.length - retainedEntries.length)
@@ -238,6 +251,7 @@ function checkSessionLog({ maxEntries, source }) {
   }
 
   assertDatedEntries(entries, source)
+  assertNonEmptyEntries(entries, source)
   if (!entriesAreChronological(entries)) {
     throw new Error(
       `${source} dated entries are not in chronological order; run node scripts/trim-session-log.mjs to repair the order.`,

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -125,7 +125,7 @@ describe('AI startup docs', () => {
     expect(sessionLog).toContain('valid ISO date (`## YYYY-MM-DD ...`)')
     expect(sessionLog).toContain('node scripts/trim-session-log.mjs --check')
     expect(startHere).toContain('valid ISO-date heading (`## YYYY-MM-DD ...`)')
-    expect(startHere).toContain('verify heading dates, chronological order, and the cap')
+    expect(startHere).toContain('empty entries, heading dates, order, and the cap')
     expect(entryCount).toBeGreaterThan(0)
     if (entryCount > 60) {
       throw new Error(

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -152,6 +152,46 @@ describe('trim-session-log script', () => {
     }
   })
 
+  it('rejects empty entries without writing output', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-empty-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const source = [
+        '# Pika Session Log',
+        '',
+        '## 2026-08-01 - Empty entry',
+        '',
+        '## 2026-08-02 - Valid entry',
+        'completed work',
+        '',
+      ].join('\n')
+
+      writeFileSync(sourcePath, source)
+
+      const commands = [
+        ['--check', '--source', sourcePath],
+        ['--source', sourcePath, '--output', outputPath, '--no-archive'],
+      ]
+
+      for (const args of commands) {
+        const result = spawnSync('node', [scriptPath, ...args], {
+          cwd: repoRoot,
+          encoding: 'utf8',
+        })
+
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('entries must include content after the heading')
+        expect(result.stderr).toContain('## 2026-08-01 - Empty entry')
+        expect(readFileSync(sourcePath, 'utf8')).toBe(source)
+        expect(existsSync(outputPath)).toBe(false)
+      }
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('defaults to compacting below the CI cap', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-buffer-'))
 


### PR DESCRIPTION
## Summary
- reject empty session-log entries in both trim and check modes
- align startup guidance and remove the known empty duplicate heading
- add dedicated regression coverage proving malformed logs do not write output

## Companion local configuration
The Pika E2E and simplification automation prompts were updated outside the repository to create a named branch before edits when started on detached HEAD. The workflow-friction review automation also gained an absolute memory-path fallback. Existing automation `cwds` were intentionally retained.

## Risk
- Profile: workspace-state
- No application runtime, schema, auth, or production behavior changes

## Validation
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts` (51 tests)
- `pnpm test` (468 files, 4,049 tests)
- `pnpm lint`
- `node scripts/trim-session-log.mjs --check`
- parsed all three edited automation TOML files
- `git diff --check`