### PR TITLE
Harden Pal delivery release readiness

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17333,3 +17333,30 @@ concurrent activation, and Classroom/Blueprint ownership boundaries.
 **Remaining:**
 - Push the approved extra correction, require complete database fixture CI,
   and run the final cumulative integration review.
+
+<!-- pika-session-log-archive-batch:18dcf003dbc4e93548d0689482bbd3913f0282e6706dc8339d4d1a6fea3e534c -->
+## 2026-08-02 — Closed compatibility cleanup authority gap
+
+**Risk profile:** high — rolling cleanup compatibility and exact-path Storage
+write/delete serialization.
+
+**Completed:**
+- Made legacy cleanup rows opportunistically bind exact registered managed
+  identities during compatibility rollout while leaving unmatched raw-only rows
+  on their migration-116 behavior.
+- Mirrored managed cleanup leases, retries, and terminal tombstones in both
+  protocol modes, and fenced all exact-path Storage updates while such a lease
+  is active.
+- Added a real compatibility-mode claim, overwrite rejection, delete,
+  completion, tombstone, and readiness fixture; corrected the fixture's
+  submission-requirement column to the deployed `label` schema.
+- Kept generic cleanup enforcement-only, migration 117 unapplied outside
+  disposable CI, permanent deletion unavailable, and PR #963 unchanged.
+
+**Validation:**
+- Pending focused checks, disposable CI replay/fixture, and final targeted
+  independent review.
+
+**Remaining:**
+- Publish the correction after local static checks, require green PR CI, and
+  complete the approved targeted review.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1111,11 +1111,13 @@ concurrency, outage recovery, and production release evidence.
 - Closed independent-review gaps by emitting sanitized error-category drain
   telemetry, reserving a 60-second cron execution budget, and replacing timing
   assumptions with database-observed claim and lock contention gates.
+- Bounded the complete drain path across claims, delivery transitions, and the
+  final count, and made ready-backlog age use the actual retry/lease-ready time.
 - Confirmed read-only that the current production adapter is enabled and has
   delivered events; no Pal code, Pal PR #50, migration, or production data was
   changed by the readiness implementation.
 
 **Validation:**
-- Full Vitest passed (475 files, 4,100 tests), plus TypeScript, lint,
+- Full Vitest passed (475 files, 4,101 tests), plus TypeScript, lint,
   architecture/design/UI policy checks, Pika audit, production build, both
   real-database/HTTP Pal harnesses, continuity validation, and diff checks.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1113,6 +1113,8 @@ concurrency, outage recovery, and production release evidence.
   assumptions with database-observed claim and lock contention gates.
 - Bounded the complete drain path across claims, delivery transitions, and the
   final count, and made ready-backlog age use the actual retry/lease-ready time.
+- Classified both direct and PostgREST-wrapped abort/timeout failures as the
+  sanitized `deadline` drain outcome.
 - Confirmed read-only that the current production adapter is enabled and has
   delivered events; no Pal code, Pal PR #50, migration, or production data was
   changed by the readiness implementation.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1108,11 +1108,14 @@ concurrency, outage recovery, and production release evidence.
 - Added a loopback-only HTTP recovery smoke that persists a 503 retry, restores
   the peer, delivers the queued event once with the same idempotency key, and
   removes its synthetic fixture.
+- Closed independent-review gaps by emitting sanitized error-category drain
+  telemetry, reserving a 60-second cron execution budget, and replacing timing
+  assumptions with database-observed claim and lock contention gates.
 - Confirmed read-only that the current production adapter is enabled and has
   delivered events; no Pal code, Pal PR #50, migration, or production data was
   changed by the readiness implementation.
 
 **Validation:**
-- Full Vitest passed (475 files, 4,096 tests), plus TypeScript, lint,
+- Full Vitest passed (475 files, 4,100 tests), plus TypeScript, lint,
   architecture/design/UI policy checks, Pika audit, production build, both
   real-database/HTTP Pal harnesses, continuity validation, and diff checks.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,32 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-02 — Closed compatibility cleanup authority gap
-
-**Risk profile:** high — rolling cleanup compatibility and exact-path Storage
-write/delete serialization.
-
-**Completed:**
-- Made legacy cleanup rows opportunistically bind exact registered managed
-  identities during compatibility rollout while leaving unmatched raw-only rows
-  on their migration-116 behavior.
-- Mirrored managed cleanup leases, retries, and terminal tombstones in both
-  protocol modes, and fenced all exact-path Storage updates while such a lease
-  is active.
-- Added a real compatibility-mode claim, overwrite rejection, delete,
-  completion, tombstone, and readiness fixture; corrected the fixture's
-  submission-requirement column to the deployed `label` schema.
-- Kept generic cleanup enforcement-only, migration 117 unapplied outside
-  disposable CI, permanent deletion unavailable, and PR #963 unchanged.
-
-**Validation:**
-- Pending focused checks, disposable CI replay/fixture, and final targeted
-  independent review.
-
-**Remaining:**
-- Publish the correction after local static checks, require green PR CI, and
-  complete the approved targeted review.
-
 ## 2026-08-03 — Preserved live references during cleanup cancellation
 
 **Risk profile:** high — migration-116 worker compatibility, cleanup lease
@@ -1119,3 +1093,26 @@ state refresh behavior.
 **Validation:**
 - Full Vitest passed (473 files, 4,093 tests), plus TypeScript, lint,
   architecture/UI policy checks, production build, and diff checks.
+
+## 2026-08-08 — Harden Pal delivery release readiness
+
+**Risk profile:** runtime-platform — delivery telemetry, PostgreSQL claim
+concurrency, outage recovery, and production release evidence.
+
+**Completed:**
+- Added privacy-safe structured logs for immediate delivery and daily outbox
+  drains, plus protected ready/retry/expired-lease/backlog-age and recent
+  delivery-latency metrics.
+- Added an ephemeral PostgreSQL concurrency harness proving one claim winner
+  for pending and expired batch and targeted claims.
+- Added a loopback-only HTTP recovery smoke that persists a 503 retry, restores
+  the peer, delivers the queued event once with the same idempotency key, and
+  removes its synthetic fixture.
+- Confirmed read-only that the current production adapter is enabled and has
+  delivered events; no Pal code, Pal PR #50, migration, or production data was
+  changed by the readiness implementation.
+
+**Validation:**
+- Full Vitest passed (475 files, 4,096 tests), plus TypeScript, lint,
+  architecture/design/UI policy checks, Pika audit, production build, both
+  real-database/HTTP Pal harnesses, continuity validation, and diff checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Check generated database types
         run: pnpm run db:types:check
 
+      - name: Verify Pal outbox claim concurrency and lease recovery
+        run: bash scripts/check-pal-outbox-concurrency.sh
+
+      - name: Verify Pal HTTP outage and queued recovery
+        run: pnpm run smoke:pal-delivery-recovery
+
       - name: Verify atomic assignment feedback returns
         run: bash scripts/check-atomic-assignment-feedback-returns.sh
 

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -175,6 +175,10 @@ drain queued delivery failures and backlog. It processes up to 10 batches of
 stop reason, and the number of rows still ready, so capacity exhaustion is
 visible rather than silently deferred for a day.
 
+The worker budget covers database claims, Pal requests, delivery-state
+transitions, and the final ready count. A hard caller deadline still returns a
+sanitized `deadline` telemetry outcome if an adapter ignores cancellation.
+
 Each batch uses at most 10 concurrent deliveries. Network attempts are bounded
 by the worker's remaining deadline, which stays well inside the 60-second row
 lease so an overlapping worker cannot reclaim a slow in-flight batch.
@@ -184,8 +188,9 @@ The same credential protects the focused outbox operations:
 - `GET /api/cron/pal-outbox` — counts plus up to 25 privacy-safe pending or
   failed summaries; no payloads or learner/source IDs. Its `observability`
   block reports the exact ready and retrying counts, expired leases, oldest
-  ready age, and p50/p95/max end-to-end delivery latency from up to the latest
-  500 deliveries in the previous 24 hours.
+  ready age measured from `next_attempt_at` or an expired `lease_expires_at`,
+  and p50/p95/max end-to-end delivery latency from up to the latest 500
+  deliveries in the previous 24 hours.
 - `POST /api/cron/pal-outbox` — deliver one bounded batch.
 - `PATCH /api/cron/pal-outbox` with `{ "outbox_id": "<uuid>" }` — explicitly
   requeue a retained non-retryable row after its cause is corrected.

--- a/docs/integrations/pal-achievements-pilot.md
+++ b/docs/integrations/pal-achievements-pilot.md
@@ -182,10 +182,21 @@ lease so an overlapping worker cannot reclaim a slow in-flight batch.
 The same credential protects the focused outbox operations:
 
 - `GET /api/cron/pal-outbox` — counts plus up to 25 privacy-safe pending or
-  failed summaries; no payloads or learner/source IDs.
+  failed summaries; no payloads or learner/source IDs. Its `observability`
+  block reports the exact ready and retrying counts, expired leases, oldest
+  ready age, and p50/p95/max end-to-end delivery latency from up to the latest
+  500 deliveries in the previous 24 hours.
 - `POST /api/cron/pal-outbox` — deliver one bounded batch.
 - `PATCH /api/cron/pal-outbox` with `{ "outbox_id": "<uuid>" }` — explicitly
   requeue a retained non-retryable row after its cause is corrected.
+
+Immediate attempts emit one privacy-safe structured `[pal-delivery]` log with
+delivery mode, event type, outcome, and duration. Daily recovery emits one
+`[pal-outbox-drain]` log with claimed, delivered, retrying, non-retryable,
+remaining-ready, stop-reason, and duration fields. These logs deliberately omit
+idempotency keys, learner IDs, source IDs, payloads, and error bodies. Use the
+protected status endpoint for current backlog and retained error-code detail;
+use the structured logs for latency and outcome trends in Vercel.
 
 Batch delivery rows use leases and `FOR UPDATE SKIP LOCKED`; targeted delivery
 uses a conditional pending-row update with the same lease fields. Overlapping
@@ -252,7 +263,17 @@ pnpm exec vitest run \
 pnpm exec tsc --noEmit
 pnpm check:architecture
 pnpm check:ui-policy
+bash scripts/check-pal-outbox-concurrency.sh
+pnpm run smoke:pal-delivery-recovery
 ```
+
+The PostgreSQL harness creates and drops a disposable database, replays the
+current migrations, and proves that two concurrent workers produce exactly one
+winner for pending and expired batch claims as well as the conditional UPDATE
+used by targeted delivery. The recovery smoke command refuses non-loopback
+Supabase targets, creates one synthetic fixture, receives a real HTTP 503,
+proves durable retry evidence, restores the local HTTP peer, drains the queued
+event once with the same idempotency key, and removes the fixture.
 
 Then run a real pilot vertical slice only after Pal's prerequisites exist:
 
@@ -267,3 +288,11 @@ Then run a real pilot vertical slice only after Pal's prerequisites exist:
    succeeds while the event remains queued.
 6. Restore Pal, run the delivery worker, and confirm the queued fact is applied
    once.
+
+Do not deliberately interrupt the production Pal service to perform step 5.
+Use the guarded local recovery smoke for the outage path. In a deployed pilot,
+verify the success path with a dedicated or already-authorized learner account,
+then inspect the protected status endpoint and `[pal-delivery]` log for the same
+time window. Production verification must not create a testing backdoor, expose
+integration credentials to a preview, or reuse a real learner's identity as a
+fixture.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eval:grading-reviews": "tsx scripts/summarize-grading-reviews.ts",
     "eval:test-ai-grading-gold-set": "tsx scripts/eval-test-ai-grading-gold-set.ts",
     "smoke:gradex": "tsx scripts/gradex-smoke.ts",
+    "smoke:pal-delivery-recovery": "tsx scripts/check-pal-delivery-recovery.ts",
     "docs:sync:test-markdown": "tsx scripts/sync-test-markdown-docs.ts",
     "e2e:install": "playwright install",
     "e2e:auth": "playwright test e2e/auth.setup.ts",

--- a/scripts/check-pal-delivery-recovery.ts
+++ b/scripts/check-pal-delivery-recovery.ts
@@ -1,0 +1,210 @@
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { createClient } from '@supabase/supabase-js'
+import { parse } from 'dotenv'
+
+import { buildSessionStartedEvent } from '@/lib/server/pal-events'
+import {
+  attemptImmediatePalEventDelivery,
+  deliverPalOutboxBatch,
+  enqueueStandalonePalEvent,
+} from '@/lib/server/pal-outbox'
+import type { Database } from '@/types/database'
+
+function requireLocalSupabase() {
+  const status = parse(execFileSync(
+    'supabase',
+    ['status', '-o', 'env'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  ))
+  const apiUrl = status.API_URL
+  const serviceRoleKey = status.SERVICE_ROLE_KEY
+  if (!apiUrl || !serviceRoleKey) {
+    throw new Error('Local Supabase API URL or service-role key is unavailable')
+  }
+  const url = new URL(apiUrl)
+  if (
+    url.protocol !== 'http:'
+    || (url.hostname !== '127.0.0.1' && url.hostname !== 'localhost')
+  ) {
+    throw new Error('Pal recovery smoke test refuses non-loopback Supabase targets')
+  }
+  return { apiUrl: url.origin, serviceRoleKey }
+}
+
+function localDatabaseContainer(): string {
+  const name = execFileSync(
+    'docker',
+    ['ps', '--filter', 'name=^supabase_db_pika$', '--format', '{{.Names}}'],
+    { encoding: 'utf8' },
+  ).trim()
+  if (name !== 'supabase_db_pika') {
+    throw new Error('Expected the local supabase_db_pika container')
+  }
+  return name
+}
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+async function main(): Promise<void> {
+  const { apiUrl, serviceRoleKey } = requireLocalSupabase()
+  const databaseContainer = localDatabaseContainer()
+  const supabase = createClient<Database>(apiUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const fixtureId = randomUUID()
+  const studentId = randomUUID()
+  const email = `pal-recovery-${fixtureId}@example.invalid`
+  const sourceId = `pal-recovery-${fixtureId}`
+  const integrationSecret = 'pal-recovery-integration-secret-32-characters'
+  const pseudonymSecret = 'pal-recovery-pseudonym-secret-32-characters-long'
+  const event = buildSessionStartedEvent({
+    learnerId: studentId,
+    sessionId: sourceId,
+    occurredAt: new Date(),
+    pseudonymSecret,
+  })
+  let fixtureCreated = false
+  let palAvailable = false
+  const receivedKeys: string[] = []
+  const server = createServer((request, response) => {
+    if (
+      request.method !== 'POST'
+      || request.url !== '/api/v1/events'
+      || request.headers.authorization !== `Bearer ${integrationSecret}`
+    ) {
+      request.resume()
+      response.writeHead(404).end()
+      return
+    }
+
+    let body = ''
+    request.setEncoding('utf8')
+    request.on('data', (chunk) => { body += chunk })
+    request.on('end', () => {
+      const payload = JSON.parse(body) as { idempotency_key?: unknown }
+      if (typeof payload.idempotency_key === 'string') {
+        receivedKeys.push(payload.idempotency_key)
+      }
+      if (!palAvailable) {
+        response.writeHead(503, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify({ status: 503 }))
+        return
+      }
+      response.writeHead(204).end()
+    })
+  })
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address() as AddressInfo
+    process.env.PAL_ENABLED = 'true'
+    process.env.PAL_API_URL = `http://127.0.0.1:${address.port}`
+    process.env.PAL_INTEGRATION_SECRET = integrationSecret
+    process.env.PAL_PSEUDONYM_SECRET = pseudonymSecret
+
+    const { error: userError } = await supabase.from('users').insert({
+      id: studentId,
+      email,
+      role: 'student',
+      email_verified_at: new Date().toISOString(),
+    })
+    if (userError) throw new Error(`Failed to create recovery fixture user: ${userError.message}`)
+    fixtureCreated = true
+
+    await enqueueStandalonePalEvent({
+      studentId,
+      sourceKind: 'pal_recovery_fixture',
+      sourceId,
+      event,
+      supabase,
+    })
+
+    const immediate = await attemptImmediatePalEventDelivery({ event, supabase })
+    if (immediate !== 'pending') {
+      throw new Error(`Unavailable Pal did not leave the event pending: ${immediate}`)
+    }
+    const { data: failedRow, error: failedError } = await supabase
+      .from('pal_event_outbox')
+      .select('status, attempts, last_error_code')
+      .eq('idempotency_key', event.idempotency_key)
+      .single()
+    if (failedError) throw new Error(`Failed to read retry evidence: ${failedError.message}`)
+    if (
+      failedRow.status !== 'pending'
+      || failedRow.attempts !== 1
+      || failedRow.last_error_code !== 'http_503'
+    ) {
+      throw new Error('Unavailable Pal did not persist the expected retry evidence')
+    }
+
+    const { error: readyError } = await supabase
+      .from('pal_event_outbox')
+      .update({ next_attempt_at: '1900-01-01T00:00:00.000Z' })
+      .eq('idempotency_key', event.idempotency_key)
+    if (readyError) throw new Error(`Failed to ready recovery fixture: ${readyError.message}`)
+
+    palAvailable = true
+    const recovery = await deliverPalOutboxBatch({
+      supabase,
+      limit: 1,
+      concurrency: 1,
+    })
+    if (recovery.delivered !== 1 || recovery.retrying !== 0) {
+      throw new Error(`Queued recovery did not deliver exactly once: ${JSON.stringify(recovery)}`)
+    }
+    const { data: deliveredRow, error: deliveredError } = await supabase
+      .from('pal_event_outbox')
+      .select('status, attempts, delivered_at')
+      .eq('idempotency_key', event.idempotency_key)
+      .single()
+    if (deliveredError) throw new Error(`Failed to read delivery evidence: ${deliveredError.message}`)
+    if (
+      deliveredRow.status !== 'delivered'
+      || deliveredRow.attempts !== 2
+      || deliveredRow.delivered_at === null
+      || receivedKeys.length !== 2
+      || receivedKeys.some((key) => key !== event.idempotency_key)
+    ) {
+      throw new Error('Queued Pal event was not recovered exactly once with one stable key')
+    }
+
+    console.info('[pal-recovery-smoke]', JSON.stringify({
+      immediate: 'pending',
+      recovery: 'delivered',
+      attempts: deliveredRow.attempts,
+      stable_idempotency_key: true,
+    }))
+  } finally {
+    await closeServer(server)
+    if (fixtureCreated) {
+      const cleanupSql = `
+        delete from public.pal_event_outbox
+        where idempotency_key = '${event.idempotency_key}';
+        delete from public.users
+        where id = '${studentId}' and email = '${email}';
+      `
+      execFileSync(
+        'docker',
+        ['exec', databaseContainer, 'psql', '-U', 'postgres', '-d', 'postgres', '-X', '-v', 'ON_ERROR_STOP=1', '-c', cleanupSql],
+        { stdio: 'ignore' },
+      )
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : 'Pal recovery smoke test failed')
+  process.exitCode = 1
+})

--- a/scripts/check-pal-outbox-concurrency.sh
+++ b/scripts/check-pal-outbox-concurrency.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+DB_CONTAINER="$(docker ps --filter 'name=^supabase_db_pika$' --format '{{.Names}}' | head -n 1)"
+if [[ -z "$DB_CONTAINER" ]]; then
+  DB_CONTAINER="$(docker ps --filter 'name=supabase_db_' --format '{{.Names}}' | head -n 1)"
+fi
+if [[ -z "$DB_CONTAINER" ]]; then
+  echo "Local Supabase database container is not running." >&2
+  exit 1
+fi
+
+TMP_DB="${PAL_OUTBOX_CONCURRENCY_DATABASE_NAME:-pika_pal_outbox_concurrency_${RANDOM}_$$}"
+cleanup() {
+  if [[ "${KEEP_PAL_OUTBOX_CONCURRENCY_DATABASE:-false}" == "true" ]]; then
+    echo "Kept disposable Pal outbox database: $TMP_DB"
+    return
+  fi
+  docker exec "$DB_CONTAINER" dropdb -U postgres --if-exists "$TMP_DB" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker exec "$DB_CONTAINER" createdb -U postgres "$TMP_DB"
+docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c '
+  drop schema public;
+  create schema extensions;
+  create extension "uuid-ossp" with schema extensions;
+  create extension pgcrypto with schema extensions;
+  create extension pg_stat_statements with schema extensions;
+  create schema vault;
+  create extension supabase_vault with schema vault;
+  create extension pg_net with schema extensions;
+' >/dev/null
+
+docker exec "$DB_CONTAINER" pg_dump -U postgres -d postgres --schema-only --no-owner --no-privileges \
+  --schema=public --schema=private --schema=auth --schema=storage \
+  | sed '/^SET log_min_messages =/d; /^CREATE SCHEMA extensions;/d; /^CREATE SCHEMA vault;/d' \
+  | docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+set client_min_messages = warning;
+do $$
+declare
+  v_policy record;
+begin
+  for v_policy in
+    select schemaname, tablename, policyname
+    from pg_policies
+    where schemaname = 'storage'
+  loop
+    execute format(
+      'drop policy %I on %I.%I',
+      v_policy.policyname,
+      v_policy.schemaname,
+      v_policy.tablename
+    );
+  end loop;
+end;
+$$;
+drop schema public cascade;
+drop schema private cascade;
+create schema public;
+SQL
+
+for migration in "$ROOT"/supabase/migrations/*.sql; do
+  docker exec -e PGOPTIONS='-c client_min_messages=warning' -i "$DB_CONTAINER" \
+    psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+    < "$migration" >/dev/null
+done
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+create table public.pal_outbox_concurrency_evidence (
+  scenario text not null,
+  worker text not null,
+  claimed integer not null,
+  primary key (scenario, worker)
+);
+
+insert into public.users (id, email, role, email_verified_at) values (
+  '7a100000-0000-4000-8000-000000000001',
+  'pal-concurrency-student@example.invalid',
+  'student',
+  clock_timestamp()
+);
+
+insert into public.pal_event_outbox (
+  id, idempotency_key, student_id, event_type, source_kind, source_id,
+  payload, status, attempts, next_attempt_at, lease_token, lease_expires_at
+)
+select
+  fixture.id,
+  fixture.idempotency_key,
+  '7a100000-0000-4000-8000-000000000001'::uuid,
+  'platform.session.started',
+  'pal_concurrency_fixture',
+  fixture.source_id,
+  jsonb_build_object(
+    'schema_version', 1,
+    'idempotency_key', fixture.idempotency_key,
+    'learner_id', 'lrn-pal-concurrency-fixture',
+    'event_type', 'platform.session.started',
+    'occurred_at', '2026-08-08T12:00:00.000Z',
+    'metadata', '{}'::jsonb
+  ),
+  'non_retryable',
+  0,
+  clock_timestamp() + interval '1 day',
+  null,
+  null
+from (values
+  ('7a100000-0000-4000-8000-000000000011'::uuid, 'pika:pal-concurrency:batch-pending', 'batch-pending'),
+  ('7a100000-0000-4000-8000-000000000012'::uuid, 'pika:pal-concurrency:batch-expired', 'batch-expired'),
+  ('7a100000-0000-4000-8000-000000000013'::uuid, 'pika:pal-concurrency:targeted-pending', 'targeted-pending'),
+  ('7a100000-0000-4000-8000-000000000014'::uuid, 'pika:pal-concurrency:targeted-expired', 'targeted-expired')
+) as fixture(id, idempotency_key, source_id);
+SQL
+
+# Two batch workers compete for one pending row. The first holds the row lock;
+# SKIP LOCKED must make the second worker claim nothing.
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+update public.pal_event_outbox
+set status = 'pending', attempts = 0, next_attempt_at = clock_timestamp() - interval '1 minute'
+where id = '7a100000-0000-4000-8000-000000000011';
+SQL
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+begin;
+with claimed as (
+  select id from public.claim_pal_event_outbox(1, 60)
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'batch_pending', 'a', count(*) from claimed;
+select pg_sleep(1);
+commit;
+SQL
+BATCH_PENDING_A_PID=$!
+sleep 0.2
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'batch_pending', 'b', count(*)
+from public.claim_pal_event_outbox(1, 60);
+SQL
+BATCH_PENDING_B_PID=$!
+wait "$BATCH_PENDING_A_PID"
+wait "$BATCH_PENDING_B_PID"
+
+# The same batch race must reclaim one expired processing lease exactly once.
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+update public.pal_event_outbox
+set status = 'processing', attempts = 1,
+    lease_token = '7a100000-0000-4000-8000-000000000030',
+    lease_expires_at = clock_timestamp() - interval '1 minute'
+where id = '7a100000-0000-4000-8000-000000000012';
+SQL
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+begin;
+with claimed as (
+  select id from public.claim_pal_event_outbox(1, 60)
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'batch_expired', 'a', count(*) from claimed;
+select pg_sleep(1);
+commit;
+SQL
+BATCH_EXPIRED_A_PID=$!
+sleep 0.2
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'batch_expired', 'b', count(*)
+from public.claim_pal_event_outbox(1, 60);
+SQL
+BATCH_EXPIRED_B_PID=$!
+wait "$BATCH_EXPIRED_A_PID"
+wait "$BATCH_EXPIRED_B_PID"
+
+# Reproduce the PostgREST conditional UPDATE used by targeted immediate
+# delivery. PostgreSQL must recheck the predicates after the row lock clears,
+# so only one competing request can claim a pending row.
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+update public.pal_event_outbox
+set status = 'pending', attempts = 0, next_attempt_at = clock_timestamp() - interval '1 minute'
+where id = '7a100000-0000-4000-8000-000000000013';
+SQL
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+begin;
+with claimed as (
+  update public.pal_event_outbox
+  set status = 'processing', attempts = attempts + 1,
+      lease_token = '7a100000-0000-4000-8000-000000000031',
+      lease_expires_at = clock_timestamp() + interval '1 minute'
+  where id = '7a100000-0000-4000-8000-000000000013'
+    and status = 'pending' and attempts = 0
+    and next_attempt_at <= clock_timestamp()
+  returning id
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'targeted_pending', 'a', count(*) from claimed;
+select pg_sleep(1);
+commit;
+SQL
+TARGETED_PENDING_A_PID=$!
+sleep 0.2
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+with claimed as (
+  update public.pal_event_outbox
+  set status = 'processing', attempts = attempts + 1,
+      lease_token = '7a100000-0000-4000-8000-000000000032',
+      lease_expires_at = clock_timestamp() + interval '1 minute'
+  where id = '7a100000-0000-4000-8000-000000000013'
+    and status = 'pending' and attempts = 0
+    and next_attempt_at <= clock_timestamp()
+  returning id
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'targeted_pending', 'b', count(*) from claimed;
+SQL
+TARGETED_PENDING_B_PID=$!
+wait "$TARGETED_PENDING_A_PID"
+wait "$TARGETED_PENDING_B_PID"
+
+# Targeted delivery must apply the same compare-and-swap rule when reclaiming
+# an expired processing lease.
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+update public.pal_event_outbox
+set status = 'processing', attempts = 1,
+    lease_token = '7a100000-0000-4000-8000-000000000033',
+    lease_expires_at = clock_timestamp() - interval '1 minute'
+where id = '7a100000-0000-4000-8000-000000000014';
+SQL
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+begin;
+with claimed as (
+  update public.pal_event_outbox
+  set status = 'processing', attempts = attempts + 1,
+      lease_token = '7a100000-0000-4000-8000-000000000034',
+      lease_expires_at = clock_timestamp() + interval '1 minute'
+  where id = '7a100000-0000-4000-8000-000000000014'
+    and status = 'processing' and attempts = 1
+    and lease_expires_at <= clock_timestamp()
+  returning id
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'targeted_expired', 'a', count(*) from claimed;
+select pg_sleep(1);
+commit;
+SQL
+TARGETED_EXPIRED_A_PID=$!
+sleep 0.2
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+with claimed as (
+  update public.pal_event_outbox
+  set status = 'processing', attempts = attempts + 1,
+      lease_token = '7a100000-0000-4000-8000-000000000035',
+      lease_expires_at = clock_timestamp() + interval '1 minute'
+  where id = '7a100000-0000-4000-8000-000000000014'
+    and status = 'processing' and attempts = 1
+    and lease_expires_at <= clock_timestamp()
+  returning id
+)
+insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
+select 'targeted_expired', 'b', count(*) from claimed;
+SQL
+TARGETED_EXPIRED_B_PID=$!
+wait "$TARGETED_EXPIRED_A_PID"
+wait "$TARGETED_EXPIRED_B_PID"
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+do $$
+declare
+  v_scenario text;
+begin
+  foreach v_scenario in array array[
+    'batch_pending', 'batch_expired', 'targeted_pending', 'targeted_expired'
+  ] loop
+    if (select sum(claimed) from public.pal_outbox_concurrency_evidence
+        where scenario = v_scenario) <> 1
+      or (select count(*) from public.pal_outbox_concurrency_evidence
+          where scenario = v_scenario and claimed = 1) <> 1
+      or (select count(*) from public.pal_outbox_concurrency_evidence
+          where scenario = v_scenario and claimed = 0) <> 1 then
+      raise exception 'Pal outbox scenario % did not have exactly one claim winner', v_scenario;
+    end if;
+  end loop;
+
+  if (select attempts from public.pal_event_outbox
+      where id = '7a100000-0000-4000-8000-000000000011') <> 1
+    or (select attempts from public.pal_event_outbox
+      where id = '7a100000-0000-4000-8000-000000000012') <> 2
+    or (select attempts from public.pal_event_outbox
+      where id = '7a100000-0000-4000-8000-000000000013') <> 1
+    or (select attempts from public.pal_event_outbox
+      where id = '7a100000-0000-4000-8000-000000000014') <> 2 then
+    raise exception 'Pal outbox attempts did not advance exactly once per winning claim';
+  end if;
+
+  if exists (
+    select 1 from public.pal_event_outbox
+    where id in (
+      '7a100000-0000-4000-8000-000000000011',
+      '7a100000-0000-4000-8000-000000000012',
+      '7a100000-0000-4000-8000-000000000013',
+      '7a100000-0000-4000-8000-000000000014'
+    ) and (
+      status <> 'processing'
+      or lease_token is null
+      or lease_expires_at <= clock_timestamp()
+    )
+  ) then
+    raise exception 'Winning Pal outbox claims did not own active processing leases';
+  end if;
+end;
+$$;
+SQL
+
+echo "Pal outbox PostgreSQL concurrency checks passed."

--- a/scripts/check-pal-outbox-concurrency.sh
+++ b/scripts/check-pal-outbox-concurrency.sh
@@ -22,6 +22,63 @@ cleanup() {
 }
 trap cleanup EXIT
 
+wait_for_worker_lock() {
+  local application_name="$1"
+  local observed=""
+
+  for _ in {1..100}; do
+    observed="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc "
+      select exists (
+        select 1
+        from pg_stat_activity
+        where datname = '$TMP_DB'
+          and application_name = '$application_name'
+          and state = 'active'
+          and wait_event = 'PgSleep'
+      );
+    ")"
+    if [[ "$observed" == "t" ]]; then
+      return
+    fi
+    sleep 0.05
+  done
+
+  echo "Worker $application_name did not acquire its claim before the contention check." >&2
+  return 1
+}
+
+wait_for_worker_contention() {
+  local application_name="$1"
+  local observed=""
+
+  for _ in {1..100}; do
+    observed="$(docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -Atc "
+      select exists (
+        select 1
+        from pg_stat_activity
+        where datname = '$TMP_DB'
+          and application_name = '$application_name'
+          and state = 'active'
+          and wait_event_type = 'Lock'
+      );
+    ")"
+    if [[ "$observed" == "t" ]]; then
+      return
+    fi
+    sleep 0.05
+  done
+
+  echo "Worker $application_name did not contend on the claimed row." >&2
+  return 1
+}
+
+release_worker() {
+  local scenario="$1"
+  docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 \
+    -c "update public.pal_outbox_concurrency_gate set released = true where scenario = '$scenario'" \
+    >/dev/null
+}
+
 docker exec "$DB_CONTAINER" createdb -U postgres "$TMP_DB"
 docker exec "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 -c '
   drop schema public;
@@ -78,6 +135,17 @@ create table public.pal_outbox_concurrency_evidence (
   primary key (scenario, worker)
 );
 
+create table public.pal_outbox_concurrency_gate (
+  scenario text primary key,
+  released boolean not null default false
+);
+
+insert into public.pal_outbox_concurrency_gate (scenario) values
+  ('batch_pending'),
+  ('batch_expired'),
+  ('targeted_pending'),
+  ('targeted_expired');
+
 insert into public.users (id, email, role, email_verified_at) values (
   '7a100000-0000-4000-8000-000000000001',
   'pal-concurrency-student@example.invalid',
@@ -124,26 +192,36 @@ update public.pal_event_outbox
 set status = 'pending', attempts = 0, next_attempt_at = clock_timestamp() - interval '1 minute'
 where id = '7a100000-0000-4000-8000-000000000011';
 SQL
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+docker exec -e PGAPPNAME=pal_batch_pending_a -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 begin;
 with claimed as (
   select id from public.claim_pal_event_outbox(1, 60)
 )
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'batch_pending', 'a', count(*) from claimed;
-select pg_sleep(1);
+do $$
+begin
+  while not (select released from public.pal_outbox_concurrency_gate
+             where scenario = 'batch_pending') loop
+    perform pg_sleep(0.05);
+  end loop;
+end;
+$$;
 commit;
 SQL
 BATCH_PENDING_A_PID=$!
-sleep 0.2
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+wait_for_worker_lock pal_batch_pending_a
+docker exec -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'batch_pending', 'b', count(*)
 from public.claim_pal_event_outbox(1, 60);
 SQL
 BATCH_PENDING_B_PID=$!
-wait "$BATCH_PENDING_A_PID"
 wait "$BATCH_PENDING_B_PID"
+release_worker batch_pending
+wait "$BATCH_PENDING_A_PID"
 
 # The same batch race must reclaim one expired processing lease exactly once.
 docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
@@ -153,26 +231,36 @@ set status = 'processing', attempts = 1,
     lease_expires_at = clock_timestamp() - interval '1 minute'
 where id = '7a100000-0000-4000-8000-000000000012';
 SQL
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+docker exec -e PGAPPNAME=pal_batch_expired_a -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 begin;
 with claimed as (
   select id from public.claim_pal_event_outbox(1, 60)
 )
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'batch_expired', 'a', count(*) from claimed;
-select pg_sleep(1);
+do $$
+begin
+  while not (select released from public.pal_outbox_concurrency_gate
+             where scenario = 'batch_expired') loop
+    perform pg_sleep(0.05);
+  end loop;
+end;
+$$;
 commit;
 SQL
 BATCH_EXPIRED_A_PID=$!
-sleep 0.2
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+wait_for_worker_lock pal_batch_expired_a
+docker exec -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'batch_expired', 'b', count(*)
 from public.claim_pal_event_outbox(1, 60);
 SQL
 BATCH_EXPIRED_B_PID=$!
-wait "$BATCH_EXPIRED_A_PID"
 wait "$BATCH_EXPIRED_B_PID"
+release_worker batch_expired
+wait "$BATCH_EXPIRED_A_PID"
 
 # Reproduce the PostgREST conditional UPDATE used by targeted immediate
 # delivery. PostgreSQL must recheck the predicates after the row lock clears,
@@ -182,7 +270,8 @@ update public.pal_event_outbox
 set status = 'pending', attempts = 0, next_attempt_at = clock_timestamp() - interval '1 minute'
 where id = '7a100000-0000-4000-8000-000000000013';
 SQL
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+docker exec -e PGAPPNAME=pal_targeted_pending_a -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 begin;
 with claimed as (
   update public.pal_event_outbox
@@ -196,12 +285,20 @@ with claimed as (
 )
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'targeted_pending', 'a', count(*) from claimed;
-select pg_sleep(1);
+do $$
+begin
+  while not (select released from public.pal_outbox_concurrency_gate
+             where scenario = 'targeted_pending') loop
+    perform pg_sleep(0.05);
+  end loop;
+end;
+$$;
 commit;
 SQL
 TARGETED_PENDING_A_PID=$!
-sleep 0.2
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+wait_for_worker_lock pal_targeted_pending_a
+docker exec -e PGAPPNAME=pal_targeted_pending_b -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 with claimed as (
   update public.pal_event_outbox
   set status = 'processing', attempts = attempts + 1,
@@ -216,6 +313,8 @@ insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'targeted_pending', 'b', count(*) from claimed;
 SQL
 TARGETED_PENDING_B_PID=$!
+wait_for_worker_contention pal_targeted_pending_b
+release_worker targeted_pending
 wait "$TARGETED_PENDING_A_PID"
 wait "$TARGETED_PENDING_B_PID"
 
@@ -228,7 +327,8 @@ set status = 'processing', attempts = 1,
     lease_expires_at = clock_timestamp() - interval '1 minute'
 where id = '7a100000-0000-4000-8000-000000000014';
 SQL
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+docker exec -e PGAPPNAME=pal_targeted_expired_a -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 begin;
 with claimed as (
   update public.pal_event_outbox
@@ -242,12 +342,20 @@ with claimed as (
 )
 insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'targeted_expired', 'a', count(*) from claimed;
-select pg_sleep(1);
+do $$
+begin
+  while not (select released from public.pal_outbox_concurrency_gate
+             where scenario = 'targeted_expired') loop
+    perform pg_sleep(0.05);
+  end loop;
+end;
+$$;
 commit;
 SQL
 TARGETED_EXPIRED_A_PID=$!
-sleep 0.2
-docker exec -i "$DB_CONTAINER" psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
+wait_for_worker_lock pal_targeted_expired_a
+docker exec -e PGAPPNAME=pal_targeted_expired_b -i "$DB_CONTAINER" \
+  psql -U postgres -d "$TMP_DB" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' &
 with claimed as (
   update public.pal_event_outbox
   set status = 'processing', attempts = attempts + 1,
@@ -262,6 +370,8 @@ insert into public.pal_outbox_concurrency_evidence (scenario, worker, claimed)
 select 'targeted_expired', 'b', count(*) from claimed;
 SQL
 TARGETED_EXPIRED_B_PID=$!
+wait_for_worker_contention pal_targeted_expired_b
+release_worker targeted_expired
 wait "$TARGETED_EXPIRED_A_PID"
 wait "$TARGETED_EXPIRED_B_PID"
 

--- a/src/app/api/cron/pal-sync/route.ts
+++ b/src/app/api/cron/pal-sync/route.ts
@@ -6,6 +6,7 @@ import { syncPalWeeklyConfigurations } from '@/lib/server/pal-weekly-config'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const maxDuration = 60
 
 export const GET = withErrorHandler('GetPalPilotSync', async (request: NextRequest) => {
   const cronSecret = process.env.CRON_SECRET

--- a/src/lib/server/pal-operations.ts
+++ b/src/lib/server/pal-operations.ts
@@ -7,8 +7,12 @@ const STATUSES = ['pending', 'processing', 'delivered', 'non_retryable'] as cons
 
 export async function loadPalOutboxStatus(input: {
   supabase?: PalOperationsClient
+  now?: Date
 } = {}) {
   const supabase = input.supabase ?? getServiceRoleClient()
+  const now = input.now ?? new Date()
+  const nowIso = now.toISOString()
+  const sinceIso = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString()
   const counts: Record<(typeof STATUSES)[number], number> = {
     pending: 0,
     processing: 0,
@@ -16,33 +20,140 @@ export async function loadPalOutboxStatus(input: {
     non_retryable: 0,
   }
 
-  for (const status of STATUSES) {
-    const { count, error } = await supabase
+  const countPromises = STATUSES.map((status) => supabase
       .from('pal_event_outbox')
       .select('id', { count: 'exact', head: true })
-      .eq('status', status)
+      .eq('status', status))
+
+  const [
+    countResults,
+    exceptionsResult,
+    retryingResult,
+    expiredResult,
+    oldestPendingResult,
+    oldestExpiredResult,
+    deliveriesResult,
+    readyResult,
+  ] = await Promise.all([
+    Promise.all(countPromises),
+    supabase
+      .from('pal_event_outbox')
+      .select(
+        'id, event_type, status, attempts, next_attempt_at, last_attempt_at, last_error_code, last_error_detail, created_at, updated_at',
+      )
+      .in('status', ['pending', 'processing', 'non_retryable'])
+      .order('created_at', { ascending: true })
+      .limit(25),
+    supabase
+      .from('pal_event_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'pending')
+      .gt('attempts', 0),
+    supabase
+      .from('pal_event_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'processing')
+      .lte('lease_expires_at', nowIso),
+    supabase
+      .from('pal_event_outbox')
+      .select('created_at')
+      .eq('status', 'pending')
+      .lte('next_attempt_at', nowIso)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('pal_event_outbox')
+      .select('created_at')
+      .eq('status', 'processing')
+      .lte('lease_expires_at', nowIso)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('pal_event_outbox')
+      .select('created_at, delivered_at')
+      .eq('status', 'delivered')
+      .not('delivered_at', 'is', null)
+      .gte('delivered_at', sinceIso)
+      .order('delivered_at', { ascending: false })
+      .limit(500),
+    supabase.rpc('count_pal_event_outbox_ready'),
+  ])
+
+  for (let index = 0; index < STATUSES.length; index += 1) {
+    const status = STATUSES[index]
+    const { count, error } = countResults[index]
     if (error) {
       throw new Error(`Failed to load Pal outbox ${status} count: ${error.message}`)
     }
     counts[status] = count ?? 0
   }
 
-  const { data, error } = await supabase
-    .from('pal_event_outbox')
-    .select(
-      'id, event_type, status, attempts, next_attempt_at, last_attempt_at, last_error_code, last_error_detail, created_at, updated_at',
-    )
-    .in('status', ['pending', 'processing', 'non_retryable'])
-    .order('created_at', { ascending: true })
-    .limit(25)
-  if (error) {
-    throw new Error(`Failed to load Pal outbox exceptions: ${error.message}`)
+  const namedResults = [
+    ['exceptions', exceptionsResult],
+    ['retrying count', retryingResult],
+    ['expired lease count', expiredResult],
+    ['oldest pending row', oldestPendingResult],
+    ['oldest expired row', oldestExpiredResult],
+    ['recent delivery latency', deliveriesResult],
+    ['ready count', readyResult],
+  ] as const
+  for (const [label, result] of namedResults) {
+    if (result.error) {
+      throw new Error(`Failed to load Pal outbox ${label}: ${result.error.message}`)
+    }
+  }
+
+  const timestamp = (value: unknown): number | null => {
+    if (typeof value !== 'string') return null
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  const oldestCandidates = [
+    oldestPendingResult.data,
+    oldestExpiredResult.data,
+  ].map((row) => {
+    const createdAt = row && typeof row === 'object' && 'created_at' in row
+      ? (row as { created_at: unknown }).created_at
+      : null
+    return { value: createdAt, milliseconds: timestamp(createdAt) }
+  }).filter((candidate): candidate is { value: string; milliseconds: number } =>
+    typeof candidate.value === 'string' && candidate.milliseconds !== null)
+  oldestCandidates.sort((left, right) => left.milliseconds - right.milliseconds)
+  const oldestReadyAt = oldestCandidates[0]?.value ?? null
+  const oldestReadyMs = oldestCandidates[0]?.milliseconds ?? null
+
+  const latencies = (deliveriesResult.data ?? []).flatMap((row) => {
+    const createdAt = timestamp(row.created_at)
+    const deliveredAt = timestamp(row.delivered_at)
+    if (createdAt === null || deliveredAt === null || deliveredAt < createdAt) return []
+    return [Math.round(deliveredAt - createdAt)]
+  }).sort((left, right) => left - right)
+  const percentile = (fraction: number): number | null => {
+    if (latencies.length === 0) return null
+    return latencies[Math.max(0, Math.ceil(latencies.length * fraction) - 1)]
   }
 
   return {
     enabled: isPalEnabled(),
     counts,
-    exceptions: data ?? [],
+    observability: {
+      ready: readyResult.data ?? 0,
+      retrying: retryingResult.count ?? 0,
+      expired_leases: expiredResult.count ?? 0,
+      oldest_ready_at: oldestReadyAt,
+      oldest_ready_age_seconds: oldestReadyMs === null
+        ? null
+        : Math.max(0, Math.floor((now.getTime() - oldestReadyMs) / 1_000)),
+      delivery_latency_24h: {
+        sample_size: latencies.length,
+        p50_ms: percentile(0.5),
+        p95_ms: percentile(0.95),
+        max_ms: latencies.at(-1) ?? null,
+      },
+    },
+    exceptions: exceptionsResult.data ?? [],
   }
 }
 

--- a/src/lib/server/pal-operations.ts
+++ b/src/lib/server/pal-operations.ts
@@ -56,18 +56,18 @@ export async function loadPalOutboxStatus(input: {
       .lte('lease_expires_at', nowIso),
     supabase
       .from('pal_event_outbox')
-      .select('created_at')
+      .select('next_attempt_at')
       .eq('status', 'pending')
       .lte('next_attempt_at', nowIso)
-      .order('created_at', { ascending: true })
+      .order('next_attempt_at', { ascending: true })
       .limit(1)
       .maybeSingle(),
     supabase
       .from('pal_event_outbox')
-      .select('created_at')
+      .select('lease_expires_at')
       .eq('status', 'processing')
       .lte('lease_expires_at', nowIso)
-      .order('created_at', { ascending: true })
+      .order('lease_expires_at', { ascending: true })
       .limit(1)
       .maybeSingle(),
     supabase
@@ -110,14 +110,15 @@ export async function loadPalOutboxStatus(input: {
     const parsed = Date.parse(value)
     return Number.isFinite(parsed) ? parsed : null
   }
-  const oldestCandidates = [
-    oldestPendingResult.data,
-    oldestExpiredResult.data,
-  ].map((row) => {
-    const createdAt = row && typeof row === 'object' && 'created_at' in row
-      ? (row as { created_at: unknown }).created_at
+  const readyTimestamps = [
+    [oldestPendingResult.data, 'next_attempt_at'],
+    [oldestExpiredResult.data, 'lease_expires_at'],
+  ] as const
+  const oldestCandidates = readyTimestamps.map(([row, field]) => {
+    const readyAt = row && typeof row === 'object' && field in row
+      ? (row as Record<typeof field, unknown>)[field]
       : null
-    return { value: createdAt, milliseconds: timestamp(createdAt) }
+    return { value: readyAt, milliseconds: timestamp(readyAt) }
   }).filter((candidate): candidate is { value: string; milliseconds: number } =>
     typeof candidate.value === 'string' && candidate.milliseconds !== null)
   oldestCandidates.sort((left, right) => left.milliseconds - right.milliseconds)

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -53,6 +53,13 @@ export type PalOutboxDrainSummary = PalOutboxDeliverySummary & {
   stoppedReason: 'disabled' | 'empty' | 'drained' | 'batch_limit' | 'time_limit'
 }
 
+function emitPalTelemetry(
+  label: '[pal-delivery]' | '[pal-outbox-drain]',
+  fields: Record<string, unknown>,
+): void {
+  console.info(label, JSON.stringify(fields))
+}
+
 function retryDelayMs(attempts: number): number {
   return Math.min(30_000 * 2 ** Math.max(0, attempts - 1), 6 * 60 * 60 * 1000)
 }
@@ -410,6 +417,7 @@ export async function attemptImmediatePalEventDelivery(input: {
 
   const timeoutMs = Math.max(1, input.timeoutMs ?? 2_000)
   const clock = input.clock ?? Date.now
+  const startedAt = clock()
   const cleanupBudgetMs = Math.min(500, Math.max(1, Math.floor(timeoutMs / 4)))
   const signal = AbortSignal.timeout(Math.max(1, timeoutMs - cleanupBudgetMs))
   const transitionSignal = AbortSignal.timeout(timeoutMs)
@@ -418,8 +426,9 @@ export async function attemptImmediatePalEventDelivery(input: {
     timeoutId = setTimeout(() => resolve('pending'), timeoutMs)
   })
 
+  let result: PalImmediateDeliveryStatus
   try {
-    return await Promise.race([
+    result = await Promise.race([
       attemptImmediatePalEventDeliveryWithinDeadline({
         event: input.event,
         supabase: input.supabase ?? getServiceRoleClient(),
@@ -435,6 +444,14 @@ export async function attemptImmediatePalEventDelivery(input: {
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
   }
+
+  emitPalTelemetry('[pal-delivery]', {
+    mode: 'immediate',
+    event_type: input.event.event_type,
+    outcome: result,
+    duration_ms: Math.max(0, Math.round(clock() - startedAt)),
+  })
+  return result
 }
 
 export async function enqueueStandalonePalEvent(input: {
@@ -588,7 +605,22 @@ export async function drainPalOutbox(input: {
       clock,
     })
     if (delivered.status === 'disabled') {
-      return { ...summary, status: 'disabled', stoppedReason: 'disabled' }
+      const disabledSummary: PalOutboxDrainSummary = {
+        ...summary,
+        status: 'disabled',
+        stoppedReason: 'disabled',
+      }
+      emitPalTelemetry('[pal-outbox-drain]', {
+        status: disabledSummary.status,
+        claimed: disabledSummary.claimed,
+        delivered: disabledSummary.delivered,
+        retrying: disabledSummary.retrying,
+        non_retryable: disabledSummary.nonRetryable,
+        remaining_ready: disabledSummary.remainingReady,
+        stopped_reason: disabledSummary.stoppedReason,
+        duration_ms: Math.max(0, Math.round(clock() - startedAt)),
+      })
+      return disabledSummary
     }
 
     summary.batches += 1
@@ -620,5 +652,15 @@ export async function drainPalOutbox(input: {
     throw new Error(`Failed to count ready Pal outbox rows: ${error.message ?? 'unknown error'}`)
   }
   summary.remainingReady = z.number().int().nonnegative().parse(data)
+  emitPalTelemetry('[pal-outbox-drain]', {
+    status: summary.status,
+    claimed: summary.claimed,
+    delivered: summary.delivered,
+    retrying: summary.retrying,
+    non_retryable: summary.nonRetryable,
+    remaining_ready: summary.remainingReady,
+    stopped_reason: summary.stoppedReason,
+    duration_ms: Math.max(0, Math.round(clock() - startedAt)),
+  })
   return summary
 }

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -593,6 +593,8 @@ function categorizePalOutboxDrainError(error: unknown):
   if (
     error.name === 'AbortError'
     || error.name === 'TimeoutError'
+    || error.message.includes('AbortError')
+    || error.message.includes('TimeoutError')
     || error.message.includes('bounded execution deadline')
   ) {
     return 'deadline'

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -494,6 +494,8 @@ export async function deliverPalOutboxBatch(input: {
   concurrency?: number
   deadlineAtMs?: number
   clock?: () => number
+  signal?: AbortSignal
+  transitionSignal?: AbortSignal
 } = {}): Promise<PalOutboxDeliverySummary> {
   if (!isPalEnabled()) {
     return {
@@ -510,10 +512,13 @@ export async function deliverPalOutboxBatch(input: {
   const fetchImpl = input.fetchImpl ?? fetch
   const now = input.now ?? new Date()
   const clock = input.clock ?? Date.now
-  const { data, error } = await supabase.rpc('claim_pal_event_outbox', {
-    p_limit: input.limit ?? 10,
-    p_lease_seconds: 60,
-  })
+  const { data, error } = await withAbortSignal(
+    supabase.rpc('claim_pal_event_outbox', {
+      p_limit: input.limit ?? 10,
+      p_lease_seconds: 60,
+    }),
+    input.signal,
+  )
 
   if (error) {
     if (error.code === '42883' || error.code === 'PGRST202') {
@@ -547,6 +552,8 @@ export async function deliverPalOutboxBatch(input: {
       now,
       deadlineAtMs: input.deadlineAtMs,
       clock,
+      signal: input.signal,
+      transitionSignal: input.transitionSignal,
     })
     if (result === 'delivered') summary.delivered += 1
     else if (result === 'retrying') summary.retrying += 1
@@ -579,9 +586,17 @@ function categorizePalOutboxDrainError(error: unknown):
   | 'count'
   | 'transition'
   | 'contract'
+  | 'deadline'
   | 'unexpected' {
   if (error instanceof z.ZodError) return 'contract'
   if (!(error instanceof Error)) return 'unexpected'
+  if (
+    error.name === 'AbortError'
+    || error.name === 'TimeoutError'
+    || error.message.includes('bounded execution deadline')
+  ) {
+    return 'deadline'
+  }
   if (error.message.includes('PAL_') || error.message.includes('Pal configuration')) {
     return 'configuration'
   }
@@ -604,7 +619,11 @@ async function drainPalOutboxWithinDeadline(
   const maxDurationMs = input.maxDurationMs ?? 8_000
   const clock = input.clock ?? Date.now
   const startedAt = clock()
-  const deliveryDeadlineAt = startedAt + Math.max(1_000, maxDurationMs - 1_000)
+  const cleanupBudgetMs = Math.min(1_000, Math.max(1, Math.floor(maxDurationMs / 4)))
+  const deliveryBudgetMs = Math.max(1, maxDurationMs - cleanupBudgetMs)
+  const deliveryDeadlineAt = startedAt + deliveryBudgetMs
+  const deliverySignal = AbortSignal.timeout(deliveryBudgetMs)
+  const transitionSignal = AbortSignal.timeout(Math.max(1, maxDurationMs))
   const summary: PalOutboxDrainSummary = {
     status: 'ok',
     claimed: 0,
@@ -630,6 +649,8 @@ async function drainPalOutboxWithinDeadline(
       concurrency: 10,
       deadlineAtMs: deliveryDeadlineAt,
       clock,
+      signal: deliverySignal,
+      transitionSignal,
     })
     if (delivered.status === 'disabled') {
       return {
@@ -663,7 +684,10 @@ async function drainPalOutboxWithinDeadline(
   }
 
   const supabase = input.supabase ?? getServiceRoleClient()
-  const { data, error } = await supabase.rpc('count_pal_event_outbox_ready')
+  const { data, error } = await withAbortSignal(
+    supabase.rpc('count_pal_event_outbox_ready'),
+    transitionSignal,
+  )
   if (error) {
     throw new Error(`Failed to count ready Pal outbox rows: ${error.message ?? 'unknown error'}`)
   }
@@ -676,9 +700,19 @@ export async function drainPalOutbox(
 ): Promise<PalOutboxDrainSummary> {
   const clock = input.clock ?? Date.now
   const startedAt = clock()
+  const maxDurationMs = Math.max(1, input.maxDurationMs ?? 8_000)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error('Pal outbox drain exceeded its bounded execution deadline'))
+    }, maxDurationMs)
+  })
 
   try {
-    const summary = await drainPalOutboxWithinDeadline(input)
+    const summary = await Promise.race([
+      drainPalOutboxWithinDeadline({ ...input, maxDurationMs }),
+      timeout,
+    ])
     emitPalTelemetry('[pal-outbox-drain]', {
       status: summary.status,
       claimed: summary.claimed,
@@ -697,5 +731,7 @@ export async function drainPalOutbox(
       duration_ms: Math.max(0, Math.round(clock() - startedAt)),
     })
     throw error
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
   }
 }

--- a/src/lib/server/pal-outbox.ts
+++ b/src/lib/server/pal-outbox.ts
@@ -563,7 +563,7 @@ export async function deliverPalOutboxBatch(input: {
   return summary
 }
 
-export async function drainPalOutbox(input: {
+type DrainPalOutboxInput = {
   supabase?: PalOutboxClient
   fetchImpl?: typeof fetch
   now?: Date
@@ -571,7 +571,34 @@ export async function drainPalOutbox(input: {
   maxBatches?: number
   maxDurationMs?: number
   clock?: () => number
-} = {}): Promise<PalOutboxDrainSummary> {
+}
+
+function categorizePalOutboxDrainError(error: unknown):
+  | 'configuration'
+  | 'claim'
+  | 'count'
+  | 'transition'
+  | 'contract'
+  | 'unexpected' {
+  if (error instanceof z.ZodError) return 'contract'
+  if (!(error instanceof Error)) return 'unexpected'
+  if (error.message.includes('PAL_') || error.message.includes('Pal configuration')) {
+    return 'configuration'
+  }
+  if (error.message.includes('claim Pal outbox')) return 'claim'
+  if (error.message.includes('count ready Pal outbox')) return 'count'
+  if (
+    error.message.includes('transition Pal outbox')
+    || error.message.includes('Pal outbox lease was lost')
+  ) {
+    return 'transition'
+  }
+  return 'unexpected'
+}
+
+async function drainPalOutboxWithinDeadline(
+  input: DrainPalOutboxInput,
+): Promise<PalOutboxDrainSummary> {
   const batchSize = input.batchSize ?? 20
   const maxBatches = input.maxBatches ?? 10
   const maxDurationMs = input.maxDurationMs ?? 8_000
@@ -605,22 +632,11 @@ export async function drainPalOutbox(input: {
       clock,
     })
     if (delivered.status === 'disabled') {
-      const disabledSummary: PalOutboxDrainSummary = {
+      return {
         ...summary,
         status: 'disabled',
         stoppedReason: 'disabled',
       }
-      emitPalTelemetry('[pal-outbox-drain]', {
-        status: disabledSummary.status,
-        claimed: disabledSummary.claimed,
-        delivered: disabledSummary.delivered,
-        retrying: disabledSummary.retrying,
-        non_retryable: disabledSummary.nonRetryable,
-        remaining_ready: disabledSummary.remainingReady,
-        stopped_reason: disabledSummary.stoppedReason,
-        duration_ms: Math.max(0, Math.round(clock() - startedAt)),
-      })
-      return disabledSummary
     }
 
     summary.batches += 1
@@ -652,15 +668,34 @@ export async function drainPalOutbox(input: {
     throw new Error(`Failed to count ready Pal outbox rows: ${error.message ?? 'unknown error'}`)
   }
   summary.remainingReady = z.number().int().nonnegative().parse(data)
-  emitPalTelemetry('[pal-outbox-drain]', {
-    status: summary.status,
-    claimed: summary.claimed,
-    delivered: summary.delivered,
-    retrying: summary.retrying,
-    non_retryable: summary.nonRetryable,
-    remaining_ready: summary.remainingReady,
-    stopped_reason: summary.stoppedReason,
-    duration_ms: Math.max(0, Math.round(clock() - startedAt)),
-  })
   return summary
+}
+
+export async function drainPalOutbox(
+  input: DrainPalOutboxInput = {},
+): Promise<PalOutboxDrainSummary> {
+  const clock = input.clock ?? Date.now
+  const startedAt = clock()
+
+  try {
+    const summary = await drainPalOutboxWithinDeadline(input)
+    emitPalTelemetry('[pal-outbox-drain]', {
+      status: summary.status,
+      claimed: summary.claimed,
+      delivered: summary.delivered,
+      retrying: summary.retrying,
+      non_retryable: summary.nonRetryable,
+      remaining_ready: summary.remainingReady,
+      stopped_reason: summary.stoppedReason,
+      duration_ms: Math.max(0, Math.round(clock() - startedAt)),
+    })
+    return summary
+  } catch (error) {
+    emitPalTelemetry('[pal-outbox-drain]', {
+      status: 'error',
+      error_category: categorizePalOutboxDrainError(error),
+      duration_ms: Math.max(0, Math.round(clock() - startedAt)),
+    })
+    throw error
+  }
 }

--- a/tests/api/cron/pal-outbox.test.ts
+++ b/tests/api/cron/pal-outbox.test.ts
@@ -34,6 +34,19 @@ describe('POST /api/cron/pal-outbox', () => {
     mockLoadPalOutboxStatus.mockResolvedValue({
       enabled: true,
       counts: { pending: 2, processing: 0, delivered: 8, non_retryable: 1 },
+      observability: {
+        ready: 1,
+        retrying: 1,
+        expired_leases: 0,
+        oldest_ready_at: '2026-08-08T15:50:00.000Z',
+        oldest_ready_age_seconds: 600,
+        delivery_latency_24h: {
+          sample_size: 8,
+          p50_ms: 120,
+          p95_ms: 650,
+          max_ms: 900,
+        },
+      },
       exceptions: [],
     })
   })
@@ -66,6 +79,12 @@ describe('POST /api/cron/pal-outbox', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toMatchObject({
       counts: { pending: 2, non_retryable: 1 },
+      observability: {
+        ready: 1,
+        retrying: 1,
+        expired_leases: 0,
+        delivery_latency_24h: { p95_ms: 650 },
+      },
     })
   })
 

--- a/tests/api/cron/pal-sync.test.ts
+++ b/tests/api/cron/pal-sync.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/server/pal-weekly-config', () => ({
   syncPalWeeklyConfigurations: mockSyncPalWeeklyConfigurations,
 }))
 
-import { GET } from '@/app/api/cron/pal-sync/route'
+import { GET, maxDuration } from '@/app/api/cron/pal-sync/route'
 
 describe('GET /api/cron/pal-sync', () => {
   beforeEach(() => {
@@ -35,6 +35,10 @@ describe('GET /api/cron/pal-sync', () => {
       remainingReady: 0,
       stoppedReason: 'drained',
     })
+  })
+
+  it('reserves an explicit serverless duration for reconciliation and recovery', () => {
+    expect(maxDuration).toBe(60)
   })
 
   it('requires cron authentication', async () => {

--- a/tests/lib/server/pal-operations.test.ts
+++ b/tests/lib/server/pal-operations.test.ts
@@ -45,8 +45,8 @@ describe('Pal outbox operations observability', () => {
       },
       { count: 3, error: null },
       { count: 1, error: null },
-      { data: { created_at: '2026-08-08T15:50:00.000Z' }, error: null },
-      { data: { created_at: '2026-08-08T15:55:00.000Z' }, error: null },
+      { data: { next_attempt_at: '2026-08-08T15:59:00.000Z' }, error: null },
+      { data: { lease_expires_at: '2026-08-08T15:55:00.000Z' }, error: null },
       {
         data: [
           {
@@ -66,6 +66,8 @@ describe('Pal outbox operations observability', () => {
       },
     ]
     const builders = results.map(query)
+    const oldestPendingBuilder = builders[7]
+    const oldestExpiredBuilder = builders[8]
     const from = vi.fn(() => builders.shift())
     const rpc = vi.fn(async () => ({ data: 2, error: null }))
 
@@ -84,8 +86,8 @@ describe('Pal outbox operations observability', () => {
         ready: 2,
         retrying: 3,
         expired_leases: 1,
-        oldest_ready_at: '2026-08-08T15:50:00.000Z',
-        oldest_ready_age_seconds: 600,
+        oldest_ready_at: '2026-08-08T15:55:00.000Z',
+        oldest_ready_age_seconds: 300,
         delivery_latency_24h: {
           sample_size: 3,
           p50_ms: 500,
@@ -95,6 +97,16 @@ describe('Pal outbox operations observability', () => {
       },
       exceptions: expect.any(Array),
     })
+    expect(oldestPendingBuilder.select).toHaveBeenCalledWith('next_attempt_at')
+    expect(oldestPendingBuilder.order).toHaveBeenCalledWith(
+      'next_attempt_at',
+      { ascending: true },
+    )
+    expect(oldestExpiredBuilder.select).toHaveBeenCalledWith('lease_expires_at')
+    expect(oldestExpiredBuilder.order).toHaveBeenCalledWith(
+      'lease_expires_at',
+      { ascending: true },
+    )
 
     const serialized = JSON.stringify(await loadPalOutboxStatus({
       supabase: {

--- a/tests/lib/server/pal-operations.test.ts
+++ b/tests/lib/server/pal-operations.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { loadPalOutboxStatus } from '@/lib/server/pal-operations'
+
+type QueryResult = {
+  data?: unknown
+  count?: number | null
+  error: { message: string } | null
+}
+
+function query(result: QueryResult) {
+  const builder: Record<string, any> = {}
+  for (const method of ['select', 'eq', 'gt', 'lte', 'gte', 'not', 'in', 'order', 'limit']) {
+    builder[method] = vi.fn(() => builder)
+  }
+  builder.maybeSingle = vi.fn(async () => result)
+  builder.then = (
+    resolve: (value: QueryResult) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(result).then(resolve, reject)
+  return builder
+}
+
+describe('Pal outbox operations observability', () => {
+  it('reports backlog, retries, expired leases, and recent delivery latency without payloads', async () => {
+    const results: QueryResult[] = [
+      { count: 4, error: null },
+      { count: 2, error: null },
+      { count: 12, error: null },
+      { count: 1, error: null },
+      {
+        data: [{
+          id: '10000000-0000-4000-8000-000000000001',
+          event_type: 'daily_log.completed',
+          status: 'pending',
+          attempts: 2,
+          next_attempt_at: '2026-08-08T15:59:00.000Z',
+          last_attempt_at: '2026-08-08T15:58:00.000Z',
+          last_error_code: 'network_error',
+          last_error_detail: 'Pal delivery failed before an HTTP response was received',
+          created_at: '2026-08-08T15:50:00.000Z',
+          updated_at: '2026-08-08T15:58:00.000Z',
+        }],
+        error: null,
+      },
+      { count: 3, error: null },
+      { count: 1, error: null },
+      { data: { created_at: '2026-08-08T15:50:00.000Z' }, error: null },
+      { data: { created_at: '2026-08-08T15:55:00.000Z' }, error: null },
+      {
+        data: [
+          {
+            created_at: '2026-08-08T15:00:00.000Z',
+            delivered_at: '2026-08-08T15:00:00.100Z',
+          },
+          {
+            created_at: '2026-08-08T15:01:00.000Z',
+            delivered_at: '2026-08-08T15:01:00.500Z',
+          },
+          {
+            created_at: '2026-08-08T15:02:00.000Z',
+            delivered_at: '2026-08-08T15:02:02.000Z',
+          },
+        ],
+        error: null,
+      },
+    ]
+    const builders = results.map(query)
+    const from = vi.fn(() => builders.shift())
+    const rpc = vi.fn(async () => ({ data: 2, error: null }))
+
+    await expect(loadPalOutboxStatus({
+      supabase: { from, rpc } as any,
+      now: new Date('2026-08-08T16:00:00.000Z'),
+    })).resolves.toEqual({
+      enabled: false,
+      counts: {
+        pending: 4,
+        processing: 2,
+        delivered: 12,
+        non_retryable: 1,
+      },
+      observability: {
+        ready: 2,
+        retrying: 3,
+        expired_leases: 1,
+        oldest_ready_at: '2026-08-08T15:50:00.000Z',
+        oldest_ready_age_seconds: 600,
+        delivery_latency_24h: {
+          sample_size: 3,
+          p50_ms: 500,
+          p95_ms: 2_000,
+          max_ms: 2_000,
+        },
+      },
+      exceptions: expect.any(Array),
+    })
+
+    const serialized = JSON.stringify(await loadPalOutboxStatus({
+      supabase: {
+        from: vi.fn(() => query({ data: [], count: 0, error: null })),
+        rpc: vi.fn(async () => ({ data: 0, error: null })),
+      } as any,
+      now: new Date('2026-08-08T16:00:00.000Z'),
+    }))
+    expect(serialized).not.toContain('payload')
+    expect(serialized).not.toContain('student_id')
+    expect(serialized).not.toContain('source_id')
+  })
+})

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -339,6 +339,36 @@ describe('Pal outbox adapter', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
+  it('bounds a batch drain when a delivery transition never resolves', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const rpc = vi.fn((name: string) => {
+      if (name === 'claim_pal_event_outbox') {
+        return Promise.resolve({ data: [claimedRow()], error: null })
+      }
+      if (name === 'complete_pal_event_outbox') {
+        return new Promise<never>(() => undefined)
+      }
+      return Promise.resolve({ data: 0, error: null })
+    })
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }))
+    const startedAt = performance.now()
+
+    await expect(drainPalOutbox({
+      supabase: { rpc },
+      fetchImpl,
+      now: occurredAt,
+      maxDurationMs: 20,
+    })).rejects.toThrow('bounded execution deadline')
+
+    expect(performance.now() - startedAt).toBeLessThan(250)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toEqual({
+      status: 'error',
+      error_category: 'deadline',
+      duration_ms: expect.any(Number),
+    })
+  })
+
   it('uses the cleanup budget to record retry after the Pal request times out', async () => {
     const supabase = buildImmediateSupabase({
       lookups: [immediateRow()],

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -369,6 +369,34 @@ describe('Pal outbox adapter', () => {
     })
   })
 
+  it('classifies a wrapped PostgREST claim timeout as a drain deadline', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const stalledRequest = Object.assign(new Promise<never>(() => undefined), {
+      abortSignal: (signal: AbortSignal) => new Promise((resolve) => {
+        const resolveTimeout = () => resolve({
+          data: null,
+          error: { message: 'TimeoutError: operation aborted by signal' },
+        })
+        if (signal.aborted) resolveTimeout()
+        else signal.addEventListener('abort', resolveTimeout, { once: true })
+      }),
+    })
+    const rpc = vi.fn(() => stalledRequest)
+    const startedAt = performance.now()
+
+    await expect(drainPalOutbox({
+      supabase: { rpc } as any,
+      maxDurationMs: 40,
+    })).rejects.toThrow('Failed to claim Pal outbox rows')
+
+    expect(performance.now() - startedAt).toBeLessThan(250)
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toEqual({
+      status: 'error',
+      error_category: 'deadline',
+      duration_ms: expect.any(Number),
+    })
+  })
+
   it('uses the cleanup budget to record retry after the Pal request times out', async () => {
     const supabase = buildImmediateSupabase({
       lookups: [immediateRow()],

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -522,4 +522,53 @@ describe('Pal outbox adapter', () => {
       duration_ms: expect.any(Number),
     })
   })
+
+  it('emits sanitized drain telemetry when claiming fails', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const rpc = vi.fn(async () => ({
+      data: null,
+      error: { message: 'database unavailable' },
+    }))
+
+    await expect(drainPalOutbox({ supabase: { rpc } })).rejects.toThrow(
+      'Failed to claim Pal outbox rows',
+    )
+
+    expect(info.mock.calls.at(-1)?.[0]).toBe('[pal-outbox-drain]')
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toEqual({
+      status: 'error',
+      error_category: 'claim',
+      duration_ms: expect.any(Number),
+    })
+  })
+
+  it('emits sanitized drain telemetry when Pal configuration is invalid', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    vi.stubEnv('PAL_INTEGRATION_SECRET', '')
+
+    await expect(drainPalOutbox()).rejects.toThrow('PAL_ENABLED requires')
+
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toEqual({
+      status: 'error',
+      error_category: 'configuration',
+      duration_ms: expect.any(Number),
+    })
+  })
+
+  it('emits sanitized drain telemetry when the final ready count fails', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const rpc = vi.fn(async (name: string) => name === 'claim_pal_event_outbox'
+      ? { data: [], error: null }
+      : { data: null, error: { message: 'count unavailable' } })
+
+    await expect(drainPalOutbox({ supabase: { rpc } })).rejects.toThrow(
+      'Failed to count ready Pal outbox rows',
+    )
+
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toEqual({
+      status: 'error',
+      error_category: 'count',
+      duration_ms: expect.any(Number),
+    })
+  })
 })

--- a/tests/lib/server/pal-outbox.test.ts
+++ b/tests/lib/server/pal-outbox.test.ts
@@ -190,6 +190,7 @@ describe('Pal outbox adapter', () => {
   })
 
   it('claims and delivers only the outbox fact committed by the current action', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     const supabase = buildImmediateSupabase({
       lookups: [immediateRow()],
       claimed: claimedRow(),
@@ -216,6 +217,13 @@ describe('Pal outbox adapter', () => {
         p_lease_token: leaseToken,
       },
     })
+    expect(info.mock.calls.at(-1)?.[0]).toBe('[pal-delivery]')
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toMatchObject({
+      mode: 'immediate',
+      event_type: 'platform.session.started',
+      outcome: 'delivered',
+      duration_ms: expect.any(Number),
+    })
   })
 
   it('does not redeliver an idempotent action whose fact is already delivered', async () => {
@@ -234,6 +242,7 @@ describe('Pal outbox adapter', () => {
   })
 
   it('leaves an immediate network failure queued for durable retry', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     const supabase = buildImmediateSupabase({
       lookups: [immediateRow()],
       claimed: claimedRow(),
@@ -252,6 +261,11 @@ describe('Pal outbox adapter', () => {
     expect(supabase.calls.at(-1)).toMatchObject({
       name: 'retry_pal_event_outbox',
       args: { p_error_code: 'network_error' },
+    })
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toMatchObject({
+      mode: 'immediate',
+      event_type: 'platform.session.started',
+      outcome: 'pending',
     })
   })
 
@@ -460,6 +474,7 @@ describe('Pal outbox adapter', () => {
   })
 
   it('drains more than one class-day of events and reports no ready backlog', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     const batchSizes = [20, 20, 20, 20, 20, 20, 0]
     let claim = 0
     const rpc = vi.fn(async (name: string, args?: Record<string, unknown>) => {
@@ -495,5 +510,16 @@ describe('Pal outbox adapter', () => {
     })
     expect(fetchImpl).toHaveBeenCalledTimes(120)
     expect(rpc).toHaveBeenCalledWith('count_pal_event_outbox_ready')
+    expect(info.mock.calls.at(-1)?.[0]).toBe('[pal-outbox-drain]')
+    expect(JSON.parse(String(info.mock.calls.at(-1)?.[1]))).toMatchObject({
+      status: 'ok',
+      claimed: 120,
+      delivered: 120,
+      retrying: 0,
+      non_retryable: 0,
+      remaining_ready: 0,
+      stopped_reason: 'drained',
+      duration_ms: expect.any(Number),
+    })
   })
 })

--- a/tests/unit/pal-outbox-concurrency-contract.test.ts
+++ b/tests/unit/pal-outbox-concurrency-contract.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+
+describe('Pal outbox real-database concurrency contract', () => {
+  it('runs competing and expired-lease claims in ephemeral Supabase CI', () => {
+    const script = readFileSync(
+      resolve(root, 'scripts/check-pal-outbox-concurrency.sh'),
+      'utf8',
+    )
+    const workflow = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8')
+
+    expect(script).toContain("name=^supabase_db_pika$")
+    expect(script).toContain('claim_pal_event_outbox')
+    expect(script).toContain("status = 'pending'")
+    expect(script).toContain("status = 'processing'")
+    expect(script).toContain('lease_expires_at')
+    expect(script).toContain('attempts')
+    expect(workflow).toContain('bash scripts/check-pal-outbox-concurrency.sh')
+  })
+
+  it('runs a real HTTP failure and queued recovery against local PostgREST', () => {
+    const script = readFileSync(
+      resolve(root, 'scripts/check-pal-delivery-recovery.ts'),
+      'utf8',
+    )
+    const workflow = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8')
+
+    expect(script).toContain("hostname !== '127.0.0.1'")
+    expect(script).toContain("status: 503")
+    expect(script).toContain('attemptImmediatePalEventDelivery')
+    expect(script).toContain('deliverPalOutboxBatch')
+    expect(script).toContain("deliveredRow.status !== 'delivered'")
+    expect(workflow).toContain('pnpm run smoke:pal-delivery-recovery')
+  })
+})

--- a/tests/unit/pal-outbox-concurrency-contract.test.ts
+++ b/tests/unit/pal-outbox-concurrency-contract.test.ts
@@ -19,6 +19,9 @@ describe('Pal outbox real-database concurrency contract', () => {
     expect(script).toContain("status = 'processing'")
     expect(script).toContain('lease_expires_at')
     expect(script).toContain('attempts')
+    expect(script).toContain('pg_stat_activity')
+    expect(script).toContain("wait_event = 'PgSleep'")
+    expect(script).not.toContain('sleep 0.2')
     expect(workflow).toContain('bash scripts/check-pal-outbox-concurrency.sh')
   })
 


### PR DESCRIPTION
## Summary\n- add privacy-safe immediate and drain telemetry plus protected backlog, retry, expired-lease, and recent latency metrics\n- add real PostgreSQL contention coverage for pending and expired batch/targeted claims\n- add a loopback-only HTTP outage/recovery smoke with durable retry and stable-idempotency evidence\n- document production-safe verification and keep PAL PR #50 out of scope\n- close review gaps with sanitized drain-error telemetry, an explicit 60-second cron budget, and database-observed contention gates\n- enforce the eight-second drain budget across claims, delivery transitions, and the final count, measure ready age from retry/lease readiness, and classify wrapped timeouts as deadline outcomes\n\n## Risk\nruntime-platform. No migration and no new dependency. The protected status endpoint adds bounded parallel reads; latency uses at most 500 delivered rows from the previous 24 hours.\n\n## Validation\n- exact-head GitHub CI: Test & Build, Architecture Database Contracts, Browser Experience Matrix\n- full Vitest with coverage, production build, TypeScript, lint, architecture, design/UI policy\n- disposable PostgreSQL claim-concurrency harness\n- loopback PostgREST plus HTTP 503/recovery smoke\n- Pika audit, continuity and diff checks\n- independent final remediation review clean