### PR TITLE
Add managed deletion health monitoring

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17465,3 +17465,110 @@ recovery preservation across managed ownership activation.
 - Require exact-head disposable CI and final read-only review, update draft PR
   #967's validation summary, and keep deployment/application of migration 117
   under fresh target-specific authorization.
+
+<!-- pika-session-log-archive-batch:2a992c45cbd84f8810a96c8499a427624855000667cc90f44561c549e9b24681 -->
+## 2026-08-03 — Serialized Blueprint adoption with raw compatibility writers
+
+**Risk profile:** high — exact-path ownership adoption and concurrent rolling
+deployment writers.
+
+**Completed:**
+- Made every embedded raw-path writer take the exact-path lifecycle fence even
+  when no managed row is committed yet, then re-read ownership after waiting.
+- Rejected explicit managed UUID/path mismatches before locking the
+  caller-supplied path, preserving the canonical object-row/path lock order.
+- Pre-locked all existing UUID and raw-path identities in one global managed
+  UUID order, including identities removed by an update; newly appearing
+  identities abort safely for retry rather than mixing path-first and
+  row-first locking.
+- Corrected the disposable fixture to adopt its deliberate legacy Blueprint
+  source before expecting readiness, and added two-session coverage for a late
+  cross-Classroom raw writer, a held wrong-path mismatch lock, and inverse
+  path/UUID ordering without deadlock. Added a separate replacement race that
+  proves previous identities are locked before a new absent raw path.
+- Kept all schema work consolidated in migration 117, left migrations 115/116
+  unchanged, applied no migration, and left PR #963 untouched.
+
+**Validation:**
+- Focused Blueprint and migration contract tests, TypeScript, shellcheck, shell
+  syntax, SQL parse, migration lineage, diff checks, and Pika audit pass.
+
+**Remaining:**
+- Push the correction, require exact-head disposable database CI, and obtain a
+  targeted independent concurrency review before the final integration gate.
+
+<!-- pika-session-log-archive-batch:6be5f94fa62dfc9ec15a57088967fab69ae32190d7db1da3d2a9971bf4c45f36 -->
+## 2026-08-03 — Serialized Blueprint adoption with raw compatibility writers
+
+**Risk profile:** high — exact-path ownership adoption and concurrent rolling
+deployment writers.
+
+**Completed:**
+- Made every embedded raw-path writer take the exact-path lifecycle fence even
+  when no managed row is committed yet, then re-read ownership after waiting.
+- Rejected explicit managed UUID/path mismatches before locking the
+  caller-supplied path, preserving the canonical object-row/path lock order.
+- Pre-locked all existing UUID and raw-path identities in one global managed
+  UUID order, including identities removed by an update; newly appearing
+  identities abort safely for retry rather than mixing path-first and
+  row-first locking.
+- Corrected the disposable fixture to adopt its deliberate legacy Blueprint
+  source before expecting readiness, and added two-session coverage for a late
+  cross-Classroom raw writer, a held wrong-path mismatch lock, and inverse
+  path/UUID ordering without deadlock. Added a separate replacement race that
+  proves previous identities are locked before a new absent raw path.
+- Kept all schema work consolidated in migration 117, left migrations 115/116
+  unchanged, applied no migration, and left PR #963 untouched.
+
+**Validation:**
+- Focused Blueprint and migration contract tests, TypeScript, shellcheck, shell
+  syntax, SQL parse, migration lineage, diff checks, and Pika audit pass.
+
+**Remaining:**
+- Push the correction, require exact-head disposable database CI, and obtain a
+  targeted independent concurrency review before the final integration gate.
+
+## 2026-08-03 — Closed managed-storage readiness and Blueprint retry blockers
+
+**Risk profile:** runtime-platform — migration 117 readiness liveness,
+provisional ownership, and idempotent Blueprint file copies.
+
+**Completed:**
+- Made serialized readiness transition expired, unreferenced reserved/verified
+  objects to `cleanup_pending` without deleting Storage bytes, and made expired
+  provisional-owner findings ignore settled cleanup/tombstone states.
+- Made Blueprint provisional-owner and target object identities deterministic
+  by operation, direction, and source managed identity; completed operations
+  are preflighted and incomplete retries reuse verified bytes.
+- Made capture and instantiation queue every exact provisional copy on any
+  downstream failure; referenced/adopted objects remain protected by the
+  managed cleanup authority check.
+- Added a narrowly scoped retry transition for queued, still-provisional
+  Blueprint copies, plus regressions for expiry, readiness, activation,
+  tombstone cleanup, failed atomic operations, and same-operation replay.
+- Corrected semantic Blueprint replays that succeed without adopting copies:
+  exact provisional copies are queued, while the database refuses cleanup for
+  any concurrently adopted/referenced winner.
+- Closed the compatibility cleanup race where a live reference could arrive
+  after a legacy worker claim but before Storage deletion: the protected delete
+  failure now restores the managed object to `ready` instead of re-queuing it.
+- Reconfirmed that migration 117 revokes all migration-115 purge entry points,
+  including `service_role`; no purge capability was added or exposed.
+- Kept migrations 115/116 unchanged, kept all corrections in unapplied
+  migration 117, applied no migration, enabled no worker, exposed no deletion,
+  and left PR #963 untouched.
+
+**Validation:**
+- Pika audit, lint, TypeScript, architecture/design/UI policy, lineage, shell
+  syntax, and diff checks pass.
+- Focused ownership/Blueprint tests pass (36 tests); the full suite passes
+  (459 files, 3,986 tests); the production build passes.
+- The semantic replay regression, TypeScript, shell syntax, and diff checks
+  pass after the final correction.
+- The extended database fixture was not executed locally because migration
+  application/replay still requires fresh authorization naming migration 117
+  and the local target; exact-head disposable CI remains required.
+
+**Remaining:**
+- Push the correction to PR #967, require exact-head CI including disposable
+  migration replay/database fixtures, and perform a final read-only review.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,81 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-03 — Serialized Blueprint adoption with raw compatibility writers
-
-**Risk profile:** high — exact-path ownership adoption and concurrent rolling
-deployment writers.
-
-**Completed:**
-- Made every embedded raw-path writer take the exact-path lifecycle fence even
-  when no managed row is committed yet, then re-read ownership after waiting.
-- Rejected explicit managed UUID/path mismatches before locking the
-  caller-supplied path, preserving the canonical object-row/path lock order.
-- Pre-locked all existing UUID and raw-path identities in one global managed
-  UUID order, including identities removed by an update; newly appearing
-  identities abort safely for retry rather than mixing path-first and
-  row-first locking.
-- Corrected the disposable fixture to adopt its deliberate legacy Blueprint
-  source before expecting readiness, and added two-session coverage for a late
-  cross-Classroom raw writer, a held wrong-path mismatch lock, and inverse
-  path/UUID ordering without deadlock. Added a separate replacement race that
-  proves previous identities are locked before a new absent raw path.
-- Kept all schema work consolidated in migration 117, left migrations 115/116
-  unchanged, applied no migration, and left PR #963 untouched.
-
-**Validation:**
-- Focused Blueprint and migration contract tests, TypeScript, shellcheck, shell
-  syntax, SQL parse, migration lineage, diff checks, and Pika audit pass.
-
-**Remaining:**
-- Push the correction, require exact-head disposable database CI, and obtain a
-  targeted independent concurrency review before the final integration gate.
-
-## 2026-08-03 — Closed managed-storage readiness and Blueprint retry blockers
-
-**Risk profile:** runtime-platform — migration 117 readiness liveness,
-provisional ownership, and idempotent Blueprint file copies.
-
-**Completed:**
-- Made serialized readiness transition expired, unreferenced reserved/verified
-  objects to `cleanup_pending` without deleting Storage bytes, and made expired
-  provisional-owner findings ignore settled cleanup/tombstone states.
-- Made Blueprint provisional-owner and target object identities deterministic
-  by operation, direction, and source managed identity; completed operations
-  are preflighted and incomplete retries reuse verified bytes.
-- Made capture and instantiation queue every exact provisional copy on any
-  downstream failure; referenced/adopted objects remain protected by the
-  managed cleanup authority check.
-- Added a narrowly scoped retry transition for queued, still-provisional
-  Blueprint copies, plus regressions for expiry, readiness, activation,
-  tombstone cleanup, failed atomic operations, and same-operation replay.
-- Corrected semantic Blueprint replays that succeed without adopting copies:
-  exact provisional copies are queued, while the database refuses cleanup for
-  any concurrently adopted/referenced winner.
-- Closed the compatibility cleanup race where a live reference could arrive
-  after a legacy worker claim but before Storage deletion: the protected delete
-  failure now restores the managed object to `ready` instead of re-queuing it.
-- Reconfirmed that migration 117 revokes all migration-115 purge entry points,
-  including `service_role`; no purge capability was added or exposed.
-- Kept migrations 115/116 unchanged, kept all corrections in unapplied
-  migration 117, applied no migration, enabled no worker, exposed no deletion,
-  and left PR #963 untouched.
-
-**Validation:**
-- Pika audit, lint, TypeScript, architecture/design/UI policy, lineage, shell
-  syntax, and diff checks pass.
-- Focused ownership/Blueprint tests pass (36 tests); the full suite passes
-  (459 files, 3,986 tests); the production build passes.
-- The semantic replay regression, TypeScript, shell syntax, and diff checks
-  pass after the final correction.
-- The extended database fixture was not executed locally because migration
-  application/replay still requires fresh authorization naming migration 117
-  and the local target; exact-head disposable CI remains required.
-
-**Remaining:**
-- Push the correction to PR #967, require exact-head CI including disposable
-  migration replay/database fixtures, and perform a final read-only review.
-
 ## 2026-08-04 — Hardened purge rollout visibility and verification gates
 
 **Risk profile:** runtime-platform — irreversible classroom purge rollout,
@@ -1086,3 +1011,63 @@ authorization, ownership, operation-conflict, and managed-storage gates.
 - Playwright visual verification passed for the student form in desktop/mobile,
   light/dark, flagged/unflagged, and keyboard-focus states; teacher was not
   applicable.
+
+## 2026-08-08 — Audit remaining managed deletion scopes
+
+**Risk profile:** runtime-platform — irreversible cold recovery loss,
+cross-Classroom student lineage, managed Storage, and durable purge recovery.
+
+**Audited:**
+- Created dedicated worktree `codex/remaining-deletion-scopes`, completed the
+  session-start workflow, and verified the local read-only schema is exactly at
+  migrations 001–120.
+- Traced cold tombstones, immutable archives, restore/compaction operations,
+  Gradex extracts, managed ownership/cleanup leases, hot/Blueprint purge
+  fences, and the complete Classroom resource graph.
+- Traced Classroom-scoped student rows, embedded JSON/provenance, managed
+  student files, existing partial roster removal, account-level data, Pal
+  ledgers, and cross-Classroom preservation boundaries.
+
+**Recommendation:**
+- Add privacy-safe read-only deletion health monitoring first, then implement
+  cold-Classroom purge and Classroom-scoped individual-student purge as
+  separate migrations and PRs with independent rollout gates.
+- Keep generic orphan cleanup disabled; neither purge scope depends on it.
+- Require cold archives to be restored before individual-student purge; do not
+  rewrite immutable archive bundles or erase user accounts/other Classrooms.
+
+**Boundary:**
+- No implementation, migration application, local reset, rollout change,
+  production query, purge, or Storage deletion was performed. PR #963 remains
+  closed and untouched. Awaiting approval of the scope and sequencing package.
+
+## 2026-08-08 — Add managed deletion health monitoring baseline
+
+**Risk profile:** runtime-platform — read-only production health aggregation
+across irreversible purge ledgers and managed-storage ownership.
+
+**Completed:**
+- Added unapplied migration 121 with a service-role-only, aggregate RPC for hot
+  Classroom and Course Blueprint purge failures/stalls, fence/lease drift,
+  deleted-object reappearance, and managed-storage ownership/reference drift.
+- Added an exact Zod response boundary, code-first missing-schema compatibility,
+  privacy-safe structured counts, and sanitized probe failures.
+- Integrated the probe after successful work in the existing authenticated
+  daily cleanup cron. Critical findings return 503; warning-only findings remain
+  observable without granting cleanup authority.
+- Documented operator response and staged rollout. Generic orphan cleanup stays
+  disabled, and no additional cron schedule or deletion capability was added.
+
+**Validation:**
+- Full Vitest passed (478 files, 4,126 tests), plus focused monitoring/migration
+  tests, TypeScript, lint, architecture boundaries, managed-storage
+  lineage, hot-Classroom purge SQL lint, production build, and diff checks.
+- After separate exact authorization, the dry run previewed only migration 121
+  and it was applied once to the dedicated local Supabase database. Rollback-only
+  database fixtures proved read-only/service-role/privacy boundaries, warning
+  and critical findings, partial/lease/reappearance detection, eight concurrent
+  readers, and a 1,000-object runtime of 9–34 ms with 6,265 shared-buffer hits.
+- Generated types match local migrations 001–121. No reset, remote migration,
+  rollout change, production query, purge, or persistent Storage deletion was
+  performed; the temporary helper and all fixtures were removed. No UI changed,
+  so visual verification was not applicable.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1059,6 +1059,8 @@ across irreversible purge ledgers and managed-storage ownership.
   reconciliation out of the daily path into a separate unscheduled,
   service-role-only diagnostic; added payload UUID/digest mismatch detection and
   made every dependency error except the exact missing-RPC signal fail closed.
+  A targeted follow-up made evidence reconciliation registry-driven so removing
+  a payload's final managed reference cannot hide the stale registry row.
 - Documented operator response and staged rollout. Generic orphan cleanup stays
   disabled, and no additional cron schedule or deletion capability was added.
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1047,7 +1047,7 @@ cross-Classroom student lineage, managed Storage, and durable purge recovery.
 across irreversible purge ledgers and managed-storage ownership.
 
 **Completed:**
-- Added unapplied migration 121 with a service-role-only, aggregate RPC for hot
+- Added migration 121 with a service-role-only, aggregate RPC for hot
   Classroom and Course Blueprint purge failures/stalls, fence/lease drift,
   deleted-object reappearance, and managed-storage ownership/reference drift.
 - Added an exact Zod response boundary, code-first missing-schema compatibility,
@@ -1055,11 +1055,15 @@ across irreversible purge ledgers and managed-storage ownership.
 - Integrated the probe after successful work in the existing authenticated
   daily cleanup cron. Critical findings return 503; warning-only findings remain
   observable without granting cleanup authority.
+- After the initial independent review of PR #980, moved recursive JSON/history
+  reconciliation out of the daily path into a separate unscheduled,
+  service-role-only diagnostic; added payload UUID/digest mismatch detection and
+  made every dependency error except the exact missing-RPC signal fail closed.
 - Documented operator response and staged rollout. Generic orphan cleanup stays
   disabled, and no additional cron schedule or deletion capability was added.
 
 **Validation:**
-- Full Vitest passed (478 files, 4,126 tests), plus focused monitoring/migration
+- Full Vitest passed (478 files, 4,128 tests), plus focused monitoring/migration
   tests, TypeScript, lint, architecture boundaries, managed-storage
   lineage, hot-Classroom purge SQL lint, production build, and diff checks.
 - After separate exact authorization, the dry run previewed only migration 121
@@ -1067,7 +1071,9 @@ across irreversible purge ledgers and managed-storage ownership.
   database fixtures proved read-only/service-role/privacy boundaries, warning
   and critical findings, partial/lease/reappearance detection, eight concurrent
   readers, and a 1,000-object runtime of 9–34 ms with 6,265 shared-buffer hits.
-- Generated types match local migrations 001–121. No reset, remote migration,
+- The originally authorized local application predates the review correction;
+  that one-time permission was not reused. Final generated types and the revised
+  rollback fixture are gated on PR CI's fresh ephemeral migration replay. No reset, remote migration,
   rollout change, production query, purge, or persistent Storage deletion was
   performed; the temporary helper and all fixtures were removed. No UI changed,
   so visual verification was not applicable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Verify managed-storage ownership and enforcement
         run: bash scripts/check-managed-storage-database.sh
 
+      - name: Verify managed deletion health monitoring
+        run: pnpm run check:managed-deletion-health-db
+
       - name: Lint hot archived classroom purge database functions
         run: pnpm run check:classroom-purge-db-lint
 

--- a/docs/guidance/hot-archived-classroom-purge.md
+++ b/docs/guidance/hot-archived-classroom-purge.md
@@ -33,6 +33,9 @@ are deliberately outside classroom ownership.
 The database fence remains after a partial failure. Browser retries and the
 authenticated cleanup cron resume the durable operation.
 
+The cleanup cron's aggregate, privacy-safe health checks and operator response
+are documented in `docs/guidance/managed-deletion-monitoring.md`.
+
 A transient object failure remains retryable but is not reclaimed before its
 `next_attempt_at`; an empty claim means “nothing is due,” not “all files are
 gone.” If Storage reports that a previously verified-deleted path exists again,

--- a/docs/guidance/managed-deletion-monitoring.md
+++ b/docs/guidance/managed-deletion-monitoring.md
@@ -1,0 +1,124 @@
+# Managed deletion monitoring
+
+This monitoring baseline is read-only. It observes the durable hot-Classroom
+and Course Blueprint purge protocols plus managed-storage ownership drift. It
+does not enable a deletion scope, claim work, retry an operation, delete a
+Storage object, change a rollout gate, or enable generic orphan cleanup.
+
+Migration 121 defines the service-role-only
+`get_managed_deletion_health_snapshot` RPC. The existing authenticated daily
+`/api/cron/cleanup-history` route calls it after its normal cleanup and purge
+safety-net work. No additional schedule is installed.
+
+## Privacy and response contract
+
+The snapshot contains only a version, timestamp, threshold, health state, and
+aggregate counts. It never returns user, teacher, Classroom, Blueprint,
+operation, managed-object, bucket/path, title, email, or content identities.
+The application validates the exact JSON shape and emits structured log fields
+containing only health/count values or a bounded application error code.
+
+The default stuck threshold is one hour. The RPC and server reader accept only
+300 through 604,800 seconds. The threshold is diagnostic; it does not expire a
+fence, authorize deletion, or change retry state.
+
+The cron behavior is:
+
+- Before migration 121 exists, missing-function/table schema codes are a
+  code-first compatibility state. Cleanup returns normally and logs
+  `schema unavailable` without provider details.
+- A healthy snapshot returns the existing successful cleanup response.
+- Warning-only findings return success and remain visible in the aggregate log.
+  They are expected to need trend/operational review, not an automatic mutation.
+- Any critical finding returns a sanitized `503` with critical and warning
+  totals after the normal cleanup work has run.
+- Query or contract validation failure returns a sanitized `503`; raw provider
+  errors are not returned or logged.
+
+## Findings
+
+Critical purge findings cover terminal non-retryable operations, operations or
+partially completed object inventories that have not advanced within the stuck
+threshold, expired object leases, missing/stale fences, and a provider object
+reappearing after the exact purge ledger recorded it deleted. Due retryable
+failed objects are warning counts until the enclosing operation becomes stale.
+
+Critical managed-storage findings cover:
+
+- Storage bytes in a managed bucket with no managed registry row;
+- verified/ready registry rows whose provider object is missing;
+- referenced objects that are not ready;
+- relational raw references with no managed UUID or with mismatched path/owner
+  evidence;
+- embedded managed-bucket references missing their relational registry, or
+  whose owner/data-subject evidence differs from the host;
+- managed Classroom objects with neither exactly one hot Classroom nor exactly
+  one cold tombstone owner;
+- objects left attached to a settled provisional owner; and
+- expired generic-cleanup leases.
+
+Warning managed-storage findings cover ready-but-unreferenced objects, expired
+upload reservations, expired provisional owners, and cleanup-pending objects
+older than the stuck threshold. These warnings are intentionally not deletion
+authority. Counts may overlap when one corrupt entity violates more than one
+contract, so totals represent findings rather than unique objects.
+
+## Operator response
+
+Treat a critical count or probe failure as an alert. First identify the finding
+category from the structured snapshot in a separately authorized,
+access-controlled diagnostic session. Do not add identifiers to the cron
+response or application logs. Do not clear a fence, mark a ledger complete,
+rewrite managed ownership, retry a purge, or remove a provider object merely to
+make the count zero. Each repair requires its own evidence-backed plan and fresh
+authorization naming the exact target and operation.
+
+Warning-only counts should be trended. In particular, a stable
+`ready_objects_unreferenced` or `stale_cleanup_pending` count is evidence for a
+possible separately gated cleanup rollout, not permission to enable it. Generic
+orphan cleanup remains disabled.
+
+## Staged rollout
+
+Migration 121 has been applied only to the dedicated local Supabase database
+under one-time authorization. It has not been applied to staging or production.
+
+1. Run static/unit/route tests and repository checks without a database reset or
+   migration application.
+2. With fresh authorization naming the disposable/local target and migration
+   121, replay the schema and validate SQL execution, query plans, empty/seeded
+   counts, privacy shape, degraded fixtures, and runtime below the cron budget.
+   After application, run `pnpm check:managed-deletion-health-db`; the harness
+   refuses an unexpected Docker project, keeps all synthetic findings inside
+   rollback-only transactions, removes its fixed Storage-owner test helper, and
+   exercises eight concurrent readers.
+3. Deploy the application code first. The missing-schema compatibility path
+   keeps the existing cron successful while emitting a bounded warning.
+4. With fresh authorization naming staging and migration 121, apply it and
+   observe at least two daily runs. Investigate every nonzero critical count and
+   establish a warning baseline before production.
+5. With separate fresh authorization naming production and migration 121,
+   apply the read-only RPC. Migration application is the production activation;
+   the aggregate query has no safe per-object canary. Observe the first
+   scheduled run and query/runtime telemetry before considering monitoring
+   broadly established. A manual production cron invocation is a separate
+   operation because it also advances existing cleanup/purge safety nets and
+   therefore requires explicit authorization.
+
+If the aggregate query cannot reliably finish within the existing 60-second
+route budget, keep migration 121 unapplied (or remove the cron call in a normal
+code rollback before application) and redesign the expensive finding category
+as a separately scheduled, read-only deep scan. Do not weaken the ownership
+contract or replace exact-object purge processing to make monitoring cheaper.
+
+## Local validation evidence
+
+The authorized migration preview contained only migration 121, and local
+history now records 001–121. The database harness proved read-only execution,
+service-role-only access, bounded thresholds, privacy-safe aggregate output,
+warning-only and critical classification, partial purge and expired lease
+detection, provider-side object reappearance, exact rollback cleanup, and eight
+concurrent readers. A 1,000-managed-object fixture completed in 9–34 ms during
+repeated runs; its `EXPLAIN (ANALYZE, BUFFERS)` execution used 6,265 shared-buffer
+hits and remained far below the five-second local guard and 60-second cron
+budget. Generated database types match the locally applied schema.

--- a/docs/guidance/managed-deletion-monitoring.md
+++ b/docs/guidance/managed-deletion-monitoring.md
@@ -75,9 +75,10 @@ contract, so totals represent findings rather than unique objects.
 The separately invoked deep diagnostic detects embedded managed-bucket payloads
 missing their relational registry, payload UUIDs that disagree with the
 registered UUID for the same host/path, and payload digests that no longer match
-the registry evidence. These recursive findings are intentionally excluded from
-the daily cron so growth in immutable assignment history cannot consume the
-cleanup route's 60-second platform budget.
+the registry evidence, including when a payload's final managed reference was
+removed while its registry row remained. These recursive findings are
+intentionally excluded from the daily cron so growth in immutable assignment
+history cannot consume the cleanup route's 60-second platform budget.
 
 ## Operator response
 

--- a/docs/guidance/managed-deletion-monitoring.md
+++ b/docs/guidance/managed-deletion-monitoring.md
@@ -8,7 +8,14 @@ Storage object, change a rollout gate, or enable generic orphan cleanup.
 Migration 121 defines the service-role-only
 `get_managed_deletion_health_snapshot` RPC. The existing authenticated daily
 `/api/cron/cleanup-history` route calls it after its normal cleanup and purge
-safety-net work. No additional schedule is installed.
+safety-net work. This lightweight snapshot uses relational/indexable evidence;
+it does not recursively parse unbounded JSON history. No additional schedule is
+installed.
+
+The same migration defines a separate service-role-only
+`get_managed_deletion_deep_health_snapshot` diagnostic for recursive embedded
+payload reconciliation. It is not called by the cron or any application route,
+has no scheduler, and requires a separately authorized operator query.
 
 ## Privacy and response contract
 
@@ -24,9 +31,11 @@ fence, authorize deletion, or change retry state.
 
 The cron behavior is:
 
-- Before migration 121 exists, missing-function/table schema codes are a
-  code-first compatibility state. Cleanup returns normally and logs
+- Before migration 121 exists, the exact PostgREST missing-RPC code `PGRST202`
+  is a code-first compatibility state. Cleanup returns normally and logs
   `schema unavailable` without provider details.
+- Missing dependency functions/tables and relation-cache errors are probe
+  failures, not rollout compatibility, and return the sanitized `503`.
 - A healthy snapshot returns the existing successful cleanup response.
 - Warning-only findings return success and remain visible in the aggregate log.
   They are expected to need trend/operational review, not an automatic mutation.
@@ -50,8 +59,8 @@ Critical managed-storage findings cover:
 - referenced objects that are not ready;
 - relational raw references with no managed UUID or with mismatched path/owner
   evidence;
-- embedded managed-bucket references missing their relational registry, or
-  whose owner/data-subject evidence differs from the host;
+- registered embedded references whose owner/data-subject evidence differs
+  from the host;
 - managed Classroom objects with neither exactly one hot Classroom nor exactly
   one cold tombstone owner;
 - objects left attached to a settled provisional owner; and
@@ -62,6 +71,13 @@ upload reservations, expired provisional owners, and cleanup-pending objects
 older than the stuck threshold. These warnings are intentionally not deletion
 authority. Counts may overlap when one corrupt entity violates more than one
 contract, so totals represent findings rather than unique objects.
+
+The separately invoked deep diagnostic detects embedded managed-bucket payloads
+missing their relational registry, payload UUIDs that disagree with the
+registered UUID for the same host/path, and payload digests that no longer match
+the registry evidence. These recursive findings are intentionally excluded from
+the daily cron so growth in immutable assignment history cannot consume the
+cleanup route's 60-second platform budget.
 
 ## Operator response
 
@@ -78,6 +94,12 @@ Warning-only counts should be trended. In particular, a stable
 possible separately gated cleanup rollout, not permission to enable it. Generic
 orphan cleanup remains disabled.
 
+Run the deep diagnostic only in an access-controlled, separately authorized
+session. Treat nonzero findings or query failure as evidence for investigation,
+not permission to rewrite a payload, registry row, or Storage object. Record its
+runtime and cancel/redesign the diagnostic if production-scale history cannot be
+scanned safely within the operator session's explicit query budget.
+
 ## Staged rollout
 
 Migration 121 has been applied only to the dedicated local Supabase database
@@ -87,7 +109,8 @@ under one-time authorization. It has not been applied to staging or production.
    migration application.
 2. With fresh authorization naming the disposable/local target and migration
    121, replay the schema and validate SQL execution, query plans, empty/seeded
-   counts, privacy shape, degraded fixtures, and runtime below the cron budget.
+   counts, privacy shape, degraded fixtures, embedded UUID/digest drift, and
+   lightweight snapshot runtime below the cron budget.
    After application, run `pnpm check:managed-deletion-health-db`; the harness
    refuses an unexpected Docker project, keeps all synthetic findings inside
    rollback-only transactions, removes its fixed Storage-owner test helper, and
@@ -105,20 +128,23 @@ under one-time authorization. It has not been applied to staging or production.
    operation because it also advances existing cleanup/purge safety nets and
    therefore requires explicit authorization.
 
-If the aggregate query cannot reliably finish within the existing 60-second
-route budget, keep migration 121 unapplied (or remove the cron call in a normal
-code rollback before application) and redesign the expensive finding category
-as a separately scheduled, read-only deep scan. Do not weaken the ownership
-contract or replace exact-object purge processing to make monitoring cheaper.
+If the lightweight aggregate cannot reliably finish within the existing
+60-second route budget, keep migration 121 unapplied (or remove the cron call in
+a normal code rollback before application). Do not add the recursive diagnostic
+to a cron, weaken the ownership contract, or replace exact-object purge
+processing to make monitoring cheaper.
 
 ## Local validation evidence
 
 The authorized migration preview contained only migration 121, and local
-history now records 001–121. The database harness proved read-only execution,
+history records 001–121. The pre-review database harness proved read-only execution,
 service-role-only access, bounded thresholds, privacy-safe aggregate output,
 warning-only and critical classification, partial purge and expired lease
 detection, provider-side object reappearance, exact rollback cleanup, and eight
 concurrent readers. A 1,000-managed-object fixture completed in 9–34 ms during
 repeated runs; its `EXPLAIN (ANALYZE, BUFFERS)` execution used 6,265 shared-buffer
 hits and remained far below the five-second local guard and 60-second cron
-budget. Generated database types match the locally applied schema.
+budget. Review then separated recursive payload work into the unscheduled deep
+diagnostic and tightened dependency failures; the one-time local application
+permission was not reused. The final migration and deep UUID/digest regression
+therefore require the PR's fresh ephemeral-database replay before merge.

--- a/docs/guidance/managed-storage-rollout.md
+++ b/docs/guidance/managed-storage-rollout.md
@@ -122,6 +122,10 @@ the exact migration and exact target under the schema rollout checklist.
    `MANAGED_STORAGE_CLEANUP_ENABLED=true` and
    `MANAGED STORAGE CLEANUP <target>`. No scheduler is installed here.
 
+The read-only operational baseline and alert/rollout contract are documented in
+`docs/guidance/managed-deletion-monitoring.md`. It does not alter the generic
+cleanup gate or create cleanup authority.
+
 The database fixture `scripts/check-managed-storage-database.sh` is run by CI
 after a fresh migration replay. Running it locally still counts as applying the
 migrations and requires separate authorization naming the local target and exact

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:ui-policy": "tsx scripts/check-ui-policy.ts",
     "check:managed-storage-lineage": "node scripts/check-managed-storage-migration-lineage.mjs",
     "check:classroom-purge-db-lint": "node scripts/check-hot-archived-classroom-purge-lint.mjs",
+    "check:managed-deletion-health-db": "bash scripts/check-managed-deletion-health-database.sh",
     "managed-storage:readiness": "tsx scripts/run-managed-storage-readiness.ts",
     "managed-storage:cleanup": "tsx scripts/run-managed-storage-cleanup.ts",
     "measure:ai-grading-prompts": "tsx scripts/measure-ai-grading-prompts.ts",

--- a/scripts/check-managed-deletion-health-database.sh
+++ b/scripts/check-managed-deletion-health-database.sh
@@ -54,6 +54,8 @@ begin
     select 1 from supabase_migrations.schema_migrations where version = '121'
   ) or to_regprocedure(
     'public.get_managed_deletion_health_snapshot(integer)'
+  ) is null or to_regprocedure(
+    'public.get_managed_deletion_deep_health_snapshot()'
   ) is null
   then raise exception 'Migration 121 is not applied to the local database'; end if;
 end;
@@ -77,6 +79,16 @@ begin
       'public.get_managed_deletion_health_snapshot(integer)', 'execute'
     )
   then raise exception 'service_role monitor privilege is missing'; end if;
+  if has_function_privilege(
+      'anon', 'public.get_managed_deletion_deep_health_snapshot()', 'execute'
+    ) or has_function_privilege(
+      'authenticated',
+      'public.get_managed_deletion_deep_health_snapshot()', 'execute'
+    ) or not has_function_privilege(
+      'service_role',
+      'public.get_managed_deletion_deep_health_snapshot()', 'execute'
+    )
+  then raise exception 'Deep monitor privileges are unsafe'; end if;
 
   select provolatile, prosecdef into strict v_volatility, v_security_definer
   from pg_proc
@@ -107,16 +119,25 @@ $thresholds$;
 do $baseline$
 declare
   v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+  v_deep_snapshot jsonb := public.get_managed_deletion_deep_health_snapshot();
 begin
   if not (v_snapshot->>'healthy')::boolean
     or (v_snapshot->>'critical_count')::integer <> 0
     or (v_snapshot->>'warning_count')::integer <> 0
   then raise exception 'Local baseline is not healthy: %', v_snapshot; end if;
+  if not (v_deep_snapshot->>'healthy')::boolean
+    or (v_deep_snapshot->>'critical_count')::integer <> 0
+  then raise exception 'Local deep baseline is not healthy: %', v_deep_snapshot; end if;
   if v_snapshot::text ~
     '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
     or v_snapshot::text ~
       '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
   then raise exception 'Identity-bearing evidence escaped the snapshot'; end if;
+  if v_deep_snapshot::text ~
+    '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
+    or v_deep_snapshot::text ~
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+  then raise exception 'Identity-bearing evidence escaped deep snapshot'; end if;
 end;
 $baseline$;
 commit;
@@ -194,6 +215,41 @@ insert into public.managed_storage_objects (
   'teacher_test_material', 'ready', clock_timestamp(), clock_timestamp(),
   'c1210000-0000-4000-8000-000000000001'
 );
+insert into public.managed_storage_objects (
+  id, storage_bucket, storage_path, classroom_id, purpose, status,
+  verified_at, ready_at, created_by_user_id
+) values
+  ('c1210000-0000-4000-8000-000000000042', 'test-documents',
+   'monitor-fixture/embedded.pdf', 'c1210000-0000-4000-8000-000000000011',
+   'teacher_test_material', 'ready', clock_timestamp(), clock_timestamp(),
+   'c1210000-0000-4000-8000-000000000001'),
+  ('c1210000-0000-4000-8000-000000000043', 'test-documents',
+   'monitor-fixture/wrong-embedded.pdf', 'c1210000-0000-4000-8000-000000000011',
+   'teacher_test_material', 'ready', clock_timestamp(), clock_timestamp(),
+   'c1210000-0000-4000-8000-000000000001');
+insert into storage.objects (bucket_id, name) values
+  ('test-documents', 'monitor-fixture/embedded.pdf'),
+  ('test-documents', 'monitor-fixture/wrong-embedded.pdf');
+insert into public.tests (id, classroom_id, title, created_by, documents) values (
+  'c1210000-0000-4000-8000-000000000044',
+  'c1210000-0000-4000-8000-000000000011', 'Monitor embedded identity',
+  'c1210000-0000-4000-8000-000000000001',
+  jsonb_build_array(jsonb_build_object(
+    'storage_bucket', 'test-documents',
+    'storage_path', 'monitor-fixture/embedded.pdf',
+    'managed_object_id', 'c1210000-0000-4000-8000-000000000042'
+  ))
+);
+-- Model out-of-band payload corruption without invoking any normal writer or
+-- cleanup trigger; the surrounding transaction rolls this state back.
+alter table public.tests disable trigger user;
+update public.tests
+set documents = jsonb_set(
+  documents, '{0,managed_object_id}',
+  '"c1210000-0000-4000-8000-000000000043"'::jsonb
+)
+where id = 'c1210000-0000-4000-8000-000000000044';
+alter table public.tests enable trigger user;
 insert into public.managed_storage_objects (
   id, storage_bucket, storage_path, classroom_id, purpose, status,
   reservation_expires_at, created_by_user_id
@@ -275,6 +331,7 @@ select storage.insert_managed_deletion_health_reappearance_fixture();
 do $critical$
 declare
   v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+  v_deep_snapshot jsonb := public.get_managed_deletion_deep_health_snapshot();
 begin
   if (v_snapshot->>'healthy')::boolean then
     raise exception 'Critical fixture reported healthy';
@@ -293,11 +350,21 @@ begin
     or (v_snapshot#>>'{managed_storage,expired_reservations}')::integer <> 1
   then raise exception 'Managed-storage findings mismatch: %',
     v_snapshot->'managed_storage'; end if;
+  if (v_deep_snapshot#>>'{findings,embedded_hosts_missing_registry}')::integer <> 0
+    or (v_deep_snapshot#>>'{findings,embedded_payload_identity_mismatches}')::integer <> 1
+    or (v_deep_snapshot#>>'{findings,embedded_evidence_mismatches}')::integer <> 1
+  then raise exception 'Deep payload findings mismatch: %',
+    v_deep_snapshot->'findings'; end if;
   if v_snapshot::text ~
     '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
     or v_snapshot::text ~
       '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
   then raise exception 'Identity-bearing evidence escaped critical snapshot'; end if;
+  if v_deep_snapshot::text ~
+    '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
+    or v_deep_snapshot::text ~
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+  then raise exception 'Identity-bearing evidence escaped deep critical snapshot'; end if;
 end;
 $critical$;
 rollback;

--- a/scripts/check-managed-deletion-health-database.sh
+++ b/scripts/check-managed-deletion-health-database.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_CONTAINER="${MANAGED_DELETION_HEALTH_DB_CONTAINER:-supabase_db_pika}"
+if ! docker inspect "$DB_CONTAINER" >/dev/null 2>&1; then
+  echo "Local Pika Supabase database container is not running." >&2
+  exit 2
+fi
+
+PROJECT_LABEL="$(docker inspect "$DB_CONTAINER" \
+  --format '{{ index .Config.Labels "com.supabase.cli.project" }}')"
+DB_BINDING="$(docker port "$DB_CONTAINER" 5432/tcp 2>/dev/null || true)"
+if [[ "$PROJECT_LABEL" != "pika" ]] || ! grep -q ':54322$' <<<"$DB_BINDING"; then
+  echo "Refusing non-local or unexpected Supabase database target." >&2
+  exit 2
+fi
+
+cleanup_storage_helper() {
+  docker exec -i "$DB_CONTAINER" sh -c \
+    'PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U supabase_storage_admin -d postgres -X -v ON_ERROR_STOP=1 -c "drop function if exists storage.insert_managed_deletion_health_reappearance_fixture()"' \
+    >/dev/null 2>&1 || true
+}
+trap cleanup_storage_helper EXIT
+
+# Provider-side bytes can reappear without a PostgreSQL write. Install one
+# fixed-input, Storage-owner-only helper so this local fixture can model that
+# impossible-through-the-app state without weakening the production trigger.
+docker exec -i "$DB_CONTAINER" sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U supabase_storage_admin -d postgres -X -v ON_ERROR_STOP=1' <<'SQL'
+create or replace function storage.insert_managed_deletion_health_reappearance_fixture()
+returns void
+language plpgsql
+security definer
+set search_path = storage, pg_temp
+as $$
+begin
+  lock table storage.objects in access exclusive mode;
+  alter table storage.objects disable trigger enforce_managed_storage_object_write;
+  insert into storage.objects (bucket_id, name)
+  values ('test-documents', 'monitor-fixture/reappeared.pdf');
+  alter table storage.objects enable trigger enforce_managed_storage_object_write;
+end;
+$$;
+revoke all on function storage.insert_managed_deletion_health_reappearance_fixture()
+  from public, anon, authenticated, service_role;
+grant execute on function storage.insert_managed_deletion_health_reappearance_fixture()
+  to postgres;
+SQL
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+do $migration$
+begin
+  if not exists (
+    select 1 from supabase_migrations.schema_migrations where version = '121'
+  ) or to_regprocedure(
+    'public.get_managed_deletion_health_snapshot(integer)'
+  ) is null
+  then raise exception 'Migration 121 is not applied to the local database'; end if;
+end;
+$migration$;
+
+begin read only;
+do $privileges$
+declare
+  v_volatility "char";
+  v_security_definer boolean;
+begin
+  if has_function_privilege(
+      'anon', 'public.get_managed_deletion_health_snapshot(integer)', 'execute'
+    ) or has_function_privilege(
+      'authenticated',
+      'public.get_managed_deletion_health_snapshot(integer)', 'execute'
+    )
+  then raise exception 'Managed deletion monitor is publicly executable'; end if;
+  if not has_function_privilege(
+      'service_role',
+      'public.get_managed_deletion_health_snapshot(integer)', 'execute'
+    )
+  then raise exception 'service_role monitor privilege is missing'; end if;
+
+  select provolatile, prosecdef into strict v_volatility, v_security_definer
+  from pg_proc
+  where oid = 'public.get_managed_deletion_health_snapshot(integer)'::regprocedure;
+  if v_volatility <> 's' or not v_security_definer then
+    raise exception 'Monitor is not stable and security definer';
+  end if;
+end;
+$privileges$;
+
+do $thresholds$
+begin
+  begin
+    perform public.get_managed_deletion_health_snapshot(299);
+    raise exception 'Low stuck threshold was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'managed_deletion_health_stuck_threshold_invalid' then raise; end if;
+  end;
+  begin
+    perform public.get_managed_deletion_health_snapshot(604801);
+    raise exception 'High stuck threshold was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'managed_deletion_health_stuck_threshold_invalid' then raise; end if;
+  end;
+end;
+$thresholds$;
+
+do $baseline$
+declare
+  v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+begin
+  if not (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'critical_count')::integer <> 0
+    or (v_snapshot->>'warning_count')::integer <> 0
+  then raise exception 'Local baseline is not healthy: %', v_snapshot; end if;
+  if v_snapshot::text ~
+    '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
+    or v_snapshot::text ~
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+  then raise exception 'Identity-bearing evidence escaped the snapshot'; end if;
+end;
+$baseline$;
+commit;
+
+-- A due retry is warning-only until the enclosing operation becomes stale.
+begin;
+insert into public.users (id, email, role) values
+  ('c1210000-0000-4000-8000-000000000001',
+   'monitor-teacher@example.test', 'teacher');
+insert into public.classrooms (id, teacher_id, title, class_code) values (
+  'c1210000-0000-4000-8000-000000000010',
+  'c1210000-0000-4000-8000-000000000001',
+  'Monitor warning fixture', 'MON121'
+);
+insert into public.classroom_purge_operations (
+  id, teacher_id, classroom_id, classroom_title, request_sha256, status,
+  source_revision, impact_summary
+) values (
+  'c1210000-0000-4000-8000-000000000020',
+  'c1210000-0000-4000-8000-000000000001',
+  'c1210000-0000-4000-8000-000000000010',
+  'Monitor warning fixture', repeat('1', 64), 'deleting_objects', 1, '{}'::jsonb
+);
+insert into public.classroom_purge_fences (
+  classroom_id, operation_id, teacher_id
+) values (
+  'c1210000-0000-4000-8000-000000000010',
+  'c1210000-0000-4000-8000-000000000020',
+  'c1210000-0000-4000-8000-000000000001'
+);
+insert into public.classroom_purge_objects (
+  id, operation_id, storage_bucket, storage_path, storage_path_sha256,
+  disposition, status, next_attempt_at
+) values (
+  'c1210000-0000-4000-8000-000000000021',
+  'c1210000-0000-4000-8000-000000000020', 'submission-images',
+  'monitor-fixture/retry.png',
+  public.managed_storage_identity_sha256(
+    'submission-images', 'monitor-fixture/retry.png'
+  ),
+  'delete', 'failed', clock_timestamp() - interval '1 minute'
+);
+do $warning$
+declare
+  v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+begin
+  if not (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'critical_count')::integer <> 0
+    or (v_snapshot#>>'{operations,classroom,due_failed_objects}')::integer <> 1
+  then raise exception 'Warning-only fixture was misclassified: %', v_snapshot; end if;
+end;
+$warning$;
+rollback;
+
+-- Critical purge, partial-progress, lease, provider-reappearance, and managed
+-- ownership findings are detected together, then fully rolled back.
+begin;
+insert into public.users (id, email, role) values
+  ('c1210000-0000-4000-8000-000000000001',
+   'monitor-teacher@example.test', 'teacher');
+insert into public.classrooms (id, teacher_id, title, class_code) values
+  ('c1210000-0000-4000-8000-000000000010',
+   'c1210000-0000-4000-8000-000000000001',
+   'Monitor purge fixture', 'MON121'),
+  ('c1210000-0000-4000-8000-000000000011',
+   'c1210000-0000-4000-8000-000000000001',
+   'Monitor storage fixture', 'MON122');
+
+insert into public.managed_storage_objects (
+  id, storage_bucket, storage_path, classroom_id, purpose, status,
+  verified_at, ready_at, created_by_user_id
+) values (
+  'c1210000-0000-4000-8000-000000000040', 'test-documents',
+  'monitor-fixture/missing.pdf', 'c1210000-0000-4000-8000-000000000011',
+  'teacher_test_material', 'ready', clock_timestamp(), clock_timestamp(),
+  'c1210000-0000-4000-8000-000000000001'
+);
+insert into public.managed_storage_objects (
+  id, storage_bucket, storage_path, classroom_id, purpose, status,
+  reservation_expires_at, created_by_user_id
+) values (
+  'c1210000-0000-4000-8000-000000000041', 'submission-images',
+  'monitor-fixture/expired.png', 'c1210000-0000-4000-8000-000000000011',
+  'student_inline_image', 'reserved', clock_timestamp() - interval '1 minute',
+  'c1210000-0000-4000-8000-000000000001'
+);
+
+insert into public.classroom_purge_operations (
+  id, teacher_id, classroom_id, classroom_title, request_sha256, status,
+  source_revision, impact_summary, updated_at
+) values (
+  'c1210000-0000-4000-8000-000000000020',
+  'c1210000-0000-4000-8000-000000000001',
+  'c1210000-0000-4000-8000-000000000010',
+  'Monitor purge fixture', repeat('1', 64), 'deleting_objects', 1, '{}'::jsonb,
+  clock_timestamp() - interval '2 hours'
+);
+insert into public.classroom_purge_fences (
+  classroom_id, operation_id, teacher_id
+) values (
+  'c1210000-0000-4000-8000-000000000010',
+  'c1210000-0000-4000-8000-000000000020',
+  'c1210000-0000-4000-8000-000000000001'
+);
+insert into public.classroom_purge_objects (
+  id, operation_id, storage_bucket, storage_path, storage_path_sha256,
+  disposition, status, next_attempt_at, deleted_at
+) values
+  ('c1210000-0000-4000-8000-000000000021',
+   'c1210000-0000-4000-8000-000000000020', 'test-documents', null,
+   public.managed_storage_identity_sha256(
+     'test-documents', 'monitor-fixture/reappeared.pdf'
+   ),
+   'delete', 'deleted', clock_timestamp(), clock_timestamp()),
+  ('c1210000-0000-4000-8000-000000000022',
+   'c1210000-0000-4000-8000-000000000020', 'submission-images',
+   'monitor-fixture/retry.png',
+   public.managed_storage_identity_sha256(
+     'submission-images', 'monitor-fixture/retry.png'
+   ),
+   'delete', 'failed', clock_timestamp() - interval '1 minute', null);
+insert into public.classroom_purge_objects (
+  id, operation_id, storage_bucket, storage_path, storage_path_sha256,
+  disposition, status, next_attempt_at, lease_token, lease_expires_at
+) values (
+  'c1210000-0000-4000-8000-000000000023',
+  'c1210000-0000-4000-8000-000000000020', 'assignment-artifacts',
+  'monitor-fixture/leased.bin',
+  public.managed_storage_identity_sha256(
+    'assignment-artifacts', 'monitor-fixture/leased.bin'
+  ),
+  'delete', 'processing', clock_timestamp(),
+  'c1210000-0000-4000-8000-000000000024',
+  clock_timestamp() - interval '1 minute'
+);
+
+insert into public.course_blueprint_purge_operations (
+  id, course_blueprint_id, teacher_id, course_blueprint_title,
+  request_sha256, inventory_sha256, finalization_sha256, source_revision,
+  status, retryable, impact_summary, error_code
+) values (
+  'c1210000-0000-4000-8000-000000000030',
+  'c1210000-0000-4000-8000-000000000031',
+  'c1210000-0000-4000-8000-000000000001', 'Monitor Blueprint',
+  repeat('2', 64), repeat('3', 64), repeat('4', 64), 1,
+  'failed', false, '{}'::jsonb, 'fixture_terminal_failure'
+);
+insert into public.course_blueprint_purge_fences (
+  course_blueprint_id, operation_id
+) values (
+  'c1210000-0000-4000-8000-000000000031',
+  'c1210000-0000-4000-8000-000000000030'
+);
+select storage.insert_managed_deletion_health_reappearance_fixture();
+
+do $critical$
+declare
+  v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+begin
+  if (v_snapshot->>'healthy')::boolean then
+    raise exception 'Critical fixture reported healthy';
+  end if;
+  if (v_snapshot#>>'{operations,classroom,stale_operations}')::integer <> 1
+    or (v_snapshot#>>'{operations,classroom,stale_partial_operations}')::integer <> 1
+    or (v_snapshot#>>'{operations,classroom,expired_object_leases}')::integer <> 1
+    or (v_snapshot#>>'{operations,classroom,due_failed_objects}')::integer <> 1
+    or (v_snapshot#>>'{operations,classroom,deleted_objects_reappeared}')::integer <> 1
+  then raise exception 'Classroom findings mismatch: %',
+    v_snapshot->'operations'->'classroom'; end if;
+  if (v_snapshot#>>'{operations,course_blueprint,terminal_failures}')::integer <> 1
+  then raise exception 'Blueprint terminal failure is missing'; end if;
+  if (v_snapshot#>>'{managed_storage,unregistered_storage_objects}')::integer <> 1
+    or (v_snapshot#>>'{managed_storage,registered_objects_missing_storage}')::integer <> 1
+    or (v_snapshot#>>'{managed_storage,expired_reservations}')::integer <> 1
+  then raise exception 'Managed-storage findings mismatch: %',
+    v_snapshot->'managed_storage'; end if;
+  if v_snapshot::text ~
+    '"(teacher_id|student_id|user_id|classroom_id|course_blueprint_id|operation_id|managed_object_id|storage_path|email|title)"[[:space:]]*:'
+    or v_snapshot::text ~
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+  then raise exception 'Identity-bearing evidence escaped critical snapshot'; end if;
+end;
+$critical$;
+rollback;
+
+-- One thousand ready objects is deliberately above the current production
+-- inventory. The aggregate must stay comfortably below the cron budget.
+begin;
+insert into public.users (id, email, role) values
+  ('c1210000-0000-4000-8000-000000000001',
+   'monitor-teacher@example.test', 'teacher');
+insert into public.classrooms (id, teacher_id, title, class_code) values (
+  'c1210000-0000-4000-8000-000000000011',
+  'c1210000-0000-4000-8000-000000000001',
+  'Monitor load fixture', 'MON122'
+);
+insert into public.managed_storage_objects (
+  id, storage_bucket, storage_path, classroom_id, purpose, status,
+  verified_at, ready_at, created_by_user_id
+)
+select
+  public.managed_storage_legacy_object_id(
+    'test-documents', 'monitor-load/' || value::text || '.pdf'
+  ),
+  'test-documents', 'monitor-load/' || value::text || '.pdf',
+  'c1210000-0000-4000-8000-000000000011', 'teacher_test_material', 'ready',
+  clock_timestamp(), clock_timestamp(),
+  'c1210000-0000-4000-8000-000000000001'
+from generate_series(1, 1000) value;
+insert into storage.objects (bucket_id, name)
+select 'test-documents', 'monitor-load/' || value::text || '.pdf'
+from generate_series(1, 1000) value;
+
+do $runtime$
+declare
+  v_started_at timestamptz := clock_timestamp();
+  v_snapshot jsonb;
+  v_elapsed_ms numeric;
+begin
+  v_snapshot := public.get_managed_deletion_health_snapshot(3600);
+  v_elapsed_ms := extract(epoch from (clock_timestamp() - v_started_at)) * 1000;
+  if (v_snapshot#>>'{managed_storage,ready_objects_unreferenced}')::integer <> 1000
+  then raise exception 'Load fixture was not counted exactly'; end if;
+  if v_elapsed_ms >= 5000 then
+    raise exception 'Health snapshot exceeded local 5-second budget: % ms', v_elapsed_ms;
+  end if;
+  raise notice 'Managed deletion health 1000-object runtime: % ms',
+    round(v_elapsed_ms, 3);
+end;
+$runtime$;
+explain (analyze, buffers, summary)
+select public.get_managed_deletion_health_snapshot(3600);
+rollback;
+
+do $restored$
+declare
+  v_snapshot jsonb := public.get_managed_deletion_health_snapshot(3600);
+begin
+  if not (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'critical_count')::integer <> 0
+    or (v_snapshot->>'warning_count')::integer <> 0
+  then raise exception 'Fixture rollback did not restore healthy state: %', v_snapshot; end if;
+end;
+$restored$;
+SQL
+
+CONCURRENT_RESULTS="$(
+  seq 1 8 | xargs -P8 -I{} docker exec "$DB_CONTAINER" \
+    psql -U postgres -d postgres -X -Atqc \
+    "select public.get_managed_deletion_health_snapshot(3600)->>'healthy'"
+)"
+if [[ "$(grep -c '^true$' <<<"$CONCURRENT_RESULTS")" -ne 8 ]]; then
+  echo "Concurrent health snapshots did not all complete healthy." >&2
+  exit 1
+fi
+
+echo "Managed deletion health database checks passed (8 concurrent readers)."

--- a/scripts/check-managed-deletion-health-database.sh
+++ b/scripts/check-managed-deletion-health-database.sh
@@ -367,6 +367,24 @@ begin
   then raise exception 'Identity-bearing evidence escaped deep critical snapshot'; end if;
 end;
 $critical$;
+
+-- Removing the final raw reference must not hide a stale registry row.
+alter table public.tests disable trigger user;
+update public.tests
+set documents = '[]'::jsonb
+where id = 'c1210000-0000-4000-8000-000000000044';
+alter table public.tests enable trigger user;
+do $removed_reference$
+declare
+  v_deep_snapshot jsonb := public.get_managed_deletion_deep_health_snapshot();
+begin
+  if (v_deep_snapshot#>>'{findings,embedded_hosts_missing_registry}')::integer <> 0
+    or (v_deep_snapshot#>>'{findings,embedded_payload_identity_mismatches}')::integer <> 0
+    or (v_deep_snapshot#>>'{findings,embedded_evidence_mismatches}')::integer <> 1
+  then raise exception 'Removed-reference evidence drift was missed: %',
+    v_deep_snapshot->'findings'; end if;
+end;
+$removed_reference$;
 rollback;
 
 -- One thousand ready objects is deliberately above the current production

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -11,6 +11,7 @@ import {
 import { chunkValues, loadChunkedRows, loadPagedRows } from '@/lib/server/query-chunks'
 import { runClassroomPurgeSafetyNet } from '@/lib/server/classroom-purge'
 import { runCourseBlueprintPurgeSafetyNet } from '@/lib/server/course-blueprint-purge'
+import { readManagedDeletionHealth } from '@/lib/server/managed-deletion-health'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -22,6 +23,48 @@ const CLEANUP_PAGE_SIZE = 1000
 const SAVE_OPERATION_RETENTION_DAYS = 35
 
 type IdRow = { id: string }
+
+function managedDeletionHealthErrorCode(error: unknown): string {
+  const code = error instanceof Error && 'code' in error ? String(error.code) : ''
+  if (
+    code === 'managed_deletion_health_query_failed'
+    || code === 'managed_deletion_health_contract_invalid'
+    || code === 'managed_deletion_health_threshold_invalid'
+  ) return code
+  return 'managed_deletion_health_unknown_failure'
+}
+
+async function respondWithManagedDeletionHealth(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  body: Record<string, unknown>,
+) {
+  try {
+    const result = await readManagedDeletionHealth({ supabase })
+    if (!result.schemaAvailable) return NextResponse.json(body)
+    if (!result.snapshot.healthy || result.snapshot.critical_count > 0) {
+      console.error('[managed-deletion-health] degraded', {
+        critical_count: result.snapshot.critical_count,
+        warning_count: result.snapshot.warning_count,
+      })
+      return NextResponse.json({
+        error: 'Managed deletion health degraded',
+        managed_deletion_health: {
+          critical_count: result.snapshot.critical_count,
+          warning_count: result.snapshot.warning_count,
+        },
+      }, { status: 503 })
+    }
+    return NextResponse.json(body)
+  } catch (error) {
+    console.error('[managed-deletion-health] probe failed', {
+      error_code: managedDeletionHealthErrorCode(error),
+    })
+    return NextResponse.json(
+      { error: 'Failed to verify managed deletion health' },
+      { status: 503 },
+    )
+  }
+}
 
 function isArchiveStagingCleanupEnabled(): boolean {
   return process.env.CLASSROOM_ARCHIVE_STAGING_CLEANUP_ENABLED
@@ -192,7 +235,7 @@ async function handle(request: NextRequest) {
   }
 
   if (classroomIds.length === 0) {
-    return NextResponse.json({
+    return respondWithManagedDeletionHealth(supabase, {
       status: 'ok',
       deleted: 0,
       ...(archiveStagingCleaned === undefined
@@ -307,7 +350,7 @@ async function handle(request: NextRequest) {
   }
   deleted += testHistoryDeleted
 
-  return NextResponse.json({
+  return respondWithManagedDeletionHealth(supabase, {
     status: 'ok',
     deleted,
     ...(archiveStagingCleaned === undefined

--- a/src/lib/server/managed-deletion-health.ts
+++ b/src/lib/server/managed-deletion-health.ts
@@ -24,7 +24,6 @@ const managedStorageHealthSchema = z.object({
   referenced_objects_not_ready: countSchema,
   raw_references_missing_identity: countSchema,
   relational_identity_mismatches: countSchema,
-  embedded_hosts_missing_registry: countSchema,
   embedded_ownership_mismatches: countSchema,
   objects_without_durable_owner: countSchema,
   settled_provisional_objects: countSchema,
@@ -54,6 +53,22 @@ export type ManagedDeletionHealthSnapshot = z.infer<
   typeof managedDeletionHealthSnapshotSchema
 >
 
+export const managedDeletionDeepHealthSnapshotSchema = z.object({
+  version: z.literal(1),
+  generated_at: z.string().datetime({ offset: true }),
+  healthy: z.boolean(),
+  critical_count: countSchema,
+  findings: z.object({
+    embedded_hosts_missing_registry: countSchema,
+    embedded_payload_identity_mismatches: countSchema,
+    embedded_evidence_mismatches: countSchema,
+  }).strict(),
+}).strict()
+
+export type ManagedDeletionDeepHealthSnapshot = z.infer<
+  typeof managedDeletionDeepHealthSnapshotSchema
+>
+
 type RpcError = { code?: string; message?: string }
 type HealthClient = {
   rpc(name: string, args: Record<string, unknown>): PromiseLike<{
@@ -75,9 +90,6 @@ export class ManagedDeletionHealthError extends Error {
 
 function isMissingSchemaError(error: RpcError): boolean {
   return error.code === 'PGRST202'
-    || error.code === 'PGRST205'
-    || error.code === '42883'
-    || error.code === '42P01'
 }
 
 function healthClient(value: ReturnType<typeof getServiceRoleClient>): HealthClient {

--- a/src/lib/server/managed-deletion-health.ts
+++ b/src/lib/server/managed-deletion-health.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+const MIN_STUCK_AFTER_SECONDS = 300
+const MAX_STUCK_AFTER_SECONDS = 604_800
+const DEFAULT_STUCK_AFTER_SECONDS = 3_600
+
+const countSchema = z.number().int().nonnegative()
+
+const operationHealthSchema = z.object({
+  terminal_failures: countSchema,
+  stale_operations: countSchema,
+  stale_partial_operations: countSchema,
+  expired_object_leases: countSchema,
+  due_failed_objects: countSchema,
+  fences_without_active_operation: countSchema,
+  active_operations_without_fence: countSchema,
+  deleted_objects_reappeared: countSchema,
+}).strict()
+
+const managedStorageHealthSchema = z.object({
+  unregistered_storage_objects: countSchema,
+  registered_objects_missing_storage: countSchema,
+  referenced_objects_not_ready: countSchema,
+  raw_references_missing_identity: countSchema,
+  relational_identity_mismatches: countSchema,
+  embedded_hosts_missing_registry: countSchema,
+  embedded_ownership_mismatches: countSchema,
+  objects_without_durable_owner: countSchema,
+  settled_provisional_objects: countSchema,
+  ready_objects_unreferenced: countSchema,
+  expired_reservations: countSchema,
+  expired_provisional_owners: countSchema,
+  stale_cleanup_pending: countSchema,
+  expired_cleanup_leases: countSchema,
+}).strict()
+
+export const managedDeletionHealthSnapshotSchema = z.object({
+  version: z.literal(1),
+  generated_at: z.string().datetime({ offset: true }),
+  stuck_after_seconds: z.number().int().min(MIN_STUCK_AFTER_SECONDS)
+    .max(MAX_STUCK_AFTER_SECONDS),
+  healthy: z.boolean(),
+  critical_count: countSchema,
+  warning_count: countSchema,
+  operations: z.object({
+    classroom: operationHealthSchema,
+    course_blueprint: operationHealthSchema,
+  }).strict(),
+  managed_storage: managedStorageHealthSchema,
+}).strict()
+
+export type ManagedDeletionHealthSnapshot = z.infer<
+  typeof managedDeletionHealthSnapshotSchema
+>
+
+type RpcError = { code?: string; message?: string }
+type HealthClient = {
+  rpc(name: string, args: Record<string, unknown>): PromiseLike<{
+    data: unknown
+    error: RpcError | null
+  }>
+}
+
+export type ManagedDeletionHealthResult =
+  | { schemaAvailable: false }
+  | { schemaAvailable: true; snapshot: ManagedDeletionHealthSnapshot }
+
+export class ManagedDeletionHealthError extends Error {
+  constructor(public readonly code: string) {
+    super('Managed deletion health could not be verified')
+    this.name = 'ManagedDeletionHealthError'
+  }
+}
+
+function isMissingSchemaError(error: RpcError): boolean {
+  return error.code === 'PGRST202'
+    || error.code === 'PGRST205'
+    || error.code === '42883'
+    || error.code === '42P01'
+}
+
+function healthClient(value: ReturnType<typeof getServiceRoleClient>): HealthClient {
+  return value as unknown as HealthClient
+}
+
+export async function readManagedDeletionHealth(input: {
+  supabase?: ReturnType<typeof getServiceRoleClient>
+  stuckAfterSeconds?: number
+} = {}): Promise<ManagedDeletionHealthResult> {
+  const stuckAfterSeconds = input.stuckAfterSeconds ?? DEFAULT_STUCK_AFTER_SECONDS
+  if (
+    !Number.isSafeInteger(stuckAfterSeconds)
+    || stuckAfterSeconds < MIN_STUCK_AFTER_SECONDS
+    || stuckAfterSeconds > MAX_STUCK_AFTER_SECONDS
+  ) {
+    throw new ManagedDeletionHealthError('managed_deletion_health_threshold_invalid')
+  }
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await healthClient(supabase).rpc(
+    'get_managed_deletion_health_snapshot',
+    { p_stuck_after_seconds: stuckAfterSeconds },
+  )
+
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      console.warn('[managed-deletion-health] schema unavailable', {
+        error_code: error.code ?? 'unknown',
+      })
+      return { schemaAvailable: false }
+    }
+    throw new ManagedDeletionHealthError('managed_deletion_health_query_failed')
+  }
+
+  const parsed = managedDeletionHealthSnapshotSchema.safeParse(data)
+  if (!parsed.success) {
+    throw new ManagedDeletionHealthError('managed_deletion_health_contract_invalid')
+  }
+
+  console.info('[managed-deletion-health] snapshot', {
+    healthy: parsed.data.healthy,
+    critical_count: parsed.data.critical_count,
+    warning_count: parsed.data.warning_count,
+  })
+  return { schemaAvailable: true, snapshot: parsed.data }
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -6967,6 +6967,10 @@ export type Database = {
         Args: { p_classroom_id: string; p_teacher_id: string }
         Returns: Json
       }
+      get_managed_deletion_health_snapshot: {
+        Args: { p_stuck_after_seconds?: number }
+        Returns: Json
+      }
       get_managed_storage_object_presence: {
         Args: { p_storage_bucket: string; p_storage_path: string }
         Returns: Json

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -6967,6 +6967,10 @@ export type Database = {
         Args: { p_classroom_id: string; p_teacher_id: string }
         Returns: Json
       }
+      get_managed_deletion_deep_health_snapshot: {
+        Args: Record<PropertyKey, never>
+        Returns: Json
+      }
       get_managed_deletion_health_snapshot: {
         Args: { p_stuck_after_seconds?: number }
         Returns: Json

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -6967,10 +6967,7 @@ export type Database = {
         Args: { p_classroom_id: string; p_teacher_id: string }
         Returns: Json
       }
-      get_managed_deletion_deep_health_snapshot: {
-        Args: Record<PropertyKey, never>
-        Returns: Json
-      }
+      get_managed_deletion_deep_health_snapshot: { Args: never; Returns: Json }
       get_managed_deletion_health_snapshot: {
         Args: { p_stuck_after_seconds?: number }
         Returns: Json

--- a/supabase/migrations/121_managed_deletion_health_monitoring.sql
+++ b/supabase/migrations/121_managed_deletion_health_monitoring.sql
@@ -38,7 +38,6 @@ declare
   v_referenced_objects_not_ready bigint;
   v_raw_references_missing_identity bigint;
   v_relational_identity_mismatches bigint;
-  v_embedded_hosts_missing_registry bigint;
   v_embedded_ownership_mismatches bigint;
   v_objects_without_durable_owner bigint;
   v_settled_provisional_objects bigint;
@@ -274,106 +273,79 @@ begin
     or (reference.expected_classroom_id is not null
       and object.classroom_id is distinct from reference.expected_classroom_id);
 
-  select count(*) into v_embedded_hosts_missing_registry
-  from (
-    select 'assignment_doc'::text host_type, id host_id, content payload
-    from public.assignment_docs
-    union all
-    select 'assignment_doc_history', id, coalesce(snapshot, patch)
-    from public.assignment_doc_history
-    union all
-    select 'test', id, documents from public.tests
-    union all
-    select 'course_blueprint_assessment', id, documents
-    from public.course_blueprint_assessments
-    union all
-    select 'course_blueprint_version', id, snapshot_json
-    from public.course_blueprint_versions
-    union all
-    select 'course_blueprint_change_proposal', id, operations_json
-    from public.course_blueprint_change_proposals
-  ) host
-  where exists (
-    select 1
-    from (
-      select distinct storage_bucket, storage_path
-      from public.managed_storage_payload_raw_references(host.payload)
-    ) raw_reference
-    where not exists (
-      select 1 from public.managed_storage_json_references reference
-      where reference.storage_bucket = raw_reference.storage_bucket
-        and reference.storage_path = raw_reference.storage_path
-        and (
-          reference.assignment_doc_id = case
-            when host.host_type = 'assignment_doc' then host.host_id end
-          or reference.assignment_doc_history_id = case
-            when host.host_type = 'assignment_doc_history' then host.host_id end
-          or reference.test_id = case when host.host_type = 'test' then host.host_id end
-          or reference.course_blueprint_assessment_id = case
-            when host.host_type = 'course_blueprint_assessment' then host.host_id end
-          or reference.course_blueprint_version_id = case
-            when host.host_type = 'course_blueprint_version' then host.host_id end
-          or reference.course_blueprint_change_proposal_id = case
-            when host.host_type = 'course_blueprint_change_proposal' then host.host_id end
-        )
-    )
-  );
-
   select count(*) into v_embedded_ownership_mismatches
   from (
-    select distinct host.host_type, host.host_id
-    from (
-      select 'assignment_doc'::text host_type, document.id host_id,
-        assignment.classroom_id, null::uuid course_blueprint_id,
-        document.id assignment_doc_id, document.student_id data_subject_user_id
-      from public.assignment_docs document
-      join public.assignments assignment on assignment.id = document.assignment_id
-      union all
-      select 'assignment_doc_history', history.id, assignment.classroom_id, null::uuid,
-        document.id, document.student_id
-      from public.assignment_doc_history history
-      join public.assignment_docs document on document.id = history.assignment_doc_id
-      join public.assignments assignment on assignment.id = document.assignment_id
-      union all
-      select 'test', id, classroom_id, null::uuid, null::uuid, null::uuid
-      from public.tests
-      union all
-      select 'course_blueprint_assessment', id, null::uuid, course_blueprint_id,
-        null::uuid, null::uuid
-      from public.course_blueprint_assessments
-      union all
-      select 'course_blueprint_version', id, null::uuid, course_blueprint_id,
-        null::uuid, null::uuid
-      from public.course_blueprint_versions
-      union all
-      select 'course_blueprint_change_proposal', id, null::uuid, course_blueprint_id,
-        null::uuid, null::uuid
-      from public.course_blueprint_change_proposals
-    ) host
-    join public.managed_storage_json_references reference on (
-      reference.assignment_doc_id = case
-        when host.host_type = 'assignment_doc' then host.host_id end
-      or reference.assignment_doc_history_id = case
-        when host.host_type = 'assignment_doc_history' then host.host_id end
-      or reference.test_id = case when host.host_type = 'test' then host.host_id end
-      or reference.course_blueprint_assessment_id = case
-        when host.host_type = 'course_blueprint_assessment' then host.host_id end
-      or reference.course_blueprint_version_id = case
-        when host.host_type = 'course_blueprint_version' then host.host_id end
-      or reference.course_blueprint_change_proposal_id = case
-        when host.host_type = 'course_blueprint_change_proposal' then host.host_id end
-    )
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, assignment.classroom_id expected_classroom_id,
+      null::uuid expected_blueprint_id, document.id expected_assignment_doc_id,
+      document.student_id expected_data_subject_user_id
+    from public.managed_storage_json_references reference
+    join public.assignment_docs document on document.id = reference.assignment_doc_id
+    join public.assignments assignment on assignment.id = document.assignment_id
     join public.managed_storage_objects object on object.id = reference.managed_object_id
-    where (host.classroom_id is not null
-        and object.classroom_id is distinct from host.classroom_id)
-      or (host.course_blueprint_id is not null
-        and object.course_blueprint_id is distinct from host.course_blueprint_id)
-      or (object.storage_bucket = 'submission-images' and (
-        object.resource_type is distinct from 'assignment_doc'
-        or object.resource_id is distinct from host.assignment_doc_id
-        or object.data_subject_user_id is distinct from host.data_subject_user_id
-      ))
-  ) mismatch;
+    where reference.assignment_doc_id is not null
+    union all
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, assignment.classroom_id, null::uuid,
+      document.id, document.student_id
+    from public.managed_storage_json_references reference
+    join public.assignment_doc_history history
+      on history.id = reference.assignment_doc_history_id
+    join public.assignment_docs document on document.id = history.assignment_doc_id
+    join public.assignments assignment on assignment.id = document.assignment_id
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where reference.assignment_doc_history_id is not null
+    union all
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, test.classroom_id, null::uuid, null::uuid, null::uuid
+    from public.managed_storage_json_references reference
+    join public.tests test on test.id = reference.test_id
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where reference.test_id is not null
+    union all
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, null::uuid, assessment.course_blueprint_id,
+      null::uuid, null::uuid
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_assessments assessment
+      on assessment.id = reference.course_blueprint_assessment_id
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where reference.course_blueprint_assessment_id is not null
+    union all
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, null::uuid, version.course_blueprint_id,
+      null::uuid, null::uuid
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_versions version
+      on version.id = reference.course_blueprint_version_id
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where reference.course_blueprint_version_id is not null
+    union all
+    select object.id, object.storage_bucket, object.classroom_id,
+      object.course_blueprint_id, object.resource_type, object.resource_id,
+      object.data_subject_user_id, null::uuid, proposal.course_blueprint_id,
+      null::uuid, null::uuid
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_change_proposals proposal
+      on proposal.id = reference.course_blueprint_change_proposal_id
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where reference.course_blueprint_change_proposal_id is not null
+  ) mismatch
+  where (mismatch.expected_classroom_id is not null
+      and mismatch.classroom_id is distinct from mismatch.expected_classroom_id)
+    or (mismatch.expected_blueprint_id is not null
+      and mismatch.course_blueprint_id is distinct from mismatch.expected_blueprint_id)
+    or (mismatch.storage_bucket = 'submission-images' and (
+      mismatch.resource_type is distinct from 'assignment_doc'
+      or mismatch.resource_id is distinct from mismatch.expected_assignment_doc_id
+      or mismatch.data_subject_user_id
+        is distinct from mismatch.expected_data_subject_user_id
+    ));
 
   select count(*) into v_objects_without_durable_owner
   from public.managed_storage_objects object
@@ -429,8 +401,8 @@ begin
     + v_blueprint_deleted_objects_reappeared
     + v_unregistered_storage_objects + v_registered_objects_missing_storage
     + v_referenced_objects_not_ready + v_raw_references_missing_identity
-    + v_relational_identity_mismatches + v_embedded_hosts_missing_registry
-    + v_embedded_ownership_mismatches + v_objects_without_durable_owner
+    + v_relational_identity_mismatches + v_embedded_ownership_mismatches
+    + v_objects_without_durable_owner
     + v_settled_provisional_objects + v_expired_cleanup_leases;
 
   v_warning_count :=
@@ -473,7 +445,6 @@ begin
       'referenced_objects_not_ready', v_referenced_objects_not_ready,
       'raw_references_missing_identity', v_raw_references_missing_identity,
       'relational_identity_mismatches', v_relational_identity_mismatches,
-      'embedded_hosts_missing_registry', v_embedded_hosts_missing_registry,
       'embedded_ownership_mismatches', v_embedded_ownership_mismatches,
       'objects_without_durable_owner', v_objects_without_durable_owner,
       'settled_provisional_objects', v_settled_provisional_objects,
@@ -493,3 +464,122 @@ grant execute on function public.get_managed_deletion_health_snapshot(integer) t
 
 comment on function public.get_managed_deletion_health_snapshot(integer) is
   'Read-only aggregate monitoring for purge liveness and managed-storage drift; returns no object identities.';
+
+-- Recursive payload reconciliation is deliberately separate from the daily
+-- cron snapshot. Assignment history is unbounded, so this diagnostic may run
+-- only as an explicitly authorized operator query with its own observation.
+create or replace function public.get_managed_deletion_deep_health_snapshot()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, storage
+as $deep_health$
+declare
+  v_generated_at timestamptz := statement_timestamp();
+  v_embedded_hosts_missing_registry bigint;
+  v_embedded_payload_identity_mismatches bigint;
+  v_embedded_evidence_mismatches bigint;
+  v_critical_count bigint;
+begin
+  with hosts as (
+    select 'assignment_doc'::text host_type, id host_id, content payload
+    from public.assignment_docs
+    union all
+    select 'assignment_doc_history', id, coalesce(snapshot, patch)
+    from public.assignment_doc_history
+    union all
+    select 'test', id, documents from public.tests
+    union all
+    select 'course_blueprint_assessment', id, documents
+    from public.course_blueprint_assessments
+    union all
+    select 'course_blueprint_version', id, snapshot_json
+    from public.course_blueprint_versions
+    union all
+    select 'course_blueprint_change_proposal', id, operations_json
+    from public.course_blueprint_change_proposals
+  ), parsed as (
+    select host.host_type, host.host_id, host.payload,
+      raw_reference.managed_object_id payload_managed_object_id,
+      raw_reference.storage_bucket, raw_reference.storage_path
+    from hosts host
+    cross join lateral public.managed_storage_payload_raw_references(
+      host.payload
+    ) raw_reference
+  ), reconciled as (
+    select parsed.*,
+      reference.managed_object_id registered_managed_object_id,
+      reference.evidence_sha256
+    from parsed
+    left join public.managed_storage_json_references reference
+      on reference.storage_bucket = parsed.storage_bucket
+      and reference.storage_path = parsed.storage_path
+      and (
+        reference.assignment_doc_id = case
+          when parsed.host_type = 'assignment_doc' then parsed.host_id end
+        or reference.assignment_doc_history_id = case
+          when parsed.host_type = 'assignment_doc_history' then parsed.host_id end
+        or reference.test_id = case
+          when parsed.host_type = 'test' then parsed.host_id end
+        or reference.course_blueprint_assessment_id = case
+          when parsed.host_type = 'course_blueprint_assessment' then parsed.host_id end
+        or reference.course_blueprint_version_id = case
+          when parsed.host_type = 'course_blueprint_version' then parsed.host_id end
+        or reference.course_blueprint_change_proposal_id = case
+          when parsed.host_type = 'course_blueprint_change_proposal'
+          then parsed.host_id end
+      )
+  )
+  select
+    count(distinct (host_type, host_id)) filter (
+      where registered_managed_object_id is null
+    ),
+    count(distinct (host_type, host_id, storage_bucket, storage_path)) filter (
+      where payload_managed_object_id is not null
+        and registered_managed_object_id is not null
+        and payload_managed_object_id is distinct from registered_managed_object_id
+    ),
+    count(distinct (host_type, host_id)) filter (
+      where registered_managed_object_id is not null
+        and evidence_sha256 is distinct from encode(
+          extensions.digest(
+            convert_to(coalesce(payload, 'null'::jsonb)::text, 'UTF8'),
+            'sha256'
+          ),
+          'hex'
+        )
+    )
+  into
+    v_embedded_hosts_missing_registry,
+    v_embedded_payload_identity_mismatches,
+    v_embedded_evidence_mismatches
+  from reconciled;
+
+  v_critical_count :=
+    v_embedded_hosts_missing_registry
+    + v_embedded_payload_identity_mismatches
+    + v_embedded_evidence_mismatches;
+
+  return jsonb_build_object(
+    'version', 1,
+    'generated_at', v_generated_at,
+    'healthy', v_critical_count = 0,
+    'critical_count', v_critical_count,
+    'findings', jsonb_build_object(
+      'embedded_hosts_missing_registry', v_embedded_hosts_missing_registry,
+      'embedded_payload_identity_mismatches',
+        v_embedded_payload_identity_mismatches,
+      'embedded_evidence_mismatches', v_embedded_evidence_mismatches
+    )
+  );
+end;
+$deep_health$;
+
+revoke all on function public.get_managed_deletion_deep_health_snapshot()
+  from public, anon, authenticated, service_role;
+grant execute on function public.get_managed_deletion_deep_health_snapshot()
+  to service_role;
+
+comment on function public.get_managed_deletion_deep_health_snapshot() is
+  'Explicit read-only recursive payload/registry reconciliation; unscheduled and returns no object identities.';

--- a/supabase/migrations/121_managed_deletion_health_monitoring.sql
+++ b/supabase/migrations/121_managed_deletion_health_monitoring.sql
@@ -1,0 +1,495 @@
+-- Privacy-safe, read-only monitoring for durable managed deletion operations
+-- and managed-storage ownership drift. Applying this migration changes no
+-- rollout setting, schedules no worker, and does not enable generic cleanup.
+
+create or replace function public.get_managed_deletion_health_snapshot(
+  p_stuck_after_seconds integer default 3600
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, storage
+as $health$
+declare
+  v_generated_at timestamptz := statement_timestamp();
+  v_stuck_before timestamptz;
+
+  v_classroom_terminal_failures bigint;
+  v_classroom_stale_operations bigint;
+  v_classroom_stale_partial_operations bigint;
+  v_classroom_expired_object_leases bigint;
+  v_classroom_due_failed_objects bigint;
+  v_classroom_fences_without_active_operation bigint;
+  v_classroom_active_operations_without_fence bigint;
+  v_classroom_deleted_objects_reappeared bigint;
+
+  v_blueprint_terminal_failures bigint;
+  v_blueprint_stale_operations bigint;
+  v_blueprint_stale_partial_operations bigint;
+  v_blueprint_expired_object_leases bigint;
+  v_blueprint_due_failed_objects bigint;
+  v_blueprint_fences_without_active_operation bigint;
+  v_blueprint_active_operations_without_fence bigint;
+  v_blueprint_deleted_objects_reappeared bigint;
+
+  v_unregistered_storage_objects bigint;
+  v_registered_objects_missing_storage bigint;
+  v_referenced_objects_not_ready bigint;
+  v_raw_references_missing_identity bigint;
+  v_relational_identity_mismatches bigint;
+  v_embedded_hosts_missing_registry bigint;
+  v_embedded_ownership_mismatches bigint;
+  v_objects_without_durable_owner bigint;
+  v_settled_provisional_objects bigint;
+  v_ready_objects_unreferenced bigint;
+  v_expired_reservations bigint;
+  v_expired_provisional_owners bigint;
+  v_stale_cleanup_pending bigint;
+  v_expired_cleanup_leases bigint;
+
+  v_critical_count bigint;
+  v_warning_count bigint;
+begin
+  if p_stuck_after_seconds is null
+    or p_stuck_after_seconds < 300
+    or p_stuck_after_seconds > 604800
+  then
+    raise exception using
+      errcode = '22023',
+      message = 'managed_deletion_health_stuck_threshold_invalid';
+  end if;
+  v_stuck_before := v_generated_at - make_interval(secs => p_stuck_after_seconds);
+
+  select count(*) into v_classroom_terminal_failures
+  from public.classroom_purge_operations
+  where status = 'failed' and retryable is false;
+
+  select count(*) into v_classroom_stale_operations
+  from public.classroom_purge_operations
+  where status <> 'completed' and updated_at <= v_stuck_before;
+
+  select count(*) into v_classroom_stale_partial_operations
+  from public.classroom_purge_operations operation
+  where operation.status <> 'completed'
+    and operation.updated_at <= v_stuck_before
+    and exists (
+      select 1 from public.classroom_purge_objects object
+      where object.operation_id = operation.id and object.status = 'deleted'
+    )
+    and exists (
+      select 1 from public.classroom_purge_objects object
+      where object.operation_id = operation.id
+        and object.status in ('pending', 'processing', 'failed')
+    );
+
+  select count(*) into v_classroom_expired_object_leases
+  from public.classroom_purge_objects
+  where status = 'processing' and lease_expires_at <= v_generated_at;
+
+  select count(*) into v_classroom_due_failed_objects
+  from public.classroom_purge_objects object
+  join public.classroom_purge_operations operation on operation.id = object.operation_id
+  where object.status = 'failed' and object.next_attempt_at <= v_generated_at
+    and operation.status <> 'completed';
+
+  select count(*) into v_classroom_fences_without_active_operation
+  from public.classroom_purge_fences fence
+  left join public.classroom_purge_operations operation on operation.id = fence.operation_id
+  where operation.id is null or operation.status = 'completed';
+
+  select count(*) into v_classroom_active_operations_without_fence
+  from public.classroom_purge_operations operation
+  left join public.classroom_purge_fences fence on fence.operation_id = operation.id
+  where operation.status <> 'completed' and fence.operation_id is null;
+
+  select count(*) into v_classroom_deleted_objects_reappeared
+  from public.classroom_purge_objects object
+  where object.status = 'deleted'
+    and exists (
+      select 1 from storage.objects stored
+      where stored.bucket_id = object.storage_bucket
+        and object.storage_path_sha256 = public.managed_storage_identity_sha256(
+          stored.bucket_id, stored.name
+        )
+    );
+
+  select count(*) into v_blueprint_terminal_failures
+  from public.course_blueprint_purge_operations
+  where status = 'failed' and retryable is false;
+
+  select count(*) into v_blueprint_stale_operations
+  from public.course_blueprint_purge_operations
+  where status <> 'completed' and updated_at <= v_stuck_before;
+
+  select count(*) into v_blueprint_stale_partial_operations
+  from public.course_blueprint_purge_operations operation
+  where operation.status <> 'completed'
+    and operation.updated_at <= v_stuck_before
+    and exists (
+      select 1 from public.course_blueprint_purge_objects object
+      where object.operation_id = operation.id and object.status = 'deleted'
+    )
+    and exists (
+      select 1 from public.course_blueprint_purge_objects object
+      where object.operation_id = operation.id
+        and object.status in ('pending', 'processing', 'failed')
+    );
+
+  select count(*) into v_blueprint_expired_object_leases
+  from public.course_blueprint_purge_objects
+  where status = 'processing' and lease_expires_at <= v_generated_at;
+
+  select count(*) into v_blueprint_due_failed_objects
+  from public.course_blueprint_purge_objects object
+  join public.course_blueprint_purge_operations operation on operation.id = object.operation_id
+  where object.status = 'failed' and object.next_attempt_at <= v_generated_at
+    and operation.status <> 'completed';
+
+  select count(*) into v_blueprint_fences_without_active_operation
+  from public.course_blueprint_purge_fences fence
+  left join public.course_blueprint_purge_operations operation on operation.id = fence.operation_id
+  where operation.id is null or operation.status = 'completed';
+
+  select count(*) into v_blueprint_active_operations_without_fence
+  from public.course_blueprint_purge_operations operation
+  left join public.course_blueprint_purge_fences fence on fence.operation_id = operation.id
+  where operation.status <> 'completed' and fence.operation_id is null;
+
+  select count(*) into v_blueprint_deleted_objects_reappeared
+  from public.course_blueprint_purge_objects object
+  where object.status = 'deleted'
+    and exists (
+      select 1 from storage.objects stored
+      where stored.bucket_id = object.storage_bucket
+        and object.storage_path_sha256 = public.managed_storage_identity_sha256(
+          stored.bucket_id, stored.name
+        )
+    );
+
+  select count(*) into v_unregistered_storage_objects
+  from storage.objects stored
+  left join public.managed_storage_objects object
+    on object.storage_bucket = stored.bucket_id and object.storage_path = stored.name
+  where stored.bucket_id in (
+    'assignment-artifacts', 'submission-images', 'test-documents',
+    'classroom-archives', 'gradex-analytics-extracts'
+  ) and object.id is null;
+
+  select count(*) into v_registered_objects_missing_storage
+  from public.managed_storage_objects object
+  left join storage.objects stored
+    on stored.bucket_id = object.storage_bucket and stored.name = object.storage_path
+  where object.status in ('verified', 'ready') and stored.id is null;
+
+  select count(*) into v_referenced_objects_not_ready
+  from public.managed_storage_objects object
+  where object.status <> 'ready'
+    and public.managed_storage_object_is_referenced(object.id);
+
+  select count(*) into v_raw_references_missing_identity
+  from (
+    select storage_path from public.assignment_submission_artifacts
+    where storage_path is not null and managed_object_id is null
+    union all
+    select storage_path from public.classroom_archives
+    where managed_object_id is null
+    union all
+    select storage_path from public.classroom_archive_operations
+    where storage_path is not null and managed_object_id is null
+    union all
+    select storage_path from public.classroom_gradex_extracts
+    where managed_object_id is null
+    union all
+    select storage_path from public.classroom_archive_object_upload_cleanup
+    where status <> 'deleted' and managed_object_id is null
+    union all
+    select storage_path from public.classroom_archive_restore_expected_objects
+    where managed_object_id is null
+    union all
+    select storage_path from public.classroom_archive_source_object_cleanup
+    where status <> 'deleted' and managed_object_id is null
+    union all
+    select storage_path from public.classroom_gradex_extract_cleanup
+    where status <> 'deleted' and managed_object_id is null
+    union all
+    select storage_path from public.assignment_artifact_storage_cleanup
+    where managed_object_id is null
+    union all
+    select storage_path from public.test_document_snapshot_storage_cleanup
+    where managed_object_id is null
+  ) reference;
+
+  select count(*) into v_relational_identity_mismatches
+  from (
+    select artifact.managed_object_id, 'assignment-artifacts'::text storage_bucket,
+      artifact.storage_path, assignment.classroom_id expected_classroom_id
+    from public.assignment_submission_artifacts artifact
+    join public.assignment_docs document on document.id = artifact.assignment_doc_id
+    join public.assignments assignment on assignment.id = document.assignment_id
+    where artifact.storage_path is not null and artifact.managed_object_id is not null
+    union all
+    select managed_object_id, storage_bucket, storage_path, classroom_id
+    from public.classroom_archives where managed_object_id is not null
+    union all
+    select managed_object_id, storage_bucket, storage_path, classroom_id
+    from public.classroom_archive_operations
+    where managed_object_id is not null and storage_path is not null
+    union all
+    select managed_object_id, storage_bucket, storage_path, classroom_id
+    from public.classroom_gradex_extracts where managed_object_id is not null
+    union all
+    select cleanup.managed_object_id, cleanup.storage_bucket, cleanup.storage_path,
+      operation.classroom_id
+    from public.classroom_archive_object_upload_cleanup cleanup
+    join public.classroom_archive_operations operation on operation.id = cleanup.operation_id
+    where cleanup.managed_object_id is not null and cleanup.status <> 'deleted'
+    union all
+    select expected.managed_object_id, expected.storage_bucket, expected.storage_path,
+      operation.classroom_id
+    from public.classroom_archive_restore_expected_objects expected
+    join public.classroom_archive_operations operation on operation.id = expected.operation_id
+    where expected.managed_object_id is not null
+    union all
+    select managed_object_id, storage_bucket, storage_path, classroom_id
+    from public.classroom_archive_source_object_cleanup
+    where managed_object_id is not null and status <> 'deleted'
+    union all
+    select cleanup.managed_object_id, cleanup.storage_bucket, cleanup.storage_path,
+      operation.classroom_id
+    from public.classroom_gradex_extract_cleanup cleanup
+    join public.classroom_archive_operations operation on operation.id = cleanup.operation_id
+    where cleanup.managed_object_id is not null and cleanup.status <> 'deleted'
+    union all
+    select managed_object_id, 'assignment-artifacts', storage_path, null::uuid
+    from public.assignment_artifact_storage_cleanup where managed_object_id is not null
+    union all
+    select managed_object_id, 'test-documents', storage_path, null::uuid
+    from public.test_document_snapshot_storage_cleanup where managed_object_id is not null
+  ) reference
+  left join public.managed_storage_objects object on object.id = reference.managed_object_id
+  where object.id is null
+    or object.storage_bucket is distinct from reference.storage_bucket
+    or object.storage_path is distinct from reference.storage_path
+    or (reference.expected_classroom_id is not null
+      and object.classroom_id is distinct from reference.expected_classroom_id);
+
+  select count(*) into v_embedded_hosts_missing_registry
+  from (
+    select 'assignment_doc'::text host_type, id host_id, content payload
+    from public.assignment_docs
+    union all
+    select 'assignment_doc_history', id, coalesce(snapshot, patch)
+    from public.assignment_doc_history
+    union all
+    select 'test', id, documents from public.tests
+    union all
+    select 'course_blueprint_assessment', id, documents
+    from public.course_blueprint_assessments
+    union all
+    select 'course_blueprint_version', id, snapshot_json
+    from public.course_blueprint_versions
+    union all
+    select 'course_blueprint_change_proposal', id, operations_json
+    from public.course_blueprint_change_proposals
+  ) host
+  where exists (
+    select 1
+    from (
+      select distinct storage_bucket, storage_path
+      from public.managed_storage_payload_raw_references(host.payload)
+    ) raw_reference
+    where not exists (
+      select 1 from public.managed_storage_json_references reference
+      where reference.storage_bucket = raw_reference.storage_bucket
+        and reference.storage_path = raw_reference.storage_path
+        and (
+          reference.assignment_doc_id = case
+            when host.host_type = 'assignment_doc' then host.host_id end
+          or reference.assignment_doc_history_id = case
+            when host.host_type = 'assignment_doc_history' then host.host_id end
+          or reference.test_id = case when host.host_type = 'test' then host.host_id end
+          or reference.course_blueprint_assessment_id = case
+            when host.host_type = 'course_blueprint_assessment' then host.host_id end
+          or reference.course_blueprint_version_id = case
+            when host.host_type = 'course_blueprint_version' then host.host_id end
+          or reference.course_blueprint_change_proposal_id = case
+            when host.host_type = 'course_blueprint_change_proposal' then host.host_id end
+        )
+    )
+  );
+
+  select count(*) into v_embedded_ownership_mismatches
+  from (
+    select distinct host.host_type, host.host_id
+    from (
+      select 'assignment_doc'::text host_type, document.id host_id,
+        assignment.classroom_id, null::uuid course_blueprint_id,
+        document.id assignment_doc_id, document.student_id data_subject_user_id
+      from public.assignment_docs document
+      join public.assignments assignment on assignment.id = document.assignment_id
+      union all
+      select 'assignment_doc_history', history.id, assignment.classroom_id, null::uuid,
+        document.id, document.student_id
+      from public.assignment_doc_history history
+      join public.assignment_docs document on document.id = history.assignment_doc_id
+      join public.assignments assignment on assignment.id = document.assignment_id
+      union all
+      select 'test', id, classroom_id, null::uuid, null::uuid, null::uuid
+      from public.tests
+      union all
+      select 'course_blueprint_assessment', id, null::uuid, course_blueprint_id,
+        null::uuid, null::uuid
+      from public.course_blueprint_assessments
+      union all
+      select 'course_blueprint_version', id, null::uuid, course_blueprint_id,
+        null::uuid, null::uuid
+      from public.course_blueprint_versions
+      union all
+      select 'course_blueprint_change_proposal', id, null::uuid, course_blueprint_id,
+        null::uuid, null::uuid
+      from public.course_blueprint_change_proposals
+    ) host
+    join public.managed_storage_json_references reference on (
+      reference.assignment_doc_id = case
+        when host.host_type = 'assignment_doc' then host.host_id end
+      or reference.assignment_doc_history_id = case
+        when host.host_type = 'assignment_doc_history' then host.host_id end
+      or reference.test_id = case when host.host_type = 'test' then host.host_id end
+      or reference.course_blueprint_assessment_id = case
+        when host.host_type = 'course_blueprint_assessment' then host.host_id end
+      or reference.course_blueprint_version_id = case
+        when host.host_type = 'course_blueprint_version' then host.host_id end
+      or reference.course_blueprint_change_proposal_id = case
+        when host.host_type = 'course_blueprint_change_proposal' then host.host_id end
+    )
+    join public.managed_storage_objects object on object.id = reference.managed_object_id
+    where (host.classroom_id is not null
+        and object.classroom_id is distinct from host.classroom_id)
+      or (host.course_blueprint_id is not null
+        and object.course_blueprint_id is distinct from host.course_blueprint_id)
+      or (object.storage_bucket = 'submission-images' and (
+        object.resource_type is distinct from 'assignment_doc'
+        or object.resource_id is distinct from host.assignment_doc_id
+        or object.data_subject_user_id is distinct from host.data_subject_user_id
+      ))
+  ) mismatch;
+
+  select count(*) into v_objects_without_durable_owner
+  from public.managed_storage_objects object
+  where object.classroom_id is not null
+    and (
+      (exists (select 1 from public.classrooms classroom
+        where classroom.id = object.classroom_id))::integer
+      + (exists (select 1 from public.classroom_cold_tombstones tombstone
+        where tombstone.classroom_id = object.classroom_id))::integer
+    ) <> 1;
+
+  select count(*) into v_settled_provisional_objects
+  from public.managed_storage_objects object
+  join public.managed_storage_provisional_owners owner
+    on owner.id = object.provisional_owner_id
+  where object.status <> 'deleted'
+    and (owner.adopted_at is not null or owner.copy_closed_at is not null);
+
+  select count(*) into v_ready_objects_unreferenced
+  from public.managed_storage_objects object
+  where object.status = 'ready'
+    and not public.managed_storage_object_is_referenced(object.id);
+
+  select count(*) into v_expired_reservations
+  from public.managed_storage_objects object
+  where object.status in ('reserved', 'verified')
+    and object.reservation_expires_at <= v_generated_at;
+
+  select count(*) into v_expired_provisional_owners
+  from public.managed_storage_provisional_owners owner
+  where owner.adopted_at is null and owner.copy_closed_at is null
+    and owner.expires_at <= v_generated_at;
+
+  select count(*) into v_stale_cleanup_pending
+  from public.managed_storage_objects object
+  where object.status = 'cleanup_pending' and object.updated_at <= v_stuck_before;
+
+  select count(*) into v_expired_cleanup_leases
+  from public.managed_storage_objects object
+  where object.status = 'cleanup_processing'
+    and object.lease_expires_at <= v_generated_at;
+
+  v_critical_count :=
+    v_classroom_terminal_failures + v_classroom_stale_operations
+    + v_classroom_stale_partial_operations + v_classroom_expired_object_leases
+    + v_classroom_fences_without_active_operation
+    + v_classroom_active_operations_without_fence
+    + v_classroom_deleted_objects_reappeared
+    + v_blueprint_terminal_failures + v_blueprint_stale_operations
+    + v_blueprint_stale_partial_operations + v_blueprint_expired_object_leases
+    + v_blueprint_fences_without_active_operation
+    + v_blueprint_active_operations_without_fence
+    + v_blueprint_deleted_objects_reappeared
+    + v_unregistered_storage_objects + v_registered_objects_missing_storage
+    + v_referenced_objects_not_ready + v_raw_references_missing_identity
+    + v_relational_identity_mismatches + v_embedded_hosts_missing_registry
+    + v_embedded_ownership_mismatches + v_objects_without_durable_owner
+    + v_settled_provisional_objects + v_expired_cleanup_leases;
+
+  v_warning_count :=
+    v_classroom_due_failed_objects + v_blueprint_due_failed_objects
+    + v_ready_objects_unreferenced + v_expired_reservations
+    + v_expired_provisional_owners + v_stale_cleanup_pending;
+
+  return jsonb_build_object(
+    'version', 1,
+    'generated_at', v_generated_at,
+    'stuck_after_seconds', p_stuck_after_seconds,
+    'healthy', v_critical_count = 0,
+    'critical_count', v_critical_count,
+    'warning_count', v_warning_count,
+    'operations', jsonb_build_object(
+      'classroom', jsonb_build_object(
+        'terminal_failures', v_classroom_terminal_failures,
+        'stale_operations', v_classroom_stale_operations,
+        'stale_partial_operations', v_classroom_stale_partial_operations,
+        'expired_object_leases', v_classroom_expired_object_leases,
+        'due_failed_objects', v_classroom_due_failed_objects,
+        'fences_without_active_operation', v_classroom_fences_without_active_operation,
+        'active_operations_without_fence', v_classroom_active_operations_without_fence,
+        'deleted_objects_reappeared', v_classroom_deleted_objects_reappeared
+      ),
+      'course_blueprint', jsonb_build_object(
+        'terminal_failures', v_blueprint_terminal_failures,
+        'stale_operations', v_blueprint_stale_operations,
+        'stale_partial_operations', v_blueprint_stale_partial_operations,
+        'expired_object_leases', v_blueprint_expired_object_leases,
+        'due_failed_objects', v_blueprint_due_failed_objects,
+        'fences_without_active_operation', v_blueprint_fences_without_active_operation,
+        'active_operations_without_fence', v_blueprint_active_operations_without_fence,
+        'deleted_objects_reappeared', v_blueprint_deleted_objects_reappeared
+      )
+    ),
+    'managed_storage', jsonb_build_object(
+      'unregistered_storage_objects', v_unregistered_storage_objects,
+      'registered_objects_missing_storage', v_registered_objects_missing_storage,
+      'referenced_objects_not_ready', v_referenced_objects_not_ready,
+      'raw_references_missing_identity', v_raw_references_missing_identity,
+      'relational_identity_mismatches', v_relational_identity_mismatches,
+      'embedded_hosts_missing_registry', v_embedded_hosts_missing_registry,
+      'embedded_ownership_mismatches', v_embedded_ownership_mismatches,
+      'objects_without_durable_owner', v_objects_without_durable_owner,
+      'settled_provisional_objects', v_settled_provisional_objects,
+      'ready_objects_unreferenced', v_ready_objects_unreferenced,
+      'expired_reservations', v_expired_reservations,
+      'expired_provisional_owners', v_expired_provisional_owners,
+      'stale_cleanup_pending', v_stale_cleanup_pending,
+      'expired_cleanup_leases', v_expired_cleanup_leases
+    )
+  );
+end;
+$health$;
+
+revoke all on function public.get_managed_deletion_health_snapshot(integer)
+  from public, anon, authenticated, service_role;
+grant execute on function public.get_managed_deletion_health_snapshot(integer) to service_role;
+
+comment on function public.get_managed_deletion_health_snapshot(integer) is
+  'Read-only aggregate monitoring for purge liveness and managed-storage drift; returns no object identities.';

--- a/supabase/migrations/121_managed_deletion_health_monitoring.sql
+++ b/supabase/migrations/121_managed_deletion_health_monitoring.sql
@@ -509,8 +509,7 @@ begin
     ) raw_reference
   ), reconciled as (
     select parsed.*,
-      reference.managed_object_id registered_managed_object_id,
-      reference.evidence_sha256
+      reference.managed_object_id registered_managed_object_id
     from parsed
     left join public.managed_storage_json_references reference
       on reference.storage_bucket = parsed.storage_bucket
@@ -539,22 +538,64 @@ begin
       where payload_managed_object_id is not null
         and registered_managed_object_id is not null
         and payload_managed_object_id is distinct from registered_managed_object_id
-    ),
-    count(distinct (host_type, host_id)) filter (
-      where registered_managed_object_id is not null
-        and evidence_sha256 is distinct from encode(
-          extensions.digest(
-            convert_to(coalesce(payload, 'null'::jsonb)::text, 'UTF8'),
-            'sha256'
-          ),
-          'hex'
-        )
     )
   into
     v_embedded_hosts_missing_registry,
-    v_embedded_payload_identity_mismatches,
-    v_embedded_evidence_mismatches
+    v_embedded_payload_identity_mismatches
   from reconciled;
+
+  -- Evidence reconciliation starts from the registry, not parsed references,
+  -- so removing a host's final embedded path still leaves detectable drift.
+  with registered_hosts as (
+    select 'assignment_doc'::text host_type, document.id host_id,
+      document.content payload, reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.assignment_docs document on document.id = reference.assignment_doc_id
+    where reference.assignment_doc_id is not null
+    union all
+    select 'assignment_doc_history', history.id, coalesce(history.snapshot, history.patch),
+      reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.assignment_doc_history history
+      on history.id = reference.assignment_doc_history_id
+    where reference.assignment_doc_history_id is not null
+    union all
+    select 'test', test.id, test.documents, reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.tests test on test.id = reference.test_id
+    where reference.test_id is not null
+    union all
+    select 'course_blueprint_assessment', assessment.id, assessment.documents,
+      reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_assessments assessment
+      on assessment.id = reference.course_blueprint_assessment_id
+    where reference.course_blueprint_assessment_id is not null
+    union all
+    select 'course_blueprint_version', version.id, version.snapshot_json,
+      reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_versions version
+      on version.id = reference.course_blueprint_version_id
+    where reference.course_blueprint_version_id is not null
+    union all
+    select 'course_blueprint_change_proposal', proposal.id, proposal.operations_json,
+      reference.evidence_sha256
+    from public.managed_storage_json_references reference
+    join public.course_blueprint_change_proposals proposal
+      on proposal.id = reference.course_blueprint_change_proposal_id
+    where reference.course_blueprint_change_proposal_id is not null
+  )
+  select count(distinct (host_type, host_id))
+  into v_embedded_evidence_mismatches
+  from registered_hosts
+  where evidence_sha256 is distinct from encode(
+    extensions.digest(
+      convert_to(coalesce(payload, 'null'::jsonb)::text, 'UTF8'),
+      'sha256'
+    ),
+    'hex'
+  );
 
   v_critical_count :=
     v_embedded_hosts_missing_registry

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -10,6 +10,7 @@ const cleanupMocks = vi.hoisted(() => ({
 }))
 const purgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
 const blueprintPurgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
+const healthMocks = vi.hoisted(() => ({ read: vi.fn() }))
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -27,6 +28,10 @@ vi.mock('@/lib/server/classroom-purge', () => ({
 
 vi.mock('@/lib/server/course-blueprint-purge', () => ({
   runCourseBlueprintPurgeSafetyNet: blueprintPurgeMocks.run,
+}))
+
+vi.mock('@/lib/server/managed-deletion-health', () => ({
+  readManagedDeletionHealth: healthMocks.read,
 }))
 
 type QueryLog = {
@@ -220,6 +225,7 @@ describe('cron cleanup-history route', () => {
     cleanupMocks.enabled.mockReturnValue(false)
     purgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
     blueprintPurgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
+    healthMocks.read.mockResolvedValue({ schemaAvailable: false })
     mockSupabaseClient.rpc.mockResolvedValue({ data: 0, error: null })
   })
 
@@ -283,6 +289,108 @@ describe('cron cleanup-history route', () => {
     })
     expect(purgeMocks.run).toHaveBeenCalledOnce()
     expect(blueprintPurgeMocks.run).toHaveBeenCalledOnce()
+  })
+
+  it('checks managed deletion health after the authenticated cleanup succeeds', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    healthMocks.read.mockResolvedValue({
+      schemaAvailable: true,
+      snapshot: {
+        healthy: true,
+        critical_count: 0,
+        warning_count: 0,
+      },
+    })
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(200)
+    expect(healthMocks.read).toHaveBeenCalledWith({ supabase: mockSupabaseClient })
+  })
+
+  it('returns 503 after cleanup when managed deletion health is degraded', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    healthMocks.read.mockResolvedValue({
+      schemaAvailable: true,
+      snapshot: {
+        healthy: false,
+        critical_count: 2,
+        warning_count: 1,
+      },
+    })
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Managed deletion health degraded',
+      managed_deletion_health: {
+        critical_count: 2,
+        warning_count: 1,
+      },
+    })
+    expect(mock.from).toHaveBeenCalled()
+  })
+
+  it('keeps warning-only managed deletion findings observable without failing cleanup', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    healthMocks.read.mockResolvedValue({
+      schemaAvailable: true,
+      snapshot: {
+        healthy: true,
+        critical_count: 0,
+        warning_count: 4,
+      },
+    })
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 0 })
+  })
+
+  it('returns 503 when the managed deletion health probe fails', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    healthMocks.read.mockRejectedValue(Object.assign(new Error('provider detail'), {
+      code: 'managed_deletion_health_query_failed',
+    }))
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to verify managed deletion health',
+    })
+    expect(console.error).toHaveBeenCalledWith(
+      '[managed-deletion-health] probe failed',
+      { error_code: 'managed_deletion_health_query_failed' },
+    )
+  })
+
+  it('does not log an unexpected health-probe error code', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    healthMocks.read.mockRejectedValue(Object.assign(new Error('provider detail'), {
+      code: 'provider-sensitive-value',
+    }))
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    await GET(cronRequest())
+
+    expect(console.error).toHaveBeenCalledWith(
+      '[managed-deletion-health] probe failed',
+      { error_code: 'managed_deletion_health_unknown_failure' },
+    )
   })
 
   it('fails when assignment save operation retention cannot be recorded', async () => {

--- a/tests/lib/server/managed-deletion-health.test.ts
+++ b/tests/lib/server/managed-deletion-health.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ManagedDeletionHealthError,
+  readManagedDeletionHealth,
+} from '@/lib/server/managed-deletion-health'
+
+const operationHealth = {
+  terminal_failures: 0,
+  stale_operations: 0,
+  stale_partial_operations: 0,
+  expired_object_leases: 0,
+  due_failed_objects: 0,
+  fences_without_active_operation: 0,
+  active_operations_without_fence: 0,
+  deleted_objects_reappeared: 0,
+}
+
+const managedStorageHealth = {
+  unregistered_storage_objects: 0,
+  registered_objects_missing_storage: 0,
+  referenced_objects_not_ready: 0,
+  raw_references_missing_identity: 0,
+  relational_identity_mismatches: 0,
+  embedded_hosts_missing_registry: 0,
+  embedded_ownership_mismatches: 0,
+  objects_without_durable_owner: 0,
+  settled_provisional_objects: 0,
+  ready_objects_unreferenced: 0,
+  expired_reservations: 0,
+  expired_provisional_owners: 0,
+  stale_cleanup_pending: 0,
+  expired_cleanup_leases: 0,
+}
+
+function snapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    generated_at: '2026-08-08T16:00:00.000Z',
+    stuck_after_seconds: 3600,
+    healthy: true,
+    critical_count: 0,
+    warning_count: 0,
+    operations: {
+      classroom: operationHealth,
+      course_blueprint: operationHealth,
+    },
+    managed_storage: managedStorageHealth,
+    ...overrides,
+  }
+}
+
+describe('managed deletion health reader', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns a validated aggregate-only health snapshot', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: snapshot(), error: null })
+
+    await expect(readManagedDeletionHealth({
+      supabase: { rpc } as any,
+      stuckAfterSeconds: 3600,
+    })).resolves.toEqual({
+      schemaAvailable: true,
+      snapshot: snapshot(),
+    })
+    expect(rpc).toHaveBeenCalledWith('get_managed_deletion_health_snapshot', {
+      p_stuck_after_seconds: 3600,
+    })
+  })
+
+  it.each(['PGRST202', '42883', 'PGRST205', '42P01'])(
+    'treats missing monitoring schema code %s as code-first compatibility',
+    async (code) => {
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      const rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { code, message: 'raw provider detail must not escape' },
+      })
+
+      await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).resolves.toEqual({
+        schemaAvailable: false,
+      })
+      expect(console.warn).toHaveBeenCalledWith(
+        '[managed-deletion-health] schema unavailable',
+        { error_code: code },
+      )
+    },
+  )
+
+  it('throws a sanitized error when the health query fails', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: '57014', message: 'sensitive provider detail' },
+    })
+
+    await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).rejects.toMatchObject({
+      name: 'ManagedDeletionHealthError',
+      code: 'managed_deletion_health_query_failed',
+    })
+  })
+
+  it('rejects malformed or identity-bearing RPC results', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: snapshot({ classroom_id: '00000000-0000-4000-8000-000000000001' }),
+      error: null,
+    })
+
+    await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).rejects.toBeInstanceOf(
+      ManagedDeletionHealthError,
+    )
+  })
+
+  it.each([299, 604801, 12.5])('rejects an unsafe stuck threshold: %s', async (value) => {
+    await expect(readManagedDeletionHealth({
+      supabase: { rpc: vi.fn() } as any,
+      stuckAfterSeconds: value,
+    })).rejects.toMatchObject({ code: 'managed_deletion_health_threshold_invalid' })
+  })
+})

--- a/tests/lib/server/managed-deletion-health.test.ts
+++ b/tests/lib/server/managed-deletion-health.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ManagedDeletionHealthError,
+  managedDeletionDeepHealthSnapshotSchema,
   readManagedDeletionHealth,
 } from '@/lib/server/managed-deletion-health'
 
@@ -21,7 +22,6 @@ const managedStorageHealth = {
   referenced_objects_not_ready: 0,
   raw_references_missing_identity: 0,
   relational_identity_mismatches: 0,
-  embedded_hosts_missing_registry: 0,
   embedded_ownership_mismatches: 0,
   objects_without_durable_owner: 0,
   settled_provisional_objects: 0,
@@ -69,22 +69,33 @@ describe('managed deletion health reader', () => {
     })
   })
 
-  it.each(['PGRST202', '42883', 'PGRST205', '42P01'])(
-    'treats missing monitoring schema code %s as code-first compatibility',
+  it('treats the exact missing-RPC signal as code-first compatibility', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST202', message: 'raw provider detail must not escape' },
+    })
+
+    await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).resolves.toEqual({
+      schemaAvailable: false,
+    })
+    expect(console.warn).toHaveBeenCalledWith(
+      '[managed-deletion-health] schema unavailable',
+      { error_code: 'PGRST202' },
+    )
+  })
+
+  it.each(['42883', 'PGRST205', '42P01'])(
+    'fails closed when an installed RPC reports dependency error %s',
     async (code) => {
-      vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       const rpc = vi.fn().mockResolvedValue({
         data: null,
         error: { code, message: 'raw provider detail must not escape' },
       })
 
-      await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).resolves.toEqual({
-        schemaAvailable: false,
+      await expect(readManagedDeletionHealth({ supabase: { rpc } as any })).rejects.toMatchObject({
+        code: 'managed_deletion_health_query_failed',
       })
-      expect(console.warn).toHaveBeenCalledWith(
-        '[managed-deletion-health] schema unavailable',
-        { error_code: code },
-      )
     },
   )
 
@@ -116,5 +127,24 @@ describe('managed deletion health reader', () => {
       supabase: { rpc: vi.fn() } as any,
       stuckAfterSeconds: value,
     })).rejects.toMatchObject({ code: 'managed_deletion_health_threshold_invalid' })
+  })
+
+  it('strictly validates aggregate-only deep diagnostic results', () => {
+    const result = managedDeletionDeepHealthSnapshotSchema.safeParse({
+      version: 1,
+      generated_at: '2026-08-08T16:00:00.000Z',
+      healthy: false,
+      critical_count: 1,
+      findings: {
+        embedded_hosts_missing_registry: 0,
+        embedded_payload_identity_mismatches: 1,
+        embedded_evidence_mismatches: 0,
+      },
+    })
+    expect(result.success).toBe(true)
+    expect(managedDeletionDeepHealthSnapshotSchema.safeParse({
+      ...(result.success ? result.data : {}),
+      classroom_id: '00000000-0000-4000-8000-000000000001',
+    }).success).toBe(false)
   })
 })

--- a/tests/unit/managed-deletion-health-database-script.test.ts
+++ b/tests/unit/managed-deletion-health-database-script.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const script = readFileSync(resolve(
+  process.cwd(),
+  'scripts/check-managed-deletion-health-database.sh',
+), 'utf8')
+
+describe('managed deletion health database harness', () => {
+  it('refuses an unexpected database container and requires migration 121', () => {
+    expect(script).toContain('com.supabase.cli.project')
+    expect(script).toContain('PROJECT_LABEL" != "pika"')
+    expect(script).toContain("version = '121'")
+    expect(script).not.toContain('--linked')
+    expect(script).not.toContain('--db-url')
+  })
+
+  it('uses rollback-only synthetic findings and a fixed provider-side helper', () => {
+    expect(script).toContain('begin read only;')
+    expect(script.match(/rollback;/g)).toHaveLength(3)
+    expect(script).toContain(
+      'storage.insert_managed_deletion_health_reappearance_fixture()',
+    )
+    expect(script).toContain("'monitor-fixture/reappeared.pdf'")
+    expect(script).toContain('trap cleanup_storage_helper EXIT')
+  })
+
+  it('checks privacy, privileges, thresholds, runtime, and concurrent readers', () => {
+    expect(script).toContain("has_function_privilege(\n      'anon'")
+    expect(script).toContain('managed_deletion_health_stuck_threshold_invalid')
+    expect(script).toContain('Identity-bearing evidence escaped')
+    expect(script).toContain('generate_series(1, 1000)')
+    expect(script).toContain('v_elapsed_ms >= 5000')
+    expect(script).toContain('explain (analyze, buffers, summary)')
+    expect(script).toContain('xargs -P8')
+  })
+})

--- a/tests/unit/managed-deletion-health-database-script.test.ts
+++ b/tests/unit/managed-deletion-health-database-script.test.ts
@@ -25,6 +25,8 @@ describe('managed deletion health database harness', () => {
     expect(script).toContain('public.get_managed_deletion_deep_health_snapshot()')
     expect(script).toContain('embedded_payload_identity_mismatches')
     expect(script).toContain('disable trigger user')
+    expect(script).toContain("set documents = '[]'::jsonb")
+    expect(script).toContain('Removed-reference evidence drift was missed')
     expect(script).toContain("'monitor-fixture/reappeared.pdf'")
     expect(script).toContain('trap cleanup_storage_helper EXIT')
   })

--- a/tests/unit/managed-deletion-health-database-script.test.ts
+++ b/tests/unit/managed-deletion-health-database-script.test.ts
@@ -22,6 +22,9 @@ describe('managed deletion health database harness', () => {
     expect(script).toContain(
       'storage.insert_managed_deletion_health_reappearance_fixture()',
     )
+    expect(script).toContain('public.get_managed_deletion_deep_health_snapshot()')
+    expect(script).toContain('embedded_payload_identity_mismatches')
+    expect(script).toContain('disable trigger user')
     expect(script).toContain("'monitor-fixture/reappeared.pdf'")
     expect(script).toContain('trap cleanup_storage_helper EXIT')
   })

--- a/tests/unit/managed-deletion-health-monitoring-migration.test.ts
+++ b/tests/unit/managed-deletion-health-monitoring-migration.test.ts
@@ -11,6 +11,10 @@ const functionBody = sql.match(
   /create or replace function public\.get_managed_deletion_health_snapshot[\s\S]*?as \$health\$([\s\S]*?)\$health\$/i,
 )?.[1] ?? ''
 
+const deepFunctionBody = sql.match(
+  /create or replace function public\.get_managed_deletion_deep_health_snapshot[\s\S]*?as \$deep_health\$([\s\S]*?)\$deep_health\$/i,
+)?.[1] ?? ''
+
 describe('managed deletion health monitoring migration', () => {
   it('adds a service-role-only aggregate health snapshot', () => {
     expect(functionBody).not.toBe('')
@@ -53,11 +57,21 @@ describe('managed deletion health monitoring migration', () => {
 
   it('covers live managed-storage ownership and embedded-reference drift', () => {
     expect(functionBody).toContain('public.managed_storage_object_is_referenced')
-    expect(functionBody).toContain('public.managed_storage_payload_raw_references')
     expect(functionBody).toContain('public.managed_storage_json_references')
     expect(functionBody).toContain('raw_references_missing_identity')
-    expect(functionBody).toContain('embedded_hosts_missing_registry')
+    expect(functionBody).not.toContain('public.managed_storage_payload_raw_references')
     expect(functionBody).toContain('expired_provisional_owners')
     expect(functionBody).toContain('stale_cleanup_pending')
+  })
+
+  it('keeps recursive payload reconciliation in a separate unscheduled diagnostic', () => {
+    expect(deepFunctionBody).not.toBe('')
+    expect(deepFunctionBody).toContain('public.managed_storage_payload_raw_references')
+    expect(deepFunctionBody).toContain('embedded_hosts_missing_registry')
+    expect(deepFunctionBody).toContain('embedded_payload_identity_mismatches')
+    expect(deepFunctionBody).toContain('embedded_evidence_mismatches')
+    expect(sql).toContain(
+      'grant execute on function public.get_managed_deletion_deep_health_snapshot()\n  to service_role',
+    )
   })
 })

--- a/tests/unit/managed-deletion-health-monitoring-migration.test.ts
+++ b/tests/unit/managed-deletion-health-monitoring-migration.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sql = readFileSync(resolve(
+  process.cwd(),
+  'supabase/migrations/121_managed_deletion_health_monitoring.sql',
+), 'utf8')
+
+const functionBody = sql.match(
+  /create or replace function public\.get_managed_deletion_health_snapshot[\s\S]*?as \$health\$([\s\S]*?)\$health\$/i,
+)?.[1] ?? ''
+
+describe('managed deletion health monitoring migration', () => {
+  it('adds a service-role-only aggregate health snapshot', () => {
+    expect(functionBody).not.toBe('')
+    expect(sql).toContain('returns jsonb')
+    expect(sql).toContain('security definer')
+    expect(sql).toContain('set search_path = public, storage')
+    expect(sql).toContain(
+      'revoke all on function public.get_managed_deletion_health_snapshot(integer)',
+    )
+    expect(sql).toContain(
+      'grant execute on function public.get_managed_deletion_health_snapshot(integer) to service_role',
+    )
+  })
+
+  it('is read-only and returns counts rather than object identities', () => {
+    expect(functionBody).not.toMatch(/\b(insert|update|delete|truncate)\s+(into|public\.|storage\.)/i)
+    expect(functionBody).not.toContain("'storage_path'")
+    expect(functionBody).not.toContain("'classroom_id'")
+    expect(functionBody).not.toContain("'teacher_id'")
+    expect(functionBody).toContain("'critical_count'")
+    expect(functionBody).toContain("'warning_count'")
+  })
+
+  it('covers both purge ledgers, fences, leases, and exact-object reappearance', () => {
+    for (const table of [
+      'classroom_purge_operations',
+      'classroom_purge_objects',
+      'classroom_purge_fences',
+      'course_blueprint_purge_operations',
+      'course_blueprint_purge_objects',
+      'course_blueprint_purge_fences',
+    ]) {
+      expect(functionBody).toContain(`public.${table}`)
+    }
+    expect(functionBody).toContain("status = 'processing'")
+    expect(functionBody).toContain('lease_expires_at <= v_generated_at')
+    expect(functionBody).toContain('public.managed_storage_identity_sha256')
+    expect(functionBody).toContain('storage.objects')
+  })
+
+  it('covers live managed-storage ownership and embedded-reference drift', () => {
+    expect(functionBody).toContain('public.managed_storage_object_is_referenced')
+    expect(functionBody).toContain('public.managed_storage_payload_raw_references')
+    expect(functionBody).toContain('public.managed_storage_json_references')
+    expect(functionBody).toContain('raw_references_missing_identity')
+    expect(functionBody).toContain('embedded_hosts_missing_registry')
+    expect(functionBody).toContain('expired_provisional_owners')
+    expect(functionBody).toContain('stale_cleanup_pending')
+  })
+})

--- a/tests/unit/managed-deletion-health-monitoring-migration.test.ts
+++ b/tests/unit/managed-deletion-health-monitoring-migration.test.ts
@@ -70,6 +70,8 @@ describe('managed deletion health monitoring migration', () => {
     expect(deepFunctionBody).toContain('embedded_hosts_missing_registry')
     expect(deepFunctionBody).toContain('embedded_payload_identity_mismatches')
     expect(deepFunctionBody).toContain('embedded_evidence_mismatches')
+    expect(deepFunctionBody).toContain('with registered_hosts as')
+    expect(deepFunctionBody).toContain('from public.managed_storage_json_references reference')
     expect(sql).toContain(
       'grant execute on function public.get_managed_deletion_deep_health_snapshot()\n  to service_role',
     )


### PR DESCRIPTION
## Summary
- add a service-role-only aggregate RPC for purge liveness and managed-storage drift
- integrate the privacy-safe snapshot into the existing authenticated cleanup-history cron
- add rollback-only local database fixtures, concurrency/runtime coverage, generated types, and operator rollout guidance

## Safety boundaries
- generic orphan cleanup remains disabled
- no new deletion authority or scheduler is introduced
- migration 121 was applied only to the authorized local Supabase stack
- no staging or production migration, rollout, purge, or object deletion was performed

## Verification
- pnpm test --run: 478 files / 4,126 tests
- pnpm build
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm check:architecture
- pnpm db:types:check
- pnpm check:managed-storage-lineage
- pnpm check:classroom-purge-db-lint
- pnpm check:managed-deletion-health-db
- Pika audit and git diff checks