### PR TITLE
Refine archived Classroom actions

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17631,3 +17631,34 @@ and verification of irreversible purge infrastructure.
 **Remaining:**
 - Complete final read-only change-set review, then commit and publish the draft
   replacement PR only when authorized.
+
+<!-- pika-session-log-archive-batch:ef4ceb5951808467b246af51b3bf7870d8c03bda3977f1945735dbc9cf3ce25c -->
+## 2026-08-04 — Stopped at purge review circuit breaker
+
+**Risk profile:** runtime-platform — irreversible deletion, managed Storage,
+authorization, concurrency, and migration compatibility.
+
+**Completed:**
+- Ran the high-risk independent review topology: security/concurrency and
+  architecture initial reviewers, one targeted security re-review, and one
+  final cumulative integration review.
+- Used two consolidated remediation batches to close retry/backoff and live-
+  lease state, durable Storage resurrection evidence, migration-115 upgrade
+  refusal, RPC-only ledger writes, operational impact/digest/fences, code-first
+  compatibility handling, and browser no-progress request storms.
+- Kept migration 118 draft and rollout-disabled; changed no local/hosted database
+  after the earlier authorized replay, and left PR #963 unchanged.
+
+**Validation:**
+- TypeScript, focused tests (47), startup tests (38), production build, lint,
+  architecture/design/UI policy, lineage, generated-type compatibility, Pika
+  audit, shell syntax, and diff checks pass.
+- The full suite before remediation batch 2 had 4,012 passing tests and only the
+  subsequently fixed startup-document budget failures.
+
+**Remaining:**
+- Two final P1s require an owner-approved third remediation batch: probe the
+  migration-118-only settings authority before cron reads legacy purge rows,
+  and pass the operational digest in the primary destructive fixture.
+- After those narrow fixes, run exact-head ephemeral DB CI and one final targeted
+  review before committing/publishing the replacement draft PR.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,36 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-04 — Stopped at purge review circuit breaker
-
-**Risk profile:** runtime-platform — irreversible deletion, managed Storage,
-authorization, concurrency, and migration compatibility.
-
-**Completed:**
-- Ran the high-risk independent review topology: security/concurrency and
-  architecture initial reviewers, one targeted security re-review, and one
-  final cumulative integration review.
-- Used two consolidated remediation batches to close retry/backoff and live-
-  lease state, durable Storage resurrection evidence, migration-115 upgrade
-  refusal, RPC-only ledger writes, operational impact/digest/fences, code-first
-  compatibility handling, and browser no-progress request storms.
-- Kept migration 118 draft and rollout-disabled; changed no local/hosted database
-  after the earlier authorized replay, and left PR #963 unchanged.
-
-**Validation:**
-- TypeScript, focused tests (47), startup tests (38), production build, lint,
-  architecture/design/UI policy, lineage, generated-type compatibility, Pika
-  audit, shell syntax, and diff checks pass.
-- The full suite before remediation batch 2 had 4,012 passing tests and only the
-  subsequently fixed startup-document budget failures.
-
-**Remaining:**
-- Two final P1s require an owner-approved third remediation batch: probe the
-  migration-118-only settings authority before cron reads legacy purge rows,
-  and pass the operational digest in the primary destructive fixture.
-- After those narrow fixes, run exact-head ephemeral DB CI and one final targeted
-  review before committing/publishing the replacement draft PR.
-
 ## 2026-08-04 — Cleared final purge review blockers
 
 **Risk profile:** runtime-platform — code-first migration compatibility and
@@ -1083,3 +1053,24 @@ authorization, exact managed Storage ownership, concurrency, and resumability.
 - No staging/production migration, rollout, purge, object deletion, or generic
   cleanup was performed. Migration 122 and its rollout still require separate,
   exact production authorization after merge.
+
+## 2026-08-10 — Refine archived Classroom action terminology
+
+**Risk profile:** low — presentation-only labels, accessible icon treatment,
+and focused regression coverage; no lifecycle behavior or rollout gates changed.
+
+**Completed:**
+- Renamed the hot-archive actions from “Use again” to “Reuse” and from
+  “Restore” to “Unarchive,” including the confirmation dialog and supporting
+  copy. Cold-archive recovery remains “Restore.”
+- Replaced the permanent-delete text action with the standard trash icon while
+  retaining the accessible “Delete permanently” name and tooltip.
+- Added component assertions and a focused teacher/student visual matrix for
+  desktop/mobile and light/dark modes.
+
+**Validation:**
+- Focused Vitest passed (2 files, 23 tests), lint passed, and the isolated
+  Playwright matrix passed (3 tests, including auth setup).
+- Screenshots were visually reviewed for all teacher matrices and the student
+  boundary. No database, migration, API behavior, feature gate, or destructive
+  operation changed.

--- a/e2e/archived-classroom-actions-visual.spec.ts
+++ b/e2e/archived-classroom-actions-visual.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test'
+
+const CLASSROOM_ID = '20000000-0000-4000-8000-000000000099'
+
+const archivedClassroom = {
+  id: CLASSROOM_ID,
+  teacher_id: '10000000-0000-4000-8000-000000000001',
+  title: 'Archived Biology',
+  class_code: 'BIO101',
+  theme_color: 'teal',
+  term_label: 'Winter 2026',
+  allow_enrollment: false,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'current_week',
+  archived_at: '2026-06-30T12:00:00.000Z',
+  created_at: '2026-01-01T12:00:00.000Z',
+  updated_at: '2026-06-30T12:00:00.000Z',
+}
+
+const matrix = [
+  { name: 'desktop-light', viewport: { width: 1440, height: 900 }, theme: 'light' as const },
+  { name: 'desktop-dark', viewport: { width: 1440, height: 900 }, theme: 'dark' as const },
+  { name: 'mobile-light', viewport: { width: 390, height: 844 }, theme: 'light' as const },
+  { name: 'mobile-dark', viewport: { width: 390, height: 844 }, theme: 'dark' as const },
+]
+
+async function newRolePage(
+  browserContextFactory: () => Promise<BrowserContext>,
+  theme: 'light' | 'dark',
+) {
+  const context = await browserContextFactory()
+  const page = await context.newPage()
+  await page.addInitScript((selectedTheme) => {
+    localStorage.setItem('theme', selectedTheme)
+  }, theme)
+  return { context, page }
+}
+
+async function mockTeacherArchive(page: Page) {
+  await page.route('**/api/teacher/classrooms?archived=true', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        classrooms: [archivedClassroom],
+        cold_archives: [],
+        cold_archive_restore_enabled: false,
+        hot_classroom_purge_enabled_ids: [CLASSROOM_ID],
+        cold_classroom_purge_enabled_ids: [],
+      }),
+    })
+  })
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  expect(await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )).toBe(false)
+}
+
+test('captures archived Classroom actions and student boundaries', async ({ browser }) => {
+  for (const entry of matrix) {
+    const { context, page } = await newRolePage(
+      () => browser.newContext({
+        storageState: '.auth/teacher.json',
+        viewport: entry.viewport,
+      }),
+      entry.theme,
+    )
+    await mockTeacherArchive(page)
+    await page.goto('/classrooms')
+    await page.getByRole('button', { name: 'Organize classrooms' }).click()
+    await page.getByRole('button', { name: 'Archived' }).click()
+
+    await expect(page.getByRole('button', { name: 'Reuse' })).toBeVisible()
+    const unarchiveButton = page.getByRole('button', { name: 'Unarchive' })
+    await expect(unarchiveButton).toBeVisible()
+    const deleteButton = page.getByRole('button', { name: 'Delete permanently' })
+    await expect(deleteButton).toBeVisible()
+    await expect(deleteButton.locator('svg.lucide-trash-2')).toBeVisible()
+    await expectNoHorizontalOverflow(page)
+    await page.evaluate(() => document.fonts.ready)
+    await page.waitForTimeout(100)
+    await page.screenshot({
+      path: `/tmp/pika-archive-actions-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+
+    await unarchiveButton.click()
+    const dialog = page.getByRole('dialog', { name: 'Unarchive Archived Biology?' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Unarchive' })).toBeVisible()
+    await page.screenshot({
+      path: `/tmp/pika-unarchive-dialog-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+    await context.close()
+  }
+
+  for (const entry of matrix) {
+    const { context, page } = await newRolePage(
+      () => browser.newContext({
+        storageState: '.auth/student.json',
+        viewport: entry.viewport,
+      }),
+      entry.theme,
+    )
+    await page.goto('/classrooms')
+    await expect(page.getByRole('button', { name: 'Reuse' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Unarchive' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Delete permanently' })).toHaveCount(0)
+    await expectNoHorizontalOverflow(page)
+    await page.screenshot({
+      path: `/tmp/pika-archive-actions-student-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+    await context.close()
+  }
+})

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -19,7 +19,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useRouter, usePathname } from 'next/navigation'
-import { Archive, CircleDot, LoaderCircle, Plus } from 'lucide-react'
+import { Archive, CircleDot, LoaderCircle, Plus, Trash2 } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
 import { ClassroomPurgeDialog } from '@/components/ClassroomPurgeDialog'
 import { ColdClassroomPurgeDialog } from '@/components/ColdClassroomPurgeDialog'
@@ -383,13 +383,13 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     ? pendingAction.mode === 'archive'
       ? `Archive ${pendingAction.classroom.title}?`
       : pendingAction.mode === 'restore-hot'
-        ? `Restore ${pendingAction.classroom.title}?`
+        ? `Unarchive ${pendingAction.classroom.title}?`
         : `Restore ${pendingAction.archive.title}?`
     : ''
 
   const dialogDescription = pendingAction
     ? pendingAction.mode === 'archive'
-      ? 'Students will lose access until the classroom is restored.'
+      ? 'Students will lose access until the classroom is unarchived.'
       : pendingAction.mode === 'restore-hot'
         ? 'Students will regain access to this classroom.'
         : 'The classroom will return to Archived with its submissions and files available.'
@@ -398,7 +398,9 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const dialogConfirmLabel = pendingAction
     ? pendingAction.mode === 'archive'
       ? 'Archive'
-      : 'Restore'
+      : pendingAction.mode === 'restore-hot'
+        ? 'Unarchive'
+        : 'Restore'
     : 'Confirm'
 
   const showCreateClassroomButton = view === 'active' && (activeClassrooms.length === 0 || isEditingClassrooms)
@@ -445,7 +447,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <p className="text-sm font-medium text-text-default">No archived classrooms</p>
               <p className="mt-1 text-sm text-text-muted">
-                Archived classrooms will appear here so you can restore them later.
+                Archived classrooms will appear here so you can unarchive them later.
               </p>
               {showCreateClassroomButton ? (
                 <Button
@@ -544,7 +546,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                             || (reusingClassroomId !== null && reusingClassroomId !== c.id)
                           }
                         >
-                          {reusingClassroomId === c.id ? 'Preparing' : 'Use again'}
+                          {reusingClassroomId === c.id ? 'Preparing' : 'Reuse'}
                         </Button>
                         <Button
                           type="button"
@@ -553,7 +555,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                           onClick={() => setPendingAction({ mode: 'restore-hot', classroom: c })}
                           disabled={openingClassroomId !== null || reusingClassroomId !== null}
                         >
-                          Restore
+                          Unarchive
                         </Button>
                         {hotClassroomPurgeEnabledIds.has(c.id) ? (
                           <Button
@@ -561,10 +563,12 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                             variant="ghost"
                             size="xs"
                             className="text-danger hover:text-danger"
+                            aria-label="Delete permanently"
+                            title="Delete permanently"
                             onClick={() => setPurgeClassroom(c)}
                             disabled={openingClassroomId !== null || reusingClassroomId !== null}
                           >
-                            Delete permanently
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         ) : null}
                       </div>

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -148,10 +148,18 @@ describe('TeacherClassroomsIndex', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Organize classrooms' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
 
-    expect(await screen.findByRole('button', { name: 'Restore' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Use again' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Delete permanently' })).toBeInTheDocument()
+    const unarchiveButton = await screen.findByRole('button', { name: 'Unarchive' })
+    expect(screen.getByRole('button', { name: 'Reuse' })).toBeInTheDocument()
+    const purgeButton = screen.getByRole('button', { name: 'Delete permanently' })
+    expect(purgeButton).toHaveAttribute('title', 'Delete permanently')
+    expect(purgeButton).toHaveTextContent('')
+    expect(purgeButton.querySelector('svg')).toHaveClass('lucide-trash-2')
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false)
+
+    fireEvent.click(unarchiveButton)
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Unarchive Archived?')).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: 'Unarchive' })).toBeInTheDocument()
   })
 
   it('prepares an archived classroom and opens creation with its Blueprint selected', async () => {
@@ -181,7 +189,7 @@ describe('TeacherClassroomsIndex', () => {
     renderTeacherClassroomsIndex([])
     fireEvent.click(screen.getByRole('button', { name: 'Organize classrooms' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Use again' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Reuse' }))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
       '/api/teacher/classrooms/archived-1/use-again',
@@ -222,7 +230,7 @@ describe('TeacherClassroomsIndex', () => {
     renderTeacherClassroomsIndex([])
     fireEvent.click(screen.getByRole('button', { name: 'Organize classrooms' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Use again' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Reuse' }))
 
     const dialog = await screen.findByRole('dialog')
     expect(within(dialog).getByText(


### PR DESCRIPTION
## Summary
- rename the hot-archive “Use again” action to “Reuse”
- rename the hot-archive “Restore” action and confirmation flow to “Unarchive” while keeping cold-archive recovery as “Restore”
- represent “Delete permanently” with the standard trash icon while preserving its accessible name and tooltip
- add focused component coverage and a teacher/student visual verification matrix

## Validation
- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/ClassroomPurgeDialog.test.tsx` (23 tests)
- `pnpm lint`
- `pnpm check:ui-policy`
- `pnpm check:design-policy`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/archived-classroom-actions-visual.spec.ts` (3 tests including auth setup)
- visually reviewed teacher desktop/mobile in light/dark mode and the student boundary

## Accessibility checklist
- checklist reviewed: yes
- keyboard behavior covered: yes — native buttons and the existing confirmation dialog behavior are unchanged
- semantic state covered by tests: yes — role/name, title, icon, and dialog assertions
- remaining manual follow-up: none
