### PR TITLE
Compact teacher Daily log table

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17688,3 +17688,28 @@ exact-head destructive purge verification.
 - Publish the draft replacement PR while leaving #963 unchanged.
 - Run exact-head database CI before enabling or deploying deletion. Migration
   118 still requires fresh authorization for every database target.
+<!-- pika-session-log-archive-batch:bd702d3cbf62f24015fd89d7fa41034dd2a7b08312c2c2ffdebada63be0ecc33 -->
+## 2026-08-04 — Verified draft hot-archive purge replacement
+
+**Risk profile:** runtime-platform — irreversible classroom deletion,
+concurrency, managed Storage ownership, and migration safety.
+
+**Completed:**
+- Reconciled existing managed-cleanup and archive-compaction concurrency
+  fixtures with migration 118's fail-fast lifecycle lock and retry contract.
+- Hardened the rollback-only purge fixture to simulate provider-side object
+  resurrection without weakening Supabase Storage ownership or app-role access.
+- Kept PR #968 draft, PR #963 unchanged, rollout gates disabled, and migration
+  118 unapplied by this remediation.
+
+**Validation:**
+- Exact-head CI run 30952362597 passed Architecture Database Contracts, Test &
+  Build, Browser Experience Matrix, and Vercel at `ab4ce5f6`.
+- Pika audit, shell syntax, diff checks, and 27 focused tests pass.
+- Targeted security/concurrency and final cumulative integration reviews found
+  no P0/P1 or merge-blocking findings.
+
+**Remaining:**
+- Keep migration 118 and deletion disabled until separately authorized rollout
+  and canary verification. Cold archives and individual-student purge remain
+  follow-up scopes.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1089,6 +1089,9 @@ autosave error feedback while preserving the mounted attempt and exam owner.
   Complete/Incomplete counts, and sortable behavior into the Log column.
 - Added accessible completion labels and preserved Log sorting in both the
   full-width table and selected-student workspace.
+- Independent PR review caught that the Complete/Incomplete count badges were
+  hidden after selecting a student; restored them in the selected workspace
+  and added a regression assertion for the accessible count label.
 - Removed the stale arbitrary-spacing exception for the deleted status-column
   width.
 
@@ -1100,3 +1103,5 @@ autosave error feedback while preserving the mounted attempt and exam owner.
 - Playwright experience matrix passes (18 tests) across teacher/student,
   desktop/mobile, and light/dark; screenshots of the teacher default and sorted
   states show no page overflow or broken layout.
+- The selected-student remediation was visually rechecked in teacher
+  desktop/mobile and light/dark states with no horizontal page overflow.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1105,3 +1105,30 @@ autosave error feedback while preserving the mounted attempt and exam owner.
   states show no page overflow or broken layout.
 - The selected-student remediation was visually rechecked in teacher
   desktop/mobile and light/dark states with no horizontal page overflow.
+
+## 2026-08-10 — Standardize resizable Daily columns
+
+**Risk profile:** none — shared client-side table layout behavior only.
+
+**Completed:**
+- Moved the Complete/Incomplete count chips immediately beside the Daily Log
+  label while preserving its sortable semantics.
+- Added adjustable First, Last, and ID widths to Daily; Log absorbs the
+  remaining space. Narrow values truncate instead of wrapping in the selected
+  workspace.
+- Extracted the assignment table's accessible pointer/keyboard resize behavior
+  into shared `@/ui` table primitives and migrated assignments to the shared
+  owner without sharing domain-specific cells.
+- Removed stale native-control and raw-layer registry entries from the former
+  assignment-local implementation.
+
+**Validation:**
+- Focused DataTable, Daily, and assignment coverage passes (29 tests), including
+  separator semantics, Arrow/Home/End resizing, pointer clamping, sorting, and
+  selected-row truncation.
+- Lint, architecture, UI policy, design policy, and Pika audit pass.
+- Playwright captures were reviewed for teacher desktop/mobile, light/dark,
+  default, sorted, selected, minimum-width resize, and the assignment reference
+  table; the student attendance boundary was also checked.
+- Composite checklist reviewed: yes; keyboard behavior covered: yes; semantic
+  state covered by tests: yes; remaining manual follow-up: none.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1078,3 +1078,25 @@ autosave error feedback while preserving the mounted attempt and exam owner.
 - Independent review identified one P1 stale-autosave completion race; the
   accepted remediation guards UI completion by the latest pending draft and
   monotonic successful-save sequence without changing persistence requests.
+## 2026-08-10 — Compact teacher Daily log table
+
+**Risk profile:** none — presentation and client-side table ordering only.
+
+**Completed:**
+- Reduced the First, Last, and ID column widths in the teacher Daily table so
+  the log preview receives more horizontal space.
+- Removed the standalone attendance-status column and combined its row marker,
+  Complete/Incomplete counts, and sortable behavior into the Log column.
+- Added accessible completion labels and preserved Log sorting in both the
+  full-width table and selected-student workspace.
+- Removed the stale arbitrary-spacing exception for the deleted status-column
+  width.
+
+**Validation:**
+- Focused component coverage passes (17 tests), including Enter/Space
+  activation, ascending and descending Complete/Incomplete sorting, focus, and
+  sortable-header semantics.
+- Lint, architecture, design policy, UI policy, and diff checks pass.
+- Playwright experience matrix passes (18 tests) across teacher/student,
+  desktop/mobile, and light/dark; screenshots of the teacher default and sorted
+  states show no page overflow or broken layout.

--- a/scripts/design-value-exceptions.json
+++ b/scripts/design-value-exceptions.json
@@ -436,12 +436,6 @@
           "count": 1,
           "fingerprint": "0e9d29b47a05a496",
           "reason": "legacy-visual-value"
-        },
-        {
-          "kind": "raw-z-index",
-          "count": 1,
-          "fingerprint": "418e44ad4f9ebdab",
-          "reason": "special-layer"
         }
       ]
     },

--- a/scripts/design-value-exceptions.json
+++ b/scripts/design-value-exceptions.json
@@ -127,8 +127,8 @@
       "values": [
         {
           "kind": "arbitrary-spacing",
-          "count": 5,
-          "fingerprint": "4f915023ef036a7b",
+          "count": 4,
+          "fingerprint": "75ff71d2b4d389c2",
           "reason": "layout-geometry"
         }
       ]

--- a/scripts/ui-control-exceptions.json
+++ b/scripts/ui-control-exceptions.json
@@ -427,11 +427,6 @@
       "reviewBy": "phase-3-assignments",
       "controls": [
         {
-          "kind": "button",
-          "count": 1,
-          "reason": "composite-widget"
-        },
-        {
           "kind": "input:checkbox",
           "count": 2,
           "reason": "native-input-capability"

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -22,7 +22,7 @@ import { LogSummary } from './LogSummary'
 import { getTodayInToronto } from '@/lib/timezone'
 import { addDaysToDateString } from '@/lib/date-string'
 import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
-import { entryHasContent, getAttendanceDotClass, getAttendanceLabel } from '@/lib/attendance'
+import { entryHasContent } from '@/lib/attendance'
 import { useClassDaysContext } from '@/hooks/useClassDays'
 import {
   Button,
@@ -30,7 +30,6 @@ import {
   DataTableBody,
   DataTableCell,
   DataTableHead,
-  DataTableHeaderCell,
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
@@ -42,14 +41,13 @@ import {
 } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
-import type { AttendanceStatus } from '@/types'
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { applyDirection, compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { fetchCachedJSON } from '@/lib/request-cache'
 import type { Classroom, Entry } from '@/types'
 import { format, parseISO } from 'date-fns'
 
-type SortColumn = 'first_name' | 'last_name' | 'id' | 'status'
+type SortColumn = 'first_name' | 'last_name' | 'id' | 'log'
 
 const SUMMARY_PANEL_DEFAULT_HEIGHT = 180
 const SUMMARY_PANEL_COLLAPSED_HEIGHT = 40
@@ -272,11 +270,9 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
   const rows = useMemo(() => {
     return [...logs].sort((a, b) => {
-      if (sortColumn === 'status') {
+      if (sortColumn === 'log') {
         const rankOf = (row: LogRow) => {
-          if (row.entry && entryHasContent(row.entry)) return 0 // present
-          if (selectedDate >= today) return 1 // pending
-          return 2 // absent
+          return row.entry && entryHasContent(row.entry) ? 0 : 1
         }
         const cmp = rankOf(a) - rankOf(b)
         if (cmp !== 0) return applyDirection(cmp, sortDirection)
@@ -297,21 +293,20 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
         sortDirection
       )
     })
-  }, [logs, sortColumn, sortDirection, selectedDate, today])
+  }, [logs, sortColumn, sortDirection])
 
-  const { presentCount, absentCount } = useMemo(() => {
-    let present = 0
-    let absent = 0
+  const { completeCount, incompleteCount } = useMemo(() => {
+    let complete = 0
+    let incomplete = 0
     for (const row of rows) {
       if (row.entry && entryHasContent(row.entry)) {
-        present++
-      } else if (selectedDate < today) {
-        absent++
+        complete++
+      } else {
+        incomplete++
       }
-      // pending (selectedDate >= today && no entry) - not counted
     }
-    return { presentCount: present, absentCount: absent }
-  }, [rows, selectedDate, today])
+    return { completeCount: complete, incompleteCount: incomplete }
+  }, [rows])
 
   const {
     scrollRef: studentTableScrollRef,
@@ -590,7 +585,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   )
 
   function renderStudentTable(showLogColumn: boolean) {
-    const visibleColumnCount = showLogColumn ? 5 : 4
+    const visibleColumnCount = 4
 
     return (
       <KeyboardNavigableTable
@@ -615,7 +610,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('first_name')}
                   density="tight"
-                  className={showLogColumn ? 'w-24 sm:w-36' : ''}
+                  className={showLogColumn ? 'w-20 sm:w-28' : ''}
                   trailing={isClassDay && rows.length > 0 ? (
                     <span className={showLogColumn ? 'hidden sm:inline-flex' : 'inline-flex'}>
                       <StudentCountBadge count={rows.length} variant="neutral" />
@@ -628,7 +623,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('last_name')}
                   density="tight"
-                  className={showLogColumn ? 'w-20 sm:w-36' : ''}
+                  className={showLogColumn ? 'w-20 sm:w-28' : ''}
                 />
                 <SortableHeaderCell
                   label="ID"
@@ -636,26 +631,32 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('id')}
                   density="tight"
-                  className={showLogColumn ? 'hidden w-32 md:table-cell' : ''}
+                  className={showLogColumn ? 'hidden w-24 md:table-cell' : ''}
                 />
-                {showLogColumn && (
-                  <DataTableHeaderCell density="tight" className="min-w-0">
-                    Log
-                  </DataTableHeaderCell>
-                )}
                 <SortableHeaderCell
-                  label={isClassDay ? '' : 'Status'}
-                  isActive={sortColumn === 'status'}
+                  label="Log"
+                  isActive={sortColumn === 'log'}
                   direction={sortDirection}
-                  onClick={() => handleSort('status')}
+                  onClick={() => handleSort('log')}
                   density="tight"
-                  align="center"
-                  className={showLogColumn ? 'w-[5.5rem]' : ''}
-                  trailing={isClassDay ? (
-                    <div className="flex items-center gap-2">
-                      <CountBadge count={presentCount} tooltip="Present" variant="success" />
-                      <CountBadge count={absentCount} tooltip="Absent" variant="danger" />
-                    </div>
+                  align={showLogColumn ? 'left' : 'center'}
+                  className={showLogColumn ? 'min-w-0' : 'w-20'}
+                  trailing={isClassDay && rows.length > 0 && showLogColumn ? (
+                    <span
+                      aria-label={`${completeCount} complete, ${incompleteCount} incomplete`}
+                      className="ml-auto flex items-center gap-2"
+                    >
+                      <CountBadge
+                        count={completeCount}
+                        tooltip={`${completeCount} complete`}
+                        variant="success"
+                      />
+                      <CountBadge
+                        count={incompleteCount}
+                        tooltip={`${incompleteCount} incomplete`}
+                        variant="danger"
+                      />
+                    </span>
                   ) : undefined}
                 />
               </DataTableRow>
@@ -665,11 +666,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                 const isSelected = selectedStudentId === row.student_id
                 const hasLog = Boolean(row.entry && entryHasContent(row.entry))
                 const logText = hasLog ? row.entry?.text || '' : ''
-                const status: AttendanceStatus = hasLog
-                  ? 'present'
-                  : selectedDate >= today
-                    ? 'pending'
-                    : 'absent'
+                const completionLabel = hasLog ? 'Complete' : 'Incomplete'
                 return (
                   <DataTableRow
                     key={row.student_id}
@@ -701,29 +698,43 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                         showLogColumn ? 'hidden md:table-cell' : '',
                       ].join(' ')}
                     >
-                      {row.email_username}
+                      <span
+                        className={showLogColumn ? 'block truncate' : ''}
+                        title={showLogColumn ? row.email_username : undefined}
+                      >
+                        {row.email_username}
+                      </span>
                     </DataTableCell>
-                    {showLogColumn && (
-                      <DataTableCell density="tight" className="min-w-0 text-text-muted">
-                        {hasLog ? (
-                          <span className="block truncate" title={logText}>
-                            {logText}
-                          </span>
-                        ) : (
-                          <span aria-label="No log for this date">—</span>
-                        )}
-                      </DataTableCell>
-                    )}
-                    <DataTableCell density="tight" align="center">
-                      {isClassDay ? (
-                        <Tooltip content={getAttendanceLabel(status)}>
+                    <DataTableCell
+                      density="tight"
+                      align={showLogColumn ? 'left' : 'center'}
+                      className={showLogColumn ? 'min-w-0 text-text-muted' : ''}
+                    >
+                      <div
+                        className={[
+                          'flex min-w-0 items-center gap-2',
+                          showLogColumn ? '' : 'justify-center',
+                        ].join(' ')}
+                      >
+                        <Tooltip content={completionLabel}>
                           <span
-                            className={`inline-block w-3 h-3 rounded-full ${getAttendanceDotClass(status)}`}
+                            aria-label={completionLabel}
+                            className={[
+                              'inline-block h-3 w-3 shrink-0 rounded-full',
+                              hasLog ? 'bg-success-solid' : 'bg-danger-solid',
+                            ].join(' ')}
                           />
                         </Tooltip>
-                      ) : (
-                        <span className="text-text-muted">—</span>
-                      )}
+                        {showLogColumn && (
+                          hasLog ? (
+                            <span className="block truncate" title={logText}>
+                              {logText}
+                            </span>
+                          ) : (
+                            <span aria-label="No log for this date">—</span>
+                          )
+                        )}
+                      </div>
                     </DataTableCell>
                   </DataTableRow>
                 )

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -41,13 +41,26 @@ import {
 } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
-import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
+import { CountBadge } from '@/components/StudentCountBadge'
 import { applyDirection, compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { fetchCachedJSON } from '@/lib/request-cache'
 import type { Classroom, Entry } from '@/types'
 import { format, parseISO } from 'date-fns'
 
 type SortColumn = 'first_name' | 'last_name' | 'id' | 'log'
+type ResizableColumn = 'first' | 'last' | 'id'
+
+const COLUMN_LIMITS: Record<ResizableColumn, { defaultWidth: number; min: number; max: number }> = {
+  first: { defaultWidth: 72, min: 60, max: 160 },
+  last: { defaultWidth: 72, min: 60, max: 160 },
+  id: { defaultWidth: 80, min: 56, max: 180 },
+}
+
+const DEFAULT_COLUMN_WIDTHS: Record<ResizableColumn, number> = {
+  first: COLUMN_LIMITS.first.defaultWidth,
+  last: COLUMN_LIMITS.last.defaultWidth,
+  id: COLUMN_LIMITS.id.defaultWidth,
+}
 
 const SUMMARY_PANEL_DEFAULT_HEIGHT = 180
 const SUMMARY_PANEL_COLLAPSED_HEIGHT = 40
@@ -122,6 +135,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const [detailPaneWidth, setDetailPaneWidth] = useState(50)
   const [summaryPanelCollapsed, setSummaryPanelCollapsed] = useState(false)
   const [summaryPanelHeight, setSummaryPanelHeight] = useState(SUMMARY_PANEL_DEFAULT_HEIGHT)
+  const [columnWidths, setColumnWidths] = useState(DEFAULT_COLUMN_WIDTHS)
   const showBlockingSpinner = useDelayedBusy(loading && logs.length === 0)
   const [today, setToday] = useState(() => getTodayInToronto())
   const refreshToday = useCallback(() => {
@@ -324,6 +338,13 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
   function handleSort(column: SortColumn) {
     setSortState((prev) => toggleSort(prev, column))
+  }
+
+  function handleColumnResize(column: ResizableColumn, width: number) {
+    setColumnWidths((current) => ({
+      ...current,
+      [column]: width,
+    }))
   }
 
   function goToLastClass() {
@@ -601,7 +622,16 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
           {refreshing && (
             <RefreshingIndicator />
           )}
-          <DataTable className={showLogColumn ? 'table-fixed' : ''}>
+          <DataTable className="table-fixed">
+            <colgroup>
+              <col style={{ width: `${columnWidths.first}px` }} />
+              <col style={{ width: `${columnWidths.last}px` }} />
+              <col
+                className={showLogColumn ? 'hidden md:table-column' : undefined}
+                style={{ width: `${columnWidths.id}px` }}
+              />
+              <col />
+            </colgroup>
             <DataTableHead>
               <DataTableRow>
                 <SortableHeaderCell
@@ -610,12 +640,13 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('first_name')}
                   density="tight"
-                  className={showLogColumn ? 'w-20 sm:w-28' : ''}
-                  trailing={isClassDay && rows.length > 0 ? (
-                    <span className={showLogColumn ? 'hidden sm:inline-flex' : 'inline-flex'}>
-                      <StudentCountBadge count={rows.length} variant="neutral" />
-                    </span>
-                  ) : undefined}
+                  buttonClassName="!pl-2 !pr-5"
+                  resize={{
+                    value: columnWidths.first,
+                    min: COLUMN_LIMITS.first.min,
+                    max: COLUMN_LIMITS.first.max,
+                    onChange: (width) => handleColumnResize('first', width),
+                  }}
                 />
                 <SortableHeaderCell
                   label="Last"
@@ -623,7 +654,13 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('last_name')}
                   density="tight"
-                  className={showLogColumn ? 'w-20 sm:w-28' : ''}
+                  buttonClassName="!pl-2 !pr-5"
+                  resize={{
+                    value: columnWidths.last,
+                    min: COLUMN_LIMITS.last.min,
+                    max: COLUMN_LIMITS.last.max,
+                    onChange: (width) => handleColumnResize('last', width),
+                  }}
                 />
                 <SortableHeaderCell
                   label="ID"
@@ -631,7 +668,16 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   direction={sortDirection}
                   onClick={() => handleSort('id')}
                   density="tight"
-                  className={showLogColumn ? 'hidden w-24 md:table-cell' : ''}
+                  buttonClassName="!pl-2 !pr-5"
+                  className={[
+                    showLogColumn ? 'hidden md:table-cell' : '',
+                  ].join(' ')}
+                  resize={{
+                    value: columnWidths.id,
+                    min: COLUMN_LIMITS.id.min,
+                    max: COLUMN_LIMITS.id.max,
+                    onChange: (width) => handleColumnResize('id', width),
+                  }}
                 />
                 <SortableHeaderCell
                   label="Log"
@@ -641,13 +687,11 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   density="tight"
                   align={showLogColumn ? 'left' : 'center'}
                   className={showLogColumn ? 'min-w-0' : ''}
+                  trailingPlacement="after-label"
                   trailing={isClassDay && rows.length > 0 ? (
                     <span
                       aria-label={`${completeCount} complete, ${incompleteCount} incomplete`}
-                      className={[
-                        'ml-auto flex items-center',
-                        showLogColumn ? 'gap-2' : 'gap-1',
-                      ].join(' ')}
+                      className="flex shrink-0 items-center gap-1"
                     >
                       <CountBadge
                         count={completeCount}
@@ -684,13 +728,13 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                     ].join(' ')}
                     onClick={() => handleRowClick(row)}
                   >
-                    <DataTableCell density="tight" className={showLogColumn ? 'min-w-0' : ''}>
-                      <span className={showLogColumn ? 'block truncate' : ''}>
+                    <DataTableCell density="tight" className="min-w-0">
+                      <span className="block truncate" title={row.student_first_name || undefined}>
                         {row.student_first_name || '—'}
                       </span>
                     </DataTableCell>
-                    <DataTableCell density="tight" className={showLogColumn ? 'min-w-0' : ''}>
-                      <span className={showLogColumn ? 'block truncate' : ''}>
+                    <DataTableCell density="tight" className="min-w-0">
+                      <span className="block truncate" title={row.student_last_name || undefined}>
                         {row.student_last_name || '—'}
                       </span>
                     </DataTableCell>
@@ -702,8 +746,8 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                       ].join(' ')}
                     >
                       <span
-                        className={showLogColumn ? 'block truncate' : ''}
-                        title={showLogColumn ? row.email_username : undefined}
+                        className="block truncate"
+                        title={row.email_username}
                       >
                         {row.email_username}
                       </span>

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -640,11 +640,14 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
                   onClick={() => handleSort('log')}
                   density="tight"
                   align={showLogColumn ? 'left' : 'center'}
-                  className={showLogColumn ? 'min-w-0' : 'w-20'}
-                  trailing={isClassDay && rows.length > 0 && showLogColumn ? (
+                  className={showLogColumn ? 'min-w-0' : ''}
+                  trailing={isClassDay && rows.length > 0 ? (
                     <span
                       aria-label={`${completeCount} complete, ${incompleteCount} incomplete`}
-                      className="ml-auto flex items-center gap-2"
+                      className={[
+                        'ml-auto flex items-center',
+                        showLogColumn ? 'gap-2' : 'gap-1',
+                      ].join(' ')}
                     >
                       <CountBadge
                         count={completeCount}

--- a/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
+++ b/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type CSSProperties, type KeyboardEvent, type PointerEvent, type ReactNode, type Ref } from 'react'
+import { useState, type CSSProperties, type ReactNode, type Ref } from 'react'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import {
   AssessmentStatusIndicator,
@@ -16,11 +16,12 @@ import {
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
+  ResizableHeaderCell,
+  SortableHeaderCell,
   TableCard,
   Tooltip,
 } from '@/ui'
 import { Spinner } from '@/components/Spinner'
-import { ChevronDown, ChevronUp } from 'lucide-react'
 import {
   hasDraftSavedGrade,
 } from '@/lib/assignments'
@@ -105,149 +106,6 @@ function clampColumnWidth(column: ResizableColumnKey, width: number): number {
 
 function getColumnStyle(width: number): CSSProperties {
   return { width: `${width}px`, maxWidth: `${width}px` }
-}
-
-function ResizeHandle({
-  column,
-  label,
-  width,
-  onResize,
-}: {
-  column: ResizableColumnKey
-  label: string
-  width: number
-  onResize: (column: ResizableColumnKey, width: number) => void
-}) {
-  function handlePointerDown(event: PointerEvent<HTMLSpanElement>) {
-    event.preventDefault()
-    event.stopPropagation()
-
-    const startX = event.clientX
-    const startWidth = width
-    const previousCursor = document.body.style.cursor
-    const previousUserSelect = document.body.style.userSelect
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
-
-    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
-      onResize(column, startWidth + moveEvent.clientX - startX)
-    }
-
-    const handlePointerUp = () => {
-      document.body.style.cursor = previousCursor
-      document.body.style.userSelect = previousUserSelect
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
-    }
-
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-  }
-
-  function handleKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
-    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
-    event.preventDefault()
-    event.stopPropagation()
-
-    if (event.key === 'Home') {
-      onResize(column, COLUMN_LIMITS[column].min)
-      return
-    }
-    if (event.key === 'End') {
-      onResize(column, COLUMN_LIMITS[column].max)
-      return
-    }
-
-    onResize(column, width + (event.key === 'ArrowRight' ? 8 : -8))
-  }
-
-  return (
-    <span
-      role="separator"
-      aria-label={`Resize ${label} column`}
-      aria-orientation="vertical"
-      aria-valuemin={COLUMN_LIMITS[column].min}
-      aria-valuemax={COLUMN_LIMITS[column].max}
-      aria-valuenow={width}
-      aria-keyshortcuts="ArrowLeft ArrowRight Home End"
-      tabIndex={0}
-      onPointerDown={handlePointerDown}
-      onKeyDown={handleKeyDown}
-      className="absolute inset-y-0 right-0 z-10 flex min-h-11 w-11 translate-x-1/2 cursor-col-resize touch-none items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-primary"
-    >
-      <span
-        aria-hidden="true"
-        className="h-5 w-px rounded-full bg-border-strong opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-      />
-    </span>
-  )
-}
-
-function ResizableSortableHeaderCell({
-  column,
-  label,
-  isActive,
-  direction,
-  onSort,
-  width,
-  onResize,
-}: {
-  column: ResizableColumnKey
-  label: string
-  isActive: boolean
-  direction: SortDirection
-  onSort: () => void
-  width: number
-  onResize: (column: ResizableColumnKey, width: number) => void
-}) {
-  const Icon = direction === 'asc' ? ChevronUp : ChevronDown
-  const ariaSort = isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
-
-  return (
-    <DataTableHeaderCell
-      className="group relative !p-0"
-      style={getColumnStyle(width)}
-      aria-sort={ariaSort}
-    >
-      <button
-        type="button"
-        onClick={onSort}
-        className="relative flex w-full items-center py-2 pl-1.5 pr-4 text-left transition-colors hover:bg-surface-hover"
-      >
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-        <Icon
-          className={[
-            'pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 shrink-0 text-text-muted',
-            isActive ? '' : 'opacity-0',
-          ].join(' ')}
-          aria-hidden="true"
-        />
-      </button>
-      <ResizeHandle column={column} label={label} width={width} onResize={onResize} />
-    </DataTableHeaderCell>
-  )
-}
-
-function ResizableHeaderCell({
-  column,
-  label,
-  width,
-  onResize,
-}: {
-  column: ResizableColumnKey
-  label: string
-  width: number
-  onResize: (column: ResizableColumnKey, width: number) => void
-}) {
-  return (
-    <DataTableHeaderCell
-      className="group relative !py-2 !pl-1.5 !pr-3"
-      style={getColumnStyle(width)}
-    >
-      <span className="block truncate">{label}</span>
-      <ResizeHandle column={column} label={label} width={width} onResize={onResize} />
-    </DataTableHeaderCell>
-  )
 }
 
 function StatusIcon({ display }: { display: AssessmentWorkStatusDisplay }) {
@@ -344,38 +202,59 @@ export function TeacherAssignmentStudentTable({
                         aria-label="Select all students"
                       />
                     </DataTableHeaderCell>
-                    <ResizableSortableHeaderCell
-                      column="first"
+                    <SortableHeaderCell
                       label="First"
                       isActive={sortColumn === 'first'}
                       direction={sortDirection}
-                      onSort={() => onToggleSort('first')}
-                      width={columnWidths.first}
-                      onResize={handleColumnResize}
+                      onClick={() => onToggleSort('first')}
+                      density={density}
+                      buttonClassName="!py-2 !pl-1.5 !pr-4"
+                      resize={{
+                        value: columnWidths.first,
+                        min: COLUMN_LIMITS.first.min,
+                        max: COLUMN_LIMITS.first.max,
+                        onChange: (width) => handleColumnResize('first', width),
+                      }}
                     />
-                    <ResizableSortableHeaderCell
-                      column="last"
+                    <SortableHeaderCell
                       label="Last"
                       isActive={sortColumn === 'last'}
                       direction={sortDirection}
-                      onSort={() => onToggleSort('last')}
-                      width={columnWidths.last}
-                      onResize={handleColumnResize}
+                      onClick={() => onToggleSort('last')}
+                      density={density}
+                      buttonClassName="!py-2 !pl-1.5 !pr-4"
+                      resize={{
+                        value: columnWidths.last,
+                        min: COLUMN_LIMITS.last.min,
+                        max: COLUMN_LIMITS.last.max,
+                        onChange: (width) => handleColumnResize('last', width),
+                      }}
                     />
-                    <ResizableSortableHeaderCell
-                      column="status"
+                    <SortableHeaderCell
                       label="Status"
                       isActive={sortColumn === 'status'}
                       direction={sortDirection}
-                      onSort={() => onToggleSort('status')}
-                      width={columnWidths.status}
-                      onResize={handleColumnResize}
+                      onClick={() => onToggleSort('status')}
+                      density={density}
+                      align="center"
+                      buttonClassName="!py-2 !pl-1.5 !pr-4"
+                      resize={{
+                        value: columnWidths.status,
+                        min: COLUMN_LIMITS.status.min,
+                        max: COLUMN_LIMITS.status.max,
+                        onChange: (width) => handleColumnResize('status', width),
+                      }}
                     />
                     <ResizableHeaderCell
-                      column="grade"
                       label="Grade"
-                      width={columnWidths.grade}
-                      onResize={handleColumnResize}
+                      align="center"
+                      className="!py-2 !pl-1.5 !pr-3"
+                      resize={{
+                        value: columnWidths.grade,
+                        min: COLUMN_LIMITS.grade.min,
+                        max: COLUMN_LIMITS.grade.max,
+                        onChange: (width) => handleColumnResize('grade', width),
+                      }}
                     />
                     <DataTableHeaderCell className="whitespace-nowrap !px-1.5 !py-2">
                       <span className="block truncate">Artifacts</span>

--- a/src/ui/DataTable.tsx
+++ b/src/ui/DataTable.tsx
@@ -1,10 +1,19 @@
 'use client'
 
-import { createContext, forwardRef, useCallback, useContext, useEffect, useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode, type Ref, type TdHTMLAttributes, type ThHTMLAttributes } from 'react'
+import { createContext, forwardRef, useCallback, useContext, useEffect, useRef, type CSSProperties, type HTMLAttributes, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type Ref, type TdHTMLAttributes, type ThHTMLAttributes } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 
 export type DataTableDensity = 'tight' | 'compact' | 'normal'
 export type SortDirection = 'asc' | 'desc'
+
+export interface ColumnResizeConfig {
+  value: number
+  min: number
+  max: number
+  onChange: (value: number) => void
+  step?: number
+  label?: string
+}
 
 const DensityContext = createContext<DataTableDensity>('compact')
 
@@ -118,7 +127,10 @@ export function SortableHeaderCell({
   density: densityProp,
   align = 'left',
   className = '',
+  buttonClassName = '',
   trailing,
+  trailingPlacement = 'after-sort',
+  resize,
 }: {
   label: string
   isActive: boolean
@@ -127,7 +139,10 @@ export function SortableHeaderCell({
   density?: DataTableDensity
   align?: 'left' | 'center' | 'right'
   className?: string
+  buttonClassName?: string
   trailing?: React.ReactNode
+  trailingPlacement?: 'after-label' | 'after-sort'
+  resize?: ColumnResizeConfig
 }) {
   const density = useDensity(densityProp)
   const alignClass =
@@ -136,7 +151,13 @@ export function SortableHeaderCell({
   const Icon = direction === 'asc' ? ChevronUp : ChevronDown
 
   return (
-    <DataTableHeaderCell density={density} align={align} className={['!p-0', className].join(' ')} aria-sort={ariaSort}>
+    <DataTableHeaderCell
+      density={density}
+      align={align}
+      className={['!p-0', resize ? 'group relative' : '', className].join(' ')}
+      aria-sort={ariaSort}
+      style={resize ? { width: `${resize.value}px`, maxWidth: `${resize.value}px` } : undefined}
+    >
       <button
         type="button"
         onClick={onClick}
@@ -145,18 +166,161 @@ export function SortableHeaderCell({
           'flex min-h-control w-full items-center gap-1 focus:outline-none focus-visible:ring-foundation focus-visible:ring-focus focus-visible:ring-inset',
           alignClass,
           'hover:bg-surface-hover transition-colors',
+          resize ? 'relative' : '',
+          buttonClassName,
         ].join(' ')}
       >
         <span className="truncate">{label}</span>
+        {trailingPlacement === 'after-label' ? trailing : null}
         <Icon
           className={[
-            'h-4 w-4 flex-shrink-0',
+            resize
+              ? 'pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2'
+              : 'h-4 w-4 flex-shrink-0',
             isActive ? 'text-text-muted' : 'opacity-0',
           ].join(' ')}
           aria-hidden="true"
         />
-        {trailing}
+        {trailingPlacement === 'after-sort' ? trailing : null}
       </button>
+      {resize ? (
+        <ColumnResizeHandle
+          label={resize.label ?? label}
+          value={resize.value}
+          min={resize.min}
+          max={resize.max}
+          step={resize.step}
+          onChange={resize.onChange}
+        />
+      ) : null}
+    </DataTableHeaderCell>
+  )
+}
+
+export function ColumnResizeHandle({
+  label,
+  value,
+  min,
+  max,
+  step = 8,
+  onChange,
+}: {
+  label: string
+  value: number
+  min: number
+  max: number
+  step?: number
+  onChange: (value: number) => void
+}) {
+  const updateValue = (nextValue: number) => {
+    onChange(Math.min(max, Math.max(min, Math.round(nextValue))))
+  }
+
+  function handlePointerDown(event: ReactPointerEvent<HTMLSpanElement>) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const startX = event.clientX
+    const startWidth = value
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      updateValue(startWidth + moveEvent.clientX - startX)
+    }
+
+    const handlePointerUp = () => {
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerUp)
+      window.removeEventListener('blur', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerUp)
+    window.addEventListener('blur', handlePointerUp)
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (event.key === 'Home') {
+      updateValue(min)
+      return
+    }
+    if (event.key === 'End') {
+      updateValue(max)
+      return
+    }
+
+    updateValue(value + (event.key === 'ArrowRight' ? step : -step))
+  }
+
+  return (
+    <span
+      role="separator"
+      aria-label={`Resize ${label} column`}
+      aria-orientation="vertical"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      aria-keyshortcuts="ArrowLeft ArrowRight Home End"
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+      className="absolute inset-y-0 right-0 z-local-menu flex min-h-control min-w-control translate-x-1/2 cursor-col-resize touch-none items-center justify-center outline-none focus-visible:ring-foundation focus-visible:ring-focus focus-visible:ring-inset"
+    >
+      <span
+        aria-hidden="true"
+        className="h-5 w-px rounded-full bg-border-strong opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      />
+    </span>
+  )
+}
+
+export function ResizableHeaderCell({
+  label,
+  resize,
+  density,
+  align = 'left',
+  className = '',
+  contentClassName = '',
+}: {
+  label: string
+  resize: ColumnResizeConfig
+  density?: DataTableDensity
+  align?: 'left' | 'center' | 'right'
+  className?: string
+  contentClassName?: string
+}) {
+  const style: CSSProperties = {
+    width: `${resize.value}px`,
+    maxWidth: `${resize.value}px`,
+  }
+
+  return (
+    <DataTableHeaderCell
+      density={density}
+      align={align}
+      className={['group relative', className].join(' ')}
+      style={style}
+    >
+      <span className={['block truncate', contentClassName].join(' ')}>{label}</span>
+      <ColumnResizeHandle
+        label={resize.label ?? label}
+        value={resize.value}
+        min={resize.min}
+        max={resize.max}
+        step={resize.step}
+        onChange={resize.onChange}
+      />
     </DataTableHeaderCell>
   )
 }

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -190,6 +190,10 @@ base controls and shell styling follow the `@/ui` contracts.
 - Import `DataTable`, `SortableHeaderCell`, `KeyboardNavigableTable`, and related table primitives
   from `@/ui`; keyboard-selectable tables require a feature-specific accessible name and matching
   row IDs so keyboard selection can move focus to the active row.
+- Pass a `resize` configuration to `SortableHeaderCell`, or use `ResizableHeaderCell` for a
+  non-sortable column, when a table exposes adjustable widths. The shared resize handle owns the
+  vertical separator semantics, min/max/current values, pointer drag behavior, and
+  Arrow/Home/End keyboard controls; feature tables continue to own their column limits and cells.
 - Menu and split-pane ownership, semantics, and verification requirements live in
   [`composite-control-conventions.md`](/docs/guidance/ui/composite-control-conventions.md).
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -25,12 +25,14 @@ export {
   DataTableCell,
   DataTableHead,
   DataTableHeaderCell,
+  ResizableHeaderCell,
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
   SortableHeaderCell,
   TableCard,
   type DataTableDensity,
+  type ColumnResizeConfig,
   type SortDirection,
 } from './DataTable'
 export { Tabs, TabPanel, type TabItem, type TabsProps } from './Tabs'

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import {
   DataTable,
@@ -56,6 +57,46 @@ describe('TableCard', () => {
       'focus-visible:ring-inset',
     )
     expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending')
+  })
+
+  it('provides shared separator semantics and keyboard resizing for sortable columns', () => {
+    const onSort = vi.fn()
+
+    function ResizableTable() {
+      const [width, setWidth] = useState(72)
+      return (
+        <DataTable className="table-fixed">
+          <DataTableHead>
+            <tr>
+              <SortableHeaderCell
+                label="First"
+                isActive={false}
+                direction="asc"
+                onClick={onSort}
+                resize={{ value: width, min: 60, max: 160, onChange: setWidth }}
+              />
+            </tr>
+          </DataTableHead>
+        </DataTable>
+      )
+    }
+
+    render(<ResizableTable />)
+
+    const separator = screen.getByRole('separator', { name: 'Resize First column' })
+    expect(separator).toHaveAttribute('aria-orientation', 'vertical')
+    expect(separator).toHaveAttribute('aria-valuemin', '60')
+    expect(separator).toHaveAttribute('aria-valuemax', '160')
+    expect(separator).toHaveAttribute('aria-valuenow', '72')
+    expect(separator).toHaveAttribute('aria-keyshortcuts', 'ArrowLeft ArrowRight Home End')
+
+    fireEvent.keyDown(separator, { key: 'Home' })
+    expect(separator).toHaveAttribute('aria-valuenow', '60')
+    fireEvent.keyDown(separator, { key: 'ArrowRight' })
+    expect(separator).toHaveAttribute('aria-valuenow', '68')
+    fireEvent.keyDown(separator, { key: 'End' })
+    expect(separator).toHaveAttribute('aria-valuenow', '160')
+    expect(onSort).not.toHaveBeenCalled()
   })
 
   it('keeps keyboard table navigation focus visible', async () => {

--- a/tests/components/TeacherAssignmentStudentTable.test.tsx
+++ b/tests/components/TeacherAssignmentStudentTable.test.tsx
@@ -81,7 +81,7 @@ describe('TeacherAssignmentStudentTable', () => {
     expect(firstResize).toHaveAttribute('aria-valuemin', '58')
     expect(firstResize).toHaveAttribute('aria-valuemax', '160')
     expect(firstResize).toHaveAttribute('aria-valuenow', '72')
-    expect(firstResize).toHaveClass('min-h-11', 'w-11')
+    expect(firstResize).toHaveClass('min-h-control', 'min-w-control')
     fireEvent.keyDown(firstResize, { key: 'End' })
     expect(firstResize).toHaveAttribute('aria-valuenow', '160')
     expect(screen.getByRole('separator', { name: 'Resize Last column' })).toBeInTheDocument()

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { TeacherAttendanceTab } from '@/app/classrooms/[classroomId]/TeacherAttendanceTab'
 import type { Classroom, Entry } from '@/types'
 
@@ -200,14 +201,20 @@ describe('TeacherAttendanceTab', () => {
     render(<TeacherAttendanceTab classroom={classroom} />)
 
     const logText = await screen.findByText(longLogText)
+    const logHeader = screen.getByRole('columnheader', {
+      name: 'Log 1 complete, 1 incomplete',
+    })
 
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(logHeader).toHaveAttribute('aria-sort', 'none')
+    expect(screen.queryByRole('columnheader', { name: 'Status' })).not.toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'Attendance students' })).toHaveAttribute(
       'aria-keyshortcuts',
       'ArrowUp ArrowDown Home End Escape',
     )
     expect(logText).toHaveClass('truncate')
     expect(logText).toHaveAttribute('title', longLogText)
+    expect(screen.getByLabelText('Complete')).toBeInTheDocument()
+    expect(screen.getByLabelText('Incomplete')).toBeInTheDocument()
     expect(screen.getByText('Class Log Summary')).toBeInTheDocument()
     expect(screen.getByTestId('class-log-summary')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Hide class log summary' })).not.toBeInTheDocument()
@@ -224,6 +231,59 @@ describe('TeacherAttendanceTab', () => {
     await waitFor(() => {
       expect(selectedRow).toHaveFocus()
     })
+  })
+
+  it('sorts the combined Log column by complete and incomplete status', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/teacher/logs?')) {
+        return mockJson({
+          logs: [
+            {
+              student_id: 'student-incomplete',
+              student_email: 'incomplete@example.com',
+              student_first_name: 'Alex',
+              student_last_name: 'Alpha',
+              entry: null,
+              history_preview: [],
+            },
+            {
+              student_id: 'student-complete',
+              student_email: 'complete@example.com',
+              student_first_name: 'Zoe',
+              student_last_name: 'Zulu',
+              entry: entry({ id: 'entry-complete', student_id: 'student-complete' }),
+              history_preview: [],
+            },
+          ],
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TeacherAttendanceTab classroom={classroom} />)
+
+    const logSortButton = await screen.findByRole('button', {
+      name: 'Log 1 complete, 1 incomplete',
+    })
+
+    logSortButton.focus()
+    expect(logSortButton).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(screen.getByRole('columnheader', { name: 'Log 1 complete, 1 incomplete' })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    )
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Zulu')
+
+    await user.keyboard(' ')
+    expect(screen.getByRole('columnheader', { name: 'Log 1 complete, 1 incomplete' })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    )
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Alpha')
   })
 
   it('shows a retryable error instead of prior-date or empty-roster data after a failed read', async () => {
@@ -323,7 +383,7 @@ describe('TeacherAttendanceTab', () => {
 
     render(<TeacherAttendanceTab classroom={classroom} onDateChange={onDateChange} />)
 
-    await screen.findByRole('columnheader', { name: 'Log' })
+    await screen.findByRole('columnheader', { name: /^Log/ })
 
     const lastClassButton = screen.getByRole('button', { name: 'Go to last class' })
     const todayButton = screen.getByRole('button', { name: 'Go to today' })
@@ -353,7 +413,7 @@ describe('TeacherAttendanceTab', () => {
 
     render(<TeacherAttendanceTab classroom={classroom} />)
 
-    await screen.findByRole('columnheader', { name: 'Log' })
+    await screen.findByRole('columnheader', { name: /^Log/ })
 
     expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Tue May 5')
     expect(screen.queryByRole('button', { name: 'Previous day' })).not.toBeInTheDocument()
@@ -376,7 +436,7 @@ describe('TeacherAttendanceTab', () => {
 
     render(<TeacherAttendanceTab classroom={classroom} onDateChange={onDateChange} />)
 
-    await screen.findByRole('columnheader', { name: 'Log' })
+    await screen.findByRole('columnheader', { name: /^Log/ })
     expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Tue May 5')
 
     todayMock.today = '2026-05-07'
@@ -474,7 +534,7 @@ describe('TeacherAttendanceTab', () => {
 
     expect(await screen.findByTestId('student-log-history')).toHaveTextContent('History for student-1')
     expect(screen.getByRole('separator', { name: 'Resize Daily panes' })).toBeInTheDocument()
-    expect(screen.queryByRole('columnheader', { name: 'Log' })).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
     expect(screen.queryByTestId('class-log-summary')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('cell', { name: 'Student1', exact: true }))
@@ -482,7 +542,7 @@ describe('TeacherAttendanceTab', () => {
     await waitFor(() => {
       expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
     })
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Log/ })).toBeInTheDocument()
     expect(screen.getByTestId('class-log-summary')).toBeInTheDocument()
   })
 
@@ -531,7 +591,7 @@ describe('TeacherAttendanceTab', () => {
     await waitFor(() => {
       expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
     })
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Log/ })).toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'Attendance students' })).toHaveFocus()
   })
 
@@ -553,7 +613,7 @@ describe('TeacherAttendanceTab', () => {
     await waitFor(() => {
       expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
     })
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Log/ })).toBeInTheDocument()
   })
 
   it('uses entry animations when switching between the full table and selected workspace', async () => {
@@ -561,7 +621,7 @@ describe('TeacherAttendanceTab', () => {
 
     const { container } = render(<TeacherAttendanceTab classroom={classroom} />)
 
-    await screen.findByRole('columnheader', { name: 'Log' })
+    await screen.findByRole('columnheader', { name: /^Log/ })
     expect(container.querySelector('.daily-table-enter')).toBeInTheDocument()
 
     fireEvent.click(await screen.findByRole('cell', { name: 'Student1', exact: true }))
@@ -575,7 +635,7 @@ describe('TeacherAttendanceTab', () => {
     await waitFor(() => {
       expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
     })
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Log/ })).toBeInTheDocument()
     expect(container.querySelector('.daily-table-enter')).toBeInTheDocument()
   })
 

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherAttendanceTab } from '@/app/classrooms/[classroomId]/TeacherAttendanceTab'
 import type { Classroom, Entry } from '@/types'
@@ -204,8 +204,14 @@ describe('TeacherAttendanceTab', () => {
     const logHeader = screen.getByRole('columnheader', {
       name: 'Log 1 complete, 1 incomplete',
     })
+    const logSortButton = within(logHeader).getByRole('button', {
+      name: 'Log 1 complete, 1 incomplete',
+    })
+    const logLabel = within(logSortButton).getByText('Log')
+    const logCounts = within(logSortButton).getByLabelText('1 complete, 1 incomplete')
 
     expect(logHeader).toHaveAttribute('aria-sort', 'none')
+    expect(logLabel.nextElementSibling).toBe(logCounts)
     expect(screen.queryByRole('columnheader', { name: 'Status' })).not.toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'Attendance students' })).toHaveAttribute(
       'aria-keyshortcuts',
@@ -221,6 +227,20 @@ describe('TeacherAttendanceTab', () => {
     expect(screen.queryByRole('button', { name: 'Show class log summary' })).not.toBeInTheDocument()
     expect(screen.getByRole('separator', { name: 'Resize class log summary' })).toBeInTheDocument()
     expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
+
+    const firstColumnResize = screen.getByRole('separator', { name: 'Resize First column' })
+    expect(firstColumnResize).toHaveAttribute('aria-valuemin', '60')
+    expect(firstColumnResize).toHaveAttribute('aria-valuemax', '160')
+    expect(firstColumnResize).toHaveAttribute('aria-valuenow', '72')
+    expect(firstColumnResize).toHaveClass('min-h-control', 'min-w-control')
+    fireEvent.keyDown(firstColumnResize, { key: 'Home' })
+    expect(firstColumnResize).toHaveAttribute('aria-valuenow', '60')
+    fireEvent.keyDown(firstColumnResize, { key: 'ArrowRight' })
+    expect(firstColumnResize).toHaveAttribute('aria-valuenow', '68')
+    fireEvent.keyDown(firstColumnResize, { key: 'End' })
+    expect(firstColumnResize).toHaveAttribute('aria-valuenow', '160')
+    expect(screen.getByRole('separator', { name: 'Resize Last column' })).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize ID column' })).toBeInTheDocument()
 
     const tableRegion = screen.getByRole('region', { name: 'Attendance students' })
     tableRegion.focus()
@@ -284,6 +304,29 @@ describe('TeacherAttendanceTab', () => {
       'descending',
     )
     expect(screen.getAllByRole('row')[1]).toHaveTextContent('Alpha')
+  })
+
+  it('resizes Daily identity columns by pointer and clamps them to their minimum width', async () => {
+    mockLogsFetch()
+
+    render(<TeacherAttendanceTab classroom={classroom} />)
+
+    const firstColumnResize = await screen.findByRole('separator', {
+      name: 'Resize First column',
+    })
+
+    const pointerDown = new Event('pointerdown', { bubbles: true })
+    Object.defineProperty(pointerDown, 'clientX', { value: 100 })
+    fireEvent(firstColumnResize, pointerDown)
+    const pointerMove = new Event('pointermove', { bubbles: true })
+    Object.defineProperty(pointerMove, 'clientX', { value: 70 })
+    window.dispatchEvent(pointerMove)
+    window.dispatchEvent(new Event('pointerup', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(firstColumnResize).toHaveAttribute('aria-valuenow', '60')
+    })
+    expect(document.body.style.cursor).toBe('')
   })
 
   it('shows a retryable error instead of prior-date or empty-roster data after a failed read', async () => {
@@ -533,6 +576,7 @@ describe('TeacherAttendanceTab', () => {
     fireEvent.click(studentCell)
 
     expect(await screen.findByTestId('student-log-history')).toHaveTextContent('History for student-1')
+    expect(within(screen.getByRole('cell', { name: 'Student1', exact: true })).getByText('Student1')).toHaveClass('truncate')
     expect(screen.getByRole('separator', { name: 'Resize Daily panes' })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', {
       name: 'Log 1 complete, 1 incomplete',

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -534,7 +534,9 @@ describe('TeacherAttendanceTab', () => {
 
     expect(await screen.findByTestId('student-log-history')).toHaveTextContent('History for student-1')
     expect(screen.getByRole('separator', { name: 'Resize Daily panes' })).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', {
+      name: 'Log 1 complete, 1 incomplete',
+    })).toHaveAttribute('aria-sort', 'none')
     expect(screen.queryByTestId('class-log-summary')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('cell', { name: 'Student1', exact: true }))


### PR DESCRIPTION
## Summary
- reduce the teacher Daily table First, Last, and ID column widths
- combine the completion marker and Complete/Incomplete counts into the sortable Log column
- remove the standalone attendance-status column while preserving selected-student behavior

## Validation
- `pnpm test tests/components/TeacherAttendanceTab.test.tsx --run` (17 tests)
- `pnpm lint`
- `pnpm run check:design-policy`
- `pnpm run check:ui-policy`
- `pnpm check:architecture`
- `pnpm exec playwright test e2e/experience-matrix.spec.ts` (18 tests)
- Pika pre-commit audit
- Playwright screenshots: teacher/student, desktop/mobile, light/dark, default and sorted states; no page overflow

## Accessibility
- composite-widget checklist reviewed
- Log sort supports Enter and Space
- `aria-sort`, focus, and Complete/Incomplete labels are covered by component tests
- remaining manual follow-up: none