### PR TITLE
Add accessible Student Tests live status

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,4 +1,4 @@
-Prod 001–121. Student Tests live-status accessibility is open in PR #986;
-focused/static/audit and Playwright teacher/student verification pass. Initial
-independent review's stale-autosave P1 is remediated with controlled coverage.
-Do not merge without explicit approval. Deletion rollouts stay unchanged.
+Prod 001–121. PR #986: Student Tests live status; gates, visuals, reviews pass.
+WT: `$HOME/.codex/worktrees/pika/` or `$HOME/.codex/worktrees/<id>/pika`. Env:
+`$HOME/Repos/.env/pika/.env.local` or collaborator `.env.example`. Draft; do not
+merge without explicit approval. Deletion unchanged.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,4 +1,4 @@
-Prod 001–121. Student Tests live-status accessibility is implemented on
-`codex/student-test-live-status-a11y`; focused/static/audit and Playwright
-teacher/student verification pass. Next: publish and independently review the
-PR; do not merge without explicit approval. Deletion rollouts stay unchanged.
+Prod 001–121. Student Tests live-status accessibility is open in PR #986;
+focused/static/audit and Playwright teacher/student verification pass. Initial
+independent review's stale-autosave P1 is remediated with controlled coverage.
+Do not merge without explicit approval. Deletion rollouts stay unchanged.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,4 +1,4 @@
-Prod 001–121. Cold purge PR #983 passes local gates; rollout and generic cleanup
-stay off. WT: `$HOME/.codex/worktrees/pika/` or
-`$HOME/.codex/worktrees/<id>/pika`. Env: `$HOME/Repos/.env/pika/.env.local` or
-collaborator `.env.example`. Next: merge; student purge remains separate.
+Prod 001–121. Student Tests live-status accessibility is implemented on
+`codex/student-test-live-status-a11y`; focused/static/audit and Playwright
+teacher/student verification pass. Next: publish and independently review the
+PR; do not merge without explicit approval. Deletion rollouts stay unchanged.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17662,3 +17662,29 @@ authorization, concurrency, and migration compatibility.
   and pass the operational digest in the primary destructive fixture.
 - After those narrow fixes, run exact-head ephemeral DB CI and one final targeted
   review before committing/publishing the replacement draft PR.
+
+<!-- pika-session-log-archive-batch:b74b6b4c0807fda8a3e42581a8231bb3928ad9a43d7c50d3b3ebc075df641ce6 -->
+## 2026-08-04 — Cleared final purge review blockers
+
+**Risk profile:** runtime-platform — code-first migration compatibility and
+exact-head destructive purge verification.
+
+**Completed:**
+- Added a migration-118-only readiness probe before the cleanup cron can read or
+  advance legacy migration-115 purge operations; pre-118 targets now fail closed
+  without RPC or Storage access.
+- Updated the primary destructive fixture to pass the complete server inventory,
+  including the operational inventory digest required by migration 118.
+- Used the owner-authorized final remediation batch and fifth targeted reviewer;
+  no P0/P1 or merge-blocking findings remain in the bounded fixes.
+
+**Validation:**
+- Focused purge/cron/migration coverage passes (3 files, 35 tests), including the
+  pre-118 no-op regression.
+- TypeScript, destructive-fixture shell syntax, migration-118 function lint,
+  continuity validation, and diff checks pass.
+
+**Remaining:**
+- Publish the draft replacement PR while leaving #963 unchanged.
+- Run exact-head database CI before enabling or deploying deletion. Migration
+  118 still requires fresh authorization for every database target.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1066,10 +1066,15 @@ autosave error feedback while preserving the mounted attempt and exam owner.
   preservation, preview isolation, and existing pressed/locking/storage rules.
 
 **Validation:**
-- Focused StudentTestForm tests pass (15 tests), plus TypeScript, lint,
+- Focused StudentTestForm tests pass (17 tests), including controlled stale
+  success/failure races so an older save cannot overwrite newer live state.
+- TypeScript, lint,
   architecture, UI policy, Pika audit, and diff checks.
 - Playwright verified real student flagged/unflagged, saving/error, response
   preservation, and keyboard-focus states plus teacher preview at desktop/mobile
   and light/dark; no layout regression or overflow was found.
 - The temporary local test fixture was deleted after capture; no API, database,
   migration, Gradex, exam-mode ownership, or dependency changes were made.
+- Independent review identified one P1 stale-autosave completion race; the
+  accepted remediation guards UI completion by the latest pending draft and
+  monotonic successful-save sequence without changing persistence requests.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,31 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-04 — Cleared final purge review blockers
-
-**Risk profile:** runtime-platform — code-first migration compatibility and
-exact-head destructive purge verification.
-
-**Completed:**
-- Added a migration-118-only readiness probe before the cleanup cron can read or
-  advance legacy migration-115 purge operations; pre-118 targets now fail closed
-  without RPC or Storage access.
-- Updated the primary destructive fixture to pass the complete server inventory,
-  including the operational inventory digest required by migration 118.
-- Used the owner-authorized final remediation batch and fifth targeted reviewer;
-  no P0/P1 or merge-blocking findings remain in the bounded fixes.
-
-**Validation:**
-- Focused purge/cron/migration coverage passes (3 files, 35 tests), including the
-  pre-118 no-op regression.
-- TypeScript, destructive-fixture shell syntax, migration-118 function lint,
-  continuity validation, and diff checks pass.
-
-**Remaining:**
-- Publish the draft replacement PR while leaving #963 unchanged.
-- Run exact-head database CI before enabling or deploying deletion. Migration
-  118 still requires fresh authorization for every database target.
-
 ## 2026-08-04 — Verified draft hot-archive purge replacement
 
 **Risk profile:** runtime-platform — irreversible classroom deletion,
@@ -1074,3 +1049,27 @@ and focused regression coverage; no lifecycle behavior or rollout gates changed.
 - Screenshots were visually reviewed for all teacher matrices and the student
   boundary. No database, migration, API behavior, feature gate, or destructive
   operation changed.
+
+## 2026-08-10 — Add Student Tests live-status accessibility
+
+**Risk profile:** exam-mode, workspace-state — student test announcements and
+autosave error feedback while preserving the mounted attempt and exam owner.
+
+**Completed:**
+- Added action-only polite flag/unflag announcements without announcing loaded
+  localStorage state or duplicating pointer/keyboard toggles.
+- Added polite autosave transition announcements for unsaved, saving, and saved
+  states while keeping the visible status layout and teacher preview unchanged.
+- Exposed save and submission errors as assertive alerts without changing API,
+  draft, retry, availability, locking, or submission behavior.
+- Added controlled timer/promise coverage for announcements, save failure draft
+  preservation, preview isolation, and existing pressed/locking/storage rules.
+
+**Validation:**
+- Focused StudentTestForm tests pass (15 tests), plus TypeScript, lint,
+  architecture, UI policy, Pika audit, and diff checks.
+- Playwright verified real student flagged/unflagged, saving/error, response
+  preservation, and keyboard-focus states plus teacher preview at desktop/mobile
+  and light/dark; no layout regression or overflow was found.
+- The temporary local test fixture was deleted after capture; no API, database,
+  migration, Gradex, exam-mode ownership, or dependency changes were made.

--- a/src/components/StudentTestForm.tsx
+++ b/src/components/StudentTestForm.tsx
@@ -68,8 +68,10 @@ export function StudentTestForm({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
+  const [autosaveAnnouncement, setAutosaveAnnouncement] = useState('')
   const [previewSubmitMessage, setPreviewSubmitMessage] = useState('')
   const [flaggedQuestions, setFlaggedQuestions] = useState<string[]>([])
+  const [flagAnnouncement, setFlagAnnouncement] = useState('')
   const [showFlaggedWarning, setShowFlaggedWarning] = useState(false)
   const shouldAutosave = enableDraftAutosave && !previewMode
 
@@ -93,7 +95,18 @@ export function StudentTestForm({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-1">
           {shouldAutosave && (
-            <p className="text-xs text-text-muted">{saveStatusLabel}</p>
+            <>
+              <p className="text-xs text-text-muted">{saveStatusLabel}</p>
+              <p
+                data-testid="student-test-autosave-status"
+                className="sr-only"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                {autosaveAnnouncement}
+              </p>
+            </>
           )}
           {!allAnswered && (
             <p className="text-sm text-text-muted">Answer all questions to submit</p>
@@ -122,10 +135,13 @@ export function StudentTestForm({
     pendingResponsesRef.current = normalized
     lastSavedResponsesRef.current = JSON.stringify(normalized)
     setSaveStatus('saved')
+    setAutosaveAnnouncement('')
   }, [initialResponses, testId])
 
   // Load and monitor flagged questions from localStorage
   useEffect(() => {
+    setFlagAnnouncement('')
+
     const loadFlaggedQuestions = () => {
       const flagged = getFlaggedQuestions(testId)
       setFlaggedQuestions(flagged)
@@ -152,10 +168,13 @@ export function StudentTestForm({
     const serialized = JSON.stringify(next)
     if (!options?.force && serialized === lastSavedResponsesRef.current) {
       setSaveStatus('saved')
+      setAutosaveAnnouncement('')
       return
     }
 
+    setError('')
     setSaveStatus('saving')
+    setAutosaveAnnouncement('Saving')
     lastSaveAttemptAtRef.current = Date.now()
 
     try {
@@ -173,13 +192,16 @@ export function StudentTestForm({
       }
       lastSavedResponsesRef.current = serialized
       setSaveStatus('saved')
+      setAutosaveAnnouncement('Saved')
     } catch (saveError) {
       console.error('Error saving test draft:', saveError)
       const message = saveError instanceof Error ? saveError.message : 'Failed to save draft'
       if (isAssessmentAvailabilityError(message)) {
         onAvailabilityLoss?.()
       }
+      setError(message)
       setSaveStatus('unsaved')
+      setAutosaveAnnouncement('Unsaved changes')
     }
   }, [apiBasePath, onAvailabilityLoss, testId, shouldAutosave])
 
@@ -234,6 +256,7 @@ export function StudentTestForm({
       })
       if (shouldAutosave) {
         setSaveStatus('unsaved')
+        setAutosaveAnnouncement('Unsaved changes')
         pendingResponsesRef.current = next
         if (saveTimeoutRef.current) {
           clearTimeout(saveTimeoutRef.current)
@@ -259,6 +282,7 @@ export function StudentTestForm({
       })
       if (shouldAutosave) {
         setSaveStatus('unsaved')
+        setAutosaveAnnouncement('Unsaved changes')
         pendingResponsesRef.current = next
         if (saveTimeoutRef.current) {
           clearTimeout(saveTimeoutRef.current)
@@ -412,16 +436,31 @@ export function StudentTestForm({
     }
   }
 
-  function handleToggleFlagged(questionId: string) {
+  function handleToggleFlagged(questionId: string, questionNumber: number) {
     if (isInteractionLocked) return
 
+    const wasFlagged = isQuestionFlagged(testId, questionId)
     toggleFlaggedQuestion(testId, questionId)
     const updated = getFlaggedQuestions(testId)
     setFlaggedQuestions(updated)
+    setFlagAnnouncement(
+      wasFlagged
+        ? `Question ${questionNumber} removed from review.`
+        : `Question ${questionNumber} flagged for review.`
+    )
   }
 
   return (
     <>
+      <p
+        data-testid="student-test-flag-status"
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {flagAnnouncement}
+      </p>
       <div className="mt-4 flex min-h-full flex-col gap-6">
         <div className="space-y-6">
           {questions.map((question, index) => (
@@ -441,7 +480,9 @@ export function StudentTestForm({
                       className={`group relative space-y-1 cursor-pointer rounded-lg px-3 py-2 transition-colors ${
                         isFlagged ? 'bg-info-bg' : 'hover:bg-surface-hover'
                       } ${isInteractionLocked ? 'cursor-not-allowed opacity-50' : ''}`}
-                      onClick={() => !isInteractionLocked && handleToggleFlagged(question.id)}
+                      onClick={() =>
+                        !isInteractionLocked && handleToggleFlagged(question.id, index + 1)
+                      }
                       title={isFlagged ? 'Unflag question' : 'Flag for review'}
                       role="button"
                       aria-label={`Flag question ${index + 1} for review`}
@@ -457,7 +498,7 @@ export function StudentTestForm({
                           !e.repeat &&
                           !isInteractionLocked
                         ) {
-                          handleToggleFlagged(question.id)
+                          handleToggleFlagged(question.id, index + 1)
                         }
                       }}
                     >
@@ -561,7 +602,14 @@ export function StudentTestForm({
           ))}
 
           {error && (
-            <div className="rounded-lg bg-danger-bg p-3 text-sm text-danger">{error}</div>
+            <div
+              className="rounded-lg bg-danger-bg p-3 text-sm text-danger"
+              role="alert"
+              aria-live="assertive"
+              aria-atomic="true"
+            >
+              {error}
+            </div>
           )}
 
           {previewSubmitMessage && (

--- a/src/components/StudentTestForm.tsx
+++ b/src/components/StudentTestForm.tsx
@@ -80,6 +80,8 @@ export function StudentTestForm({
   const pendingResponsesRef = useRef<TestResponses | null>(null)
   const lastSavedResponsesRef = useRef('')
   const lastSaveAttemptAtRef = useRef(0)
+  const saveRequestIdRef = useRef(0)
+  const latestSuccessfulSaveRequestIdRef = useRef(0)
 
   const allAnswered = questions.every((question) =>
     isCompleteTestResponseForQuestion(question, responses[question.id])
@@ -176,6 +178,11 @@ export function StudentTestForm({
     setSaveStatus('saving')
     setAutosaveAnnouncement('Saving')
     lastSaveAttemptAtRef.current = Date.now()
+    const requestId = ++saveRequestIdRef.current
+
+    const isLatestPendingDraft = () =>
+      pendingResponsesRef.current === null ||
+      serialized === JSON.stringify(pendingResponsesRef.current)
 
     try {
       const res = await fetch(`${apiBasePath}/${testId}/attempt`, {
@@ -190,7 +197,11 @@ export function StudentTestForm({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to save draft')
       }
-      lastSavedResponsesRef.current = serialized
+      if (requestId > latestSuccessfulSaveRequestIdRef.current) {
+        latestSuccessfulSaveRequestIdRef.current = requestId
+        lastSavedResponsesRef.current = serialized
+      }
+      if (!isLatestPendingDraft()) return
       setSaveStatus('saved')
       setAutosaveAnnouncement('Saved')
     } catch (saveError) {
@@ -199,6 +210,7 @@ export function StudentTestForm({
       if (isAssessmentAvailabilityError(message)) {
         onAvailabilityLoss?.()
       }
+      if (!isLatestPendingDraft()) return
       setError(message)
       setSaveStatus('unsaved')
       setAutosaveAnnouncement('Unsaved changes')

--- a/tests/components/StudentTestForm.test.tsx
+++ b/tests/components/StudentTestForm.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { StudentTestForm } from '@/components/StudentTestForm'
 import { createMockTestQuestion } from '../helpers/mocks'
 
-describe('StudentTestForm preview mode', () => {
+describe('StudentTestForm', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
     localStorage.clear()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     localStorage.clear()
@@ -118,20 +119,56 @@ describe('StudentTestForm preview mode', () => {
     )
 
     const flagToggle = screen.getByRole('button', { name: 'Flag question 1 for review' })
+    const flagStatus = screen.getByTestId('student-test-flag-status')
 
     expect(flagToggle).toHaveAttribute('aria-pressed', 'false')
+    expect(flagStatus).toHaveTextContent('')
+    expect(flagStatus).toHaveAttribute('role', 'status')
+    expect(flagStatus).toHaveAttribute('aria-live', 'polite')
+    expect(flagStatus).toHaveAttribute('aria-atomic', 'true')
 
     fireEvent.click(flagToggle)
 
     const flaggedQuestions = JSON.parse(localStorage.getItem('pika:flagged-questions:test-flag-id') || '[]')
     expect(flaggedQuestions).toEqual(['q1'])
     expect(flagToggle).toHaveAttribute('aria-pressed', 'true')
+    expect(flagStatus).toHaveTextContent('Question 1 flagged for review.')
+    expect(screen.getAllByText('Question 1 flagged for review.')).toHaveLength(1)
 
     fireEvent.click(flagToggle)
 
     const updatedFlaggedQuestions = JSON.parse(localStorage.getItem('pika:flagged-questions:test-flag-id') || '[]')
     expect(updatedFlaggedQuestions).not.toContain('q1')
     expect(flagToggle).toHaveAttribute('aria-pressed', 'false')
+    expect(flagStatus).toHaveTextContent('Question 1 removed from review.')
+    expect(screen.getAllByText('Question 1 removed from review.')).toHaveLength(1)
+  })
+
+  it('does not announce flags loaded from local storage', () => {
+    localStorage.setItem('pika:flagged-questions:test-existing-flag-id', JSON.stringify(['q1']))
+
+    render(
+      <StudentTestForm
+        testId="test-existing-flag-id"
+        questions={[
+          createMockTestQuestion({
+            id: 'q1',
+            question_text: 'Which option is correct?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        previewMode
+        onSubmitted={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Flag question 1 for review' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByTestId('student-test-flag-status')).toHaveTextContent('')
   })
 
   it('toggles flagged state exactly once for Enter and Space', () => {
@@ -153,18 +190,159 @@ describe('StudentTestForm preview mode', () => {
     )
 
     const flagToggle = screen.getByRole('button', { name: 'Flag question 1 for review' })
+    const flagStatus = screen.getByTestId('student-test-flag-status')
 
     fireEvent.keyDown(flagToggle, { key: 'Enter' })
     fireEvent.keyUp(flagToggle, { key: 'Enter' })
 
     expect(flagToggle).toHaveAttribute('aria-pressed', 'true')
     expect(JSON.parse(localStorage.getItem('pika:flagged-questions:test-flag-keyboard-id') || '[]')).toEqual(['q1'])
+    expect(flagStatus).toHaveTextContent('Question 1 flagged for review.')
+    expect(screen.getAllByText('Question 1 flagged for review.')).toHaveLength(1)
 
     fireEvent.keyDown(flagToggle, { key: ' ' })
     fireEvent.keyUp(flagToggle, { key: ' ' })
 
     expect(flagToggle).toHaveAttribute('aria-pressed', 'false')
     expect(JSON.parse(localStorage.getItem('pika:flagged-questions:test-flag-keyboard-id') || '[]')).toEqual([])
+    expect(flagStatus).toHaveTextContent('Question 1 removed from review.')
+    expect(screen.getAllByText('Question 1 removed from review.')).toHaveLength(1)
+  })
+
+  it('announces actual autosave transitions with controlled timers and promises', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'))
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    let resolveSave!: (value: { ok: boolean; json: () => Promise<Record<string, never>> }) => void
+    const saveResponse = new Promise<{ ok: boolean; json: () => Promise<Record<string, never>> }>(
+      (resolve) => {
+        resolveSave = resolve
+      }
+    )
+    fetchMock.mockReturnValueOnce(saveResponse)
+
+    render(
+      <StudentTestForm
+        testId="test-autosave-status-id"
+        questions={[
+          createMockTestQuestion({
+            id: 'q1',
+            question_text: 'Explain your reasoning.',
+            options: [],
+            question_type: 'open_response',
+            position: 0,
+          }),
+        ]}
+        enableDraftAutosave
+        onSubmitted={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByRole('textbox', { name: 'Response for question 1' })
+    const autosaveStatus = screen.getByTestId('student-test-autosave-status')
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(autosaveStatus).toHaveTextContent('')
+    expect(autosaveStatus).toHaveAttribute('role', 'status')
+    expect(autosaveStatus).toHaveAttribute('aria-live', 'polite')
+    expect(autosaveStatus).toHaveAttribute('aria-atomic', 'true')
+
+    fireEvent.change(textbox, { target: { value: 'A retained response.' } })
+
+    expect(screen.getByText('Unsaved changes', { selector: '.text-xs' })).toBeInTheDocument()
+    expect(autosaveStatus).toHaveTextContent('Unsaved changes')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+    expect(autosaveStatus).toHaveTextContent('Saving')
+
+    await act(async () => {
+      resolveSave({ ok: true, json: async () => ({}) })
+      await saveResponse
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Saved', { selector: '.text-xs' })).toBeInTheDocument()
+    expect(autosaveStatus).toHaveTextContent('Saved')
+  })
+
+  it('exposes failed autosaves as alerts and preserves the student response', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-10T12:00:00Z'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Failed to save draft' }),
+    })
+
+    render(
+      <StudentTestForm
+        testId="test-autosave-error-id"
+        questions={[
+          createMockTestQuestion({
+            id: 'q1',
+            question_text: 'Explain your reasoning.',
+            options: [],
+            question_type: 'open_response',
+            position: 0,
+          }),
+        ]}
+        enableDraftAutosave
+        onSubmitted={vi.fn()}
+      />
+    )
+
+    const textbox = screen.getByRole('textbox', { name: 'Response for question 1' })
+    fireEvent.change(textbox, { target: { value: 'Keep this response.' } })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Failed to save draft')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+    expect(alert).toHaveAttribute('aria-atomic', 'true')
+    expect(textbox).toHaveValue('Keep this response.')
+    expect(screen.getByTestId('student-test-autosave-status')).toHaveTextContent(
+      'Unsaved changes'
+    )
+  })
+
+  it('does not render autosave status in preview mode', () => {
+    render(
+      <StudentTestForm
+        testId="test-preview-autosave-id"
+        questions={[
+          createMockTestQuestion({
+            id: 'q1',
+            question_text: 'Explain your reasoning.',
+            options: [],
+            question_type: 'open_response',
+            position: 0,
+          }),
+        ]}
+        enableDraftAutosave
+        previewMode
+        onSubmitted={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Response for question 1' }), {
+      target: { value: 'Preview response.' },
+    })
+
+    expect(screen.queryByTestId('student-test-autosave-status')).not.toBeInTheDocument()
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
   })
 
   it('exposes locked flag controls as disabled and does not toggle them', () => {
@@ -376,6 +554,6 @@ describe('StudentTestForm preview mode', () => {
     })
 
     expect(onSubmitted).not.toHaveBeenCalled()
-    expect(screen.getByText('Test is not active')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Test is not active')
   })
 })

--- a/tests/components/StudentTestForm.test.tsx
+++ b/tests/components/StudentTestForm.test.tsx
@@ -271,6 +271,92 @@ describe('StudentTestForm', () => {
     expect(autosaveStatus).toHaveTextContent('Saved')
   })
 
+  it.each([
+    ['succeeds', { ok: true, json: async () => ({}) }],
+    ['fails', { ok: false, json: async () => ({ error: 'Stale save failed' }) }],
+  ])(
+    'keeps newer changes unsaved when an older autosave %s',
+    async (_outcome, firstSaveResult) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-10T12:00:00Z'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      let resolveFirstSave!: (value: typeof firstSaveResult) => void
+      let resolveSecondSave!: (value: { ok: boolean; json: () => Promise<Record<string, never>> }) => void
+      const firstSaveResponse = new Promise<typeof firstSaveResult>((resolve) => {
+        resolveFirstSave = resolve
+      })
+      const secondSaveResponse = new Promise<{
+        ok: boolean
+        json: () => Promise<Record<string, never>>
+      }>((resolve) => {
+        resolveSecondSave = resolve
+      })
+      fetchMock
+        .mockReturnValueOnce(firstSaveResponse)
+        .mockReturnValueOnce(secondSaveResponse)
+
+      render(
+        <StudentTestForm
+          testId="test-stale-autosave-id"
+          questions={[
+            createMockTestQuestion({
+              id: 'q1',
+              question_text: 'Explain your reasoning.',
+              options: [],
+              question_type: 'open_response',
+              position: 0,
+            }),
+          ]}
+          enableDraftAutosave
+          onSubmitted={vi.fn()}
+        />
+      )
+
+      const textbox = screen.getByRole('textbox', { name: 'Response for question 1' })
+      const autosaveStatus = screen.getByTestId('student-test-autosave-status')
+
+      fireEvent.change(textbox, { target: { value: 'First response.' } })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(autosaveStatus).toHaveTextContent('Saving')
+
+      fireEvent.change(textbox, { target: { value: 'Newer response.' } })
+      expect(autosaveStatus).toHaveTextContent('Unsaved changes')
+
+      await act(async () => {
+        resolveFirstSave(firstSaveResult)
+        await firstSaveResponse
+        await Promise.resolve()
+      })
+
+      expect(textbox).toHaveValue('Newer response.')
+      expect(screen.getByText('Unsaved changes', { selector: '.text-xs' })).toBeInTheDocument()
+      expect(autosaveStatus).toHaveTextContent('Unsaved changes')
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000)
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(autosaveStatus).toHaveTextContent('Saving')
+
+      await act(async () => {
+        resolveSecondSave({ ok: true, json: async () => ({}) })
+        await secondSaveResponse
+        await Promise.resolve()
+      })
+
+      expect(screen.getByText('Saved', { selector: '.text-xs' })).toBeInTheDocument()
+      expect(autosaveStatus).toHaveTextContent('Saved')
+    }
+  )
+
   it('exposes failed autosaves as alerts and preserves the student response', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-10T12:00:00Z'))


### PR DESCRIPTION
## Summary

- announce Student Test flag and unflag actions through a polite atomic live region
- announce actual autosave transitions without announcing the initial visible Saved state
- expose save and submission failures through assertive alerts while preserving drafts and existing retry/submission behavior
- keep teacher preview free of autosave status and retain existing pressed, locking, and localStorage behavior

## Risk and scope

Risk profile: `exam-mode`, `workspace-state`.

This change is limited to `StudentTestForm` accessibility state and focused component coverage. It does not change exam-mode startup, fullscreen enforcement, focus/exit telemetry, interaction locking, persistence APIs, submission rules, Gradex, schema, migrations, mobile layout, or dependencies.

Composite widget checklist reviewed: yes. Keyboard behavior covered: yes. Semantic state covered by tests: yes. Remaining manual follow-up: none.

## Verification

- `pnpm test tests/components/StudentTestForm.test.tsx` (15 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm check:ui-policy`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `node scripts/trim-session-log.mjs --check`
- `git diff --check`

Playwright verified the real student form in flagged/unflagged, saving, failed-save response-preservation, and keyboard-focus states. Teacher preview plus student form were reviewed at desktop/mobile and light/dark with no layout regression or overflow. The temporary local test fixture was deleted after capture.

## Merge

Leave this PR open. Do not merge without explicit approval.