### PR TITLE
Add durable individual-student purge

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,4 +1,6 @@
-Prod 001–122. Cold canary passed. Rollout off; health=0/0. Wait two checks
-before broad rollout. Student purge separate; generic cleanup off.
+Prod 001–122. Cold canary passed; rollout off pending checks. Branch
+`codex/individual-student-purge-audit`: disabled migration 123 + app ready;
+not applied/run. Preserves users/other Classes; Pal/remote Gradex fail closed.
+Generic cleanup off.
 WT: `$HOME/.codex/worktrees/pika/` or `$HOME/.codex/worktrees/<id>/pika`.
 Env: `$HOME/Repos/.env/pika/.env.local` or collaborator `.env.example`.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17932,3 +17932,36 @@ relational/embedded reference binding.
 **Remaining:**
 - Decide how to dispose of the 20 cleanup-only and 60 unreferenced beta files
   under separate deletion authorization, then refresh readiness separately.
+
+<!-- pika-session-log-archive-batch:ed8db04166835ade4397395ca66420bbd582712fb09399ce67e4be7265ed9e52 -->
+## 2026-08-05 — Remove authorized non-live production Storage objects
+
+**Risk profile:** irreversible production write — exact-object Storage deletion
+and terminal cleanup-ledger reconciliation.
+
+**Completed:**
+- Froze and revalidated the previously approved 20 cleanup-only and 60 fully
+  unreferenced beta objects. Both aggregate identity digests matched the prior
+  read-only inventory before any deletion began.
+- Ran a validation-only pass across all 80 objects, then removed each object
+  individually through the Storage API after a fresh exact reference check.
+- Verified the 20 cleanup-only objects against their recorded size and SHA-256
+  before removal and reconciled every matching source-cleanup ledger to terminal
+  `deleted` state.
+- Exercised the persisted-manifest retry path after two fail-closed pauses; the
+  pauses were caused by single-statement CTE visibility in the operator's success
+  check, not by reference or ownership drift.
+
+**Validation:**
+- Independent linked-project verification reports 139 Storage objects and 139
+  managed objects, all `ready`, with zero ownerless objects and zero registered
+  objects missing Storage.
+- The 274 managed JSON references remain intact. All 20 source-cleanup ledgers
+  are terminal and none are nonterminal.
+- Production remains in compatibility mode at readiness generation 0. Migrations
+  117 and 118 are applied; migration 119 is unapplied and
+  `classroom_purge_settings` remains absent.
+
+**Remaining:**
+- Refresh readiness only under separate production authorization. Do not apply
+  migration 119 or enable classroom deletion without fresh exact authorization.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17896,3 +17896,39 @@ reference binding, protected by atomic fail-safe verification.
 - Obtain fresh authorization for a 139-live-object registration/reconciliation.
   Handle the 80 non-live beta objects only under a separate cleanup/deletion
   authorization. Do not apply migration 119 or enable deletion.
+
+<!-- pika-session-log-archive-batch:bbcfdbed5ea5ea18e3cde3b7d45e502bee2a4cd2dc853e3461f641f572ef19ff -->
+## 2026-08-05 — Reconcile production live managed Storage
+
+**Risk profile:** production write — managed ownership registration and exact
+relational/embedded reference binding.
+
+**Completed:**
+- Under revised exact authorization, atomically registered the 139 live
+  Classroom-owned objects across two Classrooms: 120 submission images, 18 test
+  documents, and one verified Classroom archive.
+- Bound 24 relational/operational rows and rebuilt 274 embedded JSON reference
+  rows. Migration 118 permitted the archive operation and immutable archive row
+  to receive the same deterministic managed identity.
+- Left all 20 cleanup-only and 60 unreferenced Storage objects unregistered and
+  untouched.
+
+**Validation:**
+- Read-only post-commit verification found 139 managed objects, all `ready` and
+  all live-referenced; 274 JSON references; one exact archive binding; and 80
+  Storage objects without registry entries.
+- The 20 remaining raw relational paths are the intentionally untouched
+  cleanup-only set. Production remains in compatibility mode at readiness
+  generation 0.
+- Migration 119 remains unapplied and `classroom_purge_settings` is absent, so
+  deletion is not enabled.
+- A linked read-only breakdown identified the cleanup-only set as two PNG
+  submission images and 18 HTML test snapshots from one completed Classroom
+  archive compaction. All 20 remain pending in the archive source-cleanup
+  ledger. The unreferenced set is 41 JPEG/PNG submission images and 19 HTML
+  test snapshots with no current relational, JSON, Blueprint, or operational
+  reference. Together the non-live set uses about 7.27 MB.
+
+**Remaining:**
+- Decide how to dispose of the 20 cleanup-only and 60 unreferenced beta files
+  under separate deletion authorization, then refresh readiness separately.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,38 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Remove authorized non-live production Storage objects
-
-**Risk profile:** irreversible production write — exact-object Storage deletion
-and terminal cleanup-ledger reconciliation.
-
-**Completed:**
-- Froze and revalidated the previously approved 20 cleanup-only and 60 fully
-  unreferenced beta objects. Both aggregate identity digests matched the prior
-  read-only inventory before any deletion began.
-- Ran a validation-only pass across all 80 objects, then removed each object
-  individually through the Storage API after a fresh exact reference check.
-- Verified the 20 cleanup-only objects against their recorded size and SHA-256
-  before removal and reconciled every matching source-cleanup ledger to terminal
-  `deleted` state.
-- Exercised the persisted-manifest retry path after two fail-closed pauses; the
-  pauses were caused by single-statement CTE visibility in the operator's success
-  check, not by reference or ownership drift.
-
-**Validation:**
-- Independent linked-project verification reports 139 Storage objects and 139
-  managed objects, all `ready`, with zero ownerless objects and zero registered
-  objects missing Storage.
-- The 274 managed JSON references remain intact. All 20 source-cleanup ledgers
-  are terminal and none are nonterminal.
-- Production remains in compatibility mode at readiness generation 0. Migrations
-  117 and 118 are applied; migration 119 is unapplied and
-  `classroom_purge_settings` remains absent.
-
-**Remaining:**
-- Refresh readiness only under separate production authorization. Do not apply
-  migration 119 or enable classroom deletion without fresh exact authorization.
-
 ## 2026-08-05 — Refresh production managed Storage readiness
 
 **Risk profile:** production write — serialized readiness evidence refresh only.
@@ -1059,3 +1027,33 @@ model changes.
   mobile boundary was also checked. No overflow or visual regression remained.
 - Composite checklist reviewed: yes; keyboard behavior covered: yes; semantic
   state covered by tests: yes; remaining manual follow-up: none.
+
+## 2026-08-12 — Harden individual-student purge after independent review
+
+**Risk profile:** runtime-platform — destructive deletion protocol remains
+disabled and unapplied; this pass changes only reviewed code, migration source,
+tests, and documentation.
+
+**Completed:**
+- Replaced the archive-contract-breaking roster user column with a derived,
+  non-archive roster/student binding that is rebuilt from enrollment lineage.
+- Added authoritative account-email confirmation, operation-scoped completed
+  replay binding, stable client idempotency across lost start responses,
+  permanent purged-path reservations, and non-student-derived grading-run
+  selection hashes.
+- Expanded the rollback-only database fixture across assignment, test, survey,
+  report-card, announcement, archive, Gradex, target/classmate, replay, fence,
+  exact-object, and delayed-write cases.
+- Added a focused runbook, corrected hot/cold scope docs, and made the visual
+  teacher/student matrix a named CI gate with retained failure artifacts.
+
+**Validation:**
+- Full suite passes: 4,216 tests across 492 files. Focused remediation tests,
+  TypeScript, architecture, lint, production build, design/UI policy, Pika
+  audit, and diff checks pass.
+- Playwright passed teacher default/progress and student-boundary verification
+  across desktop/mobile and light/dark on an isolated local port; screenshots
+  were visually inspected with no overflow or contrast regression.
+- Migration 123 was not applied locally or remotely, no rollout setting changed,
+  no purge ran, and no Storage object was deleted. Ephemeral CI replay remains
+  the next database validation gate.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,41 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Reconcile production live managed Storage
-
-**Risk profile:** production write — managed ownership registration and exact
-relational/embedded reference binding.
-
-**Completed:**
-- Under revised exact authorization, atomically registered the 139 live
-  Classroom-owned objects across two Classrooms: 120 submission images, 18 test
-  documents, and one verified Classroom archive.
-- Bound 24 relational/operational rows and rebuilt 274 embedded JSON reference
-  rows. Migration 118 permitted the archive operation and immutable archive row
-  to receive the same deterministic managed identity.
-- Left all 20 cleanup-only and 60 unreferenced Storage objects unregistered and
-  untouched.
-
-**Validation:**
-- Read-only post-commit verification found 139 managed objects, all `ready` and
-  all live-referenced; 274 JSON references; one exact archive binding; and 80
-  Storage objects without registry entries.
-- The 20 remaining raw relational paths are the intentionally untouched
-  cleanup-only set. Production remains in compatibility mode at readiness
-  generation 0.
-- Migration 119 remains unapplied and `classroom_purge_settings` is absent, so
-  deletion is not enabled.
-- A linked read-only breakdown identified the cleanup-only set as two PNG
-  submission images and 18 HTML test snapshots from one completed Classroom
-  archive compaction. All 20 remain pending in the archive source-cleanup
-  ledger. The unreferenced set is 41 JPEG/PNG submission images and 19 HTML
-  test snapshots with no current relational, JSON, Blueprint, or operational
-  reference. Together the non-live set uses about 7.27 MB.
-
-**Remaining:**
-- Decide how to dispose of the 20 cleanup-only and 60 unreferenced beta files
-  under separate deletion authorization, then refresh readiness separately.
-
 ## 2026-08-05 — Remove authorized non-live production Storage objects
 
 **Risk profile:** irreversible production write — exact-object Storage deletion
@@ -954,6 +919,37 @@ autosave error feedback while preserving the mounted attempt and exam owner.
   table; the student attendance boundary was also checked.
 - Composite checklist reviewed: yes; keyboard behavior covered: yes; semantic
   state covered by tests: yes; remaining manual follow-up: none.
+
+## 2026-08-11 — Implement hot-Classroom individual-student purge
+
+**Risk profile:** runtime-platform and irreversible-deletion design; local code
+only. Migration 123 was not applied and no purge or rollout ran.
+
+**Completed:**
+- Added disabled/canary/enabled exact-triple rollout settings, stable roster
+  student lineage, durable operation/resource/object ledgers, pair and
+  whole-Classroom fences, exact Storage leases, retries, and explicit
+  finalization for one student in one hot Classroom.
+- Preserved the user and other Classrooms; staged the target's exact managed
+  objects and all retained Classroom archive/Gradex copies. Pal-backed,
+  remote-Gradex, cold, retired-assessment, and conflicting-operation targets
+  fail closed.
+- Added teacher-only impact/start/status/tick routes, cleanup-cron recovery and
+  health signals, Roster action/dialog, route/component/server/migration tests,
+  generated types, and a rollback-only CI database fixture.
+
+**Validation:**
+- Full suite passes (4,210 tests/492 files); focused purge/cron slice, build,
+  TypeScript, lint, architecture/design/UI policy, Pika audit, and diff checks pass.
+- Pika UI verification passed for teacher desktop/mobile light/dark dialog and
+  progress states plus student desktop/mobile light/dark absence boundaries.
+- Rollback-only CI fixture now covers managed-file lease authority, byte absence,
+  update ownership fences, relational deletion, and cross-Class preservation.
+
+**Remaining:**
+- Publish for independent PR review and fresh-database CI replay.
+- Local database replay awaits separate migration authorization.
+- Production migration, rollout, and purge remain separately prohibited.
 
 ## 2026-08-11 — Complete production cold-Classroom purge canary
 

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -1,34 +1,26 @@
-# Pika — AI Agent Starting Ritual
+# Pika session start
 
-**CRITICAL:** Follow this at the start of **every** AI session.
-
-**Automated:** `/session-start` or `.codex/prompts/session-start.md`.
-
----
+Follow this at every AI session start. Automate with `/session-start` or
+`.codex/prompts/session-start.md`.
 
 ## Quick Checklist
 
 ```
-[ ] Resolve repo root: git rev-parse --show-toplevel
-[ ] Verify repo root is a feature worktree, not $HOME/Repos/pika for branch work
-[ ] Ensure .env.local exists (shared setups symlink to $HOME/Repos/.env/pika/.env.local; collaborators: cp .env.example .env.local)
-[ ] Run: bash scripts/verify-env.sh
-[ ] Check status: git status --short --branch
-[ ] Read: .ai/CURRENT.md
-[ ] Read: docs/ai-instructions.md
-[ ] Check features: node scripts/features.mjs next
-[ ] Load task-specific docs routed by docs/ai-instructions.md
-[ ] Plan before coding: task, model, approach, approval
+Resolve repo root: git rev-parse --show-toplevel
+Verify feature worktree; do not branch in $HOME/Repos/pika
+Ensure .env.local exists (shared: $HOME/Repos/.env/pika/.env.local; collaborator: cp .env.example .env.local)
+Run: bash scripts/verify-env.sh
+Check: git status --short --branch
+Read: .ai/CURRENT.md and docs/ai-instructions.md
+Check: node scripts/features.mjs next
+Load task docs routed by docs/ai-instructions.md
+Plan: task, model, approach, approval
 ```
 
-Do not code if verification fails. Use `.ai/SESSION-LOG.md` only for recent handoff; use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+Do not code if verification fails. Session log is for recent handoff; journal archive is historical only.
 For docs-only or review work, use `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`.
 
----
-
 ## Worktree Rules (MANDATORY)
-
-All agents operate from exactly one current repo checkout/worktree.
 
 - Resolve the repo root with `git rev-parse --show-toplevel` before acting.
 - Use that resolved root consistently for git commands and file paths.
@@ -37,13 +29,11 @@ All agents operate from exactly one current repo checkout/worktree.
 - Worktree creation, cleanup, and shared `.env.local` setup live in `docs/dev-workflow.md`.
 - Hub-level git commands for adding/removing worktrees must use `git -C "$HOME/Repos/pika" ...`.
 
----
-
 ## End of Session (MANDATORY)
 
-1. Append a concise session entry to `.ai/SESSION-LOG.md` with a valid ISO-date heading (`## YYYY-MM-DD ...`).
+1. Append to `.ai/SESSION-LOG.md` with a valid ISO-date heading (`## YYYY-MM-DD ...`).
 2. Immediately run `node scripts/trim-session-log.mjs` in the same change. CI caps the log at 60; default trim keeps 40. Use `node scripts/trim-session-log.mjs --check` for empty entries, heading dates, order, and the cap.
-3. Update `.ai/features.json` if anything changed:
+3. Update `.ai/features.json` when needed:
    ```bash
    node scripts/features.mjs pass <feature-id>
    node scripts/features.mjs fail <feature-id>
@@ -60,12 +50,9 @@ All agents operate from exactly one current repo checkout/worktree.
    git -C "$HUB" branch -D "$BRANCH"
    ```
 
----
+## Document Hierarchy
 
-## Document Hierarchy (When Conflicts Arise)
-
-Trust in order: `.ai/features.json`, `.ai/CURRENT.md`,
+Trust: `.ai/features.json`, `.ai/CURRENT.md`,
 `docs/core/architecture.md`, `docs/core/tests.md`, root `DESIGN.md`, then
 `docs/core/project-context.md`, `docs/core/roadmap.md`,
-`docs/core/decision-log.md`, `.ai/SESSION-LOG.md` on demand, then
-`.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+`docs/core/decision-log.md`, session log, then journal archive.

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,5 +1,5 @@
 {
-  "meta": {"project":"pika","lastUpdated":"2026-08-09","phase":"Deletion","DO_NOT_DELETE_FEATURES":"APPEND-ONLY. Never delete entries.","deletionPolicy":"PROHIBITED","totalFeatures":20,"passing":19,"failing":1},
+  "meta": {"project":"pika","lastUpdated":"2026-08-11","phase":"Deletion","DO_NOT_DELETE_FEATURES":"APPEND-ONLY. Never delete entries.","deletionPolicy":"PROHIBITED","totalFeatures":21,"passing":19,"failing":2},
   "features": [
     {"id":"epic-setup","phase":"Phase 0 — Setup","description":"Next.js, TypeScript, Tailwind, and Supabase bootstrap","passes":true,"verification":"Run: pnpm test","issueRefs":[],"blockedBy":[],"addedDate":"2025-12-12"},
     {"id":"epic-auth","phase":"Phase 1 — Auth","description":"Email-code auth, password login, secure sessions, lockout, and role routing","passes":true,"verification":"Run: pnpm test. Manual smoke: signup → verify → create password → login → logout → reset password","issueRefs":[],"blockedBy":[],"addedDate":"2025-12-12"},
@@ -20,6 +20,7 @@
     {"id":"epic-managed-storage-ownership","phase":"Classroom Lifecycle Foundation","description":"Managed Storage ownership and enforcement foundation; no permanent deletion","passes":true,"verification":"Authorized migration 117 replay/fixture plus app checks","issueRefs":["#963","#967"],"blockedBy":[],"addedDate":"2026-08-02","completedDate":"2026-08-05"},
     {"id":"epic-hot-archive-purge-v2","phase":"Deletion","description":"Managed-ID hot-archive purge","passes":true,"verification":"Exact-head migration 118 replay, fixtures, and UI","issueRefs":[],"blockedBy":[],"addedDate":"2026-08-03","completedDate":"2026-08-04"},
     {"id":"epic-managed-blueprint-deletion","phase":"Course Authoring Deletion","description":"Durable deletion of Pika-owned Course Blueprints and their managed files, plus a canary proving classroom creation from the Blueprint preserved by classroom purge","passes":true,"verification":"Local migration replay and fixtures pass. Production migrations 117–120 are applied, managed storage is enforced, Course Blueprint and hot archived Classroom deletion canaries passed, and both deletion rollouts are broadly enabled with fail-closed authorization and conflict checks.","issueRefs":[],"blockedBy":[],"addedDate":"2026-08-05","completedDate":"2026-08-08"},
-    {"id":"epic-cold-archive-purge","phase":"Deletion","description":"Cold Classroom purge","passes":true,"verification":"Prod canary passed; rollout off.","issueRefs":["#983"],"blockedBy":[],"addedDate":"2026-08-09"}
+    {"id":"epic-cold-archive-purge","phase":"Deletion","description":"Cold Classroom purge","passes":true,"verification":"Prod canary passed; rollout off.","issueRefs":["#983"],"blockedBy":[],"addedDate":"2026-08-09"},
+    {"id":"epic-individual-student-purge","phase":"Deletion","description":"One-student hot-Classroom purge; preserves user/other Classes","passes":false,"verification":"Local code/tests/UI ready; pending DB replay, PR, rollout.","issueRefs":[],"blockedBy":[],"addedDate":"2026-08-11"}
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Verify cold archived classroom purge durability and preservation
         run: pnpm run check:cold-classroom-purge-db
 
+      - name: Verify individual-student purge isolation and durability
+        run: pnpm run check:student-purge-db
+
       - name: Verify atomic blueprint rollback and replay
         run: bash scripts/check-atomic-blueprint-operations.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,9 @@ jobs:
       - name: Run teacher and student browser matrix
         run: pnpm e2e:matrix
 
+      - name: Run individual-student purge browser matrix
+        run: pnpm e2e:student-purge
+
       - name: Upload browser diagnostics
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         run: pnpm e2e:student-purge
 
       - name: Upload browser diagnostics
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: browser-experience-matrix

--- a/docs/guidance/cold-archived-classroom-purge.md
+++ b/docs/guidance/cold-archived-classroom-purge.md
@@ -65,8 +65,10 @@ cron.
   lifecycle, tombstone/archive, and managed-object order. Object deletion
   requires the exact live lease in the database and Storage trigger.
 - Cold deletion is not atomic with hot-Classroom deletion. A Classroom has one
-  authoritative representation at a time. It is also not atomic with
-  individual-student purging, which remains a separate future scope.
+  authoritative representation at a time. It is also not atomic with the
+  independently gated individual-student purge. A cold Classroom must be
+  restored to hot state before an individual purge can be considered; see
+  `docs/guidance/individual-student-purge.md`.
 
 ## Teacher UX
 

--- a/docs/guidance/hot-archived-classroom-purge.md
+++ b/docs/guidance/hot-archived-classroom-purge.md
@@ -10,8 +10,9 @@ provisional operation targeting it. User accounts, Course Blueprints, immutable
 Blueprint versions, and Blueprint-owned files are preserved.
 
 Cold archived Classroom deletion is a separate state machine documented in
-`docs/guidance/cold-archived-classroom-purge.md`. Comprehensive
-individual-student purging remains a follow-up scope. Neither is an atomic
+`docs/guidance/cold-archived-classroom-purge.md`. Individual-student purging is
+a separate disabled-by-default state machine documented in
+`docs/guidance/individual-student-purge.md`. Neither is an atomic
 dependency of hot deletion because cold archives have a separate
 tombstone/recovery authority and users are deliberately outside Classroom
 ownership.
@@ -118,6 +119,6 @@ that already applied `main` can upgrade safely.
 - Before deleting the preserved production canary Blueprint, create and verify
   a Classroom from it to prove that classroom purge preserved a reusable course
   package, including its managed test material.
-- Comprehensive individual-student purging remains a separate follow-up scope.
+- Individual-student purging remains independently gated under migration 123.
 - Cold archived Classroom deletion remains independently gated under migration
   122 and never shares a migration or rollout with student purging.

--- a/docs/guidance/individual-student-purge.md
+++ b/docs/guidance/individual-student-purge.md
@@ -1,0 +1,119 @@
+# Individual-student Classroom purge
+
+## Contract and scope
+
+This operation permanently removes one joined student's data from one
+teacher-owned active or hot-archived Classroom. It is not account deletion. It
+preserves the student's `users` and `student_profiles` rows, every other
+Classroom and membership, classmates and teacher-authored course content, and
+all Course Blueprints and Blueprint files.
+
+The exact relational inventory includes the target membership and stable roster
+binding, entries and attendance evidence, assignment work/history/feedback and
+grading items, test attempts/responses/history/focus/availability and grading
+items, surveys, report-card rows, announcement reads, and affected daily-log
+summaries. Shared grading-run rows are retained after their target item and
+student identifier are removed and their counts and non-student-derived
+selection hash are recomputed.
+
+Classroom archives and Gradex extracts are immutable whole-Classroom copies.
+If any exist, their exact managed objects and Classroom ledgers are deleted
+rather than selectively rewritten. This intentionally removes restore and
+historical Gradex recovery for the entire Classroom, which the confirmation
+dialog states before startup.
+
+Cold Classrooms are excluded. Restore a cold Classroom to hot state under the
+independent restore workflow before considering an individual purge. Student
+purge is not atomic with hot- or cold-Classroom purge, Blueprint purge, archive,
+restore, compaction, grading, Pal, or remote Gradex work; conflicts fail closed.
+
+## Durable execution
+
+1. The owning teacher opens a joined roster row. The server resolves the stable
+   roster-to-user binding and returns an authoritative account email, exact row
+   counts, exact managed-object digest, source revision, archive/Gradex impact,
+   and conflicts.
+2. The teacher types that case-sensitive account email. One transaction
+   revalidates ownership, rollout, hot state, managed-storage enforcement,
+   provider conflicts, inventory digests, and revision; installs a
+   Classroom/student fence; and snapshots exact relational row IDs and managed
+   object IDs.
+3. The browser immediately advances the operation. It retains one operation UUID
+   across a lost initial response. The daily cleanup cron only resumes already
+   started retryable work; it never starts a purge.
+4. Workers lease and delete one exact managed object at a time. Storage absence
+   is authoritative before the raw path is redacted. Provider failures preserve
+   progress with bounded retries. Purged bucket/path digests remain reserved so
+   delayed or future writes cannot recreate erased bytes.
+5. Finalization locks the same Classroom/student pair, rejects inventory or
+   ownership drift, explicitly deletes every catalogued relational row in FK-safe
+   order, redacts shared grading runs, removes exact managed rows and immutable
+   archive/Gradex ledgers, then removes the active fence. The retained operation
+   has aggregate audit evidence and an operation-scoped target digest, not the
+   student's email or direct user ID.
+
+Foreign-key cascades may remove derived binding rows, but they are not the sole
+authority for product data deletion: the durable inventory and finalizer name
+and verify each owned resource family. The roster binding is derived operational
+state and is deliberately excluded from the v2 archive format; restore rebuilds
+it from enrollment plus roster identity.
+
+## Boundaries and failure handling
+
+- Only the owning teacher may inspect, start, tick, or read the exact operation.
+  Status authorization binds teacher, Classroom, operation UUID, and the retained
+  operation-scoped student digest, including after completion.
+- Writes involving the target pair, indirect child rows, archives, managed
+  ownership, or whole-Classroom fences are serialized and rejected while the
+  purge fence exists. Classmate and other-Classroom writes remain available.
+- Pal rows, remote Gradex runs, retired assessment actor records, incomplete
+  storage subject ownership, cleanup work, and active grading fail closed. These
+  require a separately designed provider-erasure or reconciliation path.
+- A retryable partial failure keeps its exact ledgers and fence. Terminal drift
+  requires operator investigation and separately authorized repair. Generic
+  orphan cleanup is not a recovery mechanism and remains disabled.
+
+## Monitoring and operator response
+
+The existing authenticated daily `/api/cron/cleanup-history` route runs the
+bounded student-purge safety net and reads
+`get_student_purge_health_snapshot`. It reports active, stuck, failed,
+orphan-fence, and processing-lease-drift counts without student identifiers.
+A degraded snapshot returns an unhealthy response and emits the structured
+`[student-purge-health]` log entry.
+
+For a degraded result, inspect the exact operation through service-only records,
+verify fence and lease state, and confirm authoritative Storage presence before
+retrying. Do not clear fences, mutate audit rows, enable generic cleanup, or
+delete provider objects without fresh authorization naming the operation and
+target.
+
+## Validation and rollout
+
+Migration 123 is additive and starts `student_purge_settings` in `disabled`
+mode. Applying it does not start a purge, install a new cron, change generic
+cleanup, or enable the UI.
+
+1. Replay migrations 001–123 in ephemeral CI. Run the rollback-only database
+   fixture, generated-type check, unit/API/component tests, architecture and Pika
+   audits, lint, build, and teacher/student desktop/mobile light/dark browser
+   verification.
+2. Deploy compatible application code with the rollout disabled. Pre-123 code
+   paths treat the missing settings/binding schema as unavailable and retain the
+   existing email-based roster display fallback; they do not expose deletion.
+3. Because this project has no staging environment, production migration 123
+   application requires fresh authorization naming production and migration 123.
+   Apply it disabled and verify schema, privileges, cron health, and normal
+   Classroom/archive flows without starting a purge.
+4. A production canary requires separate authorization naming the exact teacher,
+   Classroom, student, rollout-gate change, and irreversible purge. Observe the
+   object ledger, Storage absence, relational isolation, archive/Gradex loss,
+   preserved user/other-Classroom data, retained audit record, and next scheduled
+   cron health result.
+5. Broad enablement requires another explicit authorization after canary evidence
+   and scheduled monitoring are healthy.
+
+Local reset/application, production migration application, rollout changes,
+purge execution, and any exact Storage deletion each require their own current,
+target-specific authorization. Generic orphan cleanup remains off because this
+scope has exact ownership, fences, reservations, and resumable object processing.

--- a/e2e/student-purge-visual.spec.ts
+++ b/e2e/student-purge-visual.spec.ts
@@ -108,7 +108,7 @@ async function expectNoHorizontalOverflow(page: Page) {
   )).toBe(false)
 }
 
-test('captures individual-student purge and student boundary matrix', async ({ browser }) => {
+test('captures individual-student purge and student boundary matrix', async ({ browser }, testInfo) => {
   const discoveryContext = await browser.newContext({ storageState: '.auth/teacher.json' })
   const discoveryPage = await discoveryContext.newPage()
   await discoveryPage.goto('/classrooms')
@@ -135,7 +135,7 @@ test('captures individual-student purge and student boundary matrix', async ({ b
     await expect(dialog).toContainText('user account and data in other classrooms are kept')
     await expectNoHorizontalOverflow(page)
     await page.screenshot({
-      path: `/tmp/pika-student-purge-dialog-${entry.name}.png`,
+      path: testInfo.outputPath(`dialog-${entry.name}.png`),
       fullPage: true,
       animations: 'disabled',
     })
@@ -145,7 +145,7 @@ test('captures individual-student purge and student boundary matrix', async ({ b
     await expect(dialog.getByRole('alert')).toContainText('waiting safely')
     await expect(dialog).toContainText('Deleting files 2 of 6')
     await page.screenshot({
-      path: `/tmp/pika-student-purge-progress-${entry.name}.png`,
+      path: testInfo.outputPath(`progress-${entry.name}.png`),
       fullPage: true,
       animations: 'disabled',
     })
@@ -168,7 +168,7 @@ test('captures individual-student purge and student boundary matrix', async ({ b
     expect(studentPurgeRequestCount).toBe(0)
     await expectNoHorizontalOverflow(page)
     await page.screenshot({
-      path: `/tmp/pika-student-purge-student-boundary-${entry.name}.png`,
+      path: testInfo.outputPath(`student-boundary-${entry.name}.png`),
       fullPage: true,
       animations: 'disabled',
     })

--- a/e2e/student-purge-visual.spec.ts
+++ b/e2e/student-purge-visual.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test'
+
+const STUDENT_ID = '20000000-0000-4000-8000-000000000001'
+const OPERATION_ID = '30000000-0000-4000-8000-000000000001'
+const STUDENT_EMAIL = 'student1@example.com'
+
+const matrix = [
+  { name: 'desktop-light', viewport: { width: 1440, height: 900 }, theme: 'light' as const },
+  { name: 'desktop-dark', viewport: { width: 1440, height: 900 }, theme: 'dark' as const },
+  { name: 'mobile-light', viewport: { width: 390, height: 844 }, theme: 'light' as const },
+  { name: 'mobile-dark', viewport: { width: 390, height: 844 }, theme: 'dark' as const },
+]
+
+const impact = {
+  classroom_title: 'Test Classroom',
+  student_id: STUDENT_ID,
+  student_email: STUDENT_EMAIL,
+  source_revision: 8,
+  storage_inventory_sha256: 'a'.repeat(64),
+  relational_inventory_sha256: 'b'.repeat(64),
+  relational_row_count: 47,
+  managed_file_count: 6,
+  managed_file_bytes: 2_489_962,
+  archive_count: 1,
+  gradex_extract_count: 1,
+  resource_counts: { entries: 12, assignment_docs: 4, test_responses: 8 },
+  storage_counts: { student_inline_image: 4, classroom_archive: 1, gradex_extract: 1 },
+  conflicting_operation: null,
+  deletion_available: true,
+  unavailable_reason: null,
+}
+
+const operation = {
+  operation_id: OPERATION_ID,
+  status: 'deleting_objects',
+  retryable: true,
+  error_code: null,
+  attempt_count: 2,
+  resource_counts: impact.resource_counts,
+  storage_object_counts: { deleted: 2, pending: 4 },
+  completed_at: null,
+}
+
+async function newRolePage(
+  browserContextFactory: () => Promise<BrowserContext>,
+  theme: 'light' | 'dark',
+) {
+  const context = await browserContextFactory()
+  const page = await context.newPage()
+  await page.addInitScript((selectedTheme) => localStorage.setItem('theme', selectedTheme), theme)
+  return { context, page }
+}
+
+async function mockTeacherStudentPurge(page: Page, classroomId: string) {
+  const scopedImpact = { ...impact, classroom_id: classroomId }
+  const scopedOperation = { ...operation, classroom_id: classroomId }
+
+  await page.route(`**/api/teacher/classrooms/${classroomId}/roster`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        roster: [{
+          id: '10000000-0000-4000-8000-000000000001',
+          email: STUDENT_EMAIL,
+          first_name: 'Student1',
+          last_name: 'Test',
+          student_number: 'S1001',
+          counselor_email: null,
+          join_source: 'manual',
+          created_at: '2026-08-01T12:00:00.000Z',
+          updated_at: '2026-08-01T12:00:00.000Z',
+          joined: true,
+          student_id: STUDENT_ID,
+          joined_at: '2026-08-01T12:00:00.000Z',
+        }],
+        student_purge_enabled_ids: [STUDENT_ID],
+      }),
+    })
+  })
+  await page.route(
+    `**/api/teacher/classrooms/${classroomId}/students/${STUDENT_ID}/purge`,
+    async (route) => {
+      await route.fulfill({
+        status: route.request().method() === 'POST' ? 202 : 200,
+        contentType: 'application/json',
+        body: JSON.stringify(route.request().method() === 'POST'
+          ? { operation: scopedOperation }
+          : { impact: scopedImpact, operation: null }),
+      })
+    },
+  )
+  await page.route(
+    `**/api/teacher/classrooms/${classroomId}/students/${STUDENT_ID}/purge/${OPERATION_ID}/tick`,
+    async (route) => {
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ operation: scopedOperation, advanced: false }),
+      })
+    },
+  )
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  expect(await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )).toBe(false)
+}
+
+test('captures individual-student purge and student boundary matrix', async ({ browser }) => {
+  const discoveryContext = await browser.newContext({ storageState: '.auth/teacher.json' })
+  const discoveryPage = await discoveryContext.newPage()
+  await discoveryPage.goto('/classrooms')
+  await discoveryPage.locator('[data-testid="classroom-card"]').first().click()
+  await discoveryPage.waitForURL(/\/classrooms\/[^/?]+/)
+  const classroomId = new URL(discoveryPage.url()).pathname.split('/').at(-1)
+  await discoveryContext.close()
+  expect(classroomId).toBeTruthy()
+
+  for (const entry of matrix) {
+    const { context, page } = await newRolePage(
+      () => browser.newContext({ storageState: '.auth/teacher.json', viewport: entry.viewport }),
+      entry.theme,
+    )
+    await mockTeacherStudentPurge(page, classroomId!)
+    await page.goto(`/classrooms/${classroomId}?tab=roster`)
+    await page.getByText('Student1', { exact: true }).click()
+    await page.getByRole('button', { name: 'Roster actions' }).click()
+    await page.getByRole('menuitem', { name: 'Purge classroom data' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Purge this student’s classroom data?' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('This cannot be undone.')).toBeVisible()
+    await expect(dialog).toContainText('user account and data in other classrooms are kept')
+    await expectNoHorizontalOverflow(page)
+    await page.screenshot({
+      path: `/tmp/pika-student-purge-dialog-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+
+    await dialog.getByRole('textbox').fill(STUDENT_EMAIL)
+    await dialog.getByRole('button', { name: 'Purge classroom data' }).click()
+    await expect(dialog.getByRole('alert')).toContainText('waiting safely')
+    await expect(dialog).toContainText('Deleting files 2 of 6')
+    await page.screenshot({
+      path: `/tmp/pika-student-purge-progress-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+    await context.close()
+  }
+
+  for (const entry of matrix) {
+    const { context, page } = await newRolePage(
+      () => browser.newContext({ storageState: '.auth/student.json', viewport: entry.viewport }),
+      entry.theme,
+    )
+    let studentPurgeRequestCount = 0
+    await page.route('**/api/teacher/classrooms/*/students/*/purge**', async (route) => {
+      studentPurgeRequestCount += 1
+      await route.abort()
+    })
+    await page.goto(`/classrooms/${classroomId}?tab=roster`)
+    await expect(page.getByRole('button', { name: 'Roster actions' })).toHaveCount(0)
+    await expect(page.getByText('Purge classroom data')).toHaveCount(0)
+    expect(studentPurgeRequestCount).toBe(0)
+    await expectNoHorizontalOverflow(page)
+    await page.screenshot({
+      path: `/tmp/pika-student-purge-student-boundary-${entry.name}.png`,
+      fullPage: true,
+      animations: 'disabled',
+    })
+    await context.close()
+  }
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:managed-storage-lineage": "node scripts/check-managed-storage-migration-lineage.mjs",
     "check:classroom-purge-db-lint": "node scripts/check-hot-archived-classroom-purge-lint.mjs",
     "check:cold-classroom-purge-db": "bash scripts/check-cold-archived-classroom-purge-database.sh",
+    "check:student-purge-db": "bash scripts/check-individual-student-purge-database.sh",
     "check:managed-deletion-health-db": "bash scripts/check-managed-deletion-health-database.sh",
     "managed-storage:readiness": "tsx scripts/run-managed-storage-readiness.ts",
     "managed-storage:cleanup": "tsx scripts/run-managed-storage-cleanup.ts",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "e2e:install": "playwright install",
     "e2e:auth": "playwright test e2e/auth.setup.ts",
     "e2e:matrix": "playwright test e2e/experience-matrix.spec.ts",
+    "e2e:student-purge": "playwright test e2e/student-purge-visual.spec.ts",
     "e2e:verify": "tsx e2e/verify/run.ts",
     "e2e:snapshots": "playwright test e2e/ui-snapshots.spec.ts",
     "e2e:snapshots:update": "playwright test e2e/ui-snapshots.spec.ts --update-snapshots",

--- a/scripts/check-hot-archived-classroom-purge-lint.mjs
+++ b/scripts/check-hot-archived-classroom-purge-lint.mjs
@@ -3,8 +3,11 @@
 import { readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 
-const migrationPath = 'supabase/migrations/118_hot_archived_classroom_purge_managed_ownership.sql'
-const migration = readFileSync(migrationPath, 'utf8')
+const migrationPaths = [
+  'supabase/migrations/118_hot_archived_classroom_purge_managed_ownership.sql',
+  'supabase/migrations/123_hot_classroom_individual_student_purge.sql',
+]
+const migration = migrationPaths.map((path) => readFileSync(path, 'utf8')).join('\n')
 const migrationFunctions = new Set(
   Array.from(
     migration.matchAll(/create\s+or\s+replace\s+function\s+public\.([a-z0-9_]+)\s*\(/gi),
@@ -13,7 +16,7 @@ const migrationFunctions = new Set(
 )
 
 if (migrationFunctions.size === 0) {
-  console.error(`No PostgreSQL functions found in ${migrationPath}.`)
+  console.error(`No PostgreSQL functions found in ${migrationPaths.join(', ')}.`)
   process.exit(2)
 }
 
@@ -52,7 +55,7 @@ const findings = (report.results || []).filter(
 )
 
 if (findings.length > 0) {
-  console.error('Migration 118 PostgreSQL function lint failed:')
+  console.error('Managed purge PostgreSQL function lint failed:')
   for (const finding of findings) {
     for (const issue of finding.issues) {
       const line = issue.statement?.lineNumber ? ` line ${issue.statement.lineNumber}` : ''
@@ -62,4 +65,4 @@ if (findings.length > 0) {
   process.exit(1)
 }
 
-console.log(`Migration 118 PostgreSQL function lint passed (${migrationFunctions.size} functions).`)
+console.log(`Managed purge PostgreSQL function lint passed (${migrationFunctions.size} functions).`)

--- a/scripts/check-individual-student-purge-database.sh
+++ b/scripts/check-individual-student-purge-database.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_CONTAINER="${STUDENT_PURGE_DB_CONTAINER:-supabase_db_pika}"
+if ! docker inspect "$DB_CONTAINER" >/dev/null 2>&1; then
+  echo "Local Pika Supabase database container is not running." >&2
+  exit 2
+fi
+
+PROJECT_LABEL="$(docker inspect "$DB_CONTAINER" \
+  --format '{{ index .Config.Labels "com.supabase.cli.project" }}')"
+DB_BINDING="$(docker port "$DB_CONTAINER" 5432/tcp 2>/dev/null || true)"
+if [[ "$PROJECT_LABEL" != "pika" ]] || ! grep -q ':54322$' <<<"$DB_BINDING"; then
+  echo "Refusing non-local or unexpected Supabase database target." >&2
+  exit 2
+fi
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+do $migration$
+begin
+  if not exists (select 1 from supabase_migrations.schema_migrations where version = '123')
+    or to_regprocedure('public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text)') is null
+  then raise exception 'Migration 123 is not applied to the local database'; end if;
+end;
+$migration$;
+
+begin;
+
+do $privileges$
+declare v_table text;
+begin
+  if (select rollout_mode from public.student_purge_settings where singleton) <> 'disabled'
+  then raise exception 'Student purge rollout was enabled by migration'; end if;
+  if has_function_privilege('anon',
+      'public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text)', 'execute')
+    or has_function_privilege('authenticated',
+      'public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text)', 'execute')
+    or not has_function_privilege('service_role',
+      'public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text)', 'execute')
+  then raise exception 'Student purge entry-point privileges are unsafe'; end if;
+  foreach v_table in array array[
+    'student_purge_settings','student_purge_operations','student_purge_resources',
+    'student_purge_objects','student_purge_fences'
+  ] loop
+    if has_table_privilege('service_role', 'public.' || v_table, 'INSERT')
+      or has_table_privilege('service_role', 'public.' || v_table, 'UPDATE')
+      or has_table_privilege('service_role', 'public.' || v_table, 'DELETE')
+    then raise exception 'service_role can forge student purge authority through %', v_table; end if;
+  end loop;
+end;
+$privileges$;
+
+do $activate$
+declare v_run public.managed_storage_readiness_runs;
+begin
+  select * into v_run from public.refresh_managed_storage_readiness();
+  if v_run.status <> 'ready' then raise exception 'Managed storage readiness blocked'; end if;
+  perform public.activate_managed_storage_enforcement(v_run.generation, v_run.inventory_digest);
+end;
+$activate$;
+
+insert into public.users (id, email, role) values
+  ('d1230000-0000-4000-8000-000000000001', 'student-purge-teacher@example.test', 'teacher'),
+  ('d1230000-0000-4000-8000-000000000002', 'student-purge-target@example.test', 'student'),
+  ('d1230000-0000-4000-8000-000000000003', 'student-purge-classmate@example.test', 'student'),
+  ('d1230000-0000-4000-8000-000000000004', 'student-purge-provider-blocked@example.test', 'student');
+
+insert into public.classrooms (id, teacher_id, title, class_code) values
+  ('d1230000-0000-4000-8000-000000000010', 'd1230000-0000-4000-8000-000000000001', 'Student purge target', 'SP123A'),
+  ('d1230000-0000-4000-8000-000000000011', 'd1230000-0000-4000-8000-000000000001', 'Student purge preserved', 'SP123B');
+
+insert into public.classroom_enrollments (classroom_id, student_id) values
+  ('d1230000-0000-4000-8000-000000000010', 'd1230000-0000-4000-8000-000000000002'),
+  ('d1230000-0000-4000-8000-000000000010', 'd1230000-0000-4000-8000-000000000003'),
+  ('d1230000-0000-4000-8000-000000000010', 'd1230000-0000-4000-8000-000000000004'),
+  ('d1230000-0000-4000-8000-000000000011', 'd1230000-0000-4000-8000-000000000002');
+insert into public.classroom_roster (classroom_id, email) values
+  ('d1230000-0000-4000-8000-000000000010', 'student-purge-target@example.test'),
+  ('d1230000-0000-4000-8000-000000000010', 'student-purge-classmate@example.test'),
+  ('d1230000-0000-4000-8000-000000000010', 'student-purge-provider-blocked@example.test'),
+  ('d1230000-0000-4000-8000-000000000011', 'student-purge-target@example.test');
+insert into public.entries (student_id, classroom_id, date, text, on_time) values
+  ('d1230000-0000-4000-8000-000000000002', 'd1230000-0000-4000-8000-000000000010', '2026-08-11', 'target', true),
+  ('d1230000-0000-4000-8000-000000000003', 'd1230000-0000-4000-8000-000000000010', '2026-08-11', 'classmate', true),
+  ('d1230000-0000-4000-8000-000000000002', 'd1230000-0000-4000-8000-000000000011', '2026-08-11', 'other classroom', true);
+
+select public.begin_managed_storage_upload(
+  'd1230000-0000-4000-8000-000000000020', 'submission-images',
+  'student-purge-fixture/target.png', 'd1230000-0000-4000-8000-000000000010',
+  null, null, 'student_inline_image',
+  'd1230000-0000-4000-8000-000000000002',
+  'd1230000-0000-4000-8000-000000000002',
+  'fixture', null, 'image/png', 1
+);
+insert into storage.objects (bucket_id, name) values (
+  'submission-images', 'student-purge-fixture/target.png'
+);
+select public.verify_managed_storage_upload(
+  'd1230000-0000-4000-8000-000000000020', repeat('a', 64)
+);
+select public.managed_storage_mark_ready('d1230000-0000-4000-8000-000000000020');
+
+do $storage_authority$
+begin
+  begin
+    delete from storage.objects where bucket_id = 'submission-images'
+      and name = 'student-purge-fixture/target.png';
+    raise exception 'Managed object delete bypassed student purge lease authority';
+  exception when sqlstate '55000' then null;
+  end;
+end;
+$storage_authority$;
+
+insert into public.pal_daily_log_week_configurations (
+  student_id, period_key, config_version, period_status, eligible_days, configured_at
+) values (
+  'd1230000-0000-4000-8000-000000000004', '2026-W33', 1, 'open', 5, clock_timestamp()
+);
+
+update public.student_purge_settings set rollout_mode = 'enabled',
+  canary_teacher_id = null, canary_classroom_id = null, canary_student_id = null,
+  updated_at = clock_timestamp()
+where singleton;
+
+do $provider_block$
+declare v_inventory jsonb;
+begin
+  v_inventory := public.get_student_purge_inventory(
+    'd1230000-0000-4000-8000-000000000001',
+    'd1230000-0000-4000-8000-000000000010',
+    'd1230000-0000-4000-8000-000000000004'
+  );
+  if v_inventory->>'unavailable_reason' <> 'student_purge_external_erasure_required'
+  then raise exception 'Pal-backed student did not fail closed'; end if;
+end;
+$provider_block$;
+
+do $begin_purge$
+declare v_inventory jsonb; v_result jsonb;
+begin
+  v_inventory := public.get_student_purge_inventory(
+    'd1230000-0000-4000-8000-000000000001',
+    'd1230000-0000-4000-8000-000000000010',
+    'd1230000-0000-4000-8000-000000000002'
+  );
+  if not (v_inventory->>'deletion_available')::boolean
+  then raise exception 'Canary student purge was not available: %', v_inventory; end if;
+  v_result := public.begin_student_purge(
+    'd1230000-0000-4000-8000-000000000100',
+    'd1230000-0000-4000-8000-000000000001',
+    'd1230000-0000-4000-8000-000000000010',
+    'd1230000-0000-4000-8000-000000000002',
+    'student-purge-target@example.test',
+    (v_inventory->>'source_revision')::bigint,
+    v_inventory->>'storage_inventory_sha256',
+    v_inventory->>'relational_inventory_sha256'
+  );
+  if not (v_result->>'ok')::boolean then raise exception 'Student purge did not start: %', v_result; end if;
+end;
+$begin_purge$;
+
+do $fence$
+begin
+  begin
+    insert into public.entries (student_id, classroom_id, date, text, on_time) values (
+      'd1230000-0000-4000-8000-000000000002',
+      'd1230000-0000-4000-8000-000000000010', '2026-08-12', 'must be fenced', true
+    );
+    raise exception 'Target student write bypassed the purge fence';
+  exception when sqlstate '55000' then null;
+  end;
+  begin
+    update public.entries set student_id = 'd1230000-0000-4000-8000-000000000003'
+    where student_id = 'd1230000-0000-4000-8000-000000000002'
+      and classroom_id = 'd1230000-0000-4000-8000-000000000010';
+    raise exception 'Target row reassignment bypassed the purge fence';
+  exception when sqlstate '55000' then null;
+  end;
+  insert into public.entries (student_id, classroom_id, date, text, on_time) values (
+    'd1230000-0000-4000-8000-000000000003',
+    'd1230000-0000-4000-8000-000000000010', '2026-08-12', 'classmate allowed', true
+  );
+end;
+$fence$;
+
+do $storage_delete$
+declare v_claim jsonb; v_object jsonb; v_result jsonb;
+begin
+  v_claim := public.claim_student_purge_object(
+    'd1230000-0000-4000-8000-000000000100',
+    'd1230000-0000-4000-8000-000000000001'
+  );
+  v_object := v_claim->'object';
+  if v_object is null then raise exception 'Student purge did not claim its managed object: %', v_claim; end if;
+  begin
+    perform public.complete_student_purge_object(
+      'd1230000-0000-4000-8000-000000000100',
+      'd1230000-0000-4000-8000-000000000001',
+      (v_object->>'id')::uuid, (v_object->>'lease_token')::uuid
+    );
+    raise exception 'Student purge accepted storage completion while bytes remained';
+  exception when sqlstate '55000' then null;
+  end;
+  delete from storage.objects where bucket_id = v_object->>'storage_bucket'
+    and name = v_object->>'storage_path';
+  v_result := public.complete_student_purge_object(
+    'd1230000-0000-4000-8000-000000000100',
+    'd1230000-0000-4000-8000-000000000001',
+    (v_object->>'id')::uuid, (v_object->>'lease_token')::uuid
+  );
+  if not (v_result->>'ok')::boolean then raise exception 'Managed object completion failed: %', v_result; end if;
+end;
+$storage_delete$;
+
+do $finalize$
+declare v_result jsonb;
+begin
+  v_result := public.finalize_student_purge(
+    'd1230000-0000-4000-8000-000000000100',
+    'd1230000-0000-4000-8000-000000000001'
+  );
+  if v_result->>'operation_status' <> 'completed'
+  then raise exception 'Student purge did not finalize: %', v_result; end if;
+end;
+$finalize$;
+
+do $preservation$
+begin
+  if not exists (select 1 from public.users where id = 'd1230000-0000-4000-8000-000000000002')
+    or not exists (select 1 from public.classroom_enrollments
+      where classroom_id = 'd1230000-0000-4000-8000-000000000011'
+        and student_id = 'd1230000-0000-4000-8000-000000000002')
+    or not exists (select 1 from public.entries
+      where classroom_id = 'd1230000-0000-4000-8000-000000000011'
+        and student_id = 'd1230000-0000-4000-8000-000000000002')
+    or not exists (select 1 from public.entries
+      where classroom_id = 'd1230000-0000-4000-8000-000000000010'
+        and student_id = 'd1230000-0000-4000-8000-000000000003')
+  then raise exception 'User, other Classroom, or classmate data was removed'; end if;
+  if exists (select 1 from public.entries
+      where classroom_id = 'd1230000-0000-4000-8000-000000000010'
+        and student_id = 'd1230000-0000-4000-8000-000000000002')
+    or exists (select 1 from public.classroom_enrollments
+      where classroom_id = 'd1230000-0000-4000-8000-000000000010'
+        and student_id = 'd1230000-0000-4000-8000-000000000002')
+    or exists (select 1 from public.classroom_roster
+      where classroom_id = 'd1230000-0000-4000-8000-000000000010'
+        and student_id = 'd1230000-0000-4000-8000-000000000002')
+  then raise exception 'Target Classroom student data remained'; end if;
+  if exists (select 1 from public.managed_storage_objects
+      where id = 'd1230000-0000-4000-8000-000000000020')
+    or exists (select 1 from storage.objects where bucket_id = 'submission-images'
+      and name = 'student-purge-fixture/target.png')
+  then raise exception 'Target managed storage object remained'; end if;
+  if exists (select 1 from public.student_purge_fences
+    where operation_id = 'd1230000-0000-4000-8000-000000000100')
+  then raise exception 'Completed student purge left an active fence'; end if;
+end;
+$preservation$;
+
+rollback;
+SQL

--- a/scripts/check-individual-student-purge-database.sh
+++ b/scripts/check-individual-student-purge-database.sh
@@ -124,7 +124,7 @@ insert into public.assignment_doc_history (
 ) values (
   'd1230000-0000-4000-8000-000000000043',
   'd1230000-0000-4000-8000-000000000041', '{"type":"doc","content":[]}'::jsonb,
-  'manual_save', 0, 0
+  'autosave', 0, 0
 );
 insert into public.assignment_doc_save_operations (
   id, assignment_doc_id, save_session_id, save_sequence, metric_session_id,

--- a/scripts/check-individual-student-purge-database.sh
+++ b/scripts/check-individual-student-purge-database.sh
@@ -39,6 +39,7 @@ begin
       'public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text)', 'execute')
   then raise exception 'Student purge entry-point privileges are unsafe'; end if;
   foreach v_table in array array[
+    'classroom_roster_student_bindings',
     'student_purge_settings','student_purge_operations','student_purge_resources',
     'student_purge_objects','student_purge_fences'
   ] loop
@@ -100,6 +101,227 @@ select public.verify_managed_storage_upload(
 );
 select public.managed_storage_mark_ready('d1230000-0000-4000-8000-000000000020');
 
+-- Exercise each major relational family with both target and classmate rows.
+insert into public.announcements (id, classroom_id, content, created_by) values (
+  'd1230000-0000-4000-8000-000000000030',
+  'd1230000-0000-4000-8000-000000000010', 'fixture',
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.announcement_reads (id, announcement_id, user_id) values
+  ('d1230000-0000-4000-8000-000000000031', 'd1230000-0000-4000-8000-000000000030', 'd1230000-0000-4000-8000-000000000002'),
+  ('d1230000-0000-4000-8000-000000000032', 'd1230000-0000-4000-8000-000000000030', 'd1230000-0000-4000-8000-000000000003');
+
+insert into public.assignments (id, classroom_id, title, due_at, created_by) values (
+  'd1230000-0000-4000-8000-000000000040',
+  'd1230000-0000-4000-8000-000000000010', 'Shared assignment',
+  clock_timestamp() + interval '1 day', 'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.assignment_docs (id, assignment_id, student_id, content) values
+  ('d1230000-0000-4000-8000-000000000041', 'd1230000-0000-4000-8000-000000000040', 'd1230000-0000-4000-8000-000000000002', '{"type":"doc","content":[]}'::jsonb),
+  ('d1230000-0000-4000-8000-000000000042', 'd1230000-0000-4000-8000-000000000040', 'd1230000-0000-4000-8000-000000000003', '{"type":"doc","content":[]}'::jsonb);
+insert into public.assignment_doc_history (
+  id, assignment_doc_id, snapshot, trigger, word_count, char_count
+) values (
+  'd1230000-0000-4000-8000-000000000043',
+  'd1230000-0000-4000-8000-000000000041', '{"type":"doc","content":[]}'::jsonb,
+  'manual_save', 0, 0
+);
+insert into public.assignment_doc_save_operations (
+  id, assignment_doc_id, save_session_id, save_sequence, metric_session_id,
+  paste_word_count, keystroke_count, content_sha256, document_updated_at
+) values (
+  'd1230000-0000-4000-8000-000000000044',
+  'd1230000-0000-4000-8000-000000000041',
+  'd1230000-0000-4000-8000-000000000045', 1,
+  'd1230000-0000-4000-8000-000000000046', 0, 1, repeat('c', 64), clock_timestamp()
+);
+insert into public.assignment_feedback_entries (
+  id, assignment_id, student_id, author_type, entry_kind, body, created_by
+) values (
+  'd1230000-0000-4000-8000-000000000047',
+  'd1230000-0000-4000-8000-000000000040',
+  'd1230000-0000-4000-8000-000000000002', 'teacher', 'comment', 'target feedback',
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.assignment_ai_grading_runs (
+  id, assignment_id, status, triggered_by, selection_hash,
+  requested_student_ids_json, requested_count, gradable_count, processed_count, completed_count
+) values (
+  'd1230000-0000-4000-8000-000000000048',
+  'd1230000-0000-4000-8000-000000000040', 'completed',
+  'd1230000-0000-4000-8000-000000000001', 'student-purge-shared-assignment',
+  '["d1230000-0000-4000-8000-000000000002","d1230000-0000-4000-8000-000000000003"]'::jsonb,
+  2, 2, 2, 2
+);
+insert into public.assignment_ai_grading_run_items (
+  id, run_id, assignment_id, student_id, assignment_doc_id, queue_position, status, completed_at
+) values
+  ('d1230000-0000-4000-8000-000000000049', 'd1230000-0000-4000-8000-000000000048', 'd1230000-0000-4000-8000-000000000040', 'd1230000-0000-4000-8000-000000000002', 'd1230000-0000-4000-8000-000000000041', 0, 'completed', clock_timestamp()),
+  ('d1230000-0000-4000-8000-00000000004a', 'd1230000-0000-4000-8000-000000000048', 'd1230000-0000-4000-8000-000000000040', 'd1230000-0000-4000-8000-000000000003', 'd1230000-0000-4000-8000-000000000042', 1, 'completed', clock_timestamp());
+
+insert into public.tests (id, classroom_id, title, status, created_by) values (
+  'd1230000-0000-4000-8000-000000000050',
+  'd1230000-0000-4000-8000-000000000010', 'Shared test', 'closed',
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.test_questions (id, test_id, question_text) values (
+  'd1230000-0000-4000-8000-000000000051',
+  'd1230000-0000-4000-8000-000000000050', 'Explain'
+);
+insert into public.test_attempts (id, test_id, student_id, responses, is_submitted, submitted_at) values
+  ('d1230000-0000-4000-8000-000000000052', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000002', '{}', true, clock_timestamp()),
+  ('d1230000-0000-4000-8000-000000000053', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000003', '{}', true, clock_timestamp());
+insert into public.test_attempt_history (id, test_attempt_id, snapshot, trigger) values (
+  'd1230000-0000-4000-8000-000000000054',
+  'd1230000-0000-4000-8000-000000000052', '{}', 'submit'
+);
+insert into public.test_responses (
+  id, test_id, question_id, student_id, response_text, revision
+) values
+  ('d1230000-0000-4000-8000-000000000055', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000051', 'd1230000-0000-4000-8000-000000000002', 'target response', 1),
+  ('d1230000-0000-4000-8000-000000000056', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000051', 'd1230000-0000-4000-8000-000000000003', 'classmate response', 1);
+insert into public.test_focus_events (id, test_id, student_id, session_id, event_type) values (
+  'd1230000-0000-4000-8000-000000000057',
+  'd1230000-0000-4000-8000-000000000050',
+  'd1230000-0000-4000-8000-000000000002',
+  'd1230000-0000-4000-8000-000000000058', 'blur'
+);
+insert into public.test_student_availability (id, test_id, student_id, state, updated_by) values (
+  'd1230000-0000-4000-8000-000000000059',
+  'd1230000-0000-4000-8000-000000000050',
+  'd1230000-0000-4000-8000-000000000002', 'closed',
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.test_ai_grading_runs (
+  id, test_id, status, triggered_by, selection_hash, requested_student_ids_json,
+  requested_count, eligible_student_count, queued_response_count, processed_count, completed_count
+) values (
+  'd1230000-0000-4000-8000-00000000005a',
+  'd1230000-0000-4000-8000-000000000050', 'completed',
+  'd1230000-0000-4000-8000-000000000001', 'student-purge-shared-test',
+  '["d1230000-0000-4000-8000-000000000002","d1230000-0000-4000-8000-000000000003"]'::jsonb,
+  2, 2, 2, 2, 2
+);
+insert into public.test_ai_grading_run_items (
+  id, run_id, test_id, student_id, question_id, response_id, response_revision,
+  queue_position, status, completed_at
+) values
+  ('d1230000-0000-4000-8000-00000000005b', 'd1230000-0000-4000-8000-00000000005a', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000002', 'd1230000-0000-4000-8000-000000000051', 'd1230000-0000-4000-8000-000000000055', 1, 0, 'completed', clock_timestamp()),
+  ('d1230000-0000-4000-8000-00000000005c', 'd1230000-0000-4000-8000-00000000005a', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000003', 'd1230000-0000-4000-8000-000000000051', 'd1230000-0000-4000-8000-000000000056', 1, 1, 'completed', clock_timestamp());
+
+insert into public.surveys (id, classroom_id, title, position, created_by) values (
+  'd1230000-0000-4000-8000-000000000060',
+  'd1230000-0000-4000-8000-000000000010', 'Shared survey', 0,
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.survey_questions (id, survey_id, question_text) values (
+  'd1230000-0000-4000-8000-000000000061',
+  'd1230000-0000-4000-8000-000000000060', 'Reflection'
+);
+insert into public.survey_responses (id, survey_id, question_id, student_id, response_text) values
+  ('d1230000-0000-4000-8000-000000000062', 'd1230000-0000-4000-8000-000000000060', 'd1230000-0000-4000-8000-000000000061', 'd1230000-0000-4000-8000-000000000002', 'target survey'),
+  ('d1230000-0000-4000-8000-000000000063', 'd1230000-0000-4000-8000-000000000060', 'd1230000-0000-4000-8000-000000000061', 'd1230000-0000-4000-8000-000000000003', 'classmate survey');
+insert into public.report_cards (id, classroom_id, term, created_by) values (
+  'd1230000-0000-4000-8000-000000000070',
+  'd1230000-0000-4000-8000-000000000010', 'Fixture',
+  'd1230000-0000-4000-8000-000000000001'
+);
+insert into public.report_card_rows (id, report_card_id, student_id, final_percent) values
+  ('d1230000-0000-4000-8000-000000000071', 'd1230000-0000-4000-8000-000000000070', 'd1230000-0000-4000-8000-000000000002', 80),
+  ('d1230000-0000-4000-8000-000000000072', 'd1230000-0000-4000-8000-000000000070', 'd1230000-0000-4000-8000-000000000003', 90);
+insert into public.log_summaries (id, classroom_id, date, model) values (
+  'd1230000-0000-4000-8000-000000000073',
+  'd1230000-0000-4000-8000-000000000010', '2026-08-11', 'fixture'
+);
+
+-- Retained archive and Gradex artifacts are whole-Classroom copies and must be
+-- removed because selective rewriting is not supported.
+select public.begin_managed_storage_upload(
+  'd1230000-0000-4000-8000-000000000021', 'classroom-archives',
+  'student-purge-fixture/archive.tar.gz', 'd1230000-0000-4000-8000-000000000010',
+  null, null, 'classroom_archive', 'd1230000-0000-4000-8000-000000000001', null,
+  'classroom_archive_operation', 'd1230000-0000-4000-8000-000000000080',
+  'application/gzip', 1
+);
+select public.begin_managed_storage_upload(
+  'd1230000-0000-4000-8000-000000000022', 'gradex-analytics-extracts',
+  'student-purge-fixture/gradex.tar.gz', 'd1230000-0000-4000-8000-000000000010',
+  null, null, 'gradex_extract', 'd1230000-0000-4000-8000-000000000001', null,
+  'classroom_archive_operation', 'd1230000-0000-4000-8000-000000000082',
+  'application/gzip', 1
+);
+insert into storage.objects (bucket_id, name) values
+  ('classroom-archives', 'student-purge-fixture/archive.tar.gz'),
+  ('gradex-analytics-extracts', 'student-purge-fixture/gradex.tar.gz');
+select public.verify_managed_storage_upload('d1230000-0000-4000-8000-000000000021', repeat('b', 64));
+select public.managed_storage_mark_ready('d1230000-0000-4000-8000-000000000021');
+select public.verify_managed_storage_upload('d1230000-0000-4000-8000-000000000022', repeat('c', 64));
+select public.managed_storage_mark_ready('d1230000-0000-4000-8000-000000000022');
+insert into public.classroom_archive_operations (
+  id, teacher_id, classroom_id, operation_type, request_sha256, status,
+  source_revision, source_schema_migration, source_app_commit, retention,
+  archive_id, storage_bucket, storage_path, artifact_sha256, content_sha256,
+  compressed_byte_size, uncompressed_byte_size, verification,
+  snapshot_created_at, snapshot_expires_at, completed_at, managed_object_id
+) values (
+  'd1230000-0000-4000-8000-000000000080',
+  'd1230000-0000-4000-8000-000000000001',
+  'd1230000-0000-4000-8000-000000000010', 'export', repeat('d', 64), 'completed',
+  1, '123_fixture', 'fixture', '{"mode":"teacher_managed","delete_after":null}'::jsonb,
+  'd1230000-0000-4000-8000-000000000081', 'classroom-archives',
+  'student-purge-fixture/archive.tar.gz', repeat('b', 64), repeat('e', 64), 1, 1,
+  '{}', clock_timestamp() - interval '2 minutes', clock_timestamp() - interval '1 minute',
+  clock_timestamp(), 'd1230000-0000-4000-8000-000000000021'
+);
+insert into public.classroom_archives (
+  id, operation_id, classroom_id, teacher_id, format, format_version,
+  source_revision, source_schema_migration, source_app_commit, storage_bucket,
+  storage_path, artifact_sha256, content_sha256, compressed_byte_size,
+  uncompressed_byte_size, resource_counts, storage_object_counts, verification,
+  retention, created_at, verified_at, managed_object_id
+) values (
+  'd1230000-0000-4000-8000-000000000081',
+  'd1230000-0000-4000-8000-000000000080',
+  'd1230000-0000-4000-8000-000000000010',
+  'd1230000-0000-4000-8000-000000000001', 'pika.classroom-archive', 1, 1,
+  '123_fixture', 'fixture', 'classroom-archives', 'student-purge-fixture/archive.tar.gz',
+  repeat('b', 64), repeat('e', 64), 1, 1, '{}', '{}', '{}',
+  '{"mode":"teacher_managed","delete_after":null}'::jsonb,
+  clock_timestamp() - interval '2 minutes', clock_timestamp() - interval '1 minute',
+  'd1230000-0000-4000-8000-000000000021'
+);
+insert into public.classroom_archive_operations (
+  id, teacher_id, classroom_id, operation_type, request_sha256, status,
+  source_revision, source_schema_migration, source_app_commit, retention,
+  archive_id, storage_bucket, storage_path, artifact_sha256, content_sha256,
+  compressed_byte_size, uncompressed_byte_size, verification,
+  snapshot_created_at, snapshot_expires_at, completed_at, managed_object_id
+) values (
+  'd1230000-0000-4000-8000-000000000082',
+  'd1230000-0000-4000-8000-000000000001',
+  'd1230000-0000-4000-8000-000000000010', 'gradex_extract', repeat('f', 64), 'completed',
+  1, '123_fixture', 'fixture', '{"mode":"scheduled","delete_after":"2099-01-01T00:00:00Z"}'::jsonb,
+  'd1230000-0000-4000-8000-000000000083', 'gradex-analytics-extracts',
+  'student-purge-fixture/gradex.tar.gz', repeat('c', 64), repeat('a', 64), 1, 1,
+  '{}', clock_timestamp() - interval '2 minutes', clock_timestamp() - interval '1 minute',
+  clock_timestamp(), 'd1230000-0000-4000-8000-000000000022'
+);
+insert into public.classroom_gradex_extracts (
+  id, operation_id, source_archive_id, classroom_id, teacher_id, format, format_version,
+  source_archive_sha256, storage_bucket, storage_path, artifact_sha256, content_sha256,
+  compressed_byte_size, uncompressed_byte_size, resource_counts, verification,
+  generated_at, verified_at, delete_after, managed_object_id
+) values (
+  'd1230000-0000-4000-8000-000000000083',
+  'd1230000-0000-4000-8000-000000000082',
+  'd1230000-0000-4000-8000-000000000081',
+  'd1230000-0000-4000-8000-000000000010',
+  'd1230000-0000-4000-8000-000000000001', 'pika.classroom-gradex', 1,
+  repeat('b', 64), 'gradex-analytics-extracts', 'student-purge-fixture/gradex.tar.gz',
+  repeat('c', 64), repeat('a', 64), 1, 1, '{}', '{}', clock_timestamp(),
+  clock_timestamp(), '2099-01-01T00:00:00Z', 'd1230000-0000-4000-8000-000000000022'
+);
+
 do $storage_authority$
 begin
   begin
@@ -122,6 +344,13 @@ update public.student_purge_settings set rollout_mode = 'enabled',
   updated_at = clock_timestamp()
 where singleton;
 
+create temporary table fixture_student_purge_inventory on commit drop as
+select public.get_student_purge_inventory(
+  'd1230000-0000-4000-8000-000000000001',
+  'd1230000-0000-4000-8000-000000000010',
+  'd1230000-0000-4000-8000-000000000002'
+) as payload;
+
 do $provider_block$
 declare v_inventory jsonb;
 begin
@@ -138,11 +367,7 @@ $provider_block$;
 do $begin_purge$
 declare v_inventory jsonb; v_result jsonb;
 begin
-  v_inventory := public.get_student_purge_inventory(
-    'd1230000-0000-4000-8000-000000000001',
-    'd1230000-0000-4000-8000-000000000010',
-    'd1230000-0000-4000-8000-000000000002'
-  );
+  select payload into v_inventory from fixture_student_purge_inventory;
   if not (v_inventory->>'deletion_available')::boolean
   then raise exception 'Canary student purge was not available: %', v_inventory; end if;
   v_result := public.begin_student_purge(
@@ -186,29 +411,31 @@ $fence$;
 do $storage_delete$
 declare v_claim jsonb; v_object jsonb; v_result jsonb;
 begin
-  v_claim := public.claim_student_purge_object(
-    'd1230000-0000-4000-8000-000000000100',
-    'd1230000-0000-4000-8000-000000000001'
-  );
-  v_object := v_claim->'object';
-  if v_object is null then raise exception 'Student purge did not claim its managed object: %', v_claim; end if;
-  begin
-    perform public.complete_student_purge_object(
+  loop
+    v_claim := public.claim_student_purge_object(
+      'd1230000-0000-4000-8000-000000000100',
+      'd1230000-0000-4000-8000-000000000001'
+    );
+    v_object := v_claim->'object';
+    exit when v_object is null;
+    begin
+      perform public.complete_student_purge_object(
+        'd1230000-0000-4000-8000-000000000100',
+        'd1230000-0000-4000-8000-000000000001',
+        (v_object->>'id')::uuid, (v_object->>'lease_token')::uuid
+      );
+      raise exception 'Student purge accepted storage completion while bytes remained';
+    exception when sqlstate '55000' then null;
+    end;
+    delete from storage.objects where bucket_id = v_object->>'storage_bucket'
+      and name = v_object->>'storage_path';
+    v_result := public.complete_student_purge_object(
       'd1230000-0000-4000-8000-000000000100',
       'd1230000-0000-4000-8000-000000000001',
       (v_object->>'id')::uuid, (v_object->>'lease_token')::uuid
     );
-    raise exception 'Student purge accepted storage completion while bytes remained';
-  exception when sqlstate '55000' then null;
-  end;
-  delete from storage.objects where bucket_id = v_object->>'storage_bucket'
-    and name = v_object->>'storage_path';
-  v_result := public.complete_student_purge_object(
-    'd1230000-0000-4000-8000-000000000100',
-    'd1230000-0000-4000-8000-000000000001',
-    (v_object->>'id')::uuid, (v_object->>'lease_token')::uuid
-  );
-  if not (v_result->>'ok')::boolean then raise exception 'Managed object completion failed: %', v_result; end if;
+    if not (v_result->>'ok')::boolean then raise exception 'Managed object completion failed: %', v_result; end if;
+  end loop;
 end;
 $storage_delete$;
 
@@ -223,6 +450,49 @@ begin
   then raise exception 'Student purge did not finalize: %', v_result; end if;
 end;
 $finalize$;
+
+do $completed_replay$
+declare v_inventory jsonb; v_result jsonb;
+begin
+  select payload into v_inventory from fixture_student_purge_inventory;
+  v_result := public.begin_student_purge(
+    'd1230000-0000-4000-8000-000000000100',
+    'd1230000-0000-4000-8000-000000000001',
+    'd1230000-0000-4000-8000-000000000010',
+    'd1230000-0000-4000-8000-000000000002',
+    'student-purge-target@example.test',
+    (v_inventory->>'source_revision')::bigint,
+    v_inventory->>'storage_inventory_sha256',
+    v_inventory->>'relational_inventory_sha256'
+  );
+  if v_result->>'operation_status' <> 'completed' or not (v_result->>'replayed')::boolean
+  then raise exception 'Completed student purge replay lost its target binding: %', v_result; end if;
+end;
+$completed_replay$;
+
+do $path_reservation$
+begin
+  begin
+    perform public.begin_managed_storage_upload(
+      'd1230000-0000-4000-8000-000000000023', 'submission-images',
+      'student-purge-fixture/target.png', 'd1230000-0000-4000-8000-000000000010',
+      null, null, 'student_inline_image',
+      'd1230000-0000-4000-8000-000000000002',
+      'd1230000-0000-4000-8000-000000000002',
+      'fixture', null, 'image/png', 1
+    );
+    raise exception 'Managed row recreated a permanently purged path';
+  exception when sqlstate '55000' then null;
+  end;
+  begin
+    insert into storage.objects (bucket_id, name) values (
+      'submission-images', 'student-purge-fixture/target.png'
+    );
+    raise exception 'Storage bytes recreated a permanently purged path';
+  exception when sqlstate '55000' then null;
+  end;
+end;
+$path_reservation$;
 
 do $preservation$
 begin
@@ -243,7 +513,7 @@ begin
     or exists (select 1 from public.classroom_enrollments
       where classroom_id = 'd1230000-0000-4000-8000-000000000010'
         and student_id = 'd1230000-0000-4000-8000-000000000002')
-    or exists (select 1 from public.classroom_roster
+    or exists (select 1 from public.classroom_roster_student_bindings
       where classroom_id = 'd1230000-0000-4000-8000-000000000010'
         and student_id = 'd1230000-0000-4000-8000-000000000002')
   then raise exception 'Target Classroom student data remained'; end if;
@@ -255,6 +525,53 @@ begin
   if exists (select 1 from public.student_purge_fences
     where operation_id = 'd1230000-0000-4000-8000-000000000100')
   then raise exception 'Completed student purge left an active fence'; end if;
+  if exists (select 1 from public.assignment_docs where id = 'd1230000-0000-4000-8000-000000000041')
+    or not exists (select 1 from public.assignment_docs where id = 'd1230000-0000-4000-8000-000000000042')
+    or exists (select 1 from public.test_responses where id = 'd1230000-0000-4000-8000-000000000055')
+    or not exists (select 1 from public.test_responses where id = 'd1230000-0000-4000-8000-000000000056')
+    or exists (select 1 from public.survey_responses where id = 'd1230000-0000-4000-8000-000000000062')
+    or not exists (select 1 from public.survey_responses where id = 'd1230000-0000-4000-8000-000000000063')
+    or exists (select 1 from public.report_card_rows where id = 'd1230000-0000-4000-8000-000000000071')
+    or not exists (select 1 from public.report_card_rows where id = 'd1230000-0000-4000-8000-000000000072')
+    or exists (select 1 from public.announcement_reads where id = 'd1230000-0000-4000-8000-000000000031')
+    or not exists (select 1 from public.announcement_reads where id = 'd1230000-0000-4000-8000-000000000032')
+  then raise exception 'Target/peer relational family isolation failed'; end if;
+  if (select requested_student_ids_json from public.assignment_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-000000000048')
+      <> '["d1230000-0000-4000-8000-000000000003"]'::jsonb
+    or (select gradable_count from public.assignment_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-000000000048') <> 1
+    or (select selection_hash from public.assignment_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-000000000048') <>
+      encode(extensions.digest(convert_to(
+        'student-purge:d1230000-0000-4000-8000-000000000100:d1230000-0000-4000-8000-000000000048',
+        'UTF8'), 'sha256'), 'hex')
+    or exists (select 1 from public.assignment_ai_grading_run_items
+      where id = 'd1230000-0000-4000-8000-000000000049')
+    or not exists (select 1 from public.assignment_ai_grading_run_items
+      where id = 'd1230000-0000-4000-8000-00000000004a')
+    or (select requested_student_ids_json from public.test_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-00000000005a')
+      <> '["d1230000-0000-4000-8000-000000000003"]'::jsonb
+    or (select eligible_student_count from public.test_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-00000000005a') <> 1
+    or (select selection_hash from public.test_ai_grading_runs
+      where id = 'd1230000-0000-4000-8000-00000000005a') <>
+      encode(extensions.digest(convert_to(
+        'student-purge:d1230000-0000-4000-8000-000000000100:d1230000-0000-4000-8000-00000000005a',
+        'UTF8'), 'sha256'), 'hex')
+    or exists (select 1 from public.test_ai_grading_run_items
+      where id = 'd1230000-0000-4000-8000-00000000005b')
+    or not exists (select 1 from public.test_ai_grading_run_items
+      where id = 'd1230000-0000-4000-8000-00000000005c')
+  then raise exception 'Shared grading run redaction or peer preservation failed'; end if;
+  if exists (select 1 from public.classroom_archives
+      where id = 'd1230000-0000-4000-8000-000000000081')
+    or exists (select 1 from public.classroom_gradex_extracts
+      where id = 'd1230000-0000-4000-8000-000000000083')
+    or exists (select 1 from public.classroom_archive_operations
+      where classroom_id = 'd1230000-0000-4000-8000-000000000010')
+  then raise exception 'Retained archive or Gradex ledger remained'; end if;
 end;
 $preservation$;
 

--- a/scripts/check-individual-student-purge-database.sh
+++ b/scripts/check-individual-student-purge-database.sh
@@ -140,7 +140,7 @@ insert into public.assignment_feedback_entries (
 ) values (
   'd1230000-0000-4000-8000-000000000047',
   'd1230000-0000-4000-8000-000000000040',
-  'd1230000-0000-4000-8000-000000000002', 'teacher', 'comment', 'target feedback',
+  'd1230000-0000-4000-8000-000000000002', 'teacher', 'teacher_feedback', 'target feedback',
   'd1230000-0000-4000-8000-000000000001'
 );
 insert into public.assignment_ai_grading_runs (
@@ -164,9 +164,9 @@ insert into public.tests (id, classroom_id, title, status, created_by) values (
   'd1230000-0000-4000-8000-000000000010', 'Shared test', 'closed',
   'd1230000-0000-4000-8000-000000000001'
 );
-insert into public.test_questions (id, test_id, question_text) values (
+insert into public.test_questions (id, test_id, question_type, question_text) values (
   'd1230000-0000-4000-8000-000000000051',
-  'd1230000-0000-4000-8000-000000000050', 'Explain'
+  'd1230000-0000-4000-8000-000000000050', 'open_response', 'Explain'
 );
 insert into public.test_attempts (id, test_id, student_id, responses, is_submitted, submitted_at) values
   ('d1230000-0000-4000-8000-000000000052', 'd1230000-0000-4000-8000-000000000050', 'd1230000-0000-4000-8000-000000000002', '{}', true, clock_timestamp()),
@@ -184,7 +184,7 @@ insert into public.test_focus_events (id, test_id, student_id, session_id, event
   'd1230000-0000-4000-8000-000000000057',
   'd1230000-0000-4000-8000-000000000050',
   'd1230000-0000-4000-8000-000000000002',
-  'd1230000-0000-4000-8000-000000000058', 'blur'
+  'd1230000-0000-4000-8000-000000000058', 'away_start'
 );
 insert into public.test_student_availability (id, test_id, student_id, state, updated_by) values (
   'd1230000-0000-4000-8000-000000000059',
@@ -214,16 +214,16 @@ insert into public.surveys (id, classroom_id, title, position, created_by) value
   'd1230000-0000-4000-8000-000000000010', 'Shared survey', 0,
   'd1230000-0000-4000-8000-000000000001'
 );
-insert into public.survey_questions (id, survey_id, question_text) values (
+insert into public.survey_questions (id, survey_id, question_type, question_text) values (
   'd1230000-0000-4000-8000-000000000061',
-  'd1230000-0000-4000-8000-000000000060', 'Reflection'
+  'd1230000-0000-4000-8000-000000000060', 'short_text', 'Reflection'
 );
 insert into public.survey_responses (id, survey_id, question_id, student_id, response_text) values
   ('d1230000-0000-4000-8000-000000000062', 'd1230000-0000-4000-8000-000000000060', 'd1230000-0000-4000-8000-000000000061', 'd1230000-0000-4000-8000-000000000002', 'target survey'),
   ('d1230000-0000-4000-8000-000000000063', 'd1230000-0000-4000-8000-000000000060', 'd1230000-0000-4000-8000-000000000061', 'd1230000-0000-4000-8000-000000000003', 'classmate survey');
 insert into public.report_cards (id, classroom_id, term, created_by) values (
   'd1230000-0000-4000-8000-000000000070',
-  'd1230000-0000-4000-8000-000000000010', 'Fixture',
+  'd1230000-0000-4000-8000-000000000010', 'final',
   'd1230000-0000-4000-8000-000000000001'
 );
 insert into public.report_card_rows (id, report_card_id, student_id, final_percent) values
@@ -300,7 +300,9 @@ insert into public.classroom_archive_operations (
   'd1230000-0000-4000-8000-000000000082',
   'd1230000-0000-4000-8000-000000000001',
   'd1230000-0000-4000-8000-000000000010', 'gradex_extract', repeat('f', 64), 'completed',
-  1, '123_fixture', 'fixture', '{"mode":"scheduled","delete_after":"2099-01-01T00:00:00Z"}'::jsonb,
+  1, '123_fixture', 'fixture', jsonb_build_object(
+    'mode', 'scheduled', 'delete_after', clock_timestamp() + interval '30 days'
+  ),
   'd1230000-0000-4000-8000-000000000083', 'gradex-analytics-extracts',
   'student-purge-fixture/gradex.tar.gz', repeat('c', 64), repeat('a', 64), 1, 1,
   '{}', clock_timestamp() - interval '2 minutes', clock_timestamp() - interval '1 minute',
@@ -316,14 +318,16 @@ insert into public.classroom_gradex_extracts (
   'd1230000-0000-4000-8000-000000000082',
   'd1230000-0000-4000-8000-000000000081',
   'd1230000-0000-4000-8000-000000000010',
-  'd1230000-0000-4000-8000-000000000001', 'pika.classroom-gradex', 1,
+  'd1230000-0000-4000-8000-000000000001', 'pika.gradex-classroom-extract', 2,
   repeat('b', 64), 'gradex-analytics-extracts', 'student-purge-fixture/gradex.tar.gz',
   repeat('c', 64), repeat('a', 64), 1, 1, '{}', '{}', clock_timestamp(),
-  clock_timestamp(), '2099-01-01T00:00:00Z', 'd1230000-0000-4000-8000-000000000022'
+  clock_timestamp(), clock_timestamp() + interval '30 days',
+  'd1230000-0000-4000-8000-000000000022'
 );
 
 do $storage_authority$
 begin
+  perform set_config('storage.allow_delete_query', 'true', true);
   begin
     delete from storage.objects where bucket_id = 'submission-images'
       and name = 'student-purge-fixture/target.png';

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -12,6 +12,7 @@ import { chunkValues, loadChunkedRows, loadPagedRows } from '@/lib/server/query-
 import { runClassroomPurgeSafetyNet } from '@/lib/server/classroom-purge'
 import { runColdClassroomPurgeSafetyNet } from '@/lib/server/cold-classroom-purge'
 import { runCourseBlueprintPurgeSafetyNet } from '@/lib/server/course-blueprint-purge'
+import { readStudentPurgeHealth, runStudentPurgeSafetyNet } from '@/lib/server/student-purge'
 import { readManagedDeletionHealth } from '@/lib/server/managed-deletion-health'
 
 export const dynamic = 'force-dynamic'
@@ -164,6 +165,21 @@ async function handle(request: NextRequest) {
   const classroomPurge = await runClassroomPurgeSafetyNet()
   const coldClassroomPurge = await runColdClassroomPurgeSafetyNet(10)
   const courseBlueprintPurge = await runCourseBlueprintPurgeSafetyNet()
+  const studentPurge = await runStudentPurgeSafetyNet()
+  const studentPurgeHealth = await readStudentPurgeHealth()
+  if (studentPurgeHealth.schemaAvailable) {
+    const snapshot = studentPurgeHealth.snapshot
+    if (
+      studentPurge.failed > 0
+      || snapshot.stuck_count > 0
+      || snapshot.failed_count > 0
+      || snapshot.orphan_fence_count > 0
+      || snapshot.processing_lease_drift_count > 0
+    ) {
+      console.error('[student-purge-health] degraded', snapshot)
+      return NextResponse.json({ error: 'Student purge health degraded' }, { status: 503 })
+    }
+  }
   const objectCleanupEnabled = isClassroomArchiveObjectCleanupEnabled()
   let archiveStagingCleaned: number | undefined
   if (isArchiveStagingCleanupEnabled() || objectCleanupEnabled) {
@@ -254,6 +270,9 @@ async function handle(request: NextRequest) {
         : {}),
       ...(courseBlueprintPurge.processed > 0
         ? { course_blueprint_purge: courseBlueprintPurge }
+        : {}),
+      ...(studentPurge.processed > 0
+        ? { student_purge: studentPurge }
         : {}),
     })
   }
@@ -372,6 +391,9 @@ async function handle(request: NextRequest) {
       : {}),
     ...(courseBlueprintPurge.processed > 0
       ? { course_blueprint_purge: courseBlueprintPurge }
+      : {}),
+    ...(studentPurge.processed > 0
+      ? { student_purge: studentPurge }
       : {}),
   })
 }

--- a/src/app/api/teacher/classrooms/[id]/roster/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
+import { getStudentPurgeEnabledStudentIds } from '@/lib/server/student-purge'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -22,10 +23,22 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
     )
   }
 
-  const { data: rosterRows, error: rosterError } = await supabase
+  let rosterResponse = await supabase
     .from('classroom_roster')
-    .select('id, email, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
+    .select('id, email, student_id, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
     .eq('classroom_id', classroomId)
+
+  if (
+    rosterResponse.error
+    && ['PGRST204', '42703'].includes(rosterResponse.error.code || '')
+    && rosterResponse.error.message?.includes('student_id')
+  ) {
+    rosterResponse = await supabase
+      .from('classroom_roster')
+      .select('id, email, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
+      .eq('classroom_id', classroomId) as typeof rosterResponse
+  }
+  const { data: rosterRows, error: rosterError } = rosterResponse
 
   if (rosterError) {
     console.error('Error fetching roster:', rosterError)
@@ -53,18 +66,23 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
   }
 
   const joinedByEmail = new Map<string, { student_id: string; created_at: string }>()
+  const joinedByStudentId = new Map<string, { student_id: string; created_at: string }>()
   for (const e of enrollments || []) {
     const email = (e as any)?.users?.email
     if (!email) continue
-    joinedByEmail.set(String(email).toLowerCase().trim(), {
+    const joined = {
       student_id: (e as any).student_id,
       created_at: (e as any).created_at,
-    })
+    }
+    joinedByEmail.set(String(email).toLowerCase().trim(), joined)
+    joinedByStudentId.set(joined.student_id, joined)
   }
 
   const roster = (rosterRows || []).map((r: any) => {
     const email = String(r.email || '').toLowerCase().trim()
-    const joined = joinedByEmail.get(email)
+    const joined = r.student_id
+      ? joinedByStudentId.get(String(r.student_id))
+      : joinedByEmail.get(email)
     return {
       id: r.id,
       email: r.email,
@@ -81,5 +99,11 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
     }
   })
 
-  return NextResponse.json({ roster })
+  const studentPurgeEnabledIds = await getStudentPurgeEnabledStudentIds(
+    user.id,
+    classroomId,
+    roster.flatMap((row) => row.student_id ? [row.student_id] : []),
+  )
+
+  return NextResponse.json({ roster, student_purge_enabled_ids: studentPurgeEnabledIds })
 })

--- a/src/app/api/teacher/classrooms/[id]/roster/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/route.ts
@@ -23,21 +23,10 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
     )
   }
 
-  let rosterResponse = await supabase
+  const rosterResponse = await supabase
     .from('classroom_roster')
-    .select('id, email, student_id, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
+    .select('id, email, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
     .eq('classroom_id', classroomId)
-
-  if (
-    rosterResponse.error
-    && ['PGRST204', '42703'].includes(rosterResponse.error.code || '')
-    && rosterResponse.error.message?.includes('student_id')
-  ) {
-    rosterResponse = await supabase
-      .from('classroom_roster')
-      .select('id, email, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
-      .eq('classroom_id', classroomId) as typeof rosterResponse
-  }
   const { data: rosterRows, error: rosterError } = rosterResponse
 
   if (rosterError) {
@@ -65,8 +54,25 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
     )
   }
 
+  const bindingsResponse = await supabase
+    .from('classroom_roster_student_bindings')
+    .select('roster_id, student_id')
+    .eq('classroom_id', classroomId)
+  const bindingsUnavailable = bindingsResponse.error
+    && ['PGRST205', '42P01'].includes(bindingsResponse.error.code || '')
+  if (bindingsResponse.error && !bindingsUnavailable) {
+    console.error('Error fetching roster student bindings:', bindingsResponse.error)
+    return NextResponse.json(
+      { error: 'Failed to fetch roster' },
+      { status: 500 }
+    )
+  }
+
   const joinedByEmail = new Map<string, { student_id: string; created_at: string }>()
   const joinedByStudentId = new Map<string, { student_id: string; created_at: string }>()
+  const studentIdByRosterId = new Map(
+    (bindingsResponse.data || []).map((binding) => [binding.roster_id, binding.student_id]),
+  )
   for (const e of enrollments || []) {
     const email = (e as any)?.users?.email
     if (!email) continue
@@ -80,9 +86,13 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
 
   const roster = (rosterRows || []).map((r: any) => {
     const email = String(r.email || '').toLowerCase().trim()
-    const joined = r.student_id
-      ? joinedByStudentId.get(String(r.student_id))
+    const boundStudentId = studentIdByRosterId.get(String(r.id))
+    const joined = boundStudentId
+      ? joinedByStudentId.get(boundStudentId)
       : joinedByEmail.get(email)
+    const stableJoinedStudentId = boundStudentId
+      ? joined?.student_id
+      : bindingsUnavailable ? joined?.student_id : undefined
     return {
       id: r.id,
       email: r.email,
@@ -94,7 +104,7 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
       created_at: r.created_at,
       updated_at: r.updated_at,
       joined: !!joined,
-      student_id: joined?.student_id ?? null,
+      student_id: stableJoinedStudentId ?? null,
       joined_at: joined?.created_at ?? null,
     }
   })

--- a/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withErrorHandler } from '@/lib/api-handler'
+import { requireRole } from '@/lib/auth'
+import { assertStudentPurgeOperationTarget, getStudentPurgeStatus } from '@/lib/server/student-purge'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+const uuidSchema = z.string().uuid()
+
+export const GET = withErrorHandler('GetTeacherStudentPurgeStatus', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id, studentId, operationId } = await context.params
+  await assertStudentPurgeOperationTarget(
+    user.id,
+    uuidSchema.parse(operationId),
+    uuidSchema.parse(id),
+    uuidSchema.parse(studentId),
+  )
+  const operation = await getStudentPurgeStatus(user.id, uuidSchema.parse(operationId))
+  if (operation.classroom_id !== uuidSchema.parse(id)) {
+    return NextResponse.json({ error: 'Student data deletion not found' }, { status: 404 })
+  }
+  return NextResponse.json({ operation })
+})

--- a/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/tick/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/tick/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { ApiError, withErrorHandler } from '@/lib/api-handler'
+import { requireRole } from '@/lib/auth'
+import { advanceStudentPurge, assertStudentPurgeOperationTarget } from '@/lib/server/student-purge'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const maxDuration = 60
+const uuidSchema = z.string().uuid()
+const emptyRequestSchema = z.object({}).strict()
+
+export const POST = withErrorHandler('TickTeacherStudentPurge', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id, studentId, operationId } = await context.params
+  const text = await request.text()
+  if (text.trim()) {
+    try {
+      emptyRequestSchema.parse(JSON.parse(text))
+    } catch (error) {
+      if (error instanceof z.ZodError) throw error
+      throw new ApiError(400, 'Request body must be valid JSON')
+    }
+  }
+  const parsedOperationId = uuidSchema.parse(operationId)
+  const classroomId = uuidSchema.parse(id)
+  await assertStudentPurgeOperationTarget(
+    user.id,
+    parsedOperationId,
+    classroomId,
+    uuidSchema.parse(studentId),
+  )
+  const result = await advanceStudentPurge(user.id, parsedOperationId)
+  return NextResponse.json(result, { status: result.operation.status === 'completed' ? 200 : 202 })
+})

--- a/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/students/[studentId]/purge/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withErrorHandler } from '@/lib/api-handler'
+import { requireRole } from '@/lib/auth'
+import {
+  getActiveStudentPurgeStatus,
+  getStudentPurgeImpact,
+  startStudentPurge,
+} from '@/lib/server/student-purge'
+import { studentPurgeStartRequestSchema } from '@/lib/validations/student-purge'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const maxDuration = 60
+
+const uuidSchema = z.string().uuid()
+
+export const GET = withErrorHandler('GetTeacherStudentPurgeImpact', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id, studentId } = await context.params
+  const classroomId = uuidSchema.parse(id)
+  const parsedStudentId = uuidSchema.parse(studentId)
+  const [impact, operation] = await Promise.all([
+    getStudentPurgeImpact(user.id, classroomId, parsedStudentId),
+    getActiveStudentPurgeStatus(user.id, classroomId, parsedStudentId),
+  ])
+  return NextResponse.json({ impact, operation })
+})
+
+export const POST = withErrorHandler('PostTeacherStudentPurge', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id, studentId } = await context.params
+  const input = studentPurgeStartRequestSchema.parse(await request.json())
+  const operation = await startStudentPurge({
+    teacherId: user.id,
+    classroomId: uuidSchema.parse(id),
+    studentId: uuidSchema.parse(studentId),
+    operationId: input.operation_id,
+    confirmation: input.confirmation,
+    expectedSourceRevision: input.expected_source_revision,
+    expectedStorageInventorySha256: input.expected_storage_inventory_sha256,
+    expectedRelationalInventorySha256: input.expected_relational_inventory_sha256,
+  })
+  return NextResponse.json({ operation }, { status: operation.status === 'completed' ? 200 : 202 })
+})

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
+import { StudentPurgeDialog } from '@/components/StudentPurgeDialog'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import {
   TeacherWorkSurfaceActionCluster,
@@ -109,6 +110,7 @@ export function TeacherRosterTab({ classroom }: Props) {
   const isReadOnly = !!classroom.archived_at
   const [loading, setLoading] = useState(true)
   const [roster, setRoster] = useState<RosterRow[]>([])
+  const [studentPurgeEnabledIds, setStudentPurgeEnabledIds] = useState<Set<string>>(new Set())
   const [error, setError] = useState<string>('')
   const [isUploadModalOpen, setUploadModalOpen] = useState(false)
   const [isAddModalOpen, setAddModalOpen] = useState(false)
@@ -120,6 +122,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     rows: RemovalTarget[]
   } | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
+  const [pendingPurge, setPendingPurge] = useState<RosterRow | null>(null)
   const [selectedRosterId, setSelectedRosterId] = useState<string | null>(null)
   const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const loadRequestIdRef = useRef(0)
@@ -224,11 +227,13 @@ export function TeacherRosterTab({ classroom }: Props) {
       )
       if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setRoster(normalizeRosterRows(data.roster || []))
+      setStudentPurgeEnabledIds(new Set(data.student_purge_enabled_ids || []))
       setLoadedClassroomId(classroomId)
       clearSelection()
     } catch (err: any) {
       if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setRoster([])
+      setStudentPurgeEnabledIds(new Set())
       setLoadedClassroomId(classroomId)
       setError(err.message || 'Failed to load roster')
     } finally {
@@ -241,6 +246,7 @@ export function TeacherRosterTab({ classroom }: Props) {
   useEffect(() => {
     loadRequestIdRef.current += 1
     setRoster([])
+    setStudentPurgeEnabledIds(new Set())
     setLoadedClassroomId(null)
     setError('')
     setPendingRemoval(null)
@@ -248,6 +254,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     setUploadModalOpen(false)
     setAddModalOpen(false)
     setIsRemoving(false)
+    setPendingPurge(null)
     setEditingCounselorId(null)
     setEditingCounselorValue('')
     setIsSavingCounselor(false)
@@ -438,7 +445,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       const row = rows[0]
       return `${formatRemovalTargetName(row)}\n${row.email}\n\n${
         row.joined
-          ? 'They are currently joined. This will delete their classroom data (logs and assignment docs).'
+          ? 'They are currently joined. This removes roster membership, logs, and assignment documents. Use the separate purge action for comprehensive permanent deletion.'
           : 'They are not joined yet.'
       }`
     }
@@ -450,7 +457,7 @@ export function TeacherRosterTab({ classroom }: Props) {
 
     return `${preview}${remaining}\n\n${
       joinedCount > 0
-        ? `${joinedCount} ${joinedCount === 1 ? 'student is' : 'students are'} currently joined. This will delete their classroom data (logs and assignment docs).`
+        ? `${joinedCount} ${joinedCount === 1 ? 'student is' : 'students are'} currently joined. This removes roster membership, logs, and assignment documents; it is not a comprehensive purge.`
         : 'These students are not joined yet.'
     }`
   }
@@ -470,6 +477,23 @@ export function TeacherRosterTab({ classroom }: Props) {
       label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
       onSelect: () => openRemoveStudentDialog(removalTargetRows),
       disabled: isReadOnly || isRosterLoading || isRemoving || removalTargetRows.length === 0,
+      destructive: true,
+    })
+  }
+
+  const purgeTarget = removalTargetRows.length === 1
+    && removalTargetRows[0].joined
+    && removalTargetRows[0].student_id
+    && studentPurgeEnabledIds.has(removalTargetRows[0].student_id)
+    ? removalTargetRows[0]
+    : null
+
+  if (purgeTarget) {
+    rosterActionOptions.push({
+      id: 'purge-student',
+      label: <span className="text-danger">Purge classroom data</span>,
+      onSelect: () => setPendingPurge(purgeTarget),
+      disabled: isRosterLoading,
       destructive: true,
     })
   }
@@ -563,7 +587,7 @@ export function TeacherRosterTab({ classroom }: Props) {
             tooltip="Roster actions"
             icon={<Settings className="h-4 w-4" aria-hidden="true" />}
             items={combinedRosterActionOptions}
-            disabled={isReadOnly || isRosterLoading}
+            disabled={isRosterLoading || combinedRosterActionOptions.every((option) => option.disabled)}
             menuPlacement="down"
             menuAlign="center"
             menuClassName="w-64"
@@ -826,6 +850,22 @@ export function TeacherRosterTab({ classroom }: Props) {
         onCancel={() => (isRemoving ? null : setPendingRemoval(null))}
         onConfirm={confirmRemoveStudent}
       />
+
+      {pendingPurge?.student_id ? (
+        <StudentPurgeDialog
+          classroomId={classroom.id}
+          classroomTitle={classroom.title}
+          studentId={pendingPurge.student_id}
+          studentEmail={pendingPurge.email}
+          studentName={[pendingPurge.first_name, pendingPurge.last_name].filter(Boolean).join(' ') || 'Unnamed student'}
+          isOpen
+          onClose={() => setPendingPurge(null)}
+          onCompleted={() => {
+            setPendingPurge(null)
+            refreshRosterAfterMutation()
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/components/StudentPurgeDialog.tsx
+++ b/src/components/StudentPurgeDialog.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { AlertTriangle, CheckCircle2, FileArchive, UserRound } from 'lucide-react'
+import { Button, ContentDialog, FormField, Input } from '@/ui'
+import { fetchJSON } from '@/lib/request-cache'
+import type { StudentPurgeImpact, StudentPurgeStatus } from '@/lib/validations/student-purge'
+
+type Props = {
+  classroomId: string
+  classroomTitle: string
+  studentId: string
+  studentEmail: string
+  studentName: string
+  isOpen: boolean
+  onClose: () => void
+  onCompleted: () => void
+}
+
+type PurgeResponse = {
+  impact?: StudentPurgeImpact
+  operation?: StudentPurgeStatus | null
+  advanced?: boolean
+  error?: string
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function StudentPurgeDialog({
+  classroomId,
+  classroomTitle,
+  studentId,
+  studentEmail,
+  studentName,
+  isOpen,
+  onClose,
+  onCompleted,
+}: Props) {
+  const mountedRef = useRef(true)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [impact, setImpact] = useState<StudentPurgeImpact | null>(null)
+  const [operation, setOperation] = useState<StudentPurgeStatus | null>(null)
+  const [confirmation, setConfirmation] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isWorking, setIsWorking] = useState(false)
+  const [error, setError] = useState('')
+  const basePath = `/api/teacher/classrooms/${classroomId}/students/${studentId}/purge`
+  const totalFiles = useMemo(
+    () => operation
+      ? Object.values(operation.storage_object_counts).reduce((sum, count) => sum + count, 0)
+      : impact?.managed_file_count || 0,
+    [impact, operation],
+  )
+  const finishedFiles = operation?.storage_object_counts.deleted || 0
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setConfirmation('')
+    setError('')
+    setIsLoading(true)
+    fetchJSON<PurgeResponse>(basePath, {
+      init: { cache: 'no-store' },
+      errorMessage: 'Could not prepare student data deletion',
+    })
+      .then((body) => {
+        if (!body.impact) throw new Error(body.error || 'Could not prepare student data deletion')
+        if (!mountedRef.current) return
+        setImpact(body.impact)
+        setOperation(body.operation || null)
+      })
+      .catch((reason: unknown) => {
+        if (!mountedRef.current) return
+        setError(reason instanceof Error ? reason.message : 'Could not prepare student data deletion')
+      })
+      .finally(() => { if (mountedRef.current) setIsLoading(false) })
+  }, [basePath, isOpen])
+
+  useEffect(() => {
+    if (!operation) return
+    const scrollContainer = contentRef.current?.parentElement
+    if (scrollContainer) scrollContainer.scrollTop = 0
+  }, [error, operation])
+
+  async function runUntilSettled(initial: StudentPurgeStatus) {
+    let current = initial
+    setOperation(current)
+    for (let tick = 0; tick < 10_000 && mountedRef.current; tick += 1) {
+      if (current.status === 'completed') {
+        onCompleted()
+        return
+      }
+      if (current.status === 'failed' && current.retryable === false) {
+        throw new Error('Deletion stopped safely. No relational records were removed.')
+      }
+      const response = await fetch(`${basePath}/${current.operation_id}/tick`, { method: 'POST' })
+      const body = await response.json() as PurgeResponse
+      if (!response.ok || !body.operation) {
+        throw new Error(body.error || 'Deletion paused before it could finish')
+      }
+      current = body.operation
+      if (mountedRef.current) setOperation(current)
+      if (body.advanced === false) {
+        throw new Error('Deletion is waiting safely. Select Continue deletion shortly.')
+      }
+      if ((current.storage_object_counts.failed || 0) > 0) {
+        throw new Error('A storage request failed safely. Progress was saved; select Continue deletion to retry.')
+      }
+    }
+    throw new Error('Deletion is still in progress. Select Continue deletion to resume.')
+  }
+
+  async function startOrContinue() {
+    setIsWorking(true)
+    setError('')
+    try {
+      let current = operation
+      if (!current) {
+        const response = await fetch(basePath, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            operation_id: crypto.randomUUID(),
+            confirmation,
+            expected_source_revision: impact?.source_revision,
+            expected_storage_inventory_sha256: impact?.storage_inventory_sha256,
+            expected_relational_inventory_sha256: impact?.relational_inventory_sha256,
+          }),
+        })
+        const body = await response.json() as PurgeResponse
+        if (!response.ok || !body.operation) throw new Error(body.error || 'Could not start deletion')
+        current = body.operation
+      }
+      await runUntilSettled(current)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Deletion paused')
+    } finally {
+      if (mountedRef.current) setIsWorking(false)
+    }
+  }
+
+  function close() {
+    if (isWorking) return
+    setImpact(null)
+    setOperation(null)
+    setError('')
+    onClose()
+  }
+
+  return (
+    <ContentDialog
+      isOpen={isOpen}
+      onClose={close}
+      title="Purge this student’s classroom data?"
+      subtitle={`${studentName} · ${classroomTitle}`}
+      maxWidth="max-w-xl"
+      showHeaderClose={!isWorking}
+      showFooterClose={false}
+    >
+      {isLoading ? (
+        <div className="py-10 text-center text-sm text-text-muted">Calculating what will be removed…</div>
+      ) : (
+        <div ref={contentRef} className="space-y-5">
+          <div className="rounded-card border border-danger bg-danger-bg p-4">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-danger" aria-hidden="true" />
+              <div>
+                <p className="font-semibold text-danger">This cannot be undone.</p>
+                <p className="mt-1 text-sm text-text-default">
+                  This permanently removes this student’s submissions, tests, grades, attendance,
+                  logs, feedback, roster records, and uploaded files from this classroom.
+                </p>
+                <p className="mt-2 text-sm text-text-muted">
+                  Their user account and data in other classrooms are kept. Retained archive copies
+                  and Gradex extracts for this classroom are also removed because they may contain this data.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {impact ? (
+            <div>
+              <h4 className="text-sm font-semibold text-text-default">Deletion impact</h4>
+              <div className="mt-2 grid grid-cols-3 gap-2">
+                <div className="rounded-control border border-border bg-surface-2 p-2 sm:p-3">
+                  <UserRound className="h-4 w-4 text-text-muted" aria-hidden="true" />
+                  <p className="mt-2 text-lg font-semibold text-text-default">1</p>
+                  <p className="text-xs text-text-muted">student</p>
+                </div>
+                <div className="rounded-control border border-border bg-surface-2 p-2 sm:p-3">
+                  <CheckCircle2 className="h-4 w-4 text-text-muted" aria-hidden="true" />
+                  <p className="mt-2 text-lg font-semibold text-text-default">{impact.relational_row_count}</p>
+                  <p className="text-xs text-text-muted">records</p>
+                </div>
+                <div className="rounded-control border border-border bg-surface-2 p-2 sm:p-3">
+                  <FileArchive className="h-4 w-4 text-text-muted" aria-hidden="true" />
+                  <p className="mt-2 text-lg font-semibold text-text-default">{impact.managed_file_count}</p>
+                  <p className="text-xs text-text-muted">files · {formatBytes(impact.managed_file_bytes)}</p>
+                </div>
+              </div>
+              {(impact.archive_count > 0 || impact.gradex_extract_count > 0) ? (
+                <p className="mt-2 text-xs text-text-muted">
+                  Also removes {impact.archive_count} retained classroom archive{impact.archive_count === 1 ? '' : 's'}
+                  {' '}and {impact.gradex_extract_count} Gradex extract{impact.gradex_extract_count === 1 ? '' : 's'}.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {operation ? (
+            <div className="rounded-card border border-border bg-surface-2 p-4" aria-live="polite">
+              <p className="text-sm font-medium text-text-default">
+                {operation.status === 'completed' ? 'Deletion complete' : `Deleting files ${finishedFiles} of ${totalFiles}…`}
+              </p>
+              <p className="mt-1 text-xs text-text-muted">Progress is saved. Failed requests can be retried safely.</p>
+            </div>
+          ) : (
+            <FormField label={`Type “${studentEmail}” to confirm`} hint="The email address is case-sensitive.">
+              <Input value={confirmation} autoComplete="off" onChange={(event) => setConfirmation(event.target.value)} disabled={isWorking} />
+            </FormField>
+          )}
+
+          {impact?.conflicting_operation ? (
+            <p className="rounded-control border border-warning bg-warning-bg px-3 py-2 text-sm text-text-default">
+              Finish the active classroom operation before purging this student.
+            </p>
+          ) : null}
+          {impact && !impact.deletion_available ? (
+            <p className="rounded-control border border-warning bg-warning-bg px-3 py-2 text-sm text-text-default">
+              {impact.unavailable_reason || 'Student data deletion is not available yet.'}
+            </p>
+          ) : null}
+          {error ? <p className="rounded-control border border-danger bg-danger-bg px-3 py-2 text-sm text-danger" role="alert">{error}</p> : null}
+
+          <div className="flex flex-row justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={close} disabled={isWorking}>Cancel</Button>
+            <Button
+              type="button"
+              variant="danger"
+              onClick={startOrContinue}
+              loading={isWorking}
+              disabled={
+                isLoading
+                || impact?.deletion_available === false
+                || Boolean(impact?.conflicting_operation)
+                || (!operation && confirmation !== studentEmail)
+                || operation?.status === 'completed'
+              }
+            >
+              {operation ? 'Continue deletion' : 'Purge classroom data'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </ContentDialog>
+  )
+}

--- a/src/components/StudentPurgeDialog.tsx
+++ b/src/components/StudentPurgeDialog.tsx
@@ -41,6 +41,7 @@ export function StudentPurgeDialog({
   onCompleted,
 }: Props) {
   const mountedRef = useRef(true)
+  const operationIdRef = useRef<string | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const [impact, setImpact] = useState<StudentPurgeImpact | null>(null)
   const [operation, setOperation] = useState<StudentPurgeStatus | null>(null)
@@ -56,6 +57,7 @@ export function StudentPurgeDialog({
     [impact, operation],
   )
   const finishedFiles = operation?.storage_object_counts.deleted || 0
+  const confirmationEmail = impact?.student_email || studentEmail
 
   useEffect(() => {
     mountedRef.current = true
@@ -95,6 +97,7 @@ export function StudentPurgeDialog({
     setOperation(current)
     for (let tick = 0; tick < 10_000 && mountedRef.current; tick += 1) {
       if (current.status === 'completed') {
+        operationIdRef.current = null
         onCompleted()
         return
       }
@@ -124,11 +127,13 @@ export function StudentPurgeDialog({
     try {
       let current = operation
       if (!current) {
+        const operationId = operationIdRef.current || crypto.randomUUID()
+        operationIdRef.current = operationId
         const response = await fetch(basePath, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            operation_id: crypto.randomUUID(),
+            operation_id: operationId,
             confirmation,
             expected_source_revision: impact?.source_revision,
             expected_storage_inventory_sha256: impact?.storage_inventory_sha256,
@@ -223,7 +228,7 @@ export function StudentPurgeDialog({
               <p className="mt-1 text-xs text-text-muted">Progress is saved. Failed requests can be retried safely.</p>
             </div>
           ) : (
-            <FormField label={`Type “${studentEmail}” to confirm`} hint="The email address is case-sensitive.">
+            <FormField label={`Type “${confirmationEmail}” to confirm`} hint="The email address is case-sensitive.">
               <Input value={confirmation} autoComplete="off" onChange={(event) => setConfirmation(event.target.value)} disabled={isWorking} />
             </FormField>
           )}
@@ -251,7 +256,7 @@ export function StudentPurgeDialog({
                 isLoading
                 || impact?.deletion_available === false
                 || Boolean(impact?.conflicting_operation)
-                || (!operation && confirmation !== studentEmail)
+                || (!operation && confirmation !== confirmationEmail)
                 || operation?.status === 'completed'
               }
             >

--- a/src/lib/contracts/classroom-data.ts
+++ b/src/lib/contracts/classroom-data.ts
@@ -95,6 +95,21 @@ export const CLASSROOM_NON_OWNING_REFERENCES = [
     child_columns: ['classroom_id'],
   },
   {
+    child_table: 'classroom_roster_student_bindings',
+    parent_table: 'classrooms',
+    child_columns: ['classroom_id'],
+  },
+  {
+    child_table: 'classroom_roster_student_bindings',
+    parent_table: 'classroom_roster',
+    child_columns: ['roster_id'],
+  },
+  {
+    child_table: 'student_purge_fences',
+    parent_table: 'classrooms',
+    child_columns: ['classroom_id'],
+  },
+  {
     child_table: 'managed_storage_json_references',
     parent_table: 'assignment_docs',
     child_columns: ['assignment_doc_id'],

--- a/src/lib/server/student-purge.ts
+++ b/src/lib/server/student-purge.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import { ApiError } from '@/lib/api-error'
 import { missingStorageObjectEvidence } from '@/lib/server/storage-object-evidence'
@@ -46,6 +47,7 @@ const operationRowSchema = z.object({
   classroom_id: z.string().uuid(),
   teacher_id: z.string().uuid(),
   student_id: z.string().uuid().nullable(),
+  student_binding_sha256: z.string().regex(/^[a-f0-9]{64}$/),
   status: z.enum(['inventorying', 'deleting_objects', 'finalizing', 'completed', 'failed']),
   retryable: z.boolean().nullable(),
   error_code: z.string().nullable(),
@@ -182,7 +184,7 @@ async function readOperation(teacherId: string, operationId: string): Promise<z.
     maybeSingle(): PromiseLike<QueryResponse>
   }
   const query = db().from('student_purge_operations').select(
-    'id,classroom_id,teacher_id,student_id,status,retryable,error_code,resource_counts,attempt_count,completed_at',
+    'id,classroom_id,teacher_id,student_id,student_binding_sha256,status,retryable,error_code,resource_counts,attempt_count,completed_at',
   ) as unknown as Query
   const response = await query.eq('id', operationId).eq('teacher_id', teacherId).maybeSingle()
   if (response.error) {
@@ -236,7 +238,12 @@ export async function assertStudentPurgeOperationTarget(
   studentId: string,
 ): Promise<void> {
   const row = await readOperation(teacherId, operationId)
-  if (row.classroom_id !== classroomId || row.student_id !== studentId) {
+  const expectedBinding = createHash('sha256').update(`${operationId}:${studentId}`).digest('hex')
+  if (
+    row.classroom_id !== classroomId
+    || row.student_binding_sha256 !== expectedBinding
+    || (row.student_id !== null && row.student_id !== studentId)
+  ) {
     throw new StudentPurgeError('student_purge_not_found', 'Student data deletion not found', 404)
   }
 }

--- a/src/lib/server/student-purge.ts
+++ b/src/lib/server/student-purge.ts
@@ -1,0 +1,439 @@
+import { z } from 'zod'
+import { ApiError } from '@/lib/api-error'
+import { missingStorageObjectEvidence } from '@/lib/server/storage-object-evidence'
+import { getServiceRoleClient } from '@/lib/supabase'
+import {
+  studentPurgeImpactSchema,
+  studentPurgeStatusSchema,
+  type StudentPurgeImpact,
+  type StudentPurgeStatus,
+} from '@/lib/validations/student-purge'
+
+const rpcResultSchema = z.object({
+  ok: z.boolean(),
+  status: z.number().int(),
+  operation_id: z.string().uuid().optional(),
+  error_code: z.string().optional(),
+  error: z.string().optional(),
+  retryable: z.boolean().optional(),
+}).passthrough()
+
+const inventorySchema = z.object({
+  ok: z.boolean(),
+  status: z.number().int(),
+  error_code: z.string().optional(),
+  error: z.string().optional(),
+  classroom_id: z.string().uuid().optional(),
+  classroom_title: z.string().min(1).optional(),
+  student_id: z.string().uuid().optional(),
+  student_email: z.string().email().optional(),
+  source_revision: z.number().int().positive().optional(),
+  storage_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  relational_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  managed_file_count: z.number().int().nonnegative().optional(),
+  managed_file_bytes: z.number().int().nonnegative().optional(),
+  archive_count: z.number().int().nonnegative().optional(),
+  gradex_extract_count: z.number().int().nonnegative().optional(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()).optional(),
+  storage_counts: z.record(z.string(), z.number().int().nonnegative()).optional(),
+  conflicting_operation: z.string().nullable().optional(),
+  deletion_available: z.boolean().optional(),
+  unavailable_reason: z.string().nullable().optional(),
+}).passthrough()
+
+const operationRowSchema = z.object({
+  id: z.string().uuid(),
+  classroom_id: z.string().uuid(),
+  teacher_id: z.string().uuid(),
+  student_id: z.string().uuid().nullable(),
+  status: z.enum(['inventorying', 'deleting_objects', 'finalizing', 'completed', 'failed']),
+  retryable: z.boolean().nullable(),
+  error_code: z.string().nullable(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+  attempt_count: z.number().int().positive(),
+  completed_at: z.string().nullable(),
+}).strict()
+
+const purgeObjectSchema = z.object({
+  id: z.string().uuid(),
+  operation_id: z.string().uuid(),
+  storage_bucket: z.enum([
+    'assignment-artifacts',
+    'submission-images',
+    'test-documents',
+    'classroom-archives',
+    'gradex-analytics-extracts',
+  ]),
+  storage_path: z.string().min(1),
+  lease_token: z.string().uuid(),
+}).passthrough()
+
+const healthSchema = z.object({
+  captured_at: z.string().datetime({ offset: true }),
+  active_count: z.number().int().nonnegative(),
+  stuck_count: z.number().int().nonnegative(),
+  failed_count: z.number().int().nonnegative(),
+  orphan_fence_count: z.number().int().nonnegative(),
+  processing_lease_drift_count: z.number().int().nonnegative(),
+}).strict()
+
+type RpcError = { code?: string; message?: string }
+type QueryResponse = { data: unknown; error: RpcError | null }
+type UntypedClient = {
+  rpc(name: string, args: Record<string, unknown>): PromiseLike<QueryResponse>
+  from(table: string): {
+    select(columns: string): unknown
+  }
+}
+type PurgeStorageAdapter = {
+  from(bucket: string): {
+    remove(paths: string[]): PromiseLike<{ error: unknown }>
+  }
+}
+
+export class StudentPurgeError extends ApiError {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number,
+    public readonly retryable = false,
+  ) {
+    super(status, message)
+    this.name = 'StudentPurgeError'
+  }
+}
+
+function db(): UntypedClient {
+  return getServiceRoleClient() as unknown as UntypedClient
+}
+
+async function rpc(name: string, args: Record<string, unknown>): Promise<unknown> {
+  const { data, error } = await db().rpc(name, args)
+  if (error) {
+    throw new StudentPurgeError(
+      error.code || 'student_purge_rpc_failed',
+      error.message || 'Student data deletion failed',
+      error.code === 'P0002' ? 404 : 500,
+      true,
+    )
+  }
+  return data
+}
+
+function parseResult(value: unknown) {
+  const result = rpcResultSchema.parse(value)
+  if (!result.ok) {
+    throw new StudentPurgeError(
+      result.error_code || 'student_purge_failed',
+      result.error || 'Student data deletion could not continue',
+      result.status,
+      result.retryable || false,
+    )
+  }
+  return result
+}
+
+export function isMissingStudentPurgeSchemaError(error: RpcError | null): boolean {
+  return error?.code === 'PGRST205' || error?.code === '42P01' || error?.code === 'PGRST202'
+}
+
+export async function getStudentPurgeImpact(
+  teacherId: string,
+  classroomId: string,
+  studentId: string,
+): Promise<StudentPurgeImpact> {
+  const raw = inventorySchema.parse(await rpc('get_student_purge_inventory', {
+    p_teacher_id: teacherId,
+    p_classroom_id: classroomId,
+    p_student_id: studentId,
+  }))
+  if (!raw.ok) {
+    throw new StudentPurgeError(
+      raw.error_code || 'student_purge_inventory_failed',
+      raw.error || 'Could not prepare student data deletion',
+      raw.status,
+    )
+  }
+  const resourceCounts = raw.resource_counts || {}
+  return studentPurgeImpactSchema.parse({
+    classroom_id: raw.classroom_id,
+    classroom_title: raw.classroom_title,
+    student_id: raw.student_id,
+    student_email: raw.student_email,
+    source_revision: raw.source_revision,
+    storage_inventory_sha256: raw.storage_inventory_sha256,
+    relational_inventory_sha256: raw.relational_inventory_sha256,
+    relational_row_count: Object.values(resourceCounts).reduce((sum, count) => sum + count, 0),
+    managed_file_count: raw.managed_file_count,
+    managed_file_bytes: raw.managed_file_bytes,
+    archive_count: raw.archive_count,
+    gradex_extract_count: raw.gradex_extract_count,
+    resource_counts: resourceCounts,
+    storage_counts: raw.storage_counts || {},
+    conflicting_operation: raw.conflicting_operation || null,
+    deletion_available: raw.deletion_available,
+    unavailable_reason: raw.unavailable_reason || null,
+  })
+}
+
+async function readOperation(teacherId: string, operationId: string): Promise<z.infer<typeof operationRowSchema>> {
+  type Query = {
+    eq(column: string, value: string): Query
+    maybeSingle(): PromiseLike<QueryResponse>
+  }
+  const query = db().from('student_purge_operations').select(
+    'id,classroom_id,teacher_id,student_id,status,retryable,error_code,resource_counts,attempt_count,completed_at',
+  ) as unknown as Query
+  const response = await query.eq('id', operationId).eq('teacher_id', teacherId).maybeSingle()
+  if (response.error) {
+    throw new StudentPurgeError(response.error.code || 'student_purge_read_failed', 'Could not read deletion progress', 500, true)
+  }
+  if (!response.data) throw new StudentPurgeError('student_purge_not_found', 'Student data deletion not found', 404)
+  return operationRowSchema.parse(response.data)
+}
+
+async function countObjects(operationId: string) {
+  type Query = {
+    eq(column: string, value: string): Query
+  } & PromiseLike<QueryResponse>
+  const query = db().from('student_purge_objects').select('status') as unknown as Query
+  const response = await query.eq('operation_id', operationId)
+  if (response.error) {
+    throw new StudentPurgeError(response.error.code || 'student_purge_objects_read_failed', 'Could not read deletion progress', 500, true)
+  }
+  const counts: Record<string, number> = {}
+  for (const row of z.array(z.object({ status: z.string() })).parse(response.data || [])) {
+    counts[row.status] = (counts[row.status] || 0) + 1
+  }
+  return counts
+}
+
+export async function getStudentPurgeStatus(
+  teacherId: string,
+  operationId: string,
+): Promise<StudentPurgeStatus> {
+  const [row, objectCounts] = await Promise.all([
+    readOperation(teacherId, operationId),
+    countObjects(operationId),
+  ])
+  return studentPurgeStatusSchema.parse({
+    operation_id: row.id,
+    classroom_id: row.classroom_id,
+    status: row.status,
+    retryable: row.retryable,
+    error_code: row.error_code,
+    attempt_count: row.attempt_count,
+    resource_counts: row.resource_counts,
+    storage_object_counts: objectCounts,
+    completed_at: row.completed_at,
+  })
+}
+
+export async function assertStudentPurgeOperationTarget(
+  teacherId: string,
+  operationId: string,
+  classroomId: string,
+  studentId: string,
+): Promise<void> {
+  const row = await readOperation(teacherId, operationId)
+  if (row.classroom_id !== classroomId || row.student_id !== studentId) {
+    throw new StudentPurgeError('student_purge_not_found', 'Student data deletion not found', 404)
+  }
+}
+
+export async function getActiveStudentPurgeStatus(
+  teacherId: string,
+  classroomId: string,
+  studentId: string,
+): Promise<StudentPurgeStatus | null> {
+  type Query = {
+    eq(column: string, value: string): Query
+    in(column: string, values: string[]): Query
+    order(column: string, options: { ascending: boolean }): Query
+    limit(count: number): Query
+    maybeSingle(): PromiseLike<QueryResponse>
+  }
+  const query = db().from('student_purge_operations').select('id') as unknown as Query
+  const response = await query
+    .eq('teacher_id', teacherId)
+    .eq('classroom_id', classroomId)
+    .eq('student_id', studentId)
+    .in('status', ['inventorying', 'deleting_objects', 'finalizing', 'failed'])
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (response.error) {
+    if (isMissingStudentPurgeSchemaError(response.error)) return null
+    throw new StudentPurgeError(response.error.code || 'student_purge_read_failed', 'Could not read deletion progress', 500, true)
+  }
+  const id = z.object({ id: z.string().uuid() }).nullable().parse(response.data)?.id
+  return id ? getStudentPurgeStatus(teacherId, id) : null
+}
+
+export async function startStudentPurge(input: {
+  teacherId: string
+  classroomId: string
+  studentId: string
+  operationId: string
+  confirmation: string
+  expectedSourceRevision: number
+  expectedStorageInventorySha256: string
+  expectedRelationalInventorySha256: string
+}): Promise<StudentPurgeStatus> {
+  parseResult(await rpc('begin_student_purge', {
+    p_operation_id: input.operationId,
+    p_teacher_id: input.teacherId,
+    p_classroom_id: input.classroomId,
+    p_student_id: input.studentId,
+    p_confirmation: input.confirmation,
+    p_expected_source_revision: input.expectedSourceRevision,
+    p_expected_storage_inventory_sha256: input.expectedStorageInventorySha256,
+    p_expected_relational_inventory_sha256: input.expectedRelationalInventorySha256,
+  }))
+  return getStudentPurgeStatus(input.teacherId, input.operationId)
+}
+
+export async function deleteStudentPurgeStorageObject(
+  storage: PurgeStorageAdapter,
+  bucket: z.infer<typeof purgeObjectSchema>['storage_bucket'],
+  path: string,
+): Promise<void> {
+  const removal = await storage.from(bucket).remove([path])
+  if (removal.error && !missingStorageObjectEvidence(removal.error)) throw removal.error
+}
+
+export async function advanceStudentPurge(teacherId: string, operationId: string) {
+  const before = await getStudentPurgeStatus(teacherId, operationId)
+  if (before.status === 'completed' || (before.status === 'failed' && before.retryable === false)) {
+    return { operation: before, advanced: false }
+  }
+
+  const claim = parseResult(await rpc('claim_student_purge_object', {
+    p_operation_id: operationId,
+    p_teacher_id: teacherId,
+  }))
+  if (claim.waiting_for_storage === true) {
+    return { operation: await getStudentPurgeStatus(teacherId, operationId), advanced: false }
+  }
+  if (!claim.object) {
+    parseResult(await rpc('finalize_student_purge', {
+      p_operation_id: operationId,
+      p_teacher_id: teacherId,
+    }))
+    return { operation: await getStudentPurgeStatus(teacherId, operationId), advanced: true }
+  }
+
+  const object = purgeObjectSchema.parse(claim.object)
+  const supabase = getServiceRoleClient()
+  try {
+    await deleteStudentPurgeStorageObject(supabase.storage, object.storage_bucket, object.storage_path)
+    parseResult(await rpc('complete_student_purge_object', {
+      p_operation_id: operationId,
+      p_teacher_id: teacherId,
+      p_object_id: object.id,
+      p_lease_token: object.lease_token,
+    }))
+  } catch (error) {
+    parseResult(await rpc('fail_student_purge_object', {
+      p_operation_id: operationId,
+      p_teacher_id: teacherId,
+      p_object_id: object.id,
+      p_lease_token: object.lease_token,
+      p_error_code: error instanceof Error ? error.message : 'storage_delete_failed',
+    }))
+  }
+  return { operation: await getStudentPurgeStatus(teacherId, operationId), advanced: true }
+}
+
+export async function getStudentPurgeEnabledStudentIds(
+  teacherId: string,
+  classroomId: string,
+  studentIds: string[],
+): Promise<string[]> {
+  if (studentIds.length === 0) return []
+  type Query = { maybeSingle(): PromiseLike<QueryResponse> }
+  const response = await (db().from('student_purge_settings').select(
+    'rollout_mode,canary_teacher_id,canary_classroom_id,canary_student_id',
+  ) as unknown as Query).maybeSingle()
+  if (response.error) {
+    if (isMissingStudentPurgeSchemaError(response.error)) return []
+    throw new StudentPurgeError(response.error.code || 'student_purge_settings_failed', 'Could not read deletion availability', 500, true)
+  }
+  const settings = z.object({
+    rollout_mode: z.enum(['disabled', 'canary', 'enabled']),
+    canary_teacher_id: z.string().uuid().nullable(),
+    canary_classroom_id: z.string().uuid().nullable(),
+    canary_student_id: z.string().uuid().nullable(),
+  }).nullable().parse(response.data)
+  if (!settings || settings.rollout_mode === 'disabled') return []
+  if (settings.rollout_mode === 'enabled') return studentIds
+  return settings.canary_teacher_id === teacherId
+    && settings.canary_classroom_id === classroomId
+    && settings.canary_student_id
+    && studentIds.includes(settings.canary_student_id)
+    ? [settings.canary_student_id]
+    : []
+}
+
+export function shouldRequeueStudentPurgeSafetyNet(status: StudentPurgeStatus, advanced: boolean) {
+  return advanced
+    && status.status !== 'completed'
+    && (status.storage_object_counts.failed || 0) === 0
+    && (status.status !== 'failed' || status.retryable !== false)
+}
+
+export async function runStudentPurgeSafetyNet(maxTicks = 25) {
+  type Query = {
+    in(column: string, values: string[]): Query
+    or(filters: string): Query
+    order(column: string, options: { ascending: boolean }): Query
+    limit(count: number): PromiseLike<QueryResponse>
+  }
+  const response = await (db().from('student_purge_operations').select(
+    'id,teacher_id,status,retryable',
+  ) as unknown as Query)
+    .in('status', ['deleting_objects', 'finalizing', 'failed'])
+    .or('status.neq.failed,retryable.eq.true,retryable.is.null')
+    .order('updated_at', { ascending: true })
+    .limit(maxTicks)
+  if (response.error) {
+    if (isMissingStudentPurgeSchemaError(response.error)) return { processed: 0, completed: 0, failed: 0 }
+    throw new StudentPurgeError(response.error.code || 'student_purge_safety_net_failed', 'Could not resume student data deletions', 500, true)
+  }
+  const pending = z.array(z.object({
+    id: z.string().uuid(),
+    teacher_id: z.string().uuid(),
+    status: z.enum(['deleting_objects', 'finalizing', 'failed']),
+    retryable: z.boolean().nullable(),
+  }).strict()).parse(response.data || [])
+  let processed = 0
+  let completed = 0
+  let failed = 0
+  while (pending.length > 0 && processed < maxTicks) {
+    const row = pending.shift()
+    if (!row) break
+    try {
+      const result = await advanceStudentPurge(row.teacher_id, row.id)
+      processed += 1
+      if (result.operation.status === 'completed') completed += 1
+      else if ((result.operation.storage_object_counts.failed || 0) > 0) failed += 1
+      else if (shouldRequeueStudentPurgeSafetyNet(result.operation, result.advanced)) pending.push(row)
+    } catch {
+      processed += 1
+      failed += 1
+    }
+  }
+  return { processed, completed, failed }
+}
+
+export async function readStudentPurgeHealth() {
+  try {
+    const snapshot = healthSchema.parse(await rpc('get_student_purge_health_snapshot', {}))
+    return { schemaAvailable: true as const, snapshot }
+  } catch (error) {
+    if (error instanceof StudentPurgeError && isMissingStudentPurgeSchemaError({ code: error.code })) {
+      return { schemaAvailable: false as const, snapshot: null }
+    }
+    throw error
+  }
+}

--- a/src/lib/validations/student-purge.ts
+++ b/src/lib/validations/student-purge.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+export const studentPurgeOperationStatusSchema = z.enum([
+  'inventorying',
+  'deleting_objects',
+  'finalizing',
+  'completed',
+  'failed',
+])
+
+export const studentPurgeImpactSchema = z.object({
+  classroom_id: z.string().uuid(),
+  classroom_title: z.string().min(1),
+  student_id: z.string().uuid(),
+  student_email: z.string().email(),
+  source_revision: z.number().int().positive(),
+  storage_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  relational_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  relational_row_count: z.number().int().nonnegative(),
+  managed_file_count: z.number().int().nonnegative(),
+  managed_file_bytes: z.number().int().nonnegative(),
+  archive_count: z.number().int().nonnegative(),
+  gradex_extract_count: z.number().int().nonnegative(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+  storage_counts: z.record(z.string(), z.number().int().nonnegative()),
+  conflicting_operation: z.string().min(1).nullable(),
+  deletion_available: z.boolean(),
+  unavailable_reason: z.string().min(1).nullable(),
+}).strict()
+
+export const studentPurgeStartRequestSchema = z.object({
+  operation_id: z.string().uuid(),
+  confirmation: z.string().trim().min(1).max(320),
+  expected_source_revision: z.number().int().positive(),
+  expected_storage_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  expected_relational_inventory_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+}).strict()
+
+export const studentPurgeStatusSchema = z.object({
+  operation_id: z.string().uuid(),
+  classroom_id: z.string().uuid(),
+  status: studentPurgeOperationStatusSchema,
+  retryable: z.boolean().nullable(),
+  error_code: z.string().nullable(),
+  attempt_count: z.number().int().positive(),
+  resource_counts: z.record(z.string(), z.number().int().nonnegative()),
+  storage_object_counts: z.record(z.string(), z.number().int().nonnegative()),
+  completed_at: z.string().datetime({ offset: true }).nullable(),
+}).strict()
+
+export type StudentPurgeImpact = z.infer<typeof studentPurgeImpactSchema>
+export type StudentPurgeStatus = z.infer<typeof studentPurgeStatusSchema>

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2519,7 +2519,6 @@ export type Database = {
           id: string
           join_source: string
           last_name: string | null
-          student_id: string | null
           student_number: string | null
           updated_at: string
         }
@@ -2532,7 +2531,6 @@ export type Database = {
           id?: string
           join_source?: string
           last_name?: string | null
-          student_id?: string | null
           student_number?: string | null
           updated_at?: string
         }
@@ -2545,7 +2543,6 @@ export type Database = {
           id?: string
           join_source?: string
           last_name?: string | null
-          student_id?: string | null
           student_number?: string | null
           updated_at?: string
         }
@@ -2557,8 +2554,44 @@ export type Database = {
             referencedRelation: "classrooms"
             referencedColumns: ["id"]
           },
+        ]
+      }
+      classroom_roster_student_bindings: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          roster_id: string
+          student_id: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          roster_id: string
+          student_id: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          roster_id?: string
+          student_id?: string
+        }
+        Relationships: [
           {
-            foreignKeyName: "classroom_roster_student_id_fkey"
+            foreignKeyName: "classroom_roster_student_bindings_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_roster_student_bindings_roster_id_fkey"
+            columns: ["roster_id"]
+            isOneToOne: true
+            referencedRelation: "classroom_roster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_roster_student_bindings_student_id_fkey"
             columns: ["student_id"]
             isOneToOne: false
             referencedRelation: "users"
@@ -4604,6 +4637,41 @@ export type Database = {
           },
         ]
       }
+      student_profiles: {
+        Row: {
+          created_at: string
+          first_name: string
+          id: string
+          last_name: string
+          student_number: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          first_name: string
+          id?: string
+          last_name: string
+          student_number?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          first_name?: string
+          id?: string
+          last_name?: string
+          student_number?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_profiles_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       student_purge_fences: {
         Row: {
           classroom_id: string
@@ -4742,6 +4810,7 @@ export type Database = {
           started_at: string
           status: string
           storage_object_counts: Json
+          student_binding_sha256: string
           student_email: string | null
           student_id: string | null
           teacher_id: string
@@ -4762,6 +4831,7 @@ export type Database = {
           started_at?: string
           status?: string
           storage_object_counts?: Json
+          student_binding_sha256: string
           student_email?: string | null
           student_id?: string | null
           teacher_id: string
@@ -4782,6 +4852,7 @@ export type Database = {
           started_at?: string
           status?: string
           storage_object_counts?: Json
+          student_binding_sha256?: string
           student_email?: string | null
           student_id?: string | null
           teacher_id?: string
@@ -4870,41 +4941,6 @@ export type Database = {
             foreignKeyName: "student_purge_settings_canary_teacher_id_fkey"
             columns: ["canary_teacher_id"]
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      student_profiles: {
-        Row: {
-          created_at: string
-          first_name: string
-          id: string
-          last_name: string
-          student_number: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          first_name: string
-          id?: string
-          last_name: string
-          student_number?: string | null
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          first_name?: string
-          id?: string
-          last_name?: string
-          student_number?: string | null
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "student_profiles_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
             referencedRelation: "users"
             referencedColumns: ["id"]
           },

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2519,6 +2519,7 @@ export type Database = {
           id: string
           join_source: string
           last_name: string | null
+          student_id: string | null
           student_number: string | null
           updated_at: string
         }
@@ -2531,6 +2532,7 @@ export type Database = {
           id?: string
           join_source?: string
           last_name?: string | null
+          student_id?: string | null
           student_number?: string | null
           updated_at?: string
         }
@@ -2543,6 +2545,7 @@ export type Database = {
           id?: string
           join_source?: string
           last_name?: string | null
+          student_id?: string | null
           student_number?: string | null
           updated_at?: string
         }
@@ -2552,6 +2555,13 @@ export type Database = {
             columns: ["classroom_id"]
             isOneToOne: false
             referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "classroom_roster_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
         ]
@@ -4594,6 +4604,277 @@ export type Database = {
           },
         ]
       }
+      student_purge_fences: {
+        Row: {
+          classroom_id: string
+          created_at: string
+          operation_id: string
+          student_id: string
+          teacher_id: string
+        }
+        Insert: {
+          classroom_id: string
+          created_at?: string
+          operation_id: string
+          student_id: string
+          teacher_id: string
+        }
+        Update: {
+          classroom_id?: string
+          created_at?: string
+          operation_id?: string
+          student_id?: string
+          teacher_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_purge_fences_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_fences_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: true
+            referencedRelation: "student_purge_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_fences_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_fences_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_purge_objects: {
+        Row: {
+          attempt_count: number
+          created_at: string
+          deleted_at: string | null
+          id: string
+          last_error_code: string | null
+          lease_expires_at: string | null
+          lease_token: string | null
+          managed_storage_object_id: string | null
+          next_attempt_at: string
+          operation_id: string
+          status: string
+          storage_bucket: string
+          storage_path: string | null
+          storage_path_sha256: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          managed_storage_object_id?: string | null
+          next_attempt_at?: string
+          operation_id: string
+          status?: string
+          storage_bucket: string
+          storage_path?: string | null
+          storage_path_sha256: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          last_error_code?: string | null
+          lease_expires_at?: string | null
+          lease_token?: string | null
+          managed_storage_object_id?: string | null
+          next_attempt_at?: string
+          operation_id?: string
+          status?: string
+          storage_bucket?: string
+          storage_path?: string | null
+          storage_path_sha256?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_purge_objects_managed_storage_object_id_fkey"
+            columns: ["managed_storage_object_id"]
+            isOneToOne: false
+            referencedRelation: "managed_storage_objects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_objects_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "student_purge_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_purge_operations: {
+        Row: {
+          attempt_count: number
+          classroom_id: string
+          completed_at: string | null
+          error_code: string | null
+          id: string
+          impact_summary: Json
+          inventory_completed_at: string | null
+          request_sha256: string
+          resource_counts: Json
+          retryable: boolean | null
+          source_revision: number
+          started_at: string
+          status: string
+          storage_object_counts: Json
+          student_email: string | null
+          student_id: string | null
+          teacher_id: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          classroom_id: string
+          completed_at?: string | null
+          error_code?: string | null
+          id: string
+          impact_summary?: Json
+          inventory_completed_at?: string | null
+          request_sha256: string
+          resource_counts?: Json
+          retryable?: boolean | null
+          source_revision: number
+          started_at?: string
+          status?: string
+          storage_object_counts?: Json
+          student_email?: string | null
+          student_id?: string | null
+          teacher_id: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          classroom_id?: string
+          completed_at?: string | null
+          error_code?: string | null
+          id?: string
+          impact_summary?: Json
+          inventory_completed_at?: string | null
+          request_sha256?: string
+          resource_counts?: Json
+          retryable?: boolean | null
+          source_revision?: number
+          started_at?: string
+          status?: string
+          storage_object_counts?: Json
+          student_email?: string | null
+          student_id?: string | null
+          teacher_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_purge_operations_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_operations_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_purge_resources: {
+        Row: {
+          disposition: string
+          operation_id: string
+          row_id: string
+          table_name: string
+        }
+        Insert: {
+          disposition: string
+          operation_id: string
+          row_id: string
+          table_name: string
+        }
+        Update: {
+          disposition?: string
+          operation_id?: string
+          row_id?: string
+          table_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_purge_resources_operation_id_fkey"
+            columns: ["operation_id"]
+            isOneToOne: false
+            referencedRelation: "student_purge_operations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_purge_settings: {
+        Row: {
+          canary_classroom_id: string | null
+          canary_student_id: string | null
+          canary_teacher_id: string | null
+          rollout_mode: string
+          singleton: boolean
+          updated_at: string
+        }
+        Insert: {
+          canary_classroom_id?: string | null
+          canary_student_id?: string | null
+          canary_teacher_id?: string | null
+          rollout_mode?: string
+          singleton?: boolean
+          updated_at?: string
+        }
+        Update: {
+          canary_classroom_id?: string | null
+          canary_student_id?: string | null
+          canary_teacher_id?: string | null
+          rollout_mode?: string
+          singleton?: boolean
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_purge_settings_canary_student_id_fkey"
+            columns: ["canary_student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_purge_settings_canary_teacher_id_fkey"
+            columns: ["canary_teacher_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       student_profiles: {
         Row: {
           created_at: string
@@ -5992,6 +6273,19 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      begin_student_purge: {
+        Args: {
+          p_classroom_id: string
+          p_confirmation: string
+          p_expected_relational_inventory_sha256: string
+          p_expected_source_revision: number
+          p_expected_storage_inventory_sha256: string
+          p_operation_id: string
+          p_student_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
       bind_classroom_archive_restore_managed_object: {
         Args: {
           p_managed_object_id: string
@@ -6364,6 +6658,14 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      claim_student_purge_object: {
+        Args: {
+          p_lease_seconds?: number
+          p_operation_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
       claim_test_ai_grading_run: {
         Args: {
           p_lease_seconds?: number
@@ -6666,6 +6968,15 @@ export type Database = {
       complete_pal_event_outbox: {
         Args: { p_lease_token: string; p_outbox_id: string }
         Returns: boolean
+      }
+      complete_student_purge_object: {
+        Args: {
+          p_lease_token: string
+          p_object_id: string
+          p_operation_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
       }
       complete_test_document_snapshot_storage_cleanup: {
         Args: { p_cleanup_id: string; p_lease_token: string }
@@ -7080,6 +7391,16 @@ export type Database = {
         }
         Returns: boolean
       }
+      fail_student_purge_object: {
+        Args: {
+          p_error_code: string
+          p_lease_token: string
+          p_object_id: string
+          p_operation_id: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
       fail_test_document_snapshot_storage_cleanup: {
         Args: { p_cleanup_id: string; p_error: string; p_lease_token: string }
         Returns: boolean
@@ -7138,6 +7459,10 @@ export type Database = {
         Returns: Json
       }
       finalize_hot_archived_classroom_purge_v118: {
+        Args: { p_operation_id: string; p_teacher_id: string }
+        Returns: Json
+      }
+      finalize_student_purge: {
         Args: { p_operation_id: string; p_teacher_id: string }
         Returns: Json
       }
@@ -7211,6 +7536,18 @@ export type Database = {
       }
       get_managed_storage_object_presence: {
         Args: { p_storage_bucket: string; p_storage_path: string }
+        Returns: Json
+      }
+      get_student_purge_health_snapshot: {
+        Args: { p_failed_minutes?: number; p_stuck_minutes?: number }
+        Returns: Json
+      }
+      get_student_purge_inventory: {
+        Args: {
+          p_classroom_id: string
+          p_student_id: string
+          p_teacher_id: string
+        }
         Returns: Json
       }
       get_teacher_log_history_preview: {
@@ -7915,6 +8252,30 @@ export type Database = {
       stage_classroom_purge_objects: {
         Args: { p_objects: Json; p_operation_id: string; p_teacher_id: string }
         Returns: Json
+      }
+      student_purge_conflict: {
+        Args: { p_classroom_id: string; p_student_id: string }
+        Returns: string
+      }
+      student_purge_inventory_resources: {
+        Args: { p_classroom_id: string; p_student_id: string }
+        Returns: {
+          disposition: string
+          row_id: string
+          table_name: string
+        }[]
+      }
+      student_purge_lock: {
+        Args: { p_classroom_id: string; p_student_id: string }
+        Returns: undefined
+      }
+      student_purge_rollout_allows: {
+        Args: {
+          p_classroom_id: string
+          p_student_id: string
+          p_teacher_id: string
+        }
+        Returns: boolean
       }
       submit_assignment_doc_atomic: {
         Args: {

--- a/supabase/migrations/123_hot_classroom_individual_student_purge.sql
+++ b/supabase/migrations/123_hot_classroom_individual_student_purge.sql
@@ -875,14 +875,6 @@ begin
   if current_setting('pika.student_purge_finalize', true) = 'on' then
     return case when tg_op = 'DELETE' then old else new end;
   end if;
-  if tg_table_name = 'managed_storage_objects' and tg_op <> 'DELETE'
-    and new.storage_path is not null and exists (
-      select 1 from public.student_purge_objects purge_object
-      where purge_object.storage_bucket = new.storage_bucket
-        and purge_object.storage_path_sha256 =
-          public.managed_storage_identity_sha256(new.storage_bucket, new.storage_path)
-    )
-  then raise exception using errcode = '55000', message = 'student_purge_path_reserved'; end if;
   foreach v_row in array v_rows loop
     v_classroom_id := null;
     v_student_id := nullif(coalesce(v_row->>'student_id', v_row->>'user_id'), '')::uuid;
@@ -903,6 +895,12 @@ begin
         order by enrollment.created_at, enrollment.id limit 1;
       end if;
     elsif tg_table_name = 'managed_storage_objects' then
+      if tg_op <> 'DELETE' and nullif(v_row->>'storage_path', '') is not null and exists (
+        select 1 from public.student_purge_objects purge_object
+        where purge_object.storage_bucket = v_row->>'storage_bucket'
+          and purge_object.storage_path_sha256 = public.managed_storage_identity_sha256(
+            v_row->>'storage_bucket', v_row->>'storage_path')
+      ) then raise exception using errcode = '55000', message = 'student_purge_path_reserved'; end if;
       v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
       if v_classroom_id is null then
         select target_classroom_id into v_classroom_id from public.managed_storage_provisional_owners

--- a/supabase/migrations/123_hot_classroom_individual_student_purge.sql
+++ b/supabase/migrations/123_hot_classroom_individual_student_purge.sql
@@ -782,6 +782,9 @@ begin
     where id = p_operation_id;
     delete from public.student_purge_resources where operation_id = p_operation_id;
     delete from public.student_purge_fences where operation_id = p_operation_id;
+    -- Do not leak the trigger bypass to later statements when a service caller
+    -- invokes finalization inside a larger transaction.
+    perform set_config('pika.student_purge_finalize', 'off', true);
     return jsonb_build_object('ok', true, 'status', 200, 'operation_id', p_operation_id,
       'operation_status', 'completed');
   exception when others then

--- a/supabase/migrations/123_hot_classroom_individual_student_purge.sql
+++ b/supabase/migrations/123_hot_classroom_individual_student_purge.sql
@@ -2,20 +2,27 @@
 -- Classroom. This scope deliberately preserves the user and every other
 -- Classroom. Rollout starts disabled. Pal/remote-Gradex targets fail closed.
 
-alter table public.classroom_roster
-  add column student_id uuid references public.users (id) on delete set null;
+-- Stable joined-student lineage is operational derived state, not part of the
+-- immutable Classroom archive format. Keeping it outside classroom_roster
+-- avoids silently changing the v2 archive/restore row contract.
+create table public.classroom_roster_student_bindings (
+  roster_id uuid primary key references public.classroom_roster (id) on delete cascade,
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  created_at timestamptz not null default clock_timestamp(),
+  unique (roster_id, classroom_id, student_id)
+);
 
-update public.classroom_roster roster
-set student_id = enrollment.student_id
-from public.classroom_enrollments enrollment
+create index classroom_roster_student_bindings_classroom_student
+  on public.classroom_roster_student_bindings (classroom_id, student_id);
+
+insert into public.classroom_roster_student_bindings (roster_id, classroom_id, student_id)
+select roster.id, roster.classroom_id, enrollment.student_id
+from public.classroom_roster roster
+join public.classroom_enrollments enrollment on enrollment.classroom_id = roster.classroom_id
 join public.users student on student.id = enrollment.student_id and student.role = 'student'
-where enrollment.classroom_id = roster.classroom_id
-  and lower(btrim(student.email)) = lower(btrim(roster.email))
-  and roster.student_id is null;
-
-create unique index classroom_roster_classroom_student
-  on public.classroom_roster (classroom_id, student_id)
-  where student_id is not null;
+where lower(btrim(student.email)) = lower(btrim(roster.email))
+on conflict (roster_id) do nothing;
 
 create table public.student_purge_settings (
   singleton boolean primary key default true check (singleton),
@@ -41,6 +48,7 @@ create table public.student_purge_operations (
   classroom_id uuid not null,
   student_id uuid references public.users (id) on delete set null,
   student_email text,
+  student_binding_sha256 text not null check (student_binding_sha256 ~ '^[a-f0-9]{64}$'),
   request_sha256 text not null check (request_sha256 ~ '^[a-f0-9]{64}$'),
   status text not null default 'inventorying'
     check (status in ('inventorying', 'deleting_objects', 'finalizing', 'completed', 'failed')),
@@ -112,6 +120,8 @@ create table public.student_purge_objects (
 
 create index student_purge_objects_due on public.student_purge_objects
   (next_attempt_at, created_at) where status in ('pending', 'processing', 'failed');
+create index student_purge_objects_path_reservation on public.student_purge_objects
+  (storage_bucket, storage_path_sha256);
 
 create table public.student_purge_fences (
   classroom_id uuid not null references public.classrooms (id) on delete cascade,
@@ -122,17 +132,20 @@ create table public.student_purge_fences (
   primary key (classroom_id, student_id)
 );
 
+alter table public.classroom_roster_student_bindings enable row level security;
 alter table public.student_purge_settings enable row level security;
 alter table public.student_purge_operations enable row level security;
 alter table public.student_purge_resources enable row level security;
 alter table public.student_purge_objects enable row level security;
 alter table public.student_purge_fences enable row level security;
 
+revoke all on table public.classroom_roster_student_bindings from public, anon, authenticated, service_role;
 revoke all on table public.student_purge_settings from public, anon, authenticated, service_role;
 revoke all on table public.student_purge_operations from public, anon, authenticated, service_role;
 revoke all on table public.student_purge_resources from public, anon, authenticated, service_role;
 revoke all on table public.student_purge_objects from public, anon, authenticated, service_role;
 revoke all on table public.student_purge_fences from public, anon, authenticated, service_role;
+grant select on table public.classroom_roster_student_bindings to service_role;
 grant select on table public.student_purge_settings to service_role;
 grant select on table public.student_purge_operations to service_role;
 grant select on table public.student_purge_resources to service_role;
@@ -216,7 +229,8 @@ language sql stable set search_path = public as $$
   where enrollment.classroom_id = p_classroom_id and enrollment.student_id = p_student_id
   union all select 'classroom_roster', roster.id, 'delete'
   from public.classroom_roster roster
-  where roster.classroom_id = p_classroom_id and roster.student_id = p_student_id
+  join public.classroom_roster_student_bindings binding on binding.roster_id = roster.id
+  where binding.classroom_id = p_classroom_id and binding.student_id = p_student_id
   union all select 'entries', entry.id, 'delete'
   from public.entries entry where entry.classroom_id = p_classroom_id and entry.student_id = p_student_id
   union all select 'report_card_rows', row.id, 'delete'
@@ -427,16 +441,21 @@ declare
   v_existing public.student_purge_operations;
   v_inventory jsonb;
   v_request_sha text;
+  v_student_binding_sha text;
   v_resource record;
 begin
   perform public.student_purge_lock(p_classroom_id, p_student_id);
+  v_student_binding_sha := encode(extensions.digest(convert_to(
+    p_operation_id::text || ':' || p_student_id::text, 'UTF8'), 'sha256'), 'hex');
   v_request_sha := encode(extensions.digest(convert_to(concat_ws(':', p_teacher_id, p_classroom_id, p_student_id,
     p_expected_source_revision, p_expected_storage_inventory_sha256,
     p_expected_relational_inventory_sha256), 'UTF8'), 'sha256'), 'hex');
   select * into v_existing from public.student_purge_operations where id = p_operation_id for update;
   if found then
     if v_existing.teacher_id <> p_teacher_id or v_existing.classroom_id <> p_classroom_id
-      or v_existing.student_id is distinct from p_student_id or v_existing.request_sha256 <> v_request_sha
+      or v_existing.student_binding_sha256 <> v_student_binding_sha
+      or (v_existing.student_id is not null and v_existing.student_id <> p_student_id)
+      or v_existing.request_sha256 <> v_request_sha
     then return jsonb_build_object('ok', false, 'status', 409, 'error_code', 'idempotency_conflict',
       'error', 'Idempotency key was already used for a different deletion'); end if;
     return jsonb_build_object('ok', true, 'status', case when v_existing.status = 'completed' then 200 else 202 end,
@@ -459,11 +478,11 @@ begin
     'error', 'Student data changed; review the updated impact before trying again', 'retryable', true); end if;
 
   insert into public.student_purge_operations (
-    id, teacher_id, classroom_id, student_id, student_email, request_sha256,
+    id, teacher_id, classroom_id, student_id, student_email, student_binding_sha256, request_sha256,
     source_revision, impact_summary, resource_counts
   ) values (
     p_operation_id, p_teacher_id, p_classroom_id, p_student_id, v_inventory->>'student_email',
-    v_request_sha, p_expected_source_revision, v_inventory, v_inventory->'resource_counts'
+    v_student_binding_sha, v_request_sha, p_expected_source_revision, v_inventory, v_inventory->'resource_counts'
   );
   insert into public.student_purge_fences (classroom_id, student_id, operation_id, teacher_id)
   values (p_classroom_id, p_student_id, p_operation_id, p_teacher_id);
@@ -477,7 +496,7 @@ begin
     storage_path_sha256, status, deleted_at
   )
   select p_operation_id, object.id, object.storage_bucket, object.storage_path,
-    encode(extensions.digest(convert_to(object.storage_path, 'UTF8'), 'sha256'), 'hex'),
+    public.managed_storage_identity_sha256(object.storage_bucket, object.storage_path),
     case when object.status = 'deleted' then 'deleted' else 'pending' end,
     case when object.status = 'deleted' then clock_timestamp() else null end
   from public.managed_storage_objects object
@@ -679,6 +698,8 @@ begin
         where value #>> '{}' <> v_operation.student_id::text), '[]'::jsonb),
       error_samples_json = replace(coalesce(run.error_samples_json, '[]'::jsonb)::text,
         v_operation.student_id::text, '[purged-student]')::jsonb,
+      selection_hash = encode(extensions.digest(convert_to(
+        'student-purge:' || p_operation_id::text || ':' || run.id::text, 'UTF8'), 'sha256'), 'hex'),
       requested_count = (select count(*) from jsonb_array_elements(run.requested_student_ids_json)
         where value #>> '{}' <> v_operation.student_id::text),
       gradable_count = (select count(*) from public.assignment_ai_grading_run_items item where item.run_id = run.id),
@@ -700,6 +721,8 @@ begin
         where value #>> '{}' <> v_operation.student_id::text), '[]'::jsonb),
       error_samples_json = replace(coalesce(run.error_samples_json, '[]'::jsonb)::text,
         v_operation.student_id::text, '[purged-student]')::jsonb,
+      selection_hash = encode(extensions.digest(convert_to(
+        'student-purge:' || p_operation_id::text || ':' || run.id::text, 'UTF8'), 'sha256'), 'hex'),
       requested_count = (select count(*) from jsonb_array_elements(run.requested_student_ids_json)
         where value #>> '{}' <> v_operation.student_id::text),
       eligible_student_count = (select count(distinct item.student_id) from public.test_ai_grading_run_items item where item.run_id = run.id),
@@ -774,36 +797,40 @@ begin
 end;
 $$;
 
--- Keep roster identity stable once a student joins. Enrollment is the authority;
--- emails remain display data and are never used by finalization.
-create or replace function public.bind_classroom_roster_student_id()
+-- Enrollment is authoritative. Once a roster row is bound, later display-email
+-- edits cannot retarget its joined-student identity.
+create or replace function public.bind_classroom_roster_student()
 returns trigger language plpgsql security definer set search_path = public as $$
 begin
-  if tg_op = 'UPDATE' and old.student_id is not null
-    and new.student_id is distinct from old.student_id
-    and coalesce(current_setting('pika.student_purge_finalize', true), '') <> 'on'
-  then raise exception using errcode = '55000', message = 'roster_student_identity_immutable'; end if;
-  if new.student_id is null then
-    select enrollment.student_id into new.student_id
-    from public.classroom_enrollments enrollment
-    join public.users student on student.id = enrollment.student_id and student.role = 'student'
-    where enrollment.classroom_id = new.classroom_id
-      and lower(btrim(student.email)) = lower(btrim(new.email));
-  end if;
+  if tg_op = 'UPDATE' and new.classroom_id is distinct from old.classroom_id
+    and exists (select 1 from public.classroom_roster_student_bindings where roster_id = old.id)
+  then raise exception using errcode = '55000', message = 'roster_student_binding_classroom_immutable'; end if;
+  insert into public.classroom_roster_student_bindings (roster_id, classroom_id, student_id)
+  select new.id, new.classroom_id, enrollment.student_id
+  from public.classroom_enrollments enrollment
+  join public.users student on student.id = enrollment.student_id and student.role = 'student'
+  where enrollment.classroom_id = new.classroom_id
+    and lower(btrim(student.email)) = lower(btrim(new.email))
+  order by enrollment.created_at, enrollment.id
+  limit 1
+  on conflict (roster_id) do nothing;
   return new;
 end;
 $$;
-create trigger bind_classroom_roster_student_id
-  before insert or update of classroom_id, email, student_id on public.classroom_roster
-  for each row execute function public.bind_classroom_roster_student_id();
+create trigger bind_classroom_roster_student
+  after insert or update of classroom_id, email on public.classroom_roster
+  for each row execute function public.bind_classroom_roster_student();
 
 create or replace function public.bind_roster_after_enrollment()
 returns trigger language plpgsql security definer set search_path = public as $$
 begin
-  update public.classroom_roster roster set student_id = new.student_id
-  from public.users student where student.id = new.student_id and student.role = 'student'
-    and roster.classroom_id = new.classroom_id and lower(btrim(roster.email)) = lower(btrim(student.email))
-    and roster.student_id is null;
+  insert into public.classroom_roster_student_bindings (roster_id, classroom_id, student_id)
+  select roster.id, new.classroom_id, new.student_id
+  from public.classroom_roster roster
+  join public.users student on student.id = new.student_id and student.role = 'student'
+  where roster.classroom_id = new.classroom_id
+    and lower(btrim(roster.email)) = lower(btrim(student.email))
+  on conflict (roster_id) do nothing;
   return new;
 end;
 $$;
@@ -848,12 +875,33 @@ begin
   if current_setting('pika.student_purge_finalize', true) = 'on' then
     return case when tg_op = 'DELETE' then old else new end;
   end if;
+  if tg_table_name = 'managed_storage_objects' and tg_op <> 'DELETE'
+    and new.storage_path is not null and exists (
+      select 1 from public.student_purge_objects purge_object
+      where purge_object.storage_bucket = new.storage_bucket
+        and purge_object.storage_path_sha256 =
+          public.managed_storage_identity_sha256(new.storage_bucket, new.storage_path)
+    )
+  then raise exception using errcode = '55000', message = 'student_purge_path_reserved'; end if;
   foreach v_row in array v_rows loop
     v_classroom_id := null;
     v_student_id := nullif(coalesce(v_row->>'student_id', v_row->>'user_id'), '')::uuid;
     v_parent_id := null;
-    if tg_table_name in ('entries', 'classroom_enrollments', 'classroom_roster') then
+    if tg_table_name in ('entries', 'classroom_enrollments') then
       v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
+    elsif tg_table_name = 'classroom_roster' then
+      v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
+      select binding.student_id into v_student_id
+      from public.classroom_roster_student_bindings binding
+      where binding.roster_id = nullif(v_row->>'id', '')::uuid;
+      if v_student_id is null then
+        select enrollment.student_id into v_student_id
+        from public.classroom_enrollments enrollment
+        join public.users student on student.id = enrollment.student_id and student.role = 'student'
+        where enrollment.classroom_id = v_classroom_id
+          and lower(btrim(student.email)) = lower(btrim(v_row->>'email'))
+        order by enrollment.created_at, enrollment.id limit 1;
+      end if;
     elsif tg_table_name = 'managed_storage_objects' then
       v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
       if v_classroom_id is null then
@@ -941,6 +989,27 @@ $$;
 create trigger classroom_archive_operation_student_purge_guard
   before insert or update or delete on public.classroom_archive_operations
   for each row execute function public.reject_archive_operation_during_student_purge();
+
+-- Retain every purged bucket/path digest permanently. This closes the delayed
+-- upload race after the managed row and active fence have been removed.
+create or replace function public.reject_student_purged_storage_write()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if new.bucket_id in ('assignment-artifacts','submission-images','test-documents',
+      'classroom-archives','gradex-analytics-extracts') and exists (
+    select 1 from public.student_purge_objects purge_object
+    where purge_object.storage_bucket = new.bucket_id
+      and purge_object.storage_path_sha256 =
+        public.managed_storage_identity_sha256(new.bucket_id, new.name)
+  ) then
+    raise exception using errcode = '55000', message = 'student_purge_path_reserved';
+  end if;
+  return new;
+end;
+$$;
+create trigger storage_student_purge_path_reservation
+  before insert or update on storage.objects
+  for each row execute function public.reject_student_purged_storage_write();
 
 create or replace function public.reject_student_indirect_change_during_purge()
 returns trigger language plpgsql security definer set search_path = public as $$
@@ -1095,11 +1164,12 @@ revoke all on function public.complete_student_purge_object(uuid,uuid,uuid,uuid)
 revoke all on function public.fail_student_purge_object(uuid,uuid,uuid,uuid,text) from public, anon, authenticated;
 revoke all on function public.finalize_student_purge(uuid,uuid) from public, anon, authenticated;
 revoke all on function public.get_student_purge_health_snapshot(integer,integer) from public, anon, authenticated;
-revoke all on function public.bind_classroom_roster_student_id() from public, anon, authenticated, service_role;
+revoke all on function public.bind_classroom_roster_student() from public, anon, authenticated, service_role;
 revoke all on function public.bind_roster_after_enrollment() from public, anon, authenticated, service_role;
 revoke all on function public.reject_conflicting_purge_fence() from public, anon, authenticated, service_role;
 revoke all on function public.reject_student_resource_change_during_purge() from public, anon, authenticated, service_role;
 revoke all on function public.reject_archive_operation_during_student_purge() from public, anon, authenticated, service_role;
+revoke all on function public.reject_student_purged_storage_write() from public, anon, authenticated, service_role;
 revoke all on function public.reject_student_indirect_change_during_purge() from public, anon, authenticated, service_role;
 grant execute on function public.get_student_purge_inventory(uuid,uuid,uuid) to service_role;
 grant execute on function public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text) to service_role;

--- a/supabase/migrations/123_hot_classroom_individual_student_purge.sql
+++ b/supabase/migrations/123_hot_classroom_individual_student_purge.sql
@@ -1,0 +1,1117 @@
+-- Durable, resumable deletion of one student's data from one teacher-owned hot
+-- Classroom. This scope deliberately preserves the user and every other
+-- Classroom. Rollout starts disabled. Pal/remote-Gradex targets fail closed.
+
+alter table public.classroom_roster
+  add column student_id uuid references public.users (id) on delete set null;
+
+update public.classroom_roster roster
+set student_id = enrollment.student_id
+from public.classroom_enrollments enrollment
+join public.users student on student.id = enrollment.student_id and student.role = 'student'
+where enrollment.classroom_id = roster.classroom_id
+  and lower(btrim(student.email)) = lower(btrim(roster.email))
+  and roster.student_id is null;
+
+create unique index classroom_roster_classroom_student
+  on public.classroom_roster (classroom_id, student_id)
+  where student_id is not null;
+
+create table public.student_purge_settings (
+  singleton boolean primary key default true check (singleton),
+  rollout_mode text not null default 'disabled'
+    check (rollout_mode in ('disabled', 'canary', 'enabled')),
+  canary_teacher_id uuid references public.users (id) on delete restrict,
+  canary_classroom_id uuid,
+  canary_student_id uuid references public.users (id) on delete restrict,
+  updated_at timestamptz not null default clock_timestamp(),
+  check (
+    (rollout_mode = 'canary' and canary_teacher_id is not null
+      and canary_classroom_id is not null and canary_student_id is not null)
+    or (rollout_mode <> 'canary' and canary_teacher_id is null
+      and canary_classroom_id is null and canary_student_id is null)
+  )
+);
+
+insert into public.student_purge_settings (singleton) values (true);
+
+create table public.student_purge_operations (
+  id uuid primary key,
+  teacher_id uuid not null references public.users (id) on delete restrict,
+  classroom_id uuid not null,
+  student_id uuid references public.users (id) on delete set null,
+  student_email text,
+  request_sha256 text not null check (request_sha256 ~ '^[a-f0-9]{64}$'),
+  status text not null default 'inventorying'
+    check (status in ('inventorying', 'deleting_objects', 'finalizing', 'completed', 'failed')),
+  source_revision bigint not null check (source_revision > 0),
+  impact_summary jsonb not null default '{}'::jsonb,
+  resource_counts jsonb not null default '{}'::jsonb,
+  storage_object_counts jsonb not null default '{}'::jsonb,
+  attempt_count integer not null default 1 check (attempt_count > 0),
+  error_code text,
+  retryable boolean,
+  started_at timestamptz not null default clock_timestamp(),
+  inventory_completed_at timestamptz,
+  updated_at timestamptz not null default clock_timestamp(),
+  completed_at timestamptz,
+  check ((status = 'completed') = (completed_at is not null)),
+  check (status <> 'completed' or (student_id is null and student_email is null))
+);
+
+create unique index student_purge_one_active_per_classroom_student
+  on public.student_purge_operations (classroom_id, student_id)
+  where student_id is not null and status <> 'completed';
+create index student_purge_operations_teacher_started
+  on public.student_purge_operations (teacher_id, started_at desc);
+create index student_purge_operations_worker
+  on public.student_purge_operations (status, updated_at)
+  where status in ('deleting_objects', 'finalizing', 'failed');
+
+create table public.student_purge_resources (
+  operation_id uuid not null references public.student_purge_operations (id) on delete cascade,
+  table_name text not null,
+  row_id uuid not null,
+  disposition text not null check (disposition in ('delete', 'collateral_delete', 'redact')),
+  primary key (operation_id, table_name, row_id)
+);
+
+create table public.student_purge_objects (
+  id uuid primary key default gen_random_uuid(),
+  operation_id uuid not null references public.student_purge_operations (id) on delete cascade,
+  managed_storage_object_id uuid
+    references public.managed_storage_objects (id) on delete set null,
+  storage_bucket text not null check (storage_bucket in (
+    'assignment-artifacts', 'submission-images', 'test-documents',
+    'classroom-archives', 'gradex-analytics-extracts'
+  )),
+  storage_path text,
+  storage_path_sha256 text not null check (storage_path_sha256 ~ '^[a-f0-9]{64}$'),
+  status text not null default 'pending'
+    check (status in ('pending', 'processing', 'failed', 'deleted')),
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  next_attempt_at timestamptz not null default clock_timestamp(),
+  lease_token uuid,
+  lease_expires_at timestamptz,
+  last_error_code text,
+  deleted_at timestamptz,
+  created_at timestamptz not null default clock_timestamp(),
+  updated_at timestamptz not null default clock_timestamp(),
+  unique (operation_id, managed_storage_object_id),
+  unique (operation_id, storage_bucket, storage_path_sha256),
+  check (storage_path is null or (
+    storage_path <> '' and storage_path not like '/%' and strpos(storage_path, E'\\') = 0
+    and not ('..' = any(string_to_array(storage_path, '/')))
+  )),
+  check (
+    (status = 'processing' and lease_token is not null and lease_expires_at is not null)
+    or (status <> 'processing' and lease_token is null and lease_expires_at is null)
+  ),
+  check ((status = 'deleted') = (deleted_at is not null))
+);
+
+create index student_purge_objects_due on public.student_purge_objects
+  (next_attempt_at, created_at) where status in ('pending', 'processing', 'failed');
+
+create table public.student_purge_fences (
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete restrict,
+  operation_id uuid not null unique references public.student_purge_operations (id) on delete cascade,
+  teacher_id uuid not null references public.users (id) on delete restrict,
+  created_at timestamptz not null default clock_timestamp(),
+  primary key (classroom_id, student_id)
+);
+
+alter table public.student_purge_settings enable row level security;
+alter table public.student_purge_operations enable row level security;
+alter table public.student_purge_resources enable row level security;
+alter table public.student_purge_objects enable row level security;
+alter table public.student_purge_fences enable row level security;
+
+revoke all on table public.student_purge_settings from public, anon, authenticated, service_role;
+revoke all on table public.student_purge_operations from public, anon, authenticated, service_role;
+revoke all on table public.student_purge_resources from public, anon, authenticated, service_role;
+revoke all on table public.student_purge_objects from public, anon, authenticated, service_role;
+revoke all on table public.student_purge_fences from public, anon, authenticated, service_role;
+grant select on table public.student_purge_settings to service_role;
+grant select on table public.student_purge_operations to service_role;
+grant select on table public.student_purge_resources to service_role;
+grant select on table public.student_purge_objects to service_role;
+grant select on table public.student_purge_fences to service_role;
+
+create or replace function public.student_purge_lock(p_classroom_id uuid, p_student_id uuid)
+returns void language plpgsql set search_path = '' as $$
+begin
+  perform pg_advisory_xact_lock(hashtextextended('pika-student-purge-subject:' || p_student_id::text, 0));
+  perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || p_classroom_id::text, 0));
+  perform pg_advisory_xact_lock(hashtextextended('pika-student-purge:' || p_classroom_id::text || ':' || p_student_id::text, 0));
+end;
+$$;
+
+create or replace function public.student_purge_rollout_allows(
+  p_teacher_id uuid, p_classroom_id uuid, p_student_id uuid
+)
+returns boolean language sql stable set search_path = public as $$
+  select coalesce((
+    select rollout_mode = 'enabled'
+      or (rollout_mode = 'canary' and canary_teacher_id = p_teacher_id
+        and canary_classroom_id = p_classroom_id and canary_student_id = p_student_id)
+    from public.student_purge_settings where singleton
+  ), false)
+$$;
+
+create or replace function public.student_purge_inventory_resources(
+  p_classroom_id uuid, p_student_id uuid
+)
+returns table(table_name text, row_id uuid, disposition text)
+language sql stable set search_path = public as $$
+  select 'announcement_reads', read.id, 'delete'
+  from public.announcement_reads read
+  join public.announcements announcement on announcement.id = read.announcement_id
+  where announcement.classroom_id = p_classroom_id and read.user_id = p_student_id
+  union all select 'assignment_ai_grading_run_items', item.id, 'delete'
+  from public.assignment_ai_grading_run_items item
+  join public.assignments assignment on assignment.id = item.assignment_id
+  where assignment.classroom_id = p_classroom_id and item.student_id = p_student_id
+  union all select 'assignment_ai_grading_runs', run.id, 'redact'
+  from public.assignment_ai_grading_runs run
+  join public.assignments assignment on assignment.id = run.assignment_id
+  where assignment.classroom_id = p_classroom_id and (
+    run.requested_student_ids_json ? p_student_id::text
+    or exists (select 1 from public.assignment_ai_grading_run_items item
+      where item.run_id = run.id and item.student_id = p_student_id)
+  )
+  union all select 'assignment_doc_history', history.id, 'delete'
+  from public.assignment_doc_history history
+  join public.assignment_docs doc on doc.id = history.assignment_doc_id
+  join public.assignments assignment on assignment.id = doc.assignment_id
+  where assignment.classroom_id = p_classroom_id and doc.student_id = p_student_id
+  union all select 'assignment_doc_save_operations', save.id, 'delete'
+  from public.assignment_doc_save_operations save
+  join public.assignment_docs doc on doc.id = save.assignment_doc_id
+  join public.assignments assignment on assignment.id = doc.assignment_id
+  where assignment.classroom_id = p_classroom_id and doc.student_id = p_student_id
+  union all select 'assignment_submission_artifacts', artifact.id, 'delete'
+  from public.assignment_submission_artifacts artifact
+  join public.assignment_docs doc on doc.id = artifact.assignment_doc_id
+  join public.assignments assignment on assignment.id = doc.assignment_id
+  where assignment.classroom_id = p_classroom_id and artifact.student_id = p_student_id
+  union all select 'assignment_docs', doc.id, 'delete'
+  from public.assignment_docs doc join public.assignments assignment on assignment.id = doc.assignment_id
+  where assignment.classroom_id = p_classroom_id and doc.student_id = p_student_id
+  union all select 'assignment_feedback_entries', feedback.id, 'delete'
+  from public.assignment_feedback_entries feedback
+  join public.assignments assignment on assignment.id = feedback.assignment_id
+  where assignment.classroom_id = p_classroom_id and feedback.student_id = p_student_id
+  union all select 'assignment_repo_review_results', result.id, 'delete'
+  from public.assignment_repo_review_results result
+  join public.assignments assignment on assignment.id = result.assignment_id
+  where assignment.classroom_id = p_classroom_id and result.student_id = p_student_id
+  union all select 'assignment_repo_targets', target.id, 'delete'
+  from public.assignment_repo_targets target
+  join public.assignments assignment on assignment.id = target.assignment_id
+  where assignment.classroom_id = p_classroom_id and target.student_id = p_student_id
+  union all select 'classroom_enrollments', enrollment.id, 'delete'
+  from public.classroom_enrollments enrollment
+  where enrollment.classroom_id = p_classroom_id and enrollment.student_id = p_student_id
+  union all select 'classroom_roster', roster.id, 'delete'
+  from public.classroom_roster roster
+  where roster.classroom_id = p_classroom_id and roster.student_id = p_student_id
+  union all select 'entries', entry.id, 'delete'
+  from public.entries entry where entry.classroom_id = p_classroom_id and entry.student_id = p_student_id
+  union all select 'report_card_rows', row.id, 'delete'
+  from public.report_card_rows row join public.report_cards card on card.id = row.report_card_id
+  where card.classroom_id = p_classroom_id and row.student_id = p_student_id
+  union all select 'survey_responses', response.id, 'delete'
+  from public.survey_responses response join public.surveys survey on survey.id = response.survey_id
+  where survey.classroom_id = p_classroom_id and response.student_id = p_student_id
+  union all select 'test_ai_grading_run_items', item.id, 'delete'
+  from public.test_ai_grading_run_items item join public.tests test on test.id = item.test_id
+  where test.classroom_id = p_classroom_id and item.student_id = p_student_id
+  union all select 'test_ai_grading_runs', run.id, 'redact'
+  from public.test_ai_grading_runs run join public.tests test on test.id = run.test_id
+  where test.classroom_id = p_classroom_id and (
+    run.requested_student_ids_json ? p_student_id::text
+    or exists (select 1 from public.test_ai_grading_run_items item
+      where item.run_id = run.id and item.student_id = p_student_id)
+  )
+  union all select 'test_attempt_history', history.id, 'delete'
+  from public.test_attempt_history history
+  join public.test_attempts attempt on attempt.id = history.test_attempt_id
+  join public.tests test on test.id = attempt.test_id
+  where test.classroom_id = p_classroom_id and attempt.student_id = p_student_id
+  union all select 'test_attempts', attempt.id, 'delete'
+  from public.test_attempts attempt join public.tests test on test.id = attempt.test_id
+  where test.classroom_id = p_classroom_id and attempt.student_id = p_student_id
+  union all select 'test_focus_events', event.id, 'delete'
+  from public.test_focus_events event join public.tests test on test.id = event.test_id
+  where test.classroom_id = p_classroom_id and event.student_id = p_student_id
+  union all select 'test_responses', response.id, 'delete'
+  from public.test_responses response join public.tests test on test.id = response.test_id
+  where test.classroom_id = p_classroom_id and response.student_id = p_student_id
+  union all select 'test_student_availability', availability.id, 'delete'
+  from public.test_student_availability availability join public.tests test on test.id = availability.test_id
+  where test.classroom_id = p_classroom_id and availability.student_id = p_student_id
+  union all select 'log_summaries', summary.id, 'collateral_delete'
+  from public.log_summaries summary
+  where summary.classroom_id = p_classroom_id and exists (
+    select 1 from public.entries entry where entry.classroom_id = p_classroom_id
+      and entry.student_id = p_student_id and entry.date = summary.date
+  )
+  union all select 'developer_feedback_candidates', candidate.id, 'collateral_delete'
+  from public.developer_feedback_candidates candidate
+  where candidate.source_type = 'daily_log' and exists (
+    select 1 from public.entries entry where entry.classroom_id = p_classroom_id
+      and entry.student_id = p_student_id
+      and (p_classroom_id::text || ':' || entry.date::text) = any(candidate.source_keys)
+  )
+$$;
+
+create or replace function public.student_purge_conflict(
+  p_classroom_id uuid, p_student_id uuid
+)
+returns text language plpgsql stable set search_path = public as $$
+declare v_classroom_conflict text;
+begin
+  if exists (select 1 from public.classroom_cold_tombstones where classroom_id = p_classroom_id) then
+    return 'student_purge_cold_classroom_unsupported';
+  end if;
+  if exists (select 1 from public.classroom_purge_fences where classroom_id = p_classroom_id)
+    or exists (select 1 from public.cold_classroom_purge_fences where classroom_id = p_classroom_id)
+    or exists (select 1 from public.student_purge_fences where classroom_id = p_classroom_id)
+  then return 'classroom_purge_operation_active'; end if;
+  v_classroom_conflict := public.classroom_purge_conflict(p_classroom_id);
+  if v_classroom_conflict is not null then return v_classroom_conflict; end if;
+  if exists (
+    select 1 from public.classroom_archive_operations
+    where classroom_id = p_classroom_id and status not in ('completed', 'failed')
+  ) then return 'classroom_archive_operation_active'; end if;
+  if exists (
+    select 1 from public.assignment_ai_grading_run_items item
+    join public.assignments assignment on assignment.id = item.assignment_id
+    join public.assignment_ai_grading_runs run on run.id = item.run_id
+    where assignment.classroom_id = p_classroom_id and item.student_id = p_student_id
+      and (run.status in ('queued', 'running') or item.status in ('queued', 'processing'))
+  ) or exists (
+    select 1 from public.test_ai_grading_run_items item
+    join public.tests test on test.id = item.test_id
+    join public.test_ai_grading_runs run on run.id = item.run_id
+    where test.classroom_id = p_classroom_id and item.student_id = p_student_id
+      and (run.status in ('queued', 'running') or item.status in ('queued', 'processing'))
+  ) or exists (
+    select 1 from public.assignment_repo_review_runs run
+    join public.assignments assignment on assignment.id = run.assignment_id
+    where assignment.classroom_id = p_classroom_id and run.status in ('queued', 'running')
+  ) then return 'student_grading_operation_active'; end if;
+  if exists (select 1 from public.pal_event_outbox where student_id = p_student_id)
+    or exists (select 1 from public.pal_daily_log_week_configurations where student_id = p_student_id)
+  then return 'student_purge_external_erasure_required'; end if;
+  if exists (
+    select 1 from public.assignment_ai_grading_runs run
+    join public.assignments assignment on assignment.id = run.assignment_id
+    where assignment.classroom_id = p_classroom_id and run.gradex_run_id is not null
+      and (run.requested_student_ids_json ? p_student_id::text or exists (
+        select 1 from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.student_id = p_student_id
+      ))
+  ) then return 'student_purge_gradex_erasure_required'; end if;
+  if exists (
+    select 1 from public.classroom_retired_assessment_record_actors actor
+    join public.classroom_retired_assessment_records record on record.id = actor.record_id
+    where record.classroom_id = p_classroom_id and actor.actor_id = p_student_id
+  ) then return 'student_purge_retired_assessment_unsupported'; end if;
+  if exists (
+    select 1 from public.managed_storage_objects object
+    left join public.managed_storage_provisional_owners provisional on provisional.id = object.provisional_owner_id
+    where (object.classroom_id = p_classroom_id or provisional.target_classroom_id = p_classroom_id)
+      and object.purpose in ('student_assignment_artifact', 'student_inline_image')
+      and object.created_by_user_id = p_student_id and object.data_subject_user_id is null
+  ) then return 'student_purge_storage_subject_ownership_incomplete'; end if;
+  if exists (
+    select 1 from public.managed_storage_objects
+    where classroom_id = p_classroom_id and data_subject_user_id = p_student_id
+      and status in ('cleanup_pending', 'cleanup_processing')
+  ) then return 'managed_storage_cleanup_active'; end if;
+  return null;
+end;
+$$;
+
+create or replace function public.get_student_purge_inventory(
+  p_teacher_id uuid, p_classroom_id uuid, p_student_id uuid
+)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare
+  v_title text;
+  v_email text;
+  v_conflict text;
+  v_resource_counts jsonb;
+  v_storage_counts jsonb;
+  v_relational_hash text;
+  v_storage_hash text;
+  v_file_count integer;
+  v_file_bytes bigint;
+  v_archive_count integer;
+  v_gradex_count integer;
+  v_source_revision bigint;
+  v_rollout boolean;
+  v_enforced boolean;
+begin
+  select classroom.title into v_title from public.classrooms classroom
+  where classroom.id = p_classroom_id and classroom.teacher_id = p_teacher_id;
+  if not found then return jsonb_build_object('ok', false, 'status', 404,
+    'error_code', 'classroom_not_found', 'error', 'Classroom not found'); end if;
+  select student.email into v_email from public.users student
+  join public.classroom_enrollments enrollment on enrollment.student_id = student.id
+  where student.id = p_student_id and student.role = 'student'
+    and enrollment.classroom_id = p_classroom_id;
+  if not found then return jsonb_build_object('ok', false, 'status', 404,
+    'error_code', 'student_not_in_classroom', 'error', 'Joined student not found in classroom'); end if;
+
+  select coalesce(jsonb_object_agg(table_name, resource_count), '{}'::jsonb)
+  into v_resource_counts from (
+    select table_name, count(*)::integer resource_count
+    from public.student_purge_inventory_resources(p_classroom_id, p_student_id)
+    group by table_name order by table_name
+  ) counts;
+  select encode(extensions.digest(convert_to(coalesce(string_agg(table_name || ':' || row_id::text || ':' || disposition,
+    E'\n' order by table_name, row_id, disposition), ''), 'UTF8'), 'sha256'), 'hex')
+  into v_relational_hash from public.student_purge_inventory_resources(p_classroom_id, p_student_id);
+
+  with objects as (
+    select object.* from public.managed_storage_objects object
+    left join public.managed_storage_provisional_owners provisional
+      on provisional.id = object.provisional_owner_id
+    where (object.classroom_id = p_classroom_id or provisional.target_classroom_id = p_classroom_id)
+      and (object.data_subject_user_id = p_student_id
+        or object.purpose in ('classroom_archive', 'gradex_extract'))
+  )
+  select count(*)::integer, coalesce(sum(byte_size), 0)::bigint,
+    count(*) filter (where purpose = 'classroom_archive')::integer,
+    count(*) filter (where purpose = 'gradex_extract')::integer,
+    coalesce(jsonb_object_agg(purpose, purpose_count) filter (where purpose is not null), '{}'::jsonb),
+    encode(extensions.digest(convert_to(coalesce(string_agg(id::text || ':' || storage_bucket || ':' || storage_path,
+      E'\n' order by id), ''), 'UTF8'), 'sha256'), 'hex')
+  into v_file_count, v_file_bytes, v_archive_count, v_gradex_count, v_storage_counts, v_storage_hash
+  from (select objects.*, count(*) over (partition by purpose)::integer purpose_count from objects) listed;
+
+  v_source_revision := 1 + coalesce((select count(*) from public.student_purge_inventory_resources(
+    p_classroom_id, p_student_id)), 0) + coalesce(v_file_count, 0);
+  v_conflict := public.student_purge_conflict(p_classroom_id, p_student_id);
+  v_rollout := public.student_purge_rollout_allows(p_teacher_id, p_classroom_id, p_student_id);
+  select mode = 'enforced' into v_enforced from public.managed_storage_settings where singleton;
+  return jsonb_build_object(
+    'ok', true, 'status', 200, 'classroom_id', p_classroom_id,
+    'classroom_title', v_title, 'student_id', p_student_id, 'student_email', v_email,
+    'source_revision', v_source_revision, 'storage_inventory_sha256', v_storage_hash,
+    'relational_inventory_sha256', v_relational_hash,
+    'managed_file_count', coalesce(v_file_count, 0), 'managed_file_bytes', coalesce(v_file_bytes, 0),
+    'archive_count', coalesce(v_archive_count, 0), 'gradex_extract_count', coalesce(v_gradex_count, 0),
+    'resource_counts', v_resource_counts, 'storage_counts', coalesce(v_storage_counts, '{}'::jsonb),
+    'conflicting_operation', v_conflict,
+    'deletion_available', v_rollout and coalesce(v_enforced, false) and v_conflict is null,
+    'unavailable_reason', case
+      when not v_rollout then 'Individual-student purge is disabled'
+      when not coalesce(v_enforced, false) then 'Managed storage ownership is not enforced'
+      when v_conflict is not null then v_conflict else null end
+  );
+end;
+$$;
+
+create or replace function public.begin_student_purge(
+  p_operation_id uuid, p_teacher_id uuid, p_classroom_id uuid, p_student_id uuid,
+  p_confirmation text, p_expected_source_revision bigint,
+  p_expected_storage_inventory_sha256 text, p_expected_relational_inventory_sha256 text
+)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare
+  v_existing public.student_purge_operations;
+  v_inventory jsonb;
+  v_request_sha text;
+  v_resource record;
+begin
+  perform public.student_purge_lock(p_classroom_id, p_student_id);
+  v_request_sha := encode(extensions.digest(convert_to(concat_ws(':', p_teacher_id, p_classroom_id, p_student_id,
+    p_expected_source_revision, p_expected_storage_inventory_sha256,
+    p_expected_relational_inventory_sha256), 'UTF8'), 'sha256'), 'hex');
+  select * into v_existing from public.student_purge_operations where id = p_operation_id for update;
+  if found then
+    if v_existing.teacher_id <> p_teacher_id or v_existing.classroom_id <> p_classroom_id
+      or v_existing.student_id is distinct from p_student_id or v_existing.request_sha256 <> v_request_sha
+    then return jsonb_build_object('ok', false, 'status', 409, 'error_code', 'idempotency_conflict',
+      'error', 'Idempotency key was already used for a different deletion'); end if;
+    return jsonb_build_object('ok', true, 'status', case when v_existing.status = 'completed' then 200 else 202 end,
+      'operation_id', p_operation_id, 'operation_status', v_existing.status, 'replayed', true);
+  end if;
+  v_inventory := public.get_student_purge_inventory(p_teacher_id, p_classroom_id, p_student_id);
+  if not coalesce((v_inventory->>'ok')::boolean, false) then return v_inventory; end if;
+  if p_confirmation is distinct from v_inventory->>'student_email' then
+    return jsonb_build_object('ok', false, 'status', 400, 'error_code', 'confirmation_mismatch',
+      'error', 'Type the student email exactly to confirm');
+  end if;
+  if not coalesce((v_inventory->>'deletion_available')::boolean, false) then
+    return jsonb_build_object('ok', false, 'status', 409, 'error_code', 'student_purge_unavailable',
+      'error', v_inventory->>'unavailable_reason');
+  end if;
+  if (v_inventory->>'source_revision')::bigint <> p_expected_source_revision
+    or v_inventory->>'storage_inventory_sha256' <> p_expected_storage_inventory_sha256
+    or v_inventory->>'relational_inventory_sha256' <> p_expected_relational_inventory_sha256
+  then return jsonb_build_object('ok', false, 'status', 409, 'error_code', 'student_purge_inventory_changed',
+    'error', 'Student data changed; review the updated impact before trying again', 'retryable', true); end if;
+
+  insert into public.student_purge_operations (
+    id, teacher_id, classroom_id, student_id, student_email, request_sha256,
+    source_revision, impact_summary, resource_counts
+  ) values (
+    p_operation_id, p_teacher_id, p_classroom_id, p_student_id, v_inventory->>'student_email',
+    v_request_sha, p_expected_source_revision, v_inventory, v_inventory->'resource_counts'
+  );
+  insert into public.student_purge_fences (classroom_id, student_id, operation_id, teacher_id)
+  values (p_classroom_id, p_student_id, p_operation_id, p_teacher_id);
+  for v_resource in select * from public.student_purge_inventory_resources(p_classroom_id, p_student_id)
+  loop
+    insert into public.student_purge_resources (operation_id, table_name, row_id, disposition)
+    values (p_operation_id, v_resource.table_name, v_resource.row_id, v_resource.disposition);
+  end loop;
+  insert into public.student_purge_objects (
+    operation_id, managed_storage_object_id, storage_bucket, storage_path,
+    storage_path_sha256, status, deleted_at
+  )
+  select p_operation_id, object.id, object.storage_bucket, object.storage_path,
+    encode(extensions.digest(convert_to(object.storage_path, 'UTF8'), 'sha256'), 'hex'),
+    case when object.status = 'deleted' then 'deleted' else 'pending' end,
+    case when object.status = 'deleted' then clock_timestamp() else null end
+  from public.managed_storage_objects object
+  left join public.managed_storage_provisional_owners provisional
+    on provisional.id = object.provisional_owner_id
+  where (object.classroom_id = p_classroom_id or provisional.target_classroom_id = p_classroom_id)
+    and (object.data_subject_user_id = p_student_id
+      or object.purpose in ('classroom_archive', 'gradex_extract'));
+  update public.student_purge_operations
+  set status = case when exists (select 1 from public.student_purge_objects
+      where operation_id = p_operation_id and status <> 'deleted')
+    then 'deleting_objects' else 'finalizing' end,
+    inventory_completed_at = clock_timestamp(), updated_at = clock_timestamp()
+  where id = p_operation_id;
+  return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+    'operation_status', (select status from public.student_purge_operations where id = p_operation_id));
+exception when unique_violation then
+  return jsonb_build_object('ok', false, 'status', 409, 'error_code', 'student_purge_operation_active',
+    'error', 'A deletion is already active for this student or classroom');
+end;
+$$;
+
+create or replace function public.claim_student_purge_object(
+  p_operation_id uuid, p_teacher_id uuid, p_lease_seconds integer default 60
+)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_operation public.student_purge_operations; v_object public.student_purge_objects; v_token uuid;
+begin
+  select * into v_operation from public.student_purge_operations
+  where id = p_operation_id and teacher_id = p_teacher_id for update;
+  if not found then return jsonb_build_object('ok', false, 'status', 404,
+    'error_code', 'student_purge_not_found', 'error', 'Student data deletion not found'); end if;
+  if v_operation.status = 'completed' then return jsonb_build_object('ok', true, 'status', 200,
+    'operation_id', p_operation_id, 'operation_status', 'completed'); end if;
+  if v_operation.status = 'failed' and v_operation.retryable is false then
+    return jsonb_build_object('ok', false, 'status', 409, 'error_code', v_operation.error_code,
+      'error', 'Student data deletion stopped safely', 'retryable', false); end if;
+  update public.student_purge_objects set status = 'failed', lease_token = null,
+    lease_expires_at = null, next_attempt_at = clock_timestamp(), updated_at = clock_timestamp()
+  where operation_id = p_operation_id and status = 'processing' and lease_expires_at <= clock_timestamp();
+  select * into v_object from public.student_purge_objects
+  where operation_id = p_operation_id and status in ('pending', 'failed')
+    and next_attempt_at <= clock_timestamp() order by created_at, id for update skip locked limit 1;
+  if not found then
+    if exists (select 1 from public.student_purge_objects
+      where operation_id = p_operation_id and status <> 'deleted')
+    then return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+      'operation_status', v_operation.status, 'waiting_for_storage', true);
+    end if;
+    update public.student_purge_operations set status = 'finalizing', retryable = true,
+      error_code = null, updated_at = clock_timestamp() where id = p_operation_id;
+    return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+      'operation_status', 'finalizing');
+  end if;
+  v_token := gen_random_uuid();
+  update public.student_purge_objects set status = 'processing', attempt_count = attempt_count + 1,
+    lease_token = v_token, lease_expires_at = clock_timestamp() + make_interval(secs => greatest(15, least(p_lease_seconds, 300))),
+    last_error_code = null, updated_at = clock_timestamp() where id = v_object.id;
+  update public.student_purge_operations set status = 'deleting_objects', attempt_count = attempt_count + 1,
+    retryable = true, error_code = null, updated_at = clock_timestamp() where id = p_operation_id;
+  return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+    'operation_status', 'deleting_objects', 'object', jsonb_build_object(
+      'id', v_object.id, 'operation_id', p_operation_id, 'storage_bucket', v_object.storage_bucket,
+      'storage_path', v_object.storage_path, 'lease_token', v_token));
+end;
+$$;
+
+create or replace function public.complete_student_purge_object(
+  p_operation_id uuid, p_teacher_id uuid, p_object_id uuid, p_lease_token uuid
+)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_classroom_id uuid; v_student_id uuid; v_bucket text; v_path text;
+begin
+  select operation.classroom_id, operation.student_id, object.storage_bucket, object.storage_path
+  into v_classroom_id, v_student_id, v_bucket, v_path
+  from public.student_purge_objects object
+  join public.student_purge_operations operation on operation.id = object.operation_id
+  where object.id = p_object_id and object.operation_id = p_operation_id
+    and operation.teacher_id = p_teacher_id and object.status = 'processing'
+    and object.lease_token = p_lease_token;
+  if not found then return jsonb_build_object('ok', false, 'status', 409,
+    'error_code', 'student_purge_object_lease_lost', 'error', 'Storage deletion lease expired', 'retryable', true); end if;
+  perform public.student_purge_lock(v_classroom_id, v_student_id);
+  perform public.managed_storage_exact_lock(v_bucket, v_path);
+  if exists (select 1 from storage.objects stored where stored.bucket_id = v_bucket and stored.name = v_path) then
+    raise exception using errcode = '55000', message = 'student_purge_storage_object_still_present';
+  end if;
+  update public.student_purge_objects object set status = 'deleted', deleted_at = clock_timestamp(),
+    storage_path = null, lease_token = null, lease_expires_at = null,
+    last_error_code = null, updated_at = clock_timestamp()
+  from public.student_purge_operations operation
+  where object.id = p_object_id and object.operation_id = p_operation_id
+    and operation.id = object.operation_id and operation.teacher_id = p_teacher_id
+    and object.status = 'processing' and object.lease_token = p_lease_token
+    and object.lease_expires_at > clock_timestamp();
+  if not found then return jsonb_build_object('ok', false, 'status', 409,
+    'error_code', 'student_purge_object_lease_lost', 'error', 'Storage deletion lease expired', 'retryable', true); end if;
+  return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id);
+end;
+$$;
+
+create or replace function public.fail_student_purge_object(
+  p_operation_id uuid, p_teacher_id uuid, p_object_id uuid, p_lease_token uuid, p_error_code text
+)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_attempt integer;
+begin
+  update public.student_purge_objects object set status = 'failed', lease_token = null,
+    lease_expires_at = null, last_error_code = left(coalesce(p_error_code, 'storage_delete_failed'), 200),
+    next_attempt_at = clock_timestamp() + make_interval(secs => least(300, (2 ^ least(attempt_count, 8))::integer)),
+    updated_at = clock_timestamp()
+  from public.student_purge_operations operation
+  where object.id = p_object_id and object.operation_id = p_operation_id
+    and operation.id = object.operation_id and operation.teacher_id = p_teacher_id
+    and object.status = 'processing' and object.lease_token = p_lease_token
+  returning object.attempt_count into v_attempt;
+  if not found then return jsonb_build_object('ok', false, 'status', 409,
+    'error_code', 'student_purge_object_lease_lost', 'error', 'Storage deletion lease expired', 'retryable', true); end if;
+  update public.student_purge_operations set status = 'failed', retryable = v_attempt < 12,
+    error_code = 'student_purge_storage_delete_failed', updated_at = clock_timestamp()
+  where id = p_operation_id;
+  return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+    'operation_status', 'failed', 'retryable', v_attempt < 12);
+end;
+$$;
+
+create or replace function public.finalize_student_purge(p_operation_id uuid, p_teacher_id uuid)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare
+  v_operation public.student_purge_operations;
+  v_resource record;
+  v_expected integer;
+  v_actual integer;
+  v_error text;
+begin
+  select * into v_operation from public.student_purge_operations
+  where id = p_operation_id and teacher_id = p_teacher_id;
+  if not found then return jsonb_build_object('ok', false, 'status', 404,
+    'error_code', 'student_purge_not_found', 'error', 'Student data deletion not found'); end if;
+  if v_operation.status = 'completed' then return jsonb_build_object('ok', true, 'status', 200,
+    'operation_id', p_operation_id, 'operation_status', 'completed', 'replayed', true); end if;
+  perform public.student_purge_lock(v_operation.classroom_id, v_operation.student_id);
+  select * into v_operation from public.student_purge_operations
+  where id = p_operation_id and teacher_id = p_teacher_id for update;
+  if exists (select 1 from public.student_purge_objects
+    where operation_id = p_operation_id and status <> 'deleted')
+  then return jsonb_build_object('ok', true, 'status', 202, 'operation_id', p_operation_id,
+    'operation_status', v_operation.status, 'waiting_for_storage', true); end if;
+  if exists (
+    select 1 from public.managed_storage_objects object
+    left join public.managed_storage_provisional_owners provisional on provisional.id = object.provisional_owner_id
+    left join public.student_purge_objects staged on staged.operation_id = p_operation_id
+      and staged.managed_storage_object_id = object.id and staged.status = 'deleted'
+    where (object.classroom_id = v_operation.classroom_id
+      or provisional.target_classroom_id = v_operation.classroom_id)
+      and (object.data_subject_user_id = v_operation.student_id
+        or object.purpose in ('classroom_archive', 'gradex_extract')) and staged.id is null
+  ) then
+    update public.student_purge_operations set status = 'failed',
+      error_code = 'student_purge_storage_owner_drift', retryable = false,
+      updated_at = clock_timestamp() where id = p_operation_id;
+    return jsonb_build_object('ok', false, 'status', 409,
+      'error_code', 'student_purge_storage_owner_drift',
+      'error', 'Managed storage ownership changed; deletion stopped safely', 'retryable', false);
+  end if;
+  begin
+    update public.student_purge_operations set status = 'finalizing', updated_at = clock_timestamp()
+    where id = p_operation_id;
+    perform set_config('pika.student_purge_finalize', 'on', true);
+
+    -- Shared grading runs survive, but every target identifier and aggregate
+    -- contribution is removed after their exact item rows are deleted below.
+    for v_resource in
+      select table_name, row_id, disposition from public.student_purge_resources
+      where operation_id = p_operation_id and disposition in ('delete', 'collateral_delete')
+      order by case table_name
+        when 'assignment_doc_history' then 10 when 'assignment_doc_save_operations' then 11
+        when 'assignment_submission_artifacts' then 12 when 'assignment_ai_grading_run_items' then 13
+        when 'test_ai_grading_run_items' then 14 when 'test_attempt_history' then 15
+        when 'announcement_reads' then 20 when 'assignment_feedback_entries' then 21
+        when 'assignment_repo_review_results' then 22 when 'assignment_repo_targets' then 23
+        when 'test_focus_events' then 24 when 'test_responses' then 25
+        when 'test_student_availability' then 26 when 'survey_responses' then 27
+        when 'report_card_rows' then 28 when 'assignment_docs' then 30
+        when 'test_attempts' then 31 when 'entries' then 32
+        when 'classroom_enrollments' then 40 when 'classroom_roster' then 41
+        when 'log_summaries' then 50 when 'developer_feedback_candidates' then 51 else 100 end,
+        table_name, row_id
+    loop
+      execute format('delete from public.%I where id = $1', v_resource.table_name)
+      using v_resource.row_id;
+      get diagnostics v_actual = row_count;
+      if v_actual <> 1 then raise exception using errcode = '40001',
+        message = 'student_purge_membership_drift_' || v_resource.table_name; end if;
+    end loop;
+
+    update public.assignment_ai_grading_runs run set
+      requested_student_ids_json = coalesce((select jsonb_agg(value) from jsonb_array_elements(run.requested_student_ids_json)
+        where value #>> '{}' <> v_operation.student_id::text), '[]'::jsonb),
+      error_samples_json = replace(coalesce(run.error_samples_json, '[]'::jsonb)::text,
+        v_operation.student_id::text, '[purged-student]')::jsonb,
+      requested_count = (select count(*) from jsonb_array_elements(run.requested_student_ids_json)
+        where value #>> '{}' <> v_operation.student_id::text),
+      gradable_count = (select count(*) from public.assignment_ai_grading_run_items item where item.run_id = run.id),
+      processed_count = (select count(*) from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.status in ('completed', 'skipped', 'failed')),
+      completed_count = (select count(*) from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.status = 'completed'),
+      skipped_missing_count = (select count(*) from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.skip_reason = 'missing_doc'),
+      skipped_empty_count = (select count(*) from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.skip_reason = 'empty_doc'),
+      failed_count = (select count(*) from public.assignment_ai_grading_run_items item
+        where item.run_id = run.id and item.status = 'failed'), updated_at = clock_timestamp()
+    where run.id in (select row_id from public.student_purge_resources
+      where operation_id = p_operation_id and table_name = 'assignment_ai_grading_runs');
+
+    update public.test_ai_grading_runs run set
+      requested_student_ids_json = coalesce((select jsonb_agg(value) from jsonb_array_elements(run.requested_student_ids_json)
+        where value #>> '{}' <> v_operation.student_id::text), '[]'::jsonb),
+      error_samples_json = replace(coalesce(run.error_samples_json, '[]'::jsonb)::text,
+        v_operation.student_id::text, '[purged-student]')::jsonb,
+      requested_count = (select count(*) from jsonb_array_elements(run.requested_student_ids_json)
+        where value #>> '{}' <> v_operation.student_id::text),
+      eligible_student_count = (select count(distinct item.student_id) from public.test_ai_grading_run_items item where item.run_id = run.id),
+      queued_response_count = (select count(*) from public.test_ai_grading_run_items item where item.run_id = run.id),
+      processed_count = (select count(*) from public.test_ai_grading_run_items item where item.run_id = run.id and item.status in ('completed', 'failed')),
+      completed_count = (select count(*) from public.test_ai_grading_run_items item where item.run_id = run.id and item.status = 'completed'),
+      failed_count = (select count(*) from public.test_ai_grading_run_items item where item.run_id = run.id and item.status = 'failed'),
+      skipped_unanswered_count = 0, skipped_already_graded_count = 0, updated_at = clock_timestamp()
+    where run.id in (select row_id from public.student_purge_resources
+      where operation_id = p_operation_id and table_name = 'test_ai_grading_runs');
+
+    -- Retained archive and Gradex copies are immutable and can contain the
+    -- student, so delete their exact managed objects and all Classroom ledgers.
+    delete from public.classroom_archive_restore_staging staging
+    using public.classroom_archive_operations operation
+    where staging.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_restore_expected_objects expected
+    using public.classroom_archive_operations operation
+    where expected.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_object_upload_cleanup cleanup
+    using public.classroom_archive_operations operation
+    where cleanup.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_snapshot_resources snapshot
+    using public.classroom_archive_operations operation
+    where snapshot.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_snapshot_actors snapshot
+    using public.classroom_archive_operations operation
+    where snapshot.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_gradex_extract_cleanup cleanup
+    using public.classroom_archive_operations operation
+    where cleanup.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_gradex_extracts where classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_source_object_cleanup where classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_source_object_reservations reservation
+    using public.classroom_archive_operations operation
+    where reservation.operation_id = operation.id and operation.classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archives where classroom_id = v_operation.classroom_id;
+    delete from public.classroom_archive_operations where classroom_id = v_operation.classroom_id;
+
+    delete from public.assignment_artifact_storage_cleanup cleanup
+    where cleanup.managed_object_id in (select managed_storage_object_id from public.student_purge_objects
+      where operation_id = p_operation_id);
+    delete from public.test_document_snapshot_storage_cleanup cleanup
+    where cleanup.managed_object_id in (select managed_storage_object_id from public.student_purge_objects
+      where operation_id = p_operation_id);
+    delete from public.managed_storage_objects object using public.student_purge_objects staged
+    where staged.operation_id = p_operation_id and staged.managed_storage_object_id = object.id;
+
+    update public.student_purge_operations set status = 'completed', student_id = null,
+      student_email = null, impact_summary = jsonb_build_object(
+        'relational_rows_deleted', (select count(*) from public.student_purge_resources
+          where operation_id = p_operation_id and disposition <> 'redact'),
+        'shared_rows_redacted', (select count(*) from public.student_purge_resources
+          where operation_id = p_operation_id and disposition = 'redact'),
+        'managed_files_deleted', (select count(*) from public.student_purge_objects where operation_id = p_operation_id)
+      ), retryable = false, error_code = null, completed_at = clock_timestamp(), updated_at = clock_timestamp()
+    where id = p_operation_id;
+    delete from public.student_purge_resources where operation_id = p_operation_id;
+    delete from public.student_purge_fences where operation_id = p_operation_id;
+    return jsonb_build_object('ok', true, 'status', 200, 'operation_id', p_operation_id,
+      'operation_status', 'completed');
+  exception when others then
+    v_error := case when sqlstate = '40001' then left(sqlerrm, 160)
+      when sqlstate like '23%' then 'student_purge_constraint_drift' else 'student_purge_finalize_failed' end;
+    update public.student_purge_operations set status = 'failed', error_code = v_error,
+      retryable = sqlstate not in ('40001', '23503', '23505'), updated_at = clock_timestamp()
+    where id = p_operation_id;
+    return jsonb_build_object('ok', false, 'status', 500, 'error_code', v_error,
+      'error', 'Student data deletion paused before database finalization',
+      'retryable', sqlstate not in ('40001', '23503', '23505'));
+  end;
+end;
+$$;
+
+-- Keep roster identity stable once a student joins. Enrollment is the authority;
+-- emails remain display data and are never used by finalization.
+create or replace function public.bind_classroom_roster_student_id()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if tg_op = 'UPDATE' and old.student_id is not null
+    and new.student_id is distinct from old.student_id
+    and coalesce(current_setting('pika.student_purge_finalize', true), '') <> 'on'
+  then raise exception using errcode = '55000', message = 'roster_student_identity_immutable'; end if;
+  if new.student_id is null then
+    select enrollment.student_id into new.student_id
+    from public.classroom_enrollments enrollment
+    join public.users student on student.id = enrollment.student_id and student.role = 'student'
+    where enrollment.classroom_id = new.classroom_id
+      and lower(btrim(student.email)) = lower(btrim(new.email));
+  end if;
+  return new;
+end;
+$$;
+create trigger bind_classroom_roster_student_id
+  before insert or update of classroom_id, email, student_id on public.classroom_roster
+  for each row execute function public.bind_classroom_roster_student_id();
+
+create or replace function public.bind_roster_after_enrollment()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  update public.classroom_roster roster set student_id = new.student_id
+  from public.users student where student.id = new.student_id and student.role = 'student'
+    and roster.classroom_id = new.classroom_id and lower(btrim(roster.email)) = lower(btrim(student.email))
+    and roster.student_id is null;
+  return new;
+end;
+$$;
+create trigger bind_roster_after_enrollment
+  after insert on public.classroom_enrollments for each row execute function public.bind_roster_after_enrollment();
+
+-- Mutual exclusion with whole-Classroom deletion. Both directions are enforced
+-- by trigger as well as startup checks so neither operation can win a race.
+create or replace function public.reject_conflicting_purge_fence()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || new.classroom_id::text, 0));
+  if tg_table_name = 'student_purge_fences' then
+    if exists (select 1 from public.classroom_purge_fences where classroom_id = new.classroom_id)
+      or exists (select 1 from public.cold_classroom_purge_fences where classroom_id = new.classroom_id)
+    then raise exception using errcode = '55000', message = 'classroom_purge_operation_active'; end if;
+  elsif exists (select 1 from public.student_purge_fences where classroom_id = new.classroom_id) then
+    raise exception using errcode = '55000', message = 'student_purge_operation_active';
+  end if;
+  return new;
+end;
+$$;
+create trigger student_purge_fence_conflict before insert on public.student_purge_fences
+  for each row execute function public.reject_conflicting_purge_fence();
+create trigger hot_purge_student_fence_conflict before insert on public.classroom_purge_fences
+  for each row execute function public.reject_conflicting_purge_fence();
+create trigger cold_purge_student_fence_conflict before insert on public.cold_classroom_purge_fences
+  for each row execute function public.reject_conflicting_purge_fence();
+
+-- Pair-specific writer fence for direct student/Classroom resources and
+-- managed-file ownership. Finalization opts in only inside its transaction.
+create or replace function public.reject_student_resource_change_during_purge()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_row jsonb;
+  v_rows jsonb[] := case when tg_op = 'INSERT' then array[to_jsonb(new)]
+    when tg_op = 'DELETE' then array[to_jsonb(old)] else array[to_jsonb(old), to_jsonb(new)] end;
+  v_classroom_id uuid;
+  v_student_id uuid;
+  v_parent_id uuid;
+begin
+  if current_setting('pika.student_purge_finalize', true) = 'on' then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+  foreach v_row in array v_rows loop
+    v_classroom_id := null;
+    v_student_id := nullif(coalesce(v_row->>'student_id', v_row->>'user_id'), '')::uuid;
+    v_parent_id := null;
+    if tg_table_name in ('entries', 'classroom_enrollments', 'classroom_roster') then
+      v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
+    elsif tg_table_name = 'managed_storage_objects' then
+      v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
+      if v_classroom_id is null then
+        select target_classroom_id into v_classroom_id from public.managed_storage_provisional_owners
+        where id = nullif(v_row->>'provisional_owner_id', '')::uuid;
+      end if;
+      v_student_id := nullif(coalesce(v_row->>'data_subject_user_id',
+        case when v_row->>'purpose' in ('student_assignment_artifact', 'student_inline_image')
+          then v_row->>'created_by_user_id' end), '')::uuid;
+    elsif tg_table_name in ('assignment_docs', 'assignment_feedback_entries', 'assignment_repo_review_results',
+        'assignment_repo_targets', 'assignment_ai_grading_run_items') then
+      v_parent_id := nullif(v_row->>'assignment_id', '')::uuid;
+      select classroom_id into v_classroom_id from public.assignments where id = v_parent_id;
+    elsif tg_table_name = 'assignment_submission_artifacts' then
+      select assignment.classroom_id into v_classroom_id from public.assignment_docs doc
+        join public.assignments assignment on assignment.id = doc.assignment_id
+        where doc.id = nullif(v_row->>'assignment_doc_id', '')::uuid;
+    elsif tg_table_name in ('test_attempts', 'test_responses', 'test_focus_events',
+        'test_student_availability', 'test_ai_grading_run_items') then
+      v_parent_id := nullif(v_row->>'test_id', '')::uuid;
+      select classroom_id into v_classroom_id from public.tests where id = v_parent_id;
+    elsif tg_table_name = 'survey_responses' then
+      select classroom_id into v_classroom_id from public.surveys where id = nullif(v_row->>'survey_id', '')::uuid;
+    elsif tg_table_name = 'announcement_reads' then
+      select classroom_id into v_classroom_id from public.announcements where id = nullif(v_row->>'announcement_id', '')::uuid;
+    elsif tg_table_name = 'report_card_rows' then
+      select classroom_id into v_classroom_id from public.report_cards where id = nullif(v_row->>'report_card_id', '')::uuid;
+    elsif tg_table_name in ('pal_event_outbox', 'pal_daily_log_week_configurations') then
+      perform pg_advisory_xact_lock(hashtextextended('pika-student-purge-subject:' || v_student_id::text, 0));
+      if exists (select 1 from public.student_purge_fences where student_id = v_student_id) then
+        raise exception using errcode = '55000', message = 'student_purge_active';
+      end if;
+      continue;
+    end if;
+    if v_classroom_id is not null and v_student_id is not null then
+      perform public.student_purge_lock(v_classroom_id, v_student_id);
+      if exists (select 1 from public.student_purge_fences
+        where classroom_id = v_classroom_id and student_id = v_student_id)
+      then raise exception using errcode = '55000', message = 'student_purge_active'; end if;
+    end if;
+  end loop;
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+do $$ declare v_table text; begin
+  foreach v_table in array array[
+    'entries','classroom_enrollments','classroom_roster','managed_storage_objects',
+    'assignment_docs','assignment_feedback_entries','assignment_repo_review_results',
+    'assignment_repo_targets','assignment_submission_artifacts','assignment_ai_grading_run_items',
+    'test_attempts','test_responses','test_focus_events','test_student_availability',
+    'test_ai_grading_run_items','survey_responses','announcement_reads','report_card_rows',
+    'pal_event_outbox','pal_daily_log_week_configurations'
+  ] loop
+    execute format('create trigger student_purge_guard_%I before insert or update or delete on public.%I
+      for each row execute function public.reject_student_resource_change_during_purge()', v_table, v_table);
+  end loop;
+end $$;
+
+create or replace function public.reject_archive_operation_during_student_purge()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if current_setting('pika.student_purge_finalize', true) = 'on' then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+  if tg_op = 'UPDATE' and old.classroom_id::text > new.classroom_id::text then
+    perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || new.classroom_id::text, 0));
+    perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || old.classroom_id::text, 0));
+  else
+    perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:'
+      || case when tg_op = 'INSERT' then new.classroom_id::text else old.classroom_id::text end, 0));
+    if tg_op = 'UPDATE' and new.classroom_id is distinct from old.classroom_id then
+      perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || new.classroom_id::text, 0));
+    end if;
+  end if;
+  if exists (select 1 from public.student_purge_fences
+    where classroom_id = case when tg_op = 'INSERT' then new.classroom_id else old.classroom_id end)
+    or (tg_op = 'UPDATE' and exists (select 1 from public.student_purge_fences where classroom_id = new.classroom_id))
+  then
+    raise exception using errcode = '55000', message = 'student_purge_active';
+  end if;
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+create trigger classroom_archive_operation_student_purge_guard
+  before insert or update or delete on public.classroom_archive_operations
+  for each row execute function public.reject_archive_operation_during_student_purge();
+
+create or replace function public.reject_student_indirect_change_during_purge()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_row jsonb;
+  v_rows jsonb[] := case when tg_op = 'INSERT' then array[to_jsonb(new)]
+    when tg_op = 'DELETE' then array[to_jsonb(old)] else array[to_jsonb(old), to_jsonb(new)] end;
+  v_classroom_id uuid;
+  v_student_id uuid;
+begin
+  if current_setting('pika.student_purge_finalize', true) = 'on' then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+  foreach v_row in array v_rows loop
+    v_classroom_id := null;
+    v_student_id := null;
+    if tg_table_name in ('assignment_doc_history', 'assignment_doc_save_operations') then
+      select assignment.classroom_id, doc.student_id into v_classroom_id, v_student_id
+      from public.assignment_docs doc join public.assignments assignment on assignment.id = doc.assignment_id
+      where doc.id = nullif(v_row->>'assignment_doc_id', '')::uuid;
+    elsif tg_table_name = 'test_attempt_history' then
+      select test.classroom_id, attempt.student_id into v_classroom_id, v_student_id
+      from public.test_attempts attempt join public.tests test on test.id = attempt.test_id
+      where attempt.id = nullif(v_row->>'test_attempt_id', '')::uuid;
+    elsif tg_table_name = 'assignment_ai_grading_runs' then
+      select assignment.classroom_id into v_classroom_id from public.assignments assignment
+      where assignment.id = nullif(v_row->>'assignment_id', '')::uuid;
+    elsif tg_table_name = 'test_ai_grading_runs' then
+      select test.classroom_id into v_classroom_id from public.tests test
+      where test.id = nullif(v_row->>'test_id', '')::uuid;
+    elsif tg_table_name = 'log_summaries' then
+      v_classroom_id := nullif(v_row->>'classroom_id', '')::uuid;
+    elsif tg_table_name = 'developer_feedback_candidates' then
+      if exists (select 1 from public.student_purge_fences fence
+        where (v_row->'source_classroom_ids') ? fence.classroom_id::text)
+      then raise exception using errcode = '55000', message = 'student_purge_active'; end if;
+      continue;
+    end if;
+    if v_classroom_id is not null then
+      if v_student_id is null then
+        perform pg_advisory_xact_lock(hashtextextended('pika-classroom-operation:' || v_classroom_id::text, 0));
+      else
+        perform public.student_purge_lock(v_classroom_id, v_student_id);
+      end if;
+      if exists (select 1 from public.student_purge_fences fence
+        where fence.classroom_id = v_classroom_id
+          and (v_student_id is null or fence.student_id = v_student_id))
+      then raise exception using errcode = '55000', message = 'student_purge_active'; end if;
+    end if;
+  end loop;
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+do $$ declare v_table text; begin
+  foreach v_table in array array[
+    'assignment_doc_history','assignment_doc_save_operations','test_attempt_history',
+    'assignment_ai_grading_runs','test_ai_grading_runs','log_summaries','developer_feedback_candidates'
+  ] loop
+    execute format('create trigger student_purge_indirect_guard_%I before insert or update or delete on public.%I
+      for each row execute function public.reject_student_indirect_change_during_purge()', v_table, v_table);
+  end loop;
+end $$;
+
+-- Extend storage delete authority with an exact live student-purge lease.
+create or replace function public.enforce_managed_storage_object_delete()
+returns trigger language plpgsql security definer set search_path = public, storage as $$
+declare v_enforced boolean; v_object public.managed_storage_objects; v_referenced boolean;
+begin
+  if old.bucket_id not in ('assignment-artifacts','submission-images','test-documents',
+    'classroom-archives','gradex-analytics-extracts') then return old; end if;
+  v_enforced := public.lock_managed_storage_protocol();
+  select * into v_object from public.managed_storage_objects object
+  where object.storage_bucket = old.bucket_id and object.storage_path = old.name for update;
+  perform public.managed_storage_exact_lock(old.bucket_id, old.name);
+  if v_object.id is not null and (
+    exists (
+      select 1 from public.classroom_purge_objects purge_object
+      join public.classroom_purge_operations operation on operation.id = purge_object.operation_id
+      where purge_object.managed_storage_object_id = v_object.id and purge_object.status = 'processing'
+        and purge_object.lease_expires_at > clock_timestamp()
+        and operation.status in ('deleting_objects','failed') and (
+          exists (select 1 from public.classroom_purge_fences fence where fence.operation_id = operation.id
+            and fence.classroom_id = operation.classroom_id and operation.purge_scope = 'hot_classroom')
+          or exists (select 1 from public.cold_classroom_purge_fences fence where fence.operation_id = operation.id
+            and fence.classroom_id = operation.classroom_id and operation.purge_scope = 'cold_classroom')
+        )
+    ) or exists (
+      select 1 from public.course_blueprint_purge_objects purge_object
+      join public.course_blueprint_purge_operations operation on operation.id = purge_object.operation_id
+      join public.course_blueprint_purge_fences fence on fence.operation_id = operation.id
+        and fence.course_blueprint_id = operation.course_blueprint_id
+      where purge_object.managed_storage_object_id = v_object.id and purge_object.status = 'processing'
+        and purge_object.lease_expires_at > clock_timestamp()
+        and (operation.status = 'deleting_objects' or (operation.status = 'failed' and operation.retryable is true))
+    ) or exists (
+      select 1 from public.student_purge_objects purge_object
+      join public.student_purge_operations operation on operation.id = purge_object.operation_id
+      join public.student_purge_fences fence on fence.operation_id = operation.id
+        and fence.classroom_id = operation.classroom_id and fence.student_id = operation.student_id
+      where purge_object.managed_storage_object_id = v_object.id and purge_object.status = 'processing'
+        and purge_object.lease_expires_at > clock_timestamp()
+        and (operation.status = 'deleting_objects' or (operation.status = 'failed' and operation.retryable is true))
+    )
+  ) then return old; end if;
+  if v_object.id is null then
+    if not v_enforced then return old; end if;
+    raise exception using errcode = '55000', message = 'managed_storage_cleanup_authority_required';
+  end if;
+  if v_object.status <> 'cleanup_processing' then
+    raise exception using errcode = '55000', message = 'managed_storage_cleanup_authority_required';
+  end if;
+  v_referenced := public.managed_storage_object_is_referenced(v_object.id)
+    or case v_object.storage_bucket
+      when 'assignment-artifacts' then exists (select 1 from public.assignment_submission_artifacts
+        where storage_path = v_object.storage_path)
+      when 'test-documents' then public.test_document_snapshot_path_is_referenced(v_object.storage_path)
+      else false end;
+  if v_referenced then raise exception using errcode = '55000', message = 'managed_storage_cleanup_referenced'; end if;
+  return old;
+end;
+$$;
+
+-- Lightweight health probe used by the existing cleanup cron/monitoring path.
+create or replace function public.get_student_purge_health_snapshot(
+  p_stuck_minutes integer default 30, p_failed_minutes integer default 15
+)
+returns jsonb language sql security definer set search_path = public as $$
+  select jsonb_build_object(
+    'captured_at', clock_timestamp(),
+    'active_count', count(*) filter (where status in ('inventorying','deleting_objects','finalizing')),
+    'stuck_count', count(*) filter (where status in ('inventorying','deleting_objects','finalizing')
+      and updated_at < clock_timestamp() - make_interval(mins => greatest(p_stuck_minutes, 1))),
+    'failed_count', count(*) filter (where status = 'failed'
+      and updated_at < clock_timestamp() - make_interval(mins => greatest(p_failed_minutes, 1))),
+    'orphan_fence_count', (select count(*) from public.student_purge_fences fence
+      left join public.student_purge_operations operation on operation.id = fence.operation_id
+      where operation.id is null or operation.status = 'completed'),
+    'processing_lease_drift_count', (select count(*) from public.student_purge_objects
+      where (status = 'processing') <> (lease_token is not null and lease_expires_at is not null))
+  ) from public.student_purge_operations
+$$;
+
+revoke all on function public.student_purge_lock(uuid,uuid) from public, anon, authenticated, service_role;
+revoke all on function public.student_purge_rollout_allows(uuid,uuid,uuid) from public, anon, authenticated, service_role;
+revoke all on function public.student_purge_inventory_resources(uuid,uuid) from public, anon, authenticated, service_role;
+revoke all on function public.student_purge_conflict(uuid,uuid) from public, anon, authenticated, service_role;
+revoke all on function public.get_student_purge_inventory(uuid,uuid,uuid) from public, anon, authenticated;
+revoke all on function public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text) from public, anon, authenticated;
+revoke all on function public.claim_student_purge_object(uuid,uuid,integer) from public, anon, authenticated;
+revoke all on function public.complete_student_purge_object(uuid,uuid,uuid,uuid) from public, anon, authenticated;
+revoke all on function public.fail_student_purge_object(uuid,uuid,uuid,uuid,text) from public, anon, authenticated;
+revoke all on function public.finalize_student_purge(uuid,uuid) from public, anon, authenticated;
+revoke all on function public.get_student_purge_health_snapshot(integer,integer) from public, anon, authenticated;
+revoke all on function public.bind_classroom_roster_student_id() from public, anon, authenticated, service_role;
+revoke all on function public.bind_roster_after_enrollment() from public, anon, authenticated, service_role;
+revoke all on function public.reject_conflicting_purge_fence() from public, anon, authenticated, service_role;
+revoke all on function public.reject_student_resource_change_during_purge() from public, anon, authenticated, service_role;
+revoke all on function public.reject_archive_operation_during_student_purge() from public, anon, authenticated, service_role;
+revoke all on function public.reject_student_indirect_change_during_purge() from public, anon, authenticated, service_role;
+grant execute on function public.get_student_purge_inventory(uuid,uuid,uuid) to service_role;
+grant execute on function public.begin_student_purge(uuid,uuid,uuid,uuid,text,bigint,text,text) to service_role;
+grant execute on function public.claim_student_purge_object(uuid,uuid,integer) to service_role;
+grant execute on function public.complete_student_purge_object(uuid,uuid,uuid,uuid) to service_role;
+grant execute on function public.fail_student_purge_object(uuid,uuid,uuid,uuid,text) to service_role;
+grant execute on function public.finalize_student_purge(uuid,uuid) to service_role;
+grant execute on function public.get_student_purge_health_snapshot(integer,integer) to service_role;
+
+comment on table public.student_purge_settings is
+  'Disabled-by-default rollout gate for hot-Classroom individual-student purge.';
+comment on table public.student_purge_resources is
+  'Exact relational deletion/redaction snapshot; never inferred from cascades at finalization.';
+comment on table public.student_purge_objects is
+  'Exact managed-object deletion ledger with durable leases and retries.';

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -11,6 +11,7 @@ const cleanupMocks = vi.hoisted(() => ({
 const purgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
 const coldPurgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
 const blueprintPurgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
+const studentPurgeMocks = vi.hoisted(() => ({ run: vi.fn(), health: vi.fn() }))
 const healthMocks = vi.hoisted(() => ({ read: vi.fn() }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -33,6 +34,11 @@ vi.mock('@/lib/server/cold-classroom-purge', () => ({
 
 vi.mock('@/lib/server/course-blueprint-purge', () => ({
   runCourseBlueprintPurgeSafetyNet: blueprintPurgeMocks.run,
+}))
+
+vi.mock('@/lib/server/student-purge', () => ({
+  runStudentPurgeSafetyNet: studentPurgeMocks.run,
+  readStudentPurgeHealth: studentPurgeMocks.health,
 }))
 
 vi.mock('@/lib/server/managed-deletion-health', () => ({
@@ -231,6 +237,8 @@ describe('cron cleanup-history route', () => {
     purgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
     coldPurgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
     blueprintPurgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
+    studentPurgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
+    studentPurgeMocks.health.mockResolvedValue({ schemaAvailable: false, snapshot: null })
     healthMocks.read.mockResolvedValue({ schemaAvailable: false })
     mockSupabaseClient.rpc.mockResolvedValue({ data: 0, error: null })
   })
@@ -277,11 +285,12 @@ describe('cron cleanup-history route', () => {
     )
   })
 
-  it('advances durable hot, cold, and Blueprint purges through the authenticated safety net', async () => {
+  it('advances durable hot, cold, Blueprint, and student purges through the authenticated safety net', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
     purgeMocks.run.mockResolvedValue({ processed: 2, completed: 1, failed: 0 })
     coldPurgeMocks.run.mockResolvedValue({ processed: 1, completed: 0, failed: 0 })
     blueprintPurgeMocks.run.mockResolvedValue({ processed: 1, completed: 1, failed: 0 })
+    studentPurgeMocks.run.mockResolvedValue({ processed: 1, completed: 0, failed: 0 })
     const mock = createCleanupMock({ classrooms: [] })
     ;(mockSupabaseClient.from as any) = mock.from
 
@@ -294,10 +303,51 @@ describe('cron cleanup-history route', () => {
       classroom_purge: { processed: 2, completed: 1, failed: 0 },
       cold_classroom_purge: { processed: 1, completed: 0, failed: 0 },
       course_blueprint_purge: { processed: 1, completed: 1, failed: 0 },
+      student_purge: { processed: 1, completed: 0, failed: 0 },
     })
     expect(purgeMocks.run).toHaveBeenCalledOnce()
     expect(coldPurgeMocks.run).toHaveBeenCalledWith(10)
     expect(blueprintPurgeMocks.run).toHaveBeenCalledOnce()
+    expect(studentPurgeMocks.run).toHaveBeenCalledOnce()
+  })
+
+  it('fails observably when student purge work is stuck or partially failed', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    studentPurgeMocks.health.mockResolvedValue({
+      schemaAvailable: true,
+      snapshot: {
+        captured_at: '2026-08-11T12:00:00.000Z',
+        active_count: 1,
+        stuck_count: 1,
+        failed_count: 0,
+        orphan_fence_count: 0,
+        processing_lease_drift_count: 0,
+      },
+    })
+    const response = await GET(cronRequest())
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Student purge health degraded' })
+  })
+
+  it('fails observably when the current student purge retry fails', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    studentPurgeMocks.run.mockResolvedValue({ processed: 1, completed: 0, failed: 1 })
+    studentPurgeMocks.health.mockResolvedValue({
+      schemaAvailable: true,
+      snapshot: {
+        captured_at: '2026-08-11T12:00:00.000Z',
+        active_count: 0,
+        stuck_count: 0,
+        failed_count: 0,
+        orphan_fence_count: 0,
+        processing_lease_drift_count: 0,
+      },
+    })
+    const response = await GET(cronRequest())
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Student purge health degraded' })
   })
 
   it('checks managed deletion health after the authenticated cleanup succeeds', async () => {

--- a/tests/api/teacher/roster.test.ts
+++ b/tests/api/teacher/roster.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/app/api/teacher/classrooms/[id]/roster/route'
 import { NextRequest } from 'next/server'
 
+const purgeAvailability = vi.hoisted(() => vi.fn())
+
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
 vi.mock('@/lib/server/classrooms', () => ({
@@ -14,6 +16,9 @@ vi.mock('@/lib/server/classrooms', () => ({
     classroom: { id: 'c-1', teacher_id: 'teacher-1', archived_at: null },
   })),
 }))
+vi.mock('@/lib/server/student-purge', () => ({
+  getStudentPurgeEnabledStudentIds: (...args: unknown[]) => purgeAvailability(...args),
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
 
@@ -21,6 +26,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.from = vi.fn()
+    purgeAvailability.mockResolvedValue([])
   })
 
   it('should return 403 when not classroom owner', async () => {
@@ -115,5 +121,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
         joined_at: null,
       }),
     ])
+    expect(data.student_purge_enabled_ids).toEqual([])
+    expect(purgeAvailability).toHaveBeenCalledWith('teacher-1', 'c-1', ['student-1'])
   })
 })

--- a/tests/api/teacher/roster.test.ts
+++ b/tests/api/teacher/roster.test.ts
@@ -95,6 +95,14 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
         }
       }
 
+      if (table === 'classroom_roster_student_bindings') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST205', message: 'missing' } }),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -123,5 +131,38 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
     ])
     expect(data.student_purge_enabled_ids).toEqual([])
     expect(purgeAvailability).toHaveBeenCalledWith('teacher-1', 'c-1', ['student-1'])
+  })
+
+  it('prefers stable joined-student bindings over edited roster email', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => ({
+      select: vi.fn(() => ({
+        eq: vi.fn().mockResolvedValue(table === 'classroom_roster'
+          ? { data: [{
+              id: 'r-1', email: 'edited@example.com', student_number: null,
+              first_name: 'Ada', last_name: 'Lovelace', counselor_email: null,
+              join_source: 'manual', created_at: '2026-04-01T12:00:00.000Z',
+              updated_at: '2026-04-02T12:00:00.000Z',
+            }], error: null }
+          : table === 'classroom_enrollments'
+            ? { data: [{
+                student_id: 'student-1', created_at: '2026-04-05T12:00:00.000Z',
+                users: { email: 'original@example.com' },
+              }], error: null }
+            : { data: [{ roster_id: 'r-1', student_id: 'student-1' }], error: null }),
+      })),
+    }))
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster'),
+      { params: { id: 'c-1' } },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.roster[0]).toEqual(expect.objectContaining({
+      email: 'edited@example.com',
+      joined: true,
+      student_id: 'student-1',
+    }))
   })
 })

--- a/tests/api/teacher/student-purge-route.test.ts
+++ b/tests/api/teacher/student-purge-route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { ApiError } from '@/lib/api-error'
+import { GET as getImpact, POST as startPurge } from '@/app/api/teacher/classrooms/[id]/students/[studentId]/purge/route'
+import { GET as getStatus } from '@/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/route'
+import { POST as tickPurge } from '@/app/api/teacher/classrooms/[id]/students/[studentId]/purge/[operationId]/tick/route'
+
+const TEACHER_ID = '10000000-0000-4000-8000-000000000001'
+const CLASSROOM_ID = '20000000-0000-4000-8000-000000000001'
+const STUDENT_ID = '30000000-0000-4000-8000-000000000001'
+const OPERATION_ID = '40000000-0000-4000-8000-000000000001'
+const DIGEST = 'a'.repeat(64)
+
+const mocks = vi.hoisted(() => ({
+  requireRole: vi.fn(), impact: vi.fn(), active: vi.fn(), start: vi.fn(), status: vi.fn(), tick: vi.fn(), target: vi.fn(),
+}))
+vi.mock('@/lib/auth', () => ({ requireRole: (...args: unknown[]) => mocks.requireRole(...args) }))
+vi.mock('@/lib/server/student-purge', () => ({
+  getStudentPurgeImpact: (...args: unknown[]) => mocks.impact(...args),
+  getActiveStudentPurgeStatus: (...args: unknown[]) => mocks.active(...args),
+  startStudentPurge: (...args: unknown[]) => mocks.start(...args),
+  getStudentPurgeStatus: (...args: unknown[]) => mocks.status(...args),
+  advanceStudentPurge: (...args: unknown[]) => mocks.tick(...args),
+  assertStudentPurgeOperationTarget: (...args: unknown[]) => mocks.target(...args),
+}))
+
+const impact = { classroom_id: CLASSROOM_ID, student_id: STUDENT_ID }
+const operation = {
+  operation_id: OPERATION_ID, classroom_id: CLASSROOM_ID,
+  status: 'deleting_objects', retryable: null, error_code: null,
+  attempt_count: 1, resource_counts: {}, storage_object_counts: { pending: 1 }, completed_at: null,
+}
+const context = { params: Promise.resolve({
+  id: CLASSROOM_ID, studentId: STUDENT_ID, operationId: OPERATION_ID,
+}) } as never
+
+describe('teacher individual-student purge routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireRole.mockResolvedValue({ id: TEACHER_ID })
+    mocks.impact.mockResolvedValue(impact)
+    mocks.active.mockResolvedValue(null)
+    mocks.start.mockResolvedValue(operation)
+    mocks.status.mockResolvedValue(operation)
+    mocks.tick.mockResolvedValue({ operation, advanced: true })
+    mocks.target.mockResolvedValue(undefined)
+  })
+
+  it('binds impact to the teacher, classroom, and one student', async () => {
+    const response = await getImpact(new NextRequest('http://localhost/purge'), context)
+    expect(response.status).toBe(200)
+    expect(mocks.requireRole).toHaveBeenCalledWith('teacher')
+    expect(mocks.impact).toHaveBeenCalledWith(TEACHER_ID, CLASSROOM_ID, STUDENT_ID)
+  })
+
+  it('passes exact typed confirmation and both inventory digests', async () => {
+    const response = await startPurge(new NextRequest('http://localhost/purge', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operation_id: OPERATION_ID,
+        confirmation: 'student@example.com',
+        expected_source_revision: 7,
+        expected_storage_inventory_sha256: DIGEST,
+        expected_relational_inventory_sha256: DIGEST,
+      }),
+    }), context)
+    expect(response.status).toBe(202)
+    expect(mocks.start).toHaveBeenCalledWith({
+      teacherId: TEACHER_ID, classroomId: CLASSROOM_ID, studentId: STUDENT_ID,
+      operationId: OPERATION_ID, confirmation: 'student@example.com', expectedSourceRevision: 7,
+      expectedStorageInventorySha256: DIGEST, expectedRelationalInventorySha256: DIGEST,
+    })
+  })
+
+  it('rejects a student session before any purge state is read or changed', async () => {
+    const error = new Error('Forbidden')
+    error.name = 'AuthorizationError'
+    mocks.requireRole.mockRejectedValue(error)
+    const response = await getImpact(new NextRequest('http://localhost/purge'), context)
+    expect(response.status).toBe(403)
+    expect(mocks.impact).not.toHaveBeenCalled()
+    expect(mocks.start).not.toHaveBeenCalled()
+  })
+
+  it('binds status and retry to the teacher and Classroom URL', async () => {
+    expect((await getStatus(new NextRequest('http://localhost/status'), context)).status).toBe(200)
+    expect((await tickPurge(new NextRequest('http://localhost/tick', { method: 'POST' }), context)).status).toBe(202)
+    expect(mocks.status).toHaveBeenCalledWith(TEACHER_ID, OPERATION_ID)
+    expect(mocks.tick).toHaveBeenCalledWith(TEACHER_ID, OPERATION_ID)
+    expect(mocks.target).toHaveBeenCalledWith(TEACHER_ID, OPERATION_ID, CLASSROOM_ID, STUDENT_ID)
+  })
+
+  it('will not tick an operation through another Classroom URL', async () => {
+    mocks.target.mockRejectedValue(new ApiError(404, 'Student data deletion not found'))
+    const response = await tickPurge(new NextRequest('http://localhost/tick', { method: 'POST' }), {
+      params: Promise.resolve({
+        id: '50000000-0000-4000-8000-000000000001',
+        studentId: STUDENT_ID,
+        operationId: OPERATION_ID,
+      }),
+    } as never)
+    expect(response.status).toBe(404)
+    expect(mocks.tick).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/StudentPurgeDialog.test.tsx
+++ b/tests/components/StudentPurgeDialog.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { StudentPurgeDialog } from '@/components/StudentPurgeDialog'
+
+const CLASSROOM_ID = '10000000-0000-4000-8000-000000000001'
+const STUDENT_ID = '20000000-0000-4000-8000-000000000001'
+const EMAIL = 'student@example.com'
+
+function impact(overrides: Record<string, unknown> = {}) {
+  return {
+    classroom_id: CLASSROOM_ID,
+    classroom_title: 'Biology',
+    student_id: STUDENT_ID,
+    student_email: EMAIL,
+    source_revision: 7,
+    storage_inventory_sha256: 'a'.repeat(64),
+    relational_inventory_sha256: 'b'.repeat(64),
+    relational_row_count: 18,
+    managed_file_count: 3,
+    managed_file_bytes: 2048,
+    archive_count: 1,
+    gradex_extract_count: 1,
+    resource_counts: { entries: 2 },
+    storage_counts: { student_inline_image: 1, classroom_archive: 1, gradex_extract: 1 },
+    conflicting_operation: null,
+    deletion_available: true,
+    unavailable_reason: null,
+    ...overrides,
+  }
+}
+
+describe('StudentPurgeDialog', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('states the exact deletion and preservation contract and requires the case-sensitive email', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ impact: impact(), operation: null }),
+    })))
+    const onClose = vi.fn()
+    render(<StudentPurgeDialog
+      classroomId={CLASSROOM_ID}
+      classroomTitle="Biology"
+      studentId={STUDENT_ID}
+      studentEmail={EMAIL}
+      studentName="Ada Lovelace"
+      isOpen
+      onClose={onClose}
+      onCompleted={vi.fn()}
+    />)
+
+    const dialog = await screen.findByRole('dialog', { name: 'Purge this student’s classroom data?' })
+    expect(dialog).toHaveTextContent(/submissions, tests, grades, attendance/)
+    expect(dialog).toHaveTextContent(/user account and data in other classrooms are kept/i)
+    expect(dialog).toHaveTextContent(/archive copies and Gradex extracts/)
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toContainElement(document.activeElement)
+    const purge = within(dialog).getByRole('button', { name: 'Purge classroom data' })
+    expect(purge).toBeDisabled()
+    fireEvent.change(within(dialog).getByRole('textbox'), { target: { value: 'STUDENT@example.com' } })
+    expect(purge).toBeDisabled()
+    fireEvent.change(within(dialog).getByRole('textbox'), { target: { value: EMAIL } })
+    expect(purge).toBeEnabled()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+  })
+
+  it('keeps provider-blocked targets fail closed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        impact: impact({
+          deletion_available: false,
+          unavailable_reason: 'student_purge_external_erasure_required',
+        }),
+        operation: null,
+      }),
+    })))
+    render(<StudentPurgeDialog
+      classroomId={CLASSROOM_ID}
+      classroomTitle="Biology"
+      studentId={STUDENT_ID}
+      studentEmail={EMAIL}
+      studentName="Ada Lovelace"
+      isOpen
+      onClose={vi.fn()}
+      onCompleted={vi.fn()}
+    />)
+    expect(await screen.findByText('student_purge_external_erasure_required')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Purge classroom data' })).toBeDisabled()
+  })
+})

--- a/tests/components/StudentPurgeDialog.test.tsx
+++ b/tests/components/StudentPurgeDialog.test.tsx
@@ -89,4 +89,59 @@ describe('StudentPurgeDialog', () => {
     expect(await screen.findByText('student_purge_external_erasure_required')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Purge classroom data' })).toBeDisabled()
   })
+
+  it('uses the authoritative account email when the roster casing differs', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ operation: null, impact: impact({ student_email: 'Joined@example.com' }) }),
+    })))
+    render(<StudentPurgeDialog
+      classroomId={CLASSROOM_ID}
+      classroomTitle="Biology"
+      studentId={STUDENT_ID}
+      studentEmail="joined@example.com"
+      studentName="Ada Lovelace"
+      isOpen
+      onClose={vi.fn()}
+      onCompleted={vi.fn()}
+    />)
+    const dialog = await screen.findByRole('dialog')
+    const input = within(dialog).getByRole('textbox', {
+      name: /Type “Joined@example\.com” to confirm/,
+    })
+    const purge = within(dialog).getByRole('button', { name: 'Purge classroom data' })
+    fireEvent.change(input, { target: { value: 'joined@example.com' } })
+    expect(purge).toBeDisabled()
+    fireEvent.change(input, { target: { value: 'Joined@example.com' } })
+    expect(purge).toBeEnabled()
+  })
+
+  it('reuses the same operation id when the initial start response is lost', async () => {
+    const operationId = '30000000-0000-4000-8000-000000000001'
+    vi.stubGlobal('crypto', { randomUUID: vi.fn(() => operationId) })
+    const bodies: Array<{ operation_id: string }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (!init?.method) return { ok: true, json: async () => ({ operation: null, impact: impact() }) }
+      bodies.push(JSON.parse(String(init.body)))
+      return { ok: false, json: async () => ({ error: 'Response lost after request' }) }
+    }))
+    render(<StudentPurgeDialog
+      classroomId={CLASSROOM_ID}
+      classroomTitle="Biology"
+      studentId={STUDENT_ID}
+      studentEmail={EMAIL}
+      studentName="Ada Lovelace"
+      isOpen
+      onClose={vi.fn()}
+      onCompleted={vi.fn()}
+    />)
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.change(within(dialog).getByRole('textbox'), { target: { value: EMAIL } })
+    const purge = within(dialog).getByRole('button', { name: 'Purge classroom data' })
+    fireEvent.click(purge)
+    await within(dialog).findByRole('alert')
+    fireEvent.click(purge)
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies.map((body) => body.operation_id)).toEqual([operationId, operationId])
+  })
 })

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -314,6 +314,65 @@ describe('TeacherRosterTab', () => {
     expect(getIndividualDeleteCalls(fetchMock)).toHaveLength(0)
   })
 
+  it('shows comprehensive purge only for one rollout-enabled joined student', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster` && method === 'GET') {
+        return mockJson({
+          roster: [rosterRow, secondRosterRow],
+          student_purge_enabled_ids: [rosterRow.student_id],
+        })
+      }
+      if (url === `/api/teacher/classrooms/${classroom.id}/students/${rosterRow.student_id}/purge`) {
+        return mockJson({
+          impact: {
+            classroom_id: '10000000-0000-4000-8000-000000000001',
+            classroom_title: classroom.title,
+            student_id: '20000000-0000-4000-8000-000000000001',
+            student_email: rosterRow.email,
+            source_revision: 1,
+            storage_inventory_sha256: 'a'.repeat(64),
+            relational_inventory_sha256: 'b'.repeat(64),
+            relational_row_count: 2,
+            managed_file_count: 0,
+            managed_file_bytes: 0,
+            archive_count: 0,
+            gradex_extract_count: 0,
+            resource_counts: {}, storage_counts: {}, conflicting_operation: null,
+            deletion_available: true, unavailable_reason: null,
+          },
+          operation: null,
+        })
+      }
+      throw new Error(`Unhandled fetch: ${method} ${url}`)
+    }))
+    renderRoster()
+    await user.click(await screen.findByText('Ada'))
+    await user.click(screen.getByRole('button', { name: 'Roster actions' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Purge classroom data' }))
+    expect(await screen.findByRole('dialog', { name: 'Purge this student’s classroom data?' }))
+      .toHaveTextContent(/data in other classrooms are kept/i)
+  })
+
+  it('keeps purge available for a hot-archived Classroom while ordinary roster edits stay disabled', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster`) {
+        return mockJson({ roster: [rosterRow], student_purge_enabled_ids: [rosterRow.student_id] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    }))
+    renderRoster({ ...classroom, archived_at: '2026-08-01T00:00:00.000Z' })
+    await user.click(await screen.findByText('Ada'))
+    expect(screen.getByRole('button', { name: 'Add students' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Roster actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Remove student' })).toBeDisabled()
+    expect(screen.getByRole('menuitem', { name: 'Purge classroom data' })).toBeEnabled()
+  })
+
   it('shows and confirms removal for multiple checked students from the roster actions menu', async () => {
     const user = userEvent.setup()
     const fetchMock = mockRosterFetch()

--- a/tests/lib/server/student-purge.test.ts
+++ b/tests/lib/server/student-purge.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  assertStudentPurgeOperationTarget,
   deleteStudentPurgeStorageObject,
   getStudentPurgeEnabledStudentIds,
   isMissingStudentPurgeSchemaError,
@@ -67,6 +68,36 @@ describe('student purge server boundaries', () => {
       'classroom/student/image.png',
     )).resolves.toBeUndefined()
     expect(remove).toHaveBeenCalledWith(['classroom/student/image.png'])
+  })
+
+  it('authorizes a completed operation through its retained target binding', async () => {
+    serviceClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: '10000000-0000-4000-8000-000000000001',
+                classroom_id: '20000000-0000-4000-8000-000000000001',
+                teacher_id: '40000000-0000-4000-8000-000000000001',
+                student_id: null,
+                student_binding_sha256: 'aa2ef9bbd3f18edd16cfb5ed18f70bacde1e55210357b136233644bbd8d72c64',
+                status: 'completed', retryable: false, error_code: null,
+                resource_counts: {}, attempt_count: 2, completed_at: '2026-08-12T12:00:00.000Z',
+              },
+              error: null,
+            }),
+          })),
+        })),
+      })),
+    })
+
+    await expect(assertStudentPurgeOperationTarget(
+      '40000000-0000-4000-8000-000000000001',
+      '10000000-0000-4000-8000-000000000001',
+      '20000000-0000-4000-8000-000000000001',
+      '30000000-0000-4000-8000-000000000001',
+    )).resolves.toBeUndefined()
   })
 
   it('does not hot-loop failed or unadvanced operations', () => {

--- a/tests/lib/server/student-purge.test.ts
+++ b/tests/lib/server/student-purge.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  deleteStudentPurgeStorageObject,
+  getStudentPurgeEnabledStudentIds,
+  isMissingStudentPurgeSchemaError,
+  runStudentPurgeSafetyNet,
+  shouldRequeueStudentPurgeSafetyNet,
+} from '@/lib/server/student-purge'
+
+const serviceClient = vi.hoisted(() => ({ from: vi.fn(), rpc: vi.fn(), storage: { from: vi.fn() } }))
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => serviceClient) }))
+
+const status = {
+  operation_id: '10000000-0000-4000-8000-000000000001',
+  classroom_id: '20000000-0000-4000-8000-000000000001',
+  status: 'deleting_objects' as const,
+  retryable: true,
+  error_code: null,
+  attempt_count: 1,
+  resource_counts: {},
+  storage_object_counts: { pending: 1 },
+  completed_at: null,
+}
+
+describe('student purge server boundaries', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('treats only missing schema/RPC errors as pre-migration compatibility', () => {
+    expect(isMissingStudentPurgeSchemaError({ code: 'PGRST205' })).toBe(true)
+    expect(isMissingStudentPurgeSchemaError({ code: '42P01' })).toBe(true)
+    expect(isMissingStudentPurgeSchemaError({ code: 'PGRST202' })).toBe(true)
+    expect(isMissingStudentPurgeSchemaError({ code: '42501' })).toBe(false)
+  })
+
+  it('keeps rollout absent when migration 123 has not been applied', async () => {
+    serviceClient.from.mockReturnValue({
+      select: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({
+        data: null, error: { code: 'PGRST205', message: 'missing' },
+      }) })),
+    })
+    await expect(getStudentPurgeEnabledStudentIds('teacher', 'classroom', ['student']))
+      .resolves.toEqual([])
+  })
+
+  it('allows only the exact canary triple', async () => {
+    serviceClient.from.mockReturnValue({
+      select: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: {
+        rollout_mode: 'canary',
+        canary_teacher_id: '10000000-0000-4000-8000-000000000001',
+        canary_classroom_id: '20000000-0000-4000-8000-000000000001',
+        canary_student_id: '30000000-0000-4000-8000-000000000001',
+      }, error: null }) })),
+    })
+    await expect(getStudentPurgeEnabledStudentIds(
+      '10000000-0000-4000-8000-000000000001',
+      '20000000-0000-4000-8000-000000000001',
+      ['30000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000001'],
+    )).resolves.toEqual(['30000000-0000-4000-8000-000000000001'])
+  })
+
+  it('deletes one exact leased object and accepts authoritative absence', async () => {
+    const remove = vi.fn().mockResolvedValue({ error: { statusCode: 404, code: 'NoSuchKey' } })
+    const storage = { from: vi.fn(() => ({ remove })) }
+    await expect(deleteStudentPurgeStorageObject(
+      storage,
+      'submission-images',
+      'classroom/student/image.png',
+    )).resolves.toBeUndefined()
+    expect(remove).toHaveBeenCalledWith(['classroom/student/image.png'])
+  })
+
+  it('does not hot-loop failed or unadvanced operations', () => {
+    expect(shouldRequeueStudentPurgeSafetyNet(status, true)).toBe(true)
+    expect(shouldRequeueStudentPurgeSafetyNet(status, false)).toBe(false)
+    expect(shouldRequeueStudentPurgeSafetyNet({
+      ...status,
+      status: 'failed',
+      storage_object_counts: { failed: 1 },
+    }, true)).toBe(false)
+  })
+
+  it('is a safe no-op before migration 123 exists', async () => {
+    serviceClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        in: vi.fn(() => ({
+          or: vi.fn(() => ({
+            order: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue({ data: null, error: { code: '42P01' } }),
+            })),
+          })),
+        })),
+      })),
+    })
+    await expect(runStudentPurgeSafetyNet()).resolves.toEqual({ processed: 0, completed: 0, failed: 0 })
+    expect(serviceClient.storage.from).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/validations/student-purge.test.ts
+++ b/tests/lib/validations/student-purge.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  studentPurgeImpactSchema,
+  studentPurgeStartRequestSchema,
+  studentPurgeStatusSchema,
+} from '@/lib/validations/student-purge'
+
+const UUID = '11111111-1111-4111-8111-111111111111'
+const UUID_2 = '22222222-2222-4222-8222-222222222222'
+const HASH = 'a'.repeat(64)
+
+describe('student purge validation', () => {
+  it('accepts a complete impact contract', () => {
+    expect(studentPurgeImpactSchema.parse({
+      classroom_id: UUID,
+      classroom_title: 'Period 1',
+      student_id: UUID_2,
+      student_email: 'student@example.com',
+      source_revision: 1,
+      storage_inventory_sha256: HASH,
+      relational_inventory_sha256: HASH,
+      relational_row_count: 10,
+      managed_file_count: 2,
+      managed_file_bytes: 123,
+      archive_count: 1,
+      gradex_extract_count: 0,
+      resource_counts: { entries: 4 },
+      storage_counts: { student_inline_image: 2 },
+      conflicting_operation: null,
+      deletion_available: false,
+      unavailable_reason: 'Individual-student purge is disabled',
+    }).student_email).toBe('student@example.com')
+  })
+
+  it('requires exact inventory evidence when starting', () => {
+    expect(() => studentPurgeStartRequestSchema.parse({
+      operation_id: UUID,
+      confirmation: 'student@example.com',
+      expected_source_revision: 1,
+      expected_storage_inventory_sha256: 'not-a-hash',
+      expected_relational_inventory_sha256: HASH,
+    })).toThrow()
+  })
+
+  it('does not expose the student identity in durable status', () => {
+    const status = studentPurgeStatusSchema.parse({
+      operation_id: UUID,
+      classroom_id: UUID_2,
+      status: 'completed',
+      retryable: false,
+      error_code: null,
+      attempt_count: 1,
+      resource_counts: {},
+      storage_object_counts: { deleted: 2 },
+      completed_at: '2026-08-11T12:00:00.000Z',
+    })
+    expect(status).not.toHaveProperty('student_id')
+    expect(status).not.toHaveProperty('student_email')
+  })
+})

--- a/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
+++ b/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
@@ -39,6 +39,12 @@ describe('migration 123 individual-student purge contract', () => {
     expect(sql).toContain('else array[to_jsonb(old), to_jsonb(new)] end')
   })
 
+  it('closes the finalization writer bypass before returning to the caller', () => {
+    expect(sql).toMatch(
+      /delete from public\.student_purge_fences[\s\S]*perform set_config\('pika\.student_purge_finalize', 'off', true\);[\s\S]*return jsonb_build_object/,
+    )
+  })
+
   it('preserves the user and fails closed for unimplemented provider erasure', () => {
     expect(sql).not.toMatch(/delete\s+from\s+public\.users/)
     expect(sql).not.toMatch(/delete\s+from\s+public\.student_profiles/)

--- a/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
+++ b/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sql = readFileSync(resolve(
+  process.cwd(),
+  'supabase/migrations/123_hot_classroom_individual_student_purge.sql',
+), 'utf8').toLowerCase()
+
+describe('migration 123 individual-student purge contract', () => {
+  it('starts disabled and scopes canary rollout to an exact teacher, classroom, and student', () => {
+    expect(sql).toContain("rollout_mode text not null default 'disabled'")
+    expect(sql).toContain('canary_teacher_id')
+    expect(sql).toContain('canary_classroom_id')
+    expect(sql).toContain('canary_student_id')
+  })
+
+  it('uses durable exact relational and managed-object ledgers', () => {
+    expect(sql).toContain('create table public.student_purge_resources')
+    expect(sql).toContain('create table public.student_purge_objects')
+    expect(sql).toContain('managed_storage_object_id uuid')
+    expect(sql).toContain('references public.managed_storage_objects (id) on delete set null')
+    expect(sql).toContain('student_purge_storage_object_still_present')
+    expect(sql).toContain('student_purge_membership_drift_')
+    expect(sql).toContain('student_purge_storage_owner_drift')
+  })
+
+  it('uses fences, leases, retry backoff, and mutually excludes whole-classroom purge', () => {
+    expect(sql).toContain('create table public.student_purge_fences')
+    expect(sql).toContain('lease_token uuid')
+    expect(sql).toContain('lease_expires_at timestamptz')
+    expect(sql).toContain('next_attempt_at = clock_timestamp() + make_interval')
+    expect(sql).toContain('hot_purge_student_fence_conflict')
+    expect(sql).toContain('cold_purge_student_fence_conflict')
+    expect(sql).toContain('else array[to_jsonb(old), to_jsonb(new)] end')
+  })
+
+  it('preserves the user and fails closed for unimplemented provider erasure', () => {
+    expect(sql).not.toMatch(/delete\s+from\s+public\.users/)
+    expect(sql).not.toMatch(/delete\s+from\s+public\.student_profiles/)
+    expect(sql).toContain('student_purge_external_erasure_required')
+    expect(sql).toContain('student_purge_gradex_erasure_required')
+    expect(sql).toContain('student_purge_retired_assessment_unsupported')
+    expect(sql).toContain('student_purge_storage_subject_ownership_incomplete')
+  })
+
+  it('removes immutable class archive copies but not other classrooms or blueprints', () => {
+    expect(sql).toContain('delete from public.classroom_archives where classroom_id = v_operation.classroom_id')
+    expect(sql).toContain('delete from public.classroom_gradex_extracts where classroom_id = v_operation.classroom_id')
+    expect(sql).toContain('delete from public.classroom_archive_snapshot_actors')
+    expect(sql).toContain('delete from public.classroom_archive_snapshot_resources')
+    expect(sql).not.toMatch(/delete\s+from\s+public\.course_blueprints/)
+    expect(sql).toContain('where card.classroom_id = p_classroom_id and row.student_id = p_student_id')
+  })
+
+  it('restricts every mutating RPC to service role and exposes health drift counts', () => {
+    expect(sql).toContain('revoke all on function public.begin_student_purge')
+    expect(sql).toContain('grant execute on function public.begin_student_purge')
+    expect(sql).toContain('get_student_purge_health_snapshot')
+    expect(sql).toContain('orphan_fence_count')
+    expect(sql).toContain('processing_lease_drift_count')
+  })
+})

--- a/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
+++ b/tests/unit/hot-classroom-individual-student-purge-migration.test.ts
@@ -16,6 +16,8 @@ describe('migration 123 individual-student purge contract', () => {
   })
 
   it('uses durable exact relational and managed-object ledgers', () => {
+    expect(sql).toContain('create table public.classroom_roster_student_bindings')
+    expect(sql).not.toContain('alter table public.classroom_roster\n  add column student_id')
     expect(sql).toContain('create table public.student_purge_resources')
     expect(sql).toContain('create table public.student_purge_objects')
     expect(sql).toContain('managed_storage_object_id uuid')
@@ -23,6 +25,8 @@ describe('migration 123 individual-student purge contract', () => {
     expect(sql).toContain('student_purge_storage_object_still_present')
     expect(sql).toContain('student_purge_membership_drift_')
     expect(sql).toContain('student_purge_storage_owner_drift')
+    expect(sql).toContain('student_purge_path_reserved')
+    expect(sql).toContain('storage_student_purge_path_reservation')
   })
 
   it('uses fences, leases, retry backoff, and mutually excludes whole-classroom purge', () => {
@@ -42,6 +46,13 @@ describe('migration 123 individual-student purge contract', () => {
     expect(sql).toContain('student_purge_gradex_erasure_required')
     expect(sql).toContain('student_purge_retired_assessment_unsupported')
     expect(sql).toContain('student_purge_storage_subject_ownership_incomplete')
+  })
+
+  it('retains replay-safe target binding and removes grading selection identity', () => {
+    expect(sql).toContain('student_binding_sha256')
+    expect(sql).toContain("p_operation_id::text || ':' || p_student_id::text")
+    expect(sql).toContain("'student-purge:' || p_operation_id::text || ':' || run.id::text")
+    expect(sql).toContain('selection_hash = encode')
   })
 
   it('removes immutable class archive copies but not other classrooms or blueprints', () => {

--- a/tests/unit/individual-student-purge-database-script.test.ts
+++ b/tests/unit/individual-student-purge-database-script.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const script = readFileSync(resolve(
+  process.cwd(), 'scripts/check-individual-student-purge-database.sh',
+), 'utf8')
+
+describe('individual-student purge database fixture', () => {
+  it('refuses unexpected targets and requires migration 123', () => {
+    expect(script).toContain('com.supabase.cli.project')
+    expect(script).toContain('PROJECT_LABEL" != "pika"')
+    expect(script).toContain("version = '123'")
+  })
+
+  it('is destructive only inside a rollback-only transaction', () => {
+    expect(script).toContain('begin;')
+    expect(script).toContain('rollback;')
+    expect(script).not.toMatch(/\bcommit\s*;/i)
+  })
+
+  it('covers provider blocking, writer fences, target deletion, and cross-class preservation', () => {
+    expect(script).toContain('Pal-backed student did not fail closed')
+    expect(script).toContain('Target student write bypassed the purge fence')
+    expect(script).toContain('Target row reassignment bypassed the purge fence')
+    expect(script).toContain('Managed object delete bypassed student purge lease authority')
+    expect(script).toContain('Student purge accepted storage completion while bytes remained')
+    expect(script).toContain('Target Classroom student data remained')
+    expect(script).toContain('User, other Classroom, or classmate data was removed')
+  })
+})


### PR DESCRIPTION
## Summary
- add disabled-by-default migration 123 for durable, resumable deletion of one student data set from one eligible hot Classroom
- preserve the user account and every other Classroom while deleting exact relational resources, managed files, and retained archive/Gradex copies that may contain the target
- add teacher-only API/UI, retries, cleanup safety net, health monitoring, stable roster identity, rollout gates, and cross-scope concurrency fences
- fail closed for cold Classrooms, Pal history, remote Gradex runs, retired assessment actors, ownership gaps, and conflicting operations
- permanently reserve purged storage paths and close the finalization writer-fence bypass before returning to a service transaction

## Safety boundary
- migration 123 has not been applied locally or remotely
- rollout remains disabled; no purge has run
- generic orphan cleanup remains disabled
- production migration, deployment, rollout, and purge each require separate exact authorization

## Verification
- CI run 31596951580: Test & Build passed
- CI run 31596951580: Architecture Database Contracts passed on a clean migrations 1-123 replay
- CI run 31596951580: teacher/student Browser Experience Matrix passed, including the dedicated student-purge matrix
- focused student-purge suite: 9 files / 71 tests passed
- Pika pre-commit audit, shell syntax, and diff checks passed
- rollback-only database fixture covers privileges, fail-closed providers, writer/reassignment fences, leases, exact deletion, peer and cross-Classroom preservation, shared-run redaction, archive/Gradex cleanup, and permanent managed/storage path reservation

## Accessibility
- checklist reviewed: yes
- keyboard behavior covered: yes
- semantic state covered by tests: yes
- remaining manual follow-up: none