### PR TITLE
Add durable cleanup-history cron evidence

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,8 +1,3 @@
-Prod 001–123. Individual-student purge enabled; cold Classroom deletion and
-generic cleanup off. Migration 124 local-only on `codex/cron-run-ledger`: a
-service-only durable ledger for `/api/cron/cleanup-history`; no new schedule or
-purge authority. Fresh local 001–124 replay, fixtures, types, 4,239 tests, build,
-lint, and audit pass. Next: PR/review, compatible deploy, then separately
-authorize prod 124. Follow up migration-123 ambiguous retry count separately.
-WT: `$HOME/.codex/worktrees/pika/cron-run-ledger`.
-Env: `$HOME/Repos/.env/pika/.env.local`.
+Prod 001–123. Student purge on; cold/generic deletion off. codex/cron-run-ledger: local-only 124 adds durable cron evidence; no new authority. Replay/fixtures/types and 4,239 tests/build/audit pass. Next: PR/deploy, separate prod-124 auth. Migration-123 retry lint stays separate.
+WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
+Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. codex/cron-run-ledger: local-only 124 adds durable cron evidence; no new authority. Replay/fixtures/types and 4,239 tests/build/audit pass. Next: PR/deploy, separate prod-124 auth. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. codex/cron-run-ledger: local-only 124 adds durable cron evidence; no new authority. Replay/fixtures/types and 4,240 tests/build/audit pass. Next: PR/deploy, separate prod-124 auth. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,6 +1,8 @@
-Prod 001–122. Cold canary passed; rollout off pending checks. Branch
-`codex/individual-student-purge-audit`: disabled migration 123 + app ready;
-not applied/run. Preserves users/other Classes; Pal/remote Gradex fail closed.
-Generic cleanup off.
-WT: `$HOME/.codex/worktrees/pika/` or `$HOME/.codex/worktrees/<id>/pika`.
-Env: `$HOME/Repos/.env/pika/.env.local` or collaborator `.env.example`.
+Prod 001–123. Individual-student purge enabled; cold Classroom deletion and
+generic cleanup off. Migration 124 local-only on `codex/cron-run-ledger`: a
+service-only durable ledger for `/api/cron/cleanup-history`; no new schedule or
+purge authority. Fresh local 001–124 replay, fixtures, types, 4,239 tests, build,
+lint, and audit pass. Next: PR/review, compatible deploy, then separately
+authorize prod 124. Follow up migration-123 ambiguous retry count separately.
+WT: `$HOME/.codex/worktrees/pika/cron-run-ledger`.
+Env: `$HOME/Repos/.env/pika/.env.local`.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -17991,3 +17991,28 @@ and terminal cleanup-ledger reconciliation.
 - Decide separately whether to activate managed Storage enforcement. Activation,
   migration 119, generic cleanup, and classroom deletion each remain separately
   gated production changes.
+
+<!-- pika-session-log-archive-batch:3d2e827aa3d7f9f43fc5ca2922bc223d2d75ad78188e529ddfbe1a4b4b587eb9 -->
+## 2026-08-05 — Activate production managed Storage enforcement
+
+**Risk profile:** production write — managed Storage protocol activation only.
+
+**Completed:**
+- Revalidated generation 1 immediately before activation: readiness/run/settings
+  digest matched, the persisted and current writer revisions were all 842, no
+  archive or cleanup operation was active, and migration 119 was absent.
+- Ran the guarded production activation command exactly once using the authorized
+  generation and inventory digest.
+
+**Validation:**
+- Production settings now persist mode `enforced`, generation 1, the verified
+  digest, writer revision 842, and a non-null activation timestamp.
+- All 139 managed objects remain `ready`; all 139 Storage objects and 274 JSON
+  references remain intact, with zero ownerless or missing objects.
+- Migration 119 remains unapplied and `classroom_purge_settings` remains absent.
+  Generic cleanup and classroom deletion were not enabled.
+
+**Remaining:**
+- Verify representative production writers under enforcement before considering
+  migration 119. Applying migration 119, generic cleanup, and classroom deletion
+  remain separately gated changes.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,30 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Activate production managed Storage enforcement
-
-**Risk profile:** production write — managed Storage protocol activation only.
-
-**Completed:**
-- Revalidated generation 1 immediately before activation: readiness/run/settings
-  digest matched, the persisted and current writer revisions were all 842, no
-  archive or cleanup operation was active, and migration 119 was absent.
-- Ran the guarded production activation command exactly once using the authorized
-  generation and inventory digest.
-
-**Validation:**
-- Production settings now persist mode `enforced`, generation 1, the verified
-  digest, writer revision 842, and a non-null activation timestamp.
-- All 139 managed objects remain `ready`; all 139 Storage objects and 274 JSON
-  references remain intact, with zero ownerless or missing objects.
-- Migration 119 remains unapplied and `classroom_purge_settings` remains absent.
-  Generic cleanup and classroom deletion were not enabled.
-
-**Remaining:**
-- Verify representative production writers under enforcement before considering
-  migration 119. Applying migration 119, generic cleanup, and classroom deletion
-  remain separately gated changes.
-
 ## 2026-08-05 — Verify production managed Storage writers under enforcement
 
 **Risk profile:** bounded production smoke writes using synthetic teacher/student
@@ -1056,3 +1032,31 @@ tests, and documentation.
   active cards across desktop/mobile and light/dark, with no overflow or layout
   regression. Composite-widget checklist is not applicable because interaction
   semantics and keyboard behavior were unchanged.
+
+## 2026-08-14 — Add durable cleanup-history cron evidence
+
+**Risk profile:** runtime-platform — additive service-only observability and
+overlap serialization around the existing cleanup-history safety-net route.
+
+**Completed:**
+- Added migration 124 with a privacy-safe run ledger, scheduled/manual source
+  attribution, exact aggregate metric allowlist, overlap records, stale-run
+  supersession, one-way finalization, and an identity-free health snapshot.
+- Integrated the cron route with pre-124 compatibility and fail-closed ledger
+  errors, plus focused tests, a rollback-only database fixture, CI coverage,
+  generated types, operator guidance, and rollout instructions.
+- With explicit local authorization, applied migrations 123–124, then reset the
+  disposable database without seeds and replayed migrations 001–124 to remove
+  stale migration-121 schema state.
+
+**Validation:**
+- Full suite passes: 4,239 tests across 494 files; focused ledger coverage passes
+  43 tests. TypeScript, lint, production build, Pika audit, shell syntax, and
+  diff checks pass.
+- Fresh migration replay, migration-123 and migration-124 rollback-only
+  fixtures, generated-type drift check, and preservation of the migration-121
+  deep-health RPC all pass.
+- Database lint identified an inherited ambiguous `attempt_count` reference in
+  migration 123's storage-failure retry function. Keep that correction separate
+  from migration 124. No production migration, deploy, cron run, rollout change,
+  purge, or Storage deletion occurred.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1065,3 +1065,7 @@ overlap serialization around the existing cleanup-history safety-net route.
   successful scheduled run within 26 hours; empty, expired, or failed scheduled
   evidence stays unhealthy even after manual success. The revised fresh replay,
   database fixture, generated types, and 44 focused tests pass.
+- Final integration review caught an over-budget `.ai/CURRENT.md` that omitted
+  canonical app-managed worktree and collaborator env forms. The compressed
+  handoff restores both contracts; startup-doc coverage and the full 4,240-test
+  suite pass.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1060,3 +1060,8 @@ overlap serialization around the existing cleanup-history safety-net route.
   migration 123's storage-failure retry function. Keep that correction separate
   from migration 124. No production migration, deploy, cron run, rollout change,
   purge, or Storage deletion occurred.
+- Initial PR review found a false-green scheduled-health path. Remediation now
+  requires exact Vercel GET metadata, keeps POST manual, and requires a fresh
+  successful scheduled run within 26 hours; empty, expired, or failed scheduled
+  evidence stays unhealthy even after manual success. The revised fresh replay,
+  database fixture, generated types, and 44 focused tests pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Verify managed deletion health monitoring
         run: pnpm run check:managed-deletion-health-db
 
+      - name: Verify cleanup-history cron run ledger
+        run: pnpm run check:cleanup-history-cron-db
+
       - name: Lint hot archived classroom purge database functions
         run: pnpm run check:classroom-purge-db-lint
 

--- a/docs/guidance/individual-student-purge.md
+++ b/docs/guidance/individual-student-purge.md
@@ -82,6 +82,12 @@ orphan-fence, and processing-lease-drift counts without student identifiers.
 A degraded snapshot returns an unhealthy response and emits the structured
 `[student-purge-health]` log entry.
 
+After migration 124, each authenticated cleanup invocation also has durable
+start/completion evidence and aggregate student-purge counters in the
+service-only cleanup-history ledger. It contains no student, teacher,
+Classroom, operation, or Storage identity and grants no retry or purge
+authority.
+
 For a degraded result, inspect the exact operation through service-only records,
 verify fence and lease state, and confirm authoritative Storage presence before
 retrying. Do not clear fences, mutate audit rows, enable generic cleanup, or

--- a/docs/guidance/managed-deletion-monitoring.md
+++ b/docs/guidance/managed-deletion-monitoring.md
@@ -18,6 +18,14 @@ operation while an orphan cold fence remains critical. Cold operations use the
 same aggregate failure, stuck-operation, lease, partial-progress, and object-
 reappearance findings. The migration does not change the schedule.
 
+Migration 124 adds durable invocation evidence for the same existing
+`/api/cron/cleanup-history` route. It installs no schedule. Authenticated runs
+write one service-only ledger row at start and finalize it with the HTTP result
+and allowlisted aggregate counters. The documented Vercel
+`x-vercel-cron-schedule` header distinguishes a Vercel cron invocation from a
+manual request, so a successful no-op run remains observable after short-lived
+platform logs expire.
+
 The same migration defines a separate service-role-only
 `get_managed_deletion_deep_health_snapshot` diagnostic for recursive embedded
 payload reconciliation. It is not called by the cron or any application route,
@@ -34,6 +42,33 @@ containing only health/count values or a bounded application error code.
 The default stuck threshold is one hour. The RPC and server reader accept only
 300 through 604,800 seconds. The threshold is diagnostic; it does not expire a
 fence, authorize deletion, or change retry state.
+
+The migration-124 ledger stores no user, teacher, Classroom, Blueprint,
+operation, managed-object, bucket/path, title, email, or content identity. Its
+database validator accepts only named nonnegative counters plus the
+managed-health boolean. Direct writes are denied even to `service_role`;
+security-definer begin/finish functions own the row lifecycle, and a separate
+service-only health RPC omits run UUIDs and deployment identity.
+
+The begin function serializes the daily job. A concurrent invocation is
+recorded as `skipped_overlap` and does no cleanup work. A `running` row is
+superseded only after two hours, well beyond the route's 60-second budget. The
+finish function permits exactly one transition to `succeeded` or `failed`.
+Before migration 124 exists, only the exact missing-RPC compatibility code lets
+the route continue without a ledger; other ledger failures return a sanitized
+failure.
+
+Operators can read the latest durable evidence without scanning the table:
+
+```sql
+select public.get_cleanup_history_cron_health_snapshot(120);
+```
+
+Verify `latest_vercel_run.schedule = '0 7 * * *'`, a start time within Vercel's
+daily execution window, `status = 'succeeded'`, `http_status = 200`, zero stale
+runs, and expected aggregate counters. This proves scheduler invocation and job
+outcome; the student-purge and managed-deletion snapshots remain authoritative
+for current safety state.
 
 The cron behavior is:
 
@@ -109,9 +144,11 @@ scanned safely within the operator session's explicit query budget.
 
 ## Staged rollout
 
-Migration 121 is applied in production and the monitoring code is deployed.
-Migration 122's cold-fence extension remains unapplied until its own staged
-authorization and rollout.
+Production migrations 121–123 are applied. Cold-Classroom deletion remains
+disabled, individual-student purge is enabled, and generic cleanup remains off.
+Migration 124 and its compatible application code require normal review and
+rollout; applying migration 124 does not invoke the cron or change a deletion
+rollout.
 
 1. Run static/unit/route tests and repository checks without a database reset or
    migration application.
@@ -139,6 +176,13 @@ authorization and rollout.
    operation because it also advances existing cleanup/purge safety nets and
    therefore requires explicit authorization.
 
+For migration 124, deploy compatible code first: the exact missing-RPC path
+continues the existing job while emitting a bounded warning. Then apply
+migration 124 only with fresh target-specific authorization and inspect the
+first Vercel-scheduled ledger row through the health RPC. A manual route
+invocation remains a separate cleanup/purge operation requiring explicit
+authorization and is recorded as `manual`.
+
 If the lightweight aggregate cannot reliably finish within the existing
 60-second route budget, keep migration 121 unapplied (or remove the cron call in
 a normal code rollback before application). Do not add the recursive diagnostic
@@ -159,3 +203,9 @@ budget. Review then separated recursive payload work into the unscheduled deep
 diagnostic and tightened dependency failures; the one-time local application
 permission was not reused. The final migration and deep UUID/digest regression
 therefore require the PR's fresh ephemeral-database replay before merge.
+
+Migration 124 adds `pnpm run check:cleanup-history-cron-db`. Its rollback-only
+fixture proves service-only privileges, metric-key privacy enforcement,
+single-run serialization, durable overlap evidence, one-way finalization,
+stale-run supersession, scheduled-versus-manual attribution, bounded health
+thresholds, and identity-free operator snapshots.

--- a/docs/guidance/managed-deletion-monitoring.md
+++ b/docs/guidance/managed-deletion-monitoring.md
@@ -21,10 +21,12 @@ reappearance findings. The migration does not change the schedule.
 Migration 124 adds durable invocation evidence for the same existing
 `/api/cron/cleanup-history` route. It installs no schedule. Authenticated runs
 write one service-only ledger row at start and finalize it with the HTTP result
-and allowlisted aggregate counters. The documented Vercel
-`x-vercel-cron-schedule` header distinguishes a Vercel cron invocation from a
-manual request, so a successful no-op run remains observable after short-lived
-platform logs expire.
+and allowlisted aggregate counters. A GET with both documented Vercel signals,
+`User-Agent: vercel-cron/1.0` and the exact
+`x-vercel-cron-schedule: 0 7 * * *`, is recorded as scheduled. POST is always
+manual even if it supplies those headers. A successful no-op run therefore
+remains observable after short-lived platform logs expire without treating an
+operator POST as scheduler evidence.
 
 The same migration defines a separate service-role-only
 `get_managed_deletion_deep_health_snapshot` diagnostic for recursive embedded
@@ -61,14 +63,19 @@ failure.
 Operators can read the latest durable evidence without scanning the table:
 
 ```sql
-select public.get_cleanup_history_cron_health_snapshot(120);
+select public.get_cleanup_history_cron_health_snapshot(120, 1560);
 ```
 
-Verify `latest_vercel_run.schedule = '0 7 * * *'`, a start time within Vercel's
-daily execution window, `status = 'succeeded'`, `http_status = 200`, zero stale
-runs, and expected aggregate counters. This proves scheduler invocation and job
-outcome; the student-purge and managed-deletion snapshots remain authoritative
-for current safety state.
+The first threshold marks a running invocation stale after two hours. The
+second requires scheduled evidence within 1,560 minutes (26 hours), allowing a
+bounded execution-window cushion for the daily job. `healthy` remains false
+until a fresh scheduled run succeeds with the exact configured schedule and no
+stale run; an empty ledger, expired success, scheduled failure, or later manual
+success cannot make it green. Verify `latest_vercel_run.status = 'succeeded'`,
+`http_status = 200`, zero stale runs, and expected aggregate counters. This is
+durable operational evidence, not cryptographic provider attestation; the
+student-purge and managed-deletion snapshots remain authoritative for current
+safety state.
 
 The cron behavior is:
 
@@ -207,5 +214,6 @@ therefore require the PR's fresh ephemeral-database replay before merge.
 Migration 124 adds `pnpm run check:cleanup-history-cron-db`. Its rollback-only
 fixture proves service-only privileges, metric-key privacy enforcement,
 single-run serialization, durable overlap evidence, one-way finalization,
-stale-run supersession, scheduled-versus-manual attribution, bounded health
-thresholds, and identity-free operator snapshots.
+stale-run supersession, GET/POST scheduled-versus-manual attribution, fresh
+scheduled-evidence health, bounded thresholds, and identity-free operator
+snapshots.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:cold-classroom-purge-db": "bash scripts/check-cold-archived-classroom-purge-database.sh",
     "check:student-purge-db": "bash scripts/check-individual-student-purge-database.sh",
     "check:managed-deletion-health-db": "bash scripts/check-managed-deletion-health-database.sh",
+    "check:cleanup-history-cron-db": "bash scripts/check-cleanup-history-cron-ledger-database.sh",
     "managed-storage:readiness": "tsx scripts/run-managed-storage-readiness.ts",
     "managed-storage:cleanup": "tsx scripts/run-managed-storage-cleanup.ts",
     "measure:ai-grading-prompts": "tsx scripts/measure-ai-grading-prompts.ts",

--- a/scripts/check-cleanup-history-cron-ledger-database.sh
+++ b/scripts/check-cleanup-history-cron-ledger-database.sh
@@ -25,7 +25,7 @@ begin
   ) is null or to_regprocedure(
     'public.finish_cleanup_history_cron_run(uuid,text,integer,text,jsonb)'
   ) is null or to_regprocedure(
-    'public.get_cleanup_history_cron_health_snapshot(integer)'
+    'public.get_cleanup_history_cron_health_snapshot(integer,integer)'
   ) is null then
     raise exception 'Migration 124 is not applied to the local database';
   end if;
@@ -53,10 +53,10 @@ begin
       'public.begin_cleanup_history_cron_run(text,text,text)', 'execute'
     ) or has_function_privilege(
       'anon',
-      'public.get_cleanup_history_cron_health_snapshot(integer)', 'execute'
+      'public.get_cleanup_history_cron_health_snapshot(integer,integer)', 'execute'
     ) or not has_function_privilege(
       'service_role',
-      'public.get_cleanup_history_cron_health_snapshot(integer)', 'execute'
+      'public.get_cleanup_history_cron_health_snapshot(integer,integer)', 'execute'
     )
   then raise exception 'Cron ledger RPC privileges are unsafe'; end if;
 end;
@@ -90,6 +90,12 @@ declare
   v_run_id uuid;
   v_status text;
 begin
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120, 1560);
+  if (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'scheduled_run_healthy')::boolean
+    or v_snapshot->'latest_vercel_run' <> 'null'::jsonb
+  then raise exception 'Empty cron ledger reported healthy: %', v_snapshot; end if;
+
   v_first := public.begin_cleanup_history_cron_run(
     'vercel_cron', '0 7 * * *', 'deployment_fixture'
   );
@@ -159,18 +165,84 @@ begin
     '{"student_health_stuck":0,"managed_health_healthy":true}'::jsonb
   );
 
-  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120);
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120, 1560);
   if not (v_snapshot->>'healthy')::boolean
     or (v_snapshot->>'stale_running_count')::integer <> 0
     or v_snapshot#>>'{latest_vercel_run,schedule}' <> '0 7 * * *'
     or v_snapshot#>>'{latest_vercel_run,status}' <> 'succeeded'
     or (v_snapshot#>>'{latest_vercel_run,http_status}')::integer <> 200
+    or not (v_snapshot->>'scheduled_run_healthy')::boolean
+    or v_snapshot->>'expected_schedule' <> '0 7 * * *'
+    or (v_snapshot->>'scheduled_evidence_max_age_minutes')::integer <> 1560
   then raise exception 'Cron health snapshot mismatch: %', v_snapshot; end if;
   if v_snapshot::text ~
       '"(teacher_id|student_id|user_id|classroom_id|operation_id|storage_path|email|title)"[[:space:]]*:'
     or v_snapshot::text ~
       '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
   then raise exception 'Identity-bearing evidence escaped cron health'; end if;
+
+  v_first := public.begin_cleanup_history_cron_run(
+    'vercel_cron', '0 7 * * *', 'deployment_fixture_failed'
+  );
+  perform public.finish_cleanup_history_cron_run(
+    (v_first->>'run_id')::uuid,
+    'failed',
+    503,
+    'managed_deletion_health_degraded',
+    '{"managed_health_healthy":false,"managed_health_critical":1}'::jsonb
+  );
+  v_next := public.begin_cleanup_history_cron_run('manual', null, null);
+  perform public.finish_cleanup_history_cron_run(
+    (v_next->>'run_id')::uuid,
+    'succeeded',
+    200,
+    null,
+    '{"managed_health_healthy":true}'::jsonb
+  );
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120, 1560);
+  if (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'scheduled_run_healthy')::boolean
+    or v_snapshot#>>'{latest_run,invocation_source}' <> 'manual'
+    or v_snapshot#>>'{latest_vercel_run,status}' <> 'failed'
+  then raise exception 'Manual success masked scheduled failure: %', v_snapshot; end if;
+
+  v_first := public.begin_cleanup_history_cron_run(
+    'vercel_cron', '0 7 * * *', 'deployment_fixture_expired'
+  );
+  perform public.finish_cleanup_history_cron_run(
+    (v_first->>'run_id')::uuid,
+    'succeeded',
+    200,
+    null,
+    '{"managed_health_healthy":true}'::jsonb
+  );
+  update public.cleanup_history_cron_runs
+  set started_at = clock_timestamp() - interval '3 days',
+      completed_at = clock_timestamp() - interval '3 days' + interval '1 second'
+  where invocation_source = 'vercel_cron';
+  update public.cleanup_history_cron_runs
+  set started_at = clock_timestamp() - interval '2 days',
+      completed_at = clock_timestamp() - interval '2 days' + interval '1 second'
+  where id = (v_first->>'run_id')::uuid;
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120, 1560);
+  if (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'scheduled_run_healthy')::boolean
+  then raise exception 'Expired scheduled evidence reported healthy: %', v_snapshot; end if;
+
+  v_first := public.begin_cleanup_history_cron_run(
+    'vercel_cron', '0 7 * * *', 'deployment_fixture_fresh'
+  );
+  perform public.finish_cleanup_history_cron_run(
+    (v_first->>'run_id')::uuid,
+    'succeeded',
+    200,
+    null,
+    '{"managed_health_healthy":true}'::jsonb
+  );
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120, 1560);
+  if not (v_snapshot->>'healthy')::boolean
+    or not (v_snapshot->>'scheduled_run_healthy')::boolean
+  then raise exception 'Fresh scheduled success was not healthy: %', v_snapshot; end if;
 end;
 $lifecycle$;
 
@@ -187,6 +259,18 @@ begin
     raise exception 'High stale threshold was accepted';
   exception when sqlstate '22023' then
     if sqlerrm <> 'cleanup_history_cron_stale_threshold_invalid' then raise; end if;
+  end;
+  begin
+    perform public.get_cleanup_history_cron_health_snapshot(120, 59);
+    raise exception 'Low scheduled evidence age was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'cleanup_history_cron_scheduled_age_threshold_invalid' then raise; end if;
+  end;
+  begin
+    perform public.get_cleanup_history_cron_health_snapshot(120, 10081);
+    raise exception 'High scheduled evidence age was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'cleanup_history_cron_scheduled_age_threshold_invalid' then raise; end if;
   end;
 end;
 $threshold$;

--- a/scripts/check-cleanup-history-cron-ledger-database.sh
+++ b/scripts/check-cleanup-history-cron-ledger-database.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_CONTAINER="${CLEANUP_HISTORY_CRON_DB_CONTAINER:-supabase_db_pika}"
+if ! docker inspect "$DB_CONTAINER" >/dev/null 2>&1; then
+  echo "Local Pika Supabase database container is not running." >&2
+  exit 2
+fi
+
+PROJECT_LABEL="$(docker inspect "$DB_CONTAINER" \
+  --format '{{ index .Config.Labels "com.supabase.cli.project" }}')"
+DB_BINDING="$(docker port "$DB_CONTAINER" 5432/tcp 2>/dev/null || true)"
+if [[ "$PROJECT_LABEL" != "pika" ]] || ! grep -q ':54322$' <<<"$DB_BINDING"; then
+  echo "Refusing non-local or unexpected Supabase database target." >&2
+  exit 2
+fi
+
+docker exec -i "$DB_CONTAINER" psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 <<'SQL'
+do $migration$
+begin
+  if not exists (
+    select 1 from supabase_migrations.schema_migrations where version = '124'
+  ) or to_regprocedure(
+    'public.begin_cleanup_history_cron_run(text,text,text)'
+  ) is null or to_regprocedure(
+    'public.finish_cleanup_history_cron_run(uuid,text,integer,text,jsonb)'
+  ) is null or to_regprocedure(
+    'public.get_cleanup_history_cron_health_snapshot(integer)'
+  ) is null then
+    raise exception 'Migration 124 is not applied to the local database';
+  end if;
+end;
+$migration$;
+
+begin;
+
+do $privileges$
+begin
+  if has_table_privilege('anon', 'public.cleanup_history_cron_runs', 'select')
+    or has_table_privilege('authenticated', 'public.cleanup_history_cron_runs', 'select')
+    or has_table_privilege('service_role', 'public.cleanup_history_cron_runs', 'insert')
+    or has_table_privilege('service_role', 'public.cleanup_history_cron_runs', 'update')
+    or not has_table_privilege('service_role', 'public.cleanup_history_cron_runs', 'select')
+  then raise exception 'Cron ledger table privileges are unsafe'; end if;
+
+  if has_function_privilege(
+      'anon', 'public.begin_cleanup_history_cron_run(text,text,text)', 'execute'
+    ) or has_function_privilege(
+      'authenticated',
+      'public.begin_cleanup_history_cron_run(text,text,text)', 'execute'
+    ) or not has_function_privilege(
+      'service_role',
+      'public.begin_cleanup_history_cron_run(text,text,text)', 'execute'
+    ) or has_function_privilege(
+      'anon',
+      'public.get_cleanup_history_cron_health_snapshot(integer)', 'execute'
+    ) or not has_function_privilege(
+      'service_role',
+      'public.get_cleanup_history_cron_health_snapshot(integer)', 'execute'
+    )
+  then raise exception 'Cron ledger RPC privileges are unsafe'; end if;
+end;
+$privileges$;
+
+do $metrics$
+begin
+  if not public.cleanup_history_cron_metrics_valid(
+    '{"history_rows_deleted":3,"managed_health_healthy":true}'::jsonb
+  ) then raise exception 'Valid aggregate metrics were rejected'; end if;
+  if public.cleanup_history_cron_metrics_valid(
+    '{"student_id":"00000000-0000-4000-8000-000000000001"}'::jsonb
+  ) then raise exception 'Identity-bearing metrics were accepted'; end if;
+  if public.cleanup_history_cron_metrics_valid(
+    '{"history_rows_deleted":-1}'::jsonb
+  ) or public.cleanup_history_cron_metrics_valid(
+    '{"history_rows_deleted":1.5}'::jsonb
+  ) or public.cleanup_history_cron_metrics_valid(
+    '{"history_rows_deleted":9007199254740992}'::jsonb
+  ) then raise exception 'Unsafe aggregate count was accepted'; end if;
+end;
+$metrics$;
+
+do $lifecycle$
+declare
+  v_first jsonb;
+  v_overlap jsonb;
+  v_next jsonb;
+  v_stale jsonb;
+  v_snapshot jsonb;
+  v_run_id uuid;
+  v_status text;
+begin
+  v_first := public.begin_cleanup_history_cron_run(
+    'vercel_cron', '0 7 * * *', 'deployment_fixture'
+  );
+  if not (v_first->>'started')::boolean then
+    raise exception 'First cron run did not start: %', v_first;
+  end if;
+  v_run_id := (v_first->>'run_id')::uuid;
+
+  v_overlap := public.begin_cleanup_history_cron_run('manual', null, null);
+  if (v_overlap->>'started')::boolean then
+    raise exception 'Overlapping cron run was started: %', v_overlap;
+  end if;
+  select status into strict v_status
+  from public.cleanup_history_cron_runs
+  where id = (v_overlap->>'run_id')::uuid;
+  if v_status <> 'skipped_overlap' then
+    raise exception 'Overlap attempt was not durably recorded';
+  end if;
+
+  if not public.finish_cleanup_history_cron_run(
+    v_run_id,
+    'succeeded',
+    200,
+    null,
+    '{"history_rows_deleted":3,"managed_health_healthy":true}'::jsonb
+  ) then raise exception 'Successful cron run did not finish'; end if;
+
+  begin
+    perform public.finish_cleanup_history_cron_run(
+      v_run_id, 'succeeded', 200, null, '{}'::jsonb
+    );
+    raise exception 'Completed cron run was finalized twice';
+  exception when sqlstate 'P0001' then
+    if sqlerrm <> 'cleanup_history_cron_run_not_running' then raise; end if;
+  end;
+
+  v_next := public.begin_cleanup_history_cron_run('manual', null, null);
+  if not (v_next->>'started')::boolean then
+    raise exception 'Next cron run did not start';
+  end if;
+  if not public.finish_cleanup_history_cron_run(
+    (v_next->>'run_id')::uuid,
+    'failed',
+    503,
+    'managed_deletion_health_degraded',
+    '{"managed_health_healthy":false,"managed_health_critical":1}'::jsonb
+  ) then raise exception 'Failed cron run did not finish'; end if;
+
+  v_stale := public.begin_cleanup_history_cron_run('manual', null, null);
+  update public.cleanup_history_cron_runs
+  set started_at = clock_timestamp() - interval '3 hours'
+  where id = (v_stale->>'run_id')::uuid;
+  v_next := public.begin_cleanup_history_cron_run(
+    'vercel_cron', '0 7 * * *', 'deployment_fixture_2'
+  );
+  select status into strict v_status
+  from public.cleanup_history_cron_runs
+  where id = (v_stale->>'run_id')::uuid;
+  if v_status <> 'failed' or not (v_next->>'started')::boolean then
+    raise exception 'Stale run was not superseded safely';
+  end if;
+  perform public.finish_cleanup_history_cron_run(
+    (v_next->>'run_id')::uuid,
+    'succeeded',
+    200,
+    null,
+    '{"student_health_stuck":0,"managed_health_healthy":true}'::jsonb
+  );
+
+  v_snapshot := public.get_cleanup_history_cron_health_snapshot(120);
+  if not (v_snapshot->>'healthy')::boolean
+    or (v_snapshot->>'stale_running_count')::integer <> 0
+    or v_snapshot#>>'{latest_vercel_run,schedule}' <> '0 7 * * *'
+    or v_snapshot#>>'{latest_vercel_run,status}' <> 'succeeded'
+    or (v_snapshot#>>'{latest_vercel_run,http_status}')::integer <> 200
+  then raise exception 'Cron health snapshot mismatch: %', v_snapshot; end if;
+  if v_snapshot::text ~
+      '"(teacher_id|student_id|user_id|classroom_id|operation_id|storage_path|email|title)"[[:space:]]*:'
+    or v_snapshot::text ~
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+  then raise exception 'Identity-bearing evidence escaped cron health'; end if;
+end;
+$lifecycle$;
+
+do $threshold$
+begin
+  begin
+    perform public.get_cleanup_history_cron_health_snapshot(4);
+    raise exception 'Low stale threshold was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'cleanup_history_cron_stale_threshold_invalid' then raise; end if;
+  end;
+  begin
+    perform public.get_cleanup_history_cron_health_snapshot(10081);
+    raise exception 'High stale threshold was accepted';
+  exception when sqlstate '22023' then
+    if sqlerrm <> 'cleanup_history_cron_stale_threshold_invalid' then raise; end if;
+  end;
+end;
+$threshold$;
+
+rollback;
+SQL
+
+echo "Cleanup-history cron ledger database checks passed."

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -484,7 +484,7 @@ async function handle(request: NextRequest) {
   try {
     run = await beginCleanupHistoryCronRun({
       supabase,
-      invocation: resolveCleanupHistoryInvocation(request.headers),
+      invocation: resolveCleanupHistoryInvocation(request),
     })
   } catch (error) {
     console.error('[cron-run-ledger] begin failed', {

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -14,6 +14,13 @@ import { runColdClassroomPurgeSafetyNet } from '@/lib/server/cold-classroom-purg
 import { runCourseBlueprintPurgeSafetyNet } from '@/lib/server/course-blueprint-purge'
 import { readStudentPurgeHealth, runStudentPurgeSafetyNet } from '@/lib/server/student-purge'
 import { readManagedDeletionHealth } from '@/lib/server/managed-deletion-health'
+import {
+  beginCleanupHistoryCronRun,
+  CronRunLedgerError,
+  finishCleanupHistoryCronRun,
+  resolveCleanupHistoryInvocation,
+  type CleanupHistoryCronMetrics,
+} from '@/lib/server/cron-run-ledger'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -25,6 +32,39 @@ const CLEANUP_PAGE_SIZE = 1000
 const SAVE_OPERATION_RETENTION_DAYS = 35
 
 type IdRow = { id: string }
+
+const CRON_RESPONSE_ERROR_CODES: Record<string, string> = {
+  'Student purge health degraded': 'student_purge_health_degraded',
+  'Failed to clean classroom archive staging': 'archive_staging_cleanup_failed',
+  'Failed to clean classroom archive objects': 'archive_object_cleanup_failed',
+  'Failed to clean assignment save operations': 'save_operation_cleanup_failed',
+  'Failed to fetch classrooms': 'classroom_inventory_failed',
+  'Failed to fetch assignments': 'assignment_inventory_failed',
+  'Failed to fetch assignment docs': 'assignment_doc_inventory_failed',
+  'Failed to fetch tests': 'test_inventory_failed',
+  'Failed to fetch test attempts': 'test_attempt_inventory_failed',
+  'Failed to delete history': 'history_cleanup_failed',
+  'Managed deletion health degraded': 'managed_deletion_health_degraded',
+  'Failed to verify managed deletion health': 'managed_deletion_health_probe_failed',
+}
+
+function cronRunLedgerErrorCode(error: unknown): string {
+  return error instanceof CronRunLedgerError
+    ? error.code
+    : 'cron_run_ledger_unknown_failure'
+}
+
+async function responseErrorCode(response: NextResponse): Promise<string | null> {
+  if (response.status < 400) return null
+  try {
+    const body = await response.clone().json() as { error?: unknown }
+    return typeof body.error === 'string'
+      ? CRON_RESPONSE_ERROR_CODES[body.error] ?? 'cleanup_history_failed'
+      : 'cleanup_history_failed'
+  } catch {
+    return 'cleanup_history_failed'
+  }
+}
 
 function managedDeletionHealthErrorCode(error: unknown): string {
   const code = error instanceof Error && 'code' in error ? String(error.code) : ''
@@ -39,10 +79,14 @@ function managedDeletionHealthErrorCode(error: unknown): string {
 async function respondWithManagedDeletionHealth(
   supabase: ReturnType<typeof getServiceRoleClient>,
   body: Record<string, unknown>,
+  metrics: CleanupHistoryCronMetrics,
 ) {
   try {
     const result = await readManagedDeletionHealth({ supabase })
     if (!result.schemaAvailable) return NextResponse.json(body)
+    metrics.managed_health_healthy = result.snapshot.healthy
+    metrics.managed_health_critical = result.snapshot.critical_count
+    metrics.managed_health_warning = result.snapshot.warning_count
     if (!result.snapshot.healthy || result.snapshot.critical_count > 0) {
       console.error('[managed-deletion-health] degraded', {
         critical_count: result.snapshot.critical_count,
@@ -140,35 +184,44 @@ async function deleteHistoryByParentIds(
   return { deleted, error: null }
 }
 
-async function handle(request: NextRequest) {
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret) {
-    console.error('CRON_SECRET is not set')
-    return NextResponse.json(
-      { error: 'CRON_SECRET not configured' },
-      { status: 500 }
-    )
-  }
-
-  const authHeader = getCronAuthHeader(request)
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
+async function runCleanupHistory(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  metrics: CleanupHistoryCronMetrics,
+) {
   const cutoffDate = formatInTimeZone(
     subDays(new Date(), 30),
     TIMEZONE,
     'yyyy-MM-dd'
   )
 
-  const supabase = getServiceRoleClient()
   const classroomPurge = await runClassroomPurgeSafetyNet()
   const coldClassroomPurge = await runColdClassroomPurgeSafetyNet(10)
   const courseBlueprintPurge = await runCourseBlueprintPurgeSafetyNet()
   const studentPurge = await runStudentPurgeSafetyNet()
+  Object.assign(metrics, {
+    classroom_purge_processed: classroomPurge.processed,
+    classroom_purge_completed: classroomPurge.completed,
+    classroom_purge_failed: classroomPurge.failed,
+    cold_classroom_purge_processed: coldClassroomPurge.processed,
+    cold_classroom_purge_completed: coldClassroomPurge.completed,
+    cold_classroom_purge_failed: coldClassroomPurge.failed,
+    course_blueprint_purge_processed: courseBlueprintPurge.processed,
+    course_blueprint_purge_completed: courseBlueprintPurge.completed,
+    course_blueprint_purge_failed: courseBlueprintPurge.failed,
+    student_purge_processed: studentPurge.processed,
+    student_purge_completed: studentPurge.completed,
+    student_purge_failed: studentPurge.failed,
+  })
   const studentPurgeHealth = await readStudentPurgeHealth()
   if (studentPurgeHealth.schemaAvailable) {
     const snapshot = studentPurgeHealth.snapshot
+    Object.assign(metrics, {
+      student_health_active: snapshot.active_count,
+      student_health_stuck: snapshot.stuck_count,
+      student_health_failed: snapshot.failed_count,
+      student_health_orphan_fences: snapshot.orphan_fence_count,
+      student_health_processing_lease_drift: snapshot.processing_lease_drift_count,
+    })
     if (
       studentPurge.failed > 0
       || snapshot.stuck_count > 0
@@ -196,6 +249,7 @@ async function handle(request: NextRequest) {
       )
     }
     archiveStagingCleaned = response.data
+    metrics.archive_staging_cleaned = archiveStagingCleaned
   }
   let archiveObjectCleanup: { claimed: number; deleted: number; failed: number } | undefined
   if (objectCleanupEnabled) {
@@ -218,8 +272,12 @@ async function handle(request: NextRequest) {
       deleted: result.deleted,
       failed: result.failed,
     }
+    Object.assign(metrics, {
+      archive_objects_claimed: result.claimed,
+      archive_objects_deleted: result.deleted,
+      archive_objects_failed: result.failed,
+    })
   }
-
   const saveOperationCutoff = subDays(new Date(), SAVE_OPERATION_RETENTION_DAYS).toISOString()
   const saveOperationCleanup = await supabase.rpc(
     'cleanup_assignment_doc_save_operations',
@@ -238,6 +296,7 @@ async function handle(request: NextRequest) {
       { status: 500 }
     )
   }
+  metrics.save_operations_deleted = saveOperationCleanupCount
 
   const { ids: classroomIds, error: classroomsError } = await loadExpiredClassroomIds(
     supabase,
@@ -251,8 +310,12 @@ async function handle(request: NextRequest) {
       { status: 500 }
     )
   }
+  metrics.expired_classrooms_scanned = classroomIds.length
 
   if (classroomIds.length === 0) {
+    metrics.assignment_history_deleted = 0
+    metrics.test_history_deleted = 0
+    metrics.history_rows_deleted = 0
     return respondWithManagedDeletionHealth(supabase, {
       status: 'ok',
       deleted: 0,
@@ -274,7 +337,7 @@ async function handle(request: NextRequest) {
       ...(studentPurge.processed > 0
         ? { student_purge: studentPurge }
         : {}),
-    })
+    }, metrics)
   }
 
   let deleted = 0
@@ -326,6 +389,7 @@ async function handle(request: NextRequest) {
     )
   }
   deleted += assignmentHistoryDeleted
+  metrics.assignment_history_deleted = assignmentHistoryDeleted
 
   const { ids: testIds, error: testsError } = await loadIdsByParentIds(
     supabase,
@@ -373,6 +437,8 @@ async function handle(request: NextRequest) {
     )
   }
   deleted += testHistoryDeleted
+  metrics.test_history_deleted = testHistoryDeleted
+  metrics.history_rows_deleted = deleted
 
   return respondWithManagedDeletionHealth(supabase, {
     status: 'ok',
@@ -395,7 +461,81 @@ async function handle(request: NextRequest) {
     ...(studentPurge.processed > 0
       ? { student_purge: studentPurge }
       : {}),
-  })
+  }, metrics)
+}
+
+async function handle(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    console.error('CRON_SECRET is not set')
+    return NextResponse.json(
+      { error: 'CRON_SECRET not configured' },
+      { status: 500 }
+    )
+  }
+
+  const authHeader = getCronAuthHeader(request)
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = getServiceRoleClient()
+  let run
+  try {
+    run = await beginCleanupHistoryCronRun({
+      supabase,
+      invocation: resolveCleanupHistoryInvocation(request.headers),
+    })
+  } catch (error) {
+    console.error('[cron-run-ledger] begin failed', {
+      error_code: cronRunLedgerErrorCode(error),
+    })
+    return NextResponse.json({ error: 'Failed to record cleanup run' }, { status: 503 })
+  }
+
+  if (run.schemaAvailable && !run.started) {
+    return NextResponse.json({ error: 'Cleanup already running' }, { status: 409 })
+  }
+
+  const metrics: CleanupHistoryCronMetrics = {}
+  let response: NextResponse
+  try {
+    response = await runCleanupHistory(supabase, metrics)
+  } catch (error) {
+    try {
+      await finishCleanupHistoryCronRun({
+        supabase,
+        run,
+        status: 'failed',
+        httpStatus: 500,
+        errorCode: 'unhandled_error',
+        metrics,
+      })
+    } catch (ledgerError) {
+      console.error('[cron-run-ledger] finish failed', {
+        error_code: cronRunLedgerErrorCode(ledgerError),
+      })
+    }
+    throw error
+  }
+
+  const errorCode = await responseErrorCode(response)
+  try {
+    await finishCleanupHistoryCronRun({
+      supabase,
+      run,
+      status: errorCode === null ? 'succeeded' : 'failed',
+      httpStatus: response.status,
+      errorCode,
+      metrics,
+    })
+  } catch (error) {
+    console.error('[cron-run-ledger] finish failed', {
+      error_code: cronRunLedgerErrorCode(error),
+    })
+    return NextResponse.json({ error: 'Failed to record cleanup run' }, { status: 503 })
+  }
+  return response
 }
 
 export const GET = withErrorHandler('GetCronCleanupHistory', async (request: NextRequest) => {

--- a/src/lib/server/cron-run-ledger.ts
+++ b/src/lib/server/cron-run-ledger.ts
@@ -4,6 +4,9 @@ import { getServiceRoleClient } from '@/lib/supabase'
 const countSchema = z.number().int().nonnegative().safe()
 const errorCodeSchema = z.string().regex(/^[a-z0-9_]{1,64}$/)
 
+export const CLEANUP_HISTORY_CRON_SCHEDULE = '0 7 * * *'
+const VERCEL_CRON_USER_AGENT = 'vercel-cron/1.0'
+
 export const cleanupHistoryCronMetricsSchema = z.object({
   classroom_purge_processed: countSchema.optional(),
   classroom_purge_completed: countSchema.optional(),
@@ -77,6 +80,9 @@ export const cleanupHistoryCronHealthSchema = z.object({
   version: z.literal(1),
   captured_at: z.string().datetime({ offset: true }),
   healthy: z.boolean(),
+  scheduled_run_healthy: z.boolean(),
+  expected_schedule: z.literal(CLEANUP_HISTORY_CRON_SCHEDULE),
+  scheduled_evidence_max_age_minutes: countSchema,
   stale_running_count: countSchema,
   failed_count_7d: countSchema,
   overlap_count_7d: countSchema,
@@ -119,13 +125,25 @@ function optionalTrimmed(value: string | null | undefined): string | null {
 }
 
 export function resolveCleanupHistoryInvocation(
-  headers: Headers,
+  request: Pick<Request, 'headers' | 'method'>,
   deploymentId: string | undefined = process.env.VERCEL_DEPLOYMENT_ID,
 ): CleanupHistoryInvocation {
-  const schedule = optionalTrimmed(headers.get('x-vercel-cron-schedule'))
+  const scheduleHeader = optionalTrimmed(request.headers.get('x-vercel-cron-schedule'))
+  const userAgent = optionalTrimmed(request.headers.get('user-agent'))
+  const isPost = request.method.toUpperCase() === 'POST'
+  const hasCronMetadata = scheduleHeader !== null || userAgent === VERCEL_CRON_USER_AGENT
+  if (!isPost && hasCronMetadata && (
+    scheduleHeader !== CLEANUP_HISTORY_CRON_SCHEDULE
+    || userAgent !== VERCEL_CRON_USER_AGENT
+  )) {
+    throw new CronRunLedgerError('cron_run_invocation_invalid')
+  }
+  const isVercelCron = !isPost
+    && scheduleHeader === CLEANUP_HISTORY_CRON_SCHEDULE
+    && userAgent === VERCEL_CRON_USER_AGENT
   const parsed = invocationSchema.safeParse({
-    invocationSource: schedule === null ? 'manual' : 'vercel_cron',
-    schedule,
+    invocationSource: isVercelCron ? 'vercel_cron' : 'manual',
+    schedule: isVercelCron ? CLEANUP_HISTORY_CRON_SCHEDULE : null,
     deploymentId: optionalTrimmed(deploymentId),
   })
   if (!parsed.success) throw new CronRunLedgerError('cron_run_invocation_invalid')
@@ -212,19 +230,31 @@ export async function finishCleanupHistoryCronRun(input: {
 export async function readCleanupHistoryCronHealth(input: {
   supabase?: ReturnType<typeof getServiceRoleClient>
   staleMinutes?: number
+  scheduledEvidenceMaxAgeMinutes?: number
 } = {}): Promise<
   | { schemaAvailable: false }
   | { schemaAvailable: true; snapshot: CleanupHistoryCronHealth }
 > {
   const staleMinutes = input.staleMinutes ?? 120
+  const scheduledEvidenceMaxAgeMinutes = input.scheduledEvidenceMaxAgeMinutes ?? 1560
   if (!Number.isSafeInteger(staleMinutes) || staleMinutes < 5 || staleMinutes > 10_080) {
     throw new CronRunLedgerError('cron_run_health_threshold_invalid')
+  }
+  if (
+    !Number.isSafeInteger(scheduledEvidenceMaxAgeMinutes)
+    || scheduledEvidenceMaxAgeMinutes < 60
+    || scheduledEvidenceMaxAgeMinutes > 10_080
+  ) {
+    throw new CronRunLedgerError('cron_run_scheduled_age_threshold_invalid')
   }
 
   const supabase = input.supabase ?? getServiceRoleClient()
   const { data, error } = await ledgerClient(supabase).rpc(
     'get_cleanup_history_cron_health_snapshot',
-    { p_stale_minutes: staleMinutes },
+    {
+      p_stale_minutes: staleMinutes,
+      p_scheduled_max_age_minutes: scheduledEvidenceMaxAgeMinutes,
+    },
   )
   if (error) {
     if (isMissingSchemaError(error)) return { schemaAvailable: false }

--- a/src/lib/server/cron-run-ledger.ts
+++ b/src/lib/server/cron-run-ledger.ts
@@ -1,0 +1,236 @@
+import { z } from 'zod'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+const countSchema = z.number().int().nonnegative().safe()
+const errorCodeSchema = z.string().regex(/^[a-z0-9_]{1,64}$/)
+
+export const cleanupHistoryCronMetricsSchema = z.object({
+  classroom_purge_processed: countSchema.optional(),
+  classroom_purge_completed: countSchema.optional(),
+  classroom_purge_failed: countSchema.optional(),
+  cold_classroom_purge_processed: countSchema.optional(),
+  cold_classroom_purge_completed: countSchema.optional(),
+  cold_classroom_purge_failed: countSchema.optional(),
+  course_blueprint_purge_processed: countSchema.optional(),
+  course_blueprint_purge_completed: countSchema.optional(),
+  course_blueprint_purge_failed: countSchema.optional(),
+  student_purge_processed: countSchema.optional(),
+  student_purge_completed: countSchema.optional(),
+  student_purge_failed: countSchema.optional(),
+  student_health_active: countSchema.optional(),
+  student_health_stuck: countSchema.optional(),
+  student_health_failed: countSchema.optional(),
+  student_health_orphan_fences: countSchema.optional(),
+  student_health_processing_lease_drift: countSchema.optional(),
+  archive_staging_cleaned: countSchema.optional(),
+  archive_objects_claimed: countSchema.optional(),
+  archive_objects_deleted: countSchema.optional(),
+  archive_objects_failed: countSchema.optional(),
+  save_operations_deleted: countSchema.optional(),
+  expired_classrooms_scanned: countSchema.optional(),
+  assignment_history_deleted: countSchema.optional(),
+  test_history_deleted: countSchema.optional(),
+  history_rows_deleted: countSchema.optional(),
+  managed_health_healthy: z.boolean().optional(),
+  managed_health_critical: countSchema.optional(),
+  managed_health_warning: countSchema.optional(),
+}).strict()
+
+export type CleanupHistoryCronMetrics = z.infer<typeof cleanupHistoryCronMetricsSchema>
+
+const invocationSchema = z.object({
+  invocationSource: z.enum(['vercel_cron', 'manual']),
+  schedule: z.string().min(1).max(128).regex(/^[\x20-\x7e]+$/).nullable(),
+  deploymentId: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/).nullable(),
+}).strict().superRefine((value, context) => {
+  if ((value.invocationSource === 'vercel_cron') !== (value.schedule !== null)) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Vercel cron invocations require a schedule',
+      path: ['schedule'],
+    })
+  }
+})
+
+export type CleanupHistoryInvocation = z.infer<typeof invocationSchema>
+
+const beginResultSchema = z.object({
+  run_id: z.string().uuid(),
+  started: z.boolean(),
+}).strict()
+
+const runEvidenceSchema = z.object({
+  schedule: z.string().nullable(),
+  status: z.enum(['running', 'succeeded', 'failed', 'skipped_overlap']),
+  started_at: z.string().datetime({ offset: true }),
+  completed_at: z.string().datetime({ offset: true }).nullable(),
+  http_status: z.number().int().min(200).max(599).nullable(),
+  error_code: errorCodeSchema.nullable(),
+  metrics: cleanupHistoryCronMetricsSchema,
+}).strict()
+
+const completedRunSchema = runEvidenceSchema.extend({
+  invocation_source: z.enum(['vercel_cron', 'manual']),
+})
+
+export const cleanupHistoryCronHealthSchema = z.object({
+  version: z.literal(1),
+  captured_at: z.string().datetime({ offset: true }),
+  healthy: z.boolean(),
+  stale_running_count: countSchema,
+  failed_count_7d: countSchema,
+  overlap_count_7d: countSchema,
+  latest_run: completedRunSchema.nullable(),
+  latest_vercel_run: runEvidenceSchema.nullable(),
+}).strict()
+
+export type CleanupHistoryCronHealth = z.infer<typeof cleanupHistoryCronHealthSchema>
+
+type RpcError = { code?: string; message?: string }
+type LedgerClient = {
+  rpc(name: string, args: Record<string, unknown>): PromiseLike<{
+    data: unknown
+    error: RpcError | null
+  }>
+}
+
+export type CleanupHistoryCronRun =
+  | { schemaAvailable: false }
+  | { schemaAvailable: true; runId: string; started: boolean }
+
+export class CronRunLedgerError extends Error {
+  constructor(public readonly code: string) {
+    super('Cron run ledger could not be updated')
+    this.name = 'CronRunLedgerError'
+  }
+}
+
+function ledgerClient(value: ReturnType<typeof getServiceRoleClient>): LedgerClient {
+  return value as unknown as LedgerClient
+}
+
+function isMissingSchemaError(error: RpcError): boolean {
+  return error.code === 'PGRST202'
+}
+
+function optionalTrimmed(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+export function resolveCleanupHistoryInvocation(
+  headers: Headers,
+  deploymentId: string | undefined = process.env.VERCEL_DEPLOYMENT_ID,
+): CleanupHistoryInvocation {
+  const schedule = optionalTrimmed(headers.get('x-vercel-cron-schedule'))
+  const parsed = invocationSchema.safeParse({
+    invocationSource: schedule === null ? 'manual' : 'vercel_cron',
+    schedule,
+    deploymentId: optionalTrimmed(deploymentId),
+  })
+  if (!parsed.success) throw new CronRunLedgerError('cron_run_invocation_invalid')
+  return parsed.data
+}
+
+export async function beginCleanupHistoryCronRun(input: {
+  supabase?: ReturnType<typeof getServiceRoleClient>
+  invocation: CleanupHistoryInvocation
+}): Promise<CleanupHistoryCronRun> {
+  const invocation = invocationSchema.safeParse(input.invocation)
+  if (!invocation.success) throw new CronRunLedgerError('cron_run_invocation_invalid')
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await ledgerClient(supabase).rpc(
+    'begin_cleanup_history_cron_run',
+    {
+      p_invocation_source: invocation.data.invocationSource,
+      p_schedule: invocation.data.schedule,
+      p_deployment_id: invocation.data.deploymentId,
+    },
+  )
+
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      console.warn('[cron-run-ledger] schema unavailable', {
+        error_code: error.code ?? 'unknown',
+      })
+      return { schemaAvailable: false }
+    }
+    throw new CronRunLedgerError('cron_run_begin_failed')
+  }
+
+  const parsed = beginResultSchema.safeParse(data)
+  if (!parsed.success) throw new CronRunLedgerError('cron_run_begin_contract_invalid')
+  return {
+    schemaAvailable: true,
+    runId: parsed.data.run_id,
+    started: parsed.data.started,
+  }
+}
+
+export async function finishCleanupHistoryCronRun(input: {
+  supabase?: ReturnType<typeof getServiceRoleClient>
+  run: CleanupHistoryCronRun
+  status: 'succeeded' | 'failed'
+  httpStatus: number
+  errorCode: string | null
+  metrics: CleanupHistoryCronMetrics
+}): Promise<void> {
+  if (!input.run.schemaAvailable || !input.run.started) return
+
+  const metrics = cleanupHistoryCronMetricsSchema.safeParse(input.metrics)
+  if (!metrics.success) throw new CronRunLedgerError('cron_run_metrics_invalid')
+  const errorCode = input.errorCode === null
+    ? { success: true as const, data: null }
+    : errorCodeSchema.safeParse(input.errorCode)
+  const validOutcome = Number.isSafeInteger(input.httpStatus)
+    && input.httpStatus >= 200
+    && input.httpStatus <= 599
+    && errorCode.success
+    && (
+      (input.status === 'succeeded' && input.httpStatus < 300 && errorCode.data === null)
+      || (input.status === 'failed' && input.httpStatus >= 400 && errorCode.data !== null)
+    )
+  if (!validOutcome) throw new CronRunLedgerError('cron_run_outcome_invalid')
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await ledgerClient(supabase).rpc(
+    'finish_cleanup_history_cron_run',
+    {
+      p_run_id: input.run.runId,
+      p_status: input.status,
+      p_http_status: input.httpStatus,
+      p_error_code: errorCode.data,
+      p_metrics: metrics.data,
+    },
+  )
+  if (error || data !== true) {
+    throw new CronRunLedgerError('cron_run_finish_failed')
+  }
+}
+
+export async function readCleanupHistoryCronHealth(input: {
+  supabase?: ReturnType<typeof getServiceRoleClient>
+  staleMinutes?: number
+} = {}): Promise<
+  | { schemaAvailable: false }
+  | { schemaAvailable: true; snapshot: CleanupHistoryCronHealth }
+> {
+  const staleMinutes = input.staleMinutes ?? 120
+  if (!Number.isSafeInteger(staleMinutes) || staleMinutes < 5 || staleMinutes > 10_080) {
+    throw new CronRunLedgerError('cron_run_health_threshold_invalid')
+  }
+
+  const supabase = input.supabase ?? getServiceRoleClient()
+  const { data, error } = await ledgerClient(supabase).rpc(
+    'get_cleanup_history_cron_health_snapshot',
+    { p_stale_minutes: staleMinutes },
+  )
+  if (error) {
+    if (isMissingSchemaError(error)) return { schemaAvailable: false }
+    throw new CronRunLedgerError('cron_run_health_query_failed')
+  }
+  const parsed = cleanupHistoryCronHealthSchema.safeParse(data)
+  if (!parsed.success) throw new CronRunLedgerError('cron_run_health_contract_invalid')
+  return { schemaAvailable: true, snapshot: parsed.data }
+}

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2775,6 +2775,48 @@ export type Database = {
           },
         ]
       }
+      cleanup_history_cron_runs: {
+        Row: {
+          completed_at: string | null
+          deployment_id: string | null
+          error_code: string | null
+          http_status: number | null
+          id: string
+          invocation_source: string
+          job_name: string
+          metrics: Json
+          schedule: string | null
+          started_at: string
+          status: string
+        }
+        Insert: {
+          completed_at?: string | null
+          deployment_id?: string | null
+          error_code?: string | null
+          http_status?: number | null
+          id?: string
+          invocation_source: string
+          job_name?: string
+          metrics?: Json
+          schedule?: string | null
+          started_at?: string
+          status: string
+        }
+        Update: {
+          completed_at?: string | null
+          deployment_id?: string | null
+          error_code?: string | null
+          http_status?: number | null
+          id?: string
+          invocation_source?: string
+          job_name?: string
+          metrics?: Json
+          schedule?: string | null
+          started_at?: string
+          status?: string
+        }
+        Relationships: []
+      }
       cold_classroom_purge_fences: {
         Row: {
           archive_id: string
@@ -6206,6 +6248,14 @@ export type Database = {
         }
         Returns: Json
       }
+      begin_cleanup_history_cron_run: {
+        Args: {
+          p_deployment_id?: string
+          p_invocation_source: string
+          p_schedule?: string
+        }
+        Returns: Json
+      }
       begin_cold_archived_classroom_purge: {
         Args: {
           p_archive_id: string
@@ -6831,6 +6881,10 @@ export type Database = {
       cleanup_expired_classroom_archive_snapshots: {
         Args: never
         Returns: number
+      }
+      cleanup_history_cron_metrics_valid: {
+        Args: { p_metrics: Json }
+        Returns: boolean
       }
       clear_test_open_response_grades_atomic: {
         Args: {
@@ -7541,8 +7595,22 @@ export type Database = {
         }
         Returns: Json
       }
+      finish_cleanup_history_cron_run: {
+        Args: {
+          p_error_code: string
+          p_http_status: number
+          p_metrics?: Json
+          p_run_id: string
+          p_status: string
+        }
+        Returns: boolean
+      }
       get_classroom_archive_source_object_presence: {
         Args: { p_storage_bucket: string; p_storage_path: string }
+        Returns: Json
+      }
+      get_cleanup_history_cron_health_snapshot: {
+        Args: { p_stale_minutes?: number }
         Returns: Json
       }
       get_cold_archived_classroom_purge_inventory: {

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -7610,7 +7610,7 @@ export type Database = {
         Returns: Json
       }
       get_cleanup_history_cron_health_snapshot: {
-        Args: { p_stale_minutes?: number }
+        Args: { p_scheduled_max_age_minutes?: number; p_stale_minutes?: number }
         Returns: Json
       }
       get_cold_archived_classroom_purge_inventory: {

--- a/supabase/migrations/124_cleanup_history_cron_run_ledger.sql
+++ b/supabase/migrations/124_cleanup_history_cron_run_ledger.sql
@@ -242,7 +242,8 @@ end;
 $$;
 
 create function public.get_cleanup_history_cron_health_snapshot(
-  p_stale_minutes integer default 120
+  p_stale_minutes integer default 120,
+  p_scheduled_max_age_minutes integer default 1560
 )
 returns jsonb
 language plpgsql
@@ -256,11 +257,18 @@ declare
   v_stale_running bigint;
   v_failed_7d bigint;
   v_overlap_7d bigint;
+  v_scheduled_run_healthy boolean;
 begin
   if p_stale_minutes < 5 or p_stale_minutes > 10080 then
     raise exception using
       errcode = '22023',
       message = 'cleanup_history_cron_stale_threshold_invalid';
+  end if;
+  if p_scheduled_max_age_minutes < 60
+    or p_scheduled_max_age_minutes > 10080 then
+    raise exception using
+      errcode = '22023',
+      message = 'cleanup_history_cron_scheduled_age_threshold_invalid';
   end if;
 
   select * into v_latest
@@ -290,11 +298,20 @@ begin
   where status = 'skipped_overlap'
     and started_at >= clock_timestamp() - interval '7 days';
 
+  v_scheduled_run_healthy := v_latest_vercel.id is not null
+    and v_latest_vercel.schedule = '0 7 * * *'
+    and v_latest_vercel.status = 'succeeded'
+    and v_latest_vercel.completed_at is not null
+    and v_latest_vercel.started_at >= clock_timestamp()
+      - make_interval(mins => p_scheduled_max_age_minutes);
+
   return jsonb_build_object(
     'version', 1,
     'captured_at', clock_timestamp(),
-    'healthy', v_stale_running = 0
-      and coalesce(v_latest.status = 'succeeded', true),
+    'healthy', v_stale_running = 0 and v_scheduled_run_healthy,
+    'scheduled_run_healthy', v_scheduled_run_healthy,
+    'expected_schedule', '0 7 * * *',
+    'scheduled_evidence_max_age_minutes', p_scheduled_max_age_minutes,
     'stale_running_count', v_stale_running,
     'failed_count_7d', v_failed_7d,
     'overlap_count_7d', v_overlap_7d,
@@ -323,11 +340,11 @@ $$;
 
 revoke all on function public.begin_cleanup_history_cron_run(text, text, text),
   public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb),
-  public.get_cleanup_history_cron_health_snapshot(integer)
+  public.get_cleanup_history_cron_health_snapshot(integer, integer)
   from public, anon, authenticated;
 grant execute on function public.begin_cleanup_history_cron_run(text, text, text),
   public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb),
-  public.get_cleanup_history_cron_health_snapshot(integer)
+  public.get_cleanup_history_cron_health_snapshot(integer, integer)
   to service_role;
 
 comment on table public.cleanup_history_cron_runs is
@@ -336,5 +353,5 @@ comment on function public.begin_cleanup_history_cron_run(text, text, text) is
   'Serializes cleanup-history runs, records overlap attempts, and supersedes only runs stale beyond two hours.';
 comment on function public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb) is
   'Finalizes one running cleanup-history ledger row with allowlisted aggregate metrics.';
-comment on function public.get_cleanup_history_cron_health_snapshot(integer) is
-  'Returns privacy-safe latest-run and failure aggregates for operator verification.';
+comment on function public.get_cleanup_history_cron_health_snapshot(integer, integer) is
+  'Returns privacy-safe latest-run aggregates and requires fresh successful scheduled evidence for health.';

--- a/supabase/migrations/124_cleanup_history_cron_run_ledger.sql
+++ b/supabase/migrations/124_cleanup_history_cron_run_ledger.sql
@@ -1,0 +1,340 @@
+-- Durable, privacy-safe evidence for the existing daily cleanup-history cron.
+-- This migration installs no schedule and grants no cleanup or deletion authority.
+
+create function public.cleanup_history_cron_metrics_valid(p_metrics jsonb)
+returns boolean
+language sql
+immutable
+set search_path = ''
+as $$
+  select coalesce(jsonb_typeof(p_metrics) = 'object'
+    and pg_column_size(p_metrics) <= 8192
+    and not exists (
+      select 1
+      from jsonb_each(p_metrics) entry
+      where entry.key not in (
+        'classroom_purge_processed',
+        'classroom_purge_completed',
+        'classroom_purge_failed',
+        'cold_classroom_purge_processed',
+        'cold_classroom_purge_completed',
+        'cold_classroom_purge_failed',
+        'course_blueprint_purge_processed',
+        'course_blueprint_purge_completed',
+        'course_blueprint_purge_failed',
+        'student_purge_processed',
+        'student_purge_completed',
+        'student_purge_failed',
+        'student_health_active',
+        'student_health_stuck',
+        'student_health_failed',
+        'student_health_orphan_fences',
+        'student_health_processing_lease_drift',
+        'archive_staging_cleaned',
+        'archive_objects_claimed',
+        'archive_objects_deleted',
+        'archive_objects_failed',
+        'save_operations_deleted',
+        'expired_classrooms_scanned',
+        'assignment_history_deleted',
+        'test_history_deleted',
+        'history_rows_deleted',
+        'managed_health_healthy',
+        'managed_health_critical',
+        'managed_health_warning'
+      )
+    )
+    and not exists (
+      select 1
+      from jsonb_each(p_metrics) entry
+      where case
+        when entry.key = 'managed_health_healthy'
+          then jsonb_typeof(entry.value) <> 'boolean'
+        else jsonb_typeof(entry.value) <> 'number'
+          or entry.value::text !~ '^(0|[1-9][0-9]*)$'
+          or (entry.value::text)::numeric > 9007199254740991
+      end
+    ), false)
+$$;
+
+create table public.cleanup_history_cron_runs (
+  id uuid primary key default gen_random_uuid(),
+  job_name text not null default 'cleanup-history'
+    check (job_name = 'cleanup-history'),
+  invocation_source text not null
+    check (invocation_source in ('vercel_cron', 'manual')),
+  schedule text,
+  deployment_id text,
+  status text not null
+    check (status in ('running', 'succeeded', 'failed', 'skipped_overlap')),
+  started_at timestamptz not null default clock_timestamp(),
+  completed_at timestamptz,
+  http_status smallint,
+  error_code text,
+  metrics jsonb not null default '{}'::jsonb,
+  check (
+    (invocation_source = 'vercel_cron' and schedule is not null)
+    or (invocation_source = 'manual' and schedule is null)
+  ),
+  check (schedule is null or schedule ~ '^[ -~]{1,128}$'),
+  check (deployment_id is null or deployment_id ~ '^[A-Za-z0-9_-]{1,128}$'),
+  check (error_code is null or error_code ~ '^[a-z0-9_]{1,64}$'),
+  check (public.cleanup_history_cron_metrics_valid(metrics)),
+  check (
+    (status = 'running'
+      and completed_at is null and http_status is null and error_code is null)
+    or (status = 'succeeded'
+      and completed_at is not null and http_status between 200 and 299
+      and error_code is null)
+    or (status = 'failed'
+      and completed_at is not null and http_status between 400 and 599
+      and error_code is not null)
+    or (status = 'skipped_overlap'
+      and completed_at is not null and http_status = 409
+      and error_code = 'overlap')
+  )
+);
+
+create unique index cleanup_history_cron_runs_one_running
+  on public.cleanup_history_cron_runs (job_name)
+  where status = 'running';
+create index cleanup_history_cron_runs_started
+  on public.cleanup_history_cron_runs (started_at desc);
+create index cleanup_history_cron_runs_vercel_started
+  on public.cleanup_history_cron_runs (started_at desc)
+  where invocation_source = 'vercel_cron';
+
+alter table public.cleanup_history_cron_runs enable row level security;
+
+revoke all on function public.cleanup_history_cron_metrics_valid(jsonb)
+  from public, anon, authenticated, service_role;
+revoke all on table public.cleanup_history_cron_runs
+  from public, anon, authenticated, service_role;
+grant select on table public.cleanup_history_cron_runs to service_role;
+
+create function public.begin_cleanup_history_cron_run(
+  p_invocation_source text,
+  p_schedule text default null,
+  p_deployment_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_run_id uuid;
+  v_active_id uuid;
+begin
+  if p_invocation_source not in ('vercel_cron', 'manual')
+    or (p_invocation_source = 'vercel_cron') <> (p_schedule is not null)
+    or (p_schedule is not null and p_schedule !~ '^[ -~]{1,128}$')
+    or (p_deployment_id is not null
+      and p_deployment_id !~ '^[A-Za-z0-9_-]{1,128}$') then
+    raise exception using
+      errcode = '22023',
+      message = 'cleanup_history_cron_invocation_invalid';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('pika-cron:cleanup-history', 0)
+  );
+
+  update public.cleanup_history_cron_runs
+  set status = 'failed',
+      completed_at = clock_timestamp(),
+      http_status = 500,
+      error_code = 'stale_run_superseded'
+  where job_name = 'cleanup-history'
+    and status = 'running'
+    and started_at < clock_timestamp() - interval '2 hours';
+
+  select id into v_active_id
+  from public.cleanup_history_cron_runs
+  where job_name = 'cleanup-history'
+    and status = 'running'
+  for update;
+
+  if v_active_id is not null then
+    insert into public.cleanup_history_cron_runs (
+      invocation_source,
+      schedule,
+      deployment_id,
+      status,
+      completed_at,
+      http_status,
+      error_code
+    ) values (
+      p_invocation_source,
+      p_schedule,
+      p_deployment_id,
+      'skipped_overlap',
+      clock_timestamp(),
+      409,
+      'overlap'
+    ) returning id into v_run_id;
+
+    return jsonb_build_object('run_id', v_run_id, 'started', false);
+  end if;
+
+  insert into public.cleanup_history_cron_runs (
+    invocation_source,
+    schedule,
+    deployment_id,
+    status
+  ) values (
+    p_invocation_source,
+    p_schedule,
+    p_deployment_id,
+    'running'
+  ) returning id into v_run_id;
+
+  return jsonb_build_object('run_id', v_run_id, 'started', true);
+end;
+$$;
+
+create function public.finish_cleanup_history_cron_run(
+  p_run_id uuid,
+  p_status text,
+  p_http_status integer,
+  p_error_code text,
+  p_metrics jsonb default '{}'::jsonb
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_updated integer;
+begin
+  if p_status not in ('succeeded', 'failed')
+    or p_http_status < 200 or p_http_status > 599
+    or not public.cleanup_history_cron_metrics_valid(p_metrics)
+    or (p_error_code is not null and p_error_code !~ '^[a-z0-9_]{1,64}$')
+    or (p_status = 'succeeded'
+      and (p_http_status >= 300 or p_error_code is not null))
+    or (p_status = 'failed'
+      and (p_http_status < 400 or p_error_code is null)) then
+    raise exception using
+      errcode = '22023',
+      message = 'cleanup_history_cron_outcome_invalid';
+  end if;
+
+  update public.cleanup_history_cron_runs
+  set status = p_status,
+      completed_at = clock_timestamp(),
+      http_status = p_http_status,
+      error_code = p_error_code,
+      metrics = p_metrics
+  where id = p_run_id
+    and job_name = 'cleanup-history'
+    and status = 'running';
+  get diagnostics v_updated = row_count;
+
+  if v_updated <> 1 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'cleanup_history_cron_run_not_running';
+  end if;
+  return true;
+end;
+$$;
+
+create function public.get_cleanup_history_cron_health_snapshot(
+  p_stale_minutes integer default 120
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_latest public.cleanup_history_cron_runs%rowtype;
+  v_latest_vercel public.cleanup_history_cron_runs%rowtype;
+  v_stale_running bigint;
+  v_failed_7d bigint;
+  v_overlap_7d bigint;
+begin
+  if p_stale_minutes < 5 or p_stale_minutes > 10080 then
+    raise exception using
+      errcode = '22023',
+      message = 'cleanup_history_cron_stale_threshold_invalid';
+  end if;
+
+  select * into v_latest
+  from public.cleanup_history_cron_runs
+  order by started_at desc
+  limit 1;
+
+  select * into v_latest_vercel
+  from public.cleanup_history_cron_runs
+  where invocation_source = 'vercel_cron'
+  order by started_at desc
+  limit 1;
+
+  select count(*) into v_stale_running
+  from public.cleanup_history_cron_runs
+  where status = 'running'
+    and started_at < clock_timestamp()
+      - make_interval(mins => p_stale_minutes);
+
+  select count(*) into v_failed_7d
+  from public.cleanup_history_cron_runs
+  where status = 'failed'
+    and started_at >= clock_timestamp() - interval '7 days';
+
+  select count(*) into v_overlap_7d
+  from public.cleanup_history_cron_runs
+  where status = 'skipped_overlap'
+    and started_at >= clock_timestamp() - interval '7 days';
+
+  return jsonb_build_object(
+    'version', 1,
+    'captured_at', clock_timestamp(),
+    'healthy', v_stale_running = 0
+      and coalesce(v_latest.status = 'succeeded', true),
+    'stale_running_count', v_stale_running,
+    'failed_count_7d', v_failed_7d,
+    'overlap_count_7d', v_overlap_7d,
+    'latest_run', case when v_latest.id is null then null else jsonb_build_object(
+      'invocation_source', v_latest.invocation_source,
+      'schedule', v_latest.schedule,
+      'status', v_latest.status,
+      'started_at', v_latest.started_at,
+      'completed_at', v_latest.completed_at,
+      'http_status', v_latest.http_status,
+      'error_code', v_latest.error_code,
+      'metrics', v_latest.metrics
+    ) end,
+    'latest_vercel_run', case when v_latest_vercel.id is null then null else jsonb_build_object(
+      'schedule', v_latest_vercel.schedule,
+      'status', v_latest_vercel.status,
+      'started_at', v_latest_vercel.started_at,
+      'completed_at', v_latest_vercel.completed_at,
+      'http_status', v_latest_vercel.http_status,
+      'error_code', v_latest_vercel.error_code,
+      'metrics', v_latest_vercel.metrics
+    ) end
+  );
+end;
+$$;
+
+revoke all on function public.begin_cleanup_history_cron_run(text, text, text),
+  public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb),
+  public.get_cleanup_history_cron_health_snapshot(integer)
+  from public, anon, authenticated;
+grant execute on function public.begin_cleanup_history_cron_run(text, text, text),
+  public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb),
+  public.get_cleanup_history_cron_health_snapshot(integer)
+  to service_role;
+
+comment on table public.cleanup_history_cron_runs is
+  'Service-only, privacy-safe run evidence for the existing cleanup-history cron; grants no cleanup authority.';
+comment on function public.begin_cleanup_history_cron_run(text, text, text) is
+  'Serializes cleanup-history runs, records overlap attempts, and supersedes only runs stale beyond two hours.';
+comment on function public.finish_cleanup_history_cron_run(uuid, text, integer, text, jsonb) is
+  'Finalizes one running cleanup-history ledger row with allowlisted aggregate metrics.';
+comment on function public.get_cleanup_history_cron_health_snapshot(integer) is
+  'Returns privacy-safe latest-run and failure aggregates for operator verification.';

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -13,6 +13,11 @@ const coldPurgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
 const blueprintPurgeMocks = vi.hoisted(() => ({ run: vi.fn() }))
 const studentPurgeMocks = vi.hoisted(() => ({ run: vi.fn(), health: vi.fn() }))
 const healthMocks = vi.hoisted(() => ({ read: vi.fn() }))
+const ledgerMocks = vi.hoisted(() => ({
+  begin: vi.fn(),
+  finish: vi.fn(),
+  resolve: vi.fn(),
+}))
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -43,6 +48,17 @@ vi.mock('@/lib/server/student-purge', () => ({
 
 vi.mock('@/lib/server/managed-deletion-health', () => ({
   readManagedDeletionHealth: healthMocks.read,
+}))
+
+vi.mock('@/lib/server/cron-run-ledger', () => ({
+  CronRunLedgerError: class CronRunLedgerError extends Error {
+    constructor(public readonly code: string) {
+      super('Cron run ledger could not be updated')
+    }
+  },
+  beginCleanupHistoryCronRun: ledgerMocks.begin,
+  finishCleanupHistoryCronRun: ledgerMocks.finish,
+  resolveCleanupHistoryInvocation: ledgerMocks.resolve,
 }))
 
 type QueryLog = {
@@ -240,6 +256,13 @@ describe('cron cleanup-history route', () => {
     studentPurgeMocks.run.mockResolvedValue({ processed: 0, completed: 0, failed: 0 })
     studentPurgeMocks.health.mockResolvedValue({ schemaAvailable: false, snapshot: null })
     healthMocks.read.mockResolvedValue({ schemaAvailable: false })
+    ledgerMocks.resolve.mockReturnValue({
+      invocationSource: 'manual',
+      schedule: null,
+      deploymentId: null,
+    })
+    ledgerMocks.begin.mockResolvedValue({ schemaAvailable: false })
+    ledgerMocks.finish.mockResolvedValue(undefined)
     mockSupabaseClient.rpc.mockResolvedValue({ data: 0, error: null })
   })
 
@@ -265,6 +288,94 @@ describe('cron cleanup-history route', () => {
 
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(ledgerMocks.begin).not.toHaveBeenCalled()
+  })
+
+  it('records an authenticated Vercel invocation and its aggregate success metrics', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    ledgerMocks.resolve.mockReturnValue({
+      invocationSource: 'vercel_cron',
+      schedule: '0 7 * * *',
+      deploymentId: 'deployment-1',
+    })
+    ledgerMocks.begin.mockResolvedValue({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000111',
+      started: true,
+    })
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(new NextRequest(
+      'http://localhost:3000/api/cron/cleanup-history',
+      { headers: {
+        authorization: 'Bearer secret',
+        'x-vercel-cron-schedule': '0 7 * * *',
+      } },
+    ))
+
+    expect(response.status).toBe(200)
+    expect(ledgerMocks.resolve).toHaveBeenCalledWith(expect.any(Headers))
+    expect(ledgerMocks.begin).toHaveBeenCalledWith({
+      supabase: mockSupabaseClient,
+      invocation: {
+        invocationSource: 'vercel_cron',
+        schedule: '0 7 * * *',
+        deploymentId: 'deployment-1',
+      },
+    })
+    expect(ledgerMocks.finish).toHaveBeenCalledWith({
+      supabase: mockSupabaseClient,
+      run: {
+        schemaAvailable: true,
+        runId: '00000000-0000-4000-8000-000000000111',
+        started: true,
+      },
+      status: 'succeeded',
+      httpStatus: 200,
+      errorCode: null,
+      metrics: expect.objectContaining({
+        classroom_purge_processed: 0,
+        cold_classroom_purge_processed: 0,
+        course_blueprint_purge_processed: 0,
+        student_purge_processed: 0,
+        save_operations_deleted: 0,
+        expired_classrooms_scanned: 0,
+        history_rows_deleted: 0,
+      }),
+    })
+  })
+
+  it('records an overlap without running cleanup work', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    ledgerMocks.begin.mockResolvedValue({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000222',
+      started: false,
+    })
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Cleanup already running' })
+    expect(purgeMocks.run).not.toHaveBeenCalled()
+    expect(ledgerMocks.finish).not.toHaveBeenCalled()
+  })
+
+  it('fails before cleanup when the durable start record cannot be written', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const error = Object.assign(new Error('sanitized'), { code: 'cron_run_begin_failed' })
+    ledgerMocks.begin.mockRejectedValue(error)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to record cleanup run' })
+    expect(console.error).toHaveBeenCalledWith('[cron-run-ledger] begin failed', {
+      error_code: 'cron_run_ledger_unknown_failure',
+    })
+    expect(purgeMocks.run).not.toHaveBeenCalled()
   })
 
   it('returns deleted=0 when no expired classrooms are found', async () => {
@@ -314,6 +425,11 @@ describe('cron cleanup-history route', () => {
   it('fails observably when student purge work is stuck or partially failed', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    ledgerMocks.begin.mockResolvedValue({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000333',
+      started: true,
+    })
     studentPurgeMocks.health.mockResolvedValue({
       schemaAvailable: true,
       snapshot: {
@@ -328,6 +444,56 @@ describe('cron cleanup-history route', () => {
     const response = await GET(cronRequest())
     expect(response.status).toBe(503)
     await expect(response.json()).resolves.toEqual({ error: 'Student purge health degraded' })
+    expect(ledgerMocks.finish).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      httpStatus: 503,
+      errorCode: 'student_purge_health_degraded',
+      metrics: expect.objectContaining({
+        student_health_active: 1,
+        student_health_stuck: 1,
+      }),
+    }))
+  })
+
+  it('records an unhandled worker failure before standardized error handling', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    ledgerMocks.begin.mockResolvedValue({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000444',
+      started: true,
+    })
+    purgeMocks.run.mockRejectedValue(new Error('worker failed'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Internal server error' })
+    expect(ledgerMocks.finish).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      httpStatus: 500,
+      errorCode: 'unhandled_error',
+    }))
+  })
+
+  it('returns 503 when final ledger persistence fails after cleanup', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    ledgerMocks.begin.mockResolvedValue({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000555',
+      started: true,
+    })
+    ledgerMocks.finish.mockRejectedValue(Object.assign(new Error('sanitized'), {
+      code: 'cron_run_finish_failed',
+    }))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const mock = createCleanupMock({ classrooms: [] })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to record cleanup run' })
   })
 
   it('fails observably when the current student purge retry fails', async () => {

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -310,12 +310,15 @@ describe('cron cleanup-history route', () => {
       'http://localhost:3000/api/cron/cleanup-history',
       { headers: {
         authorization: 'Bearer secret',
+        'user-agent': 'vercel-cron/1.0',
         'x-vercel-cron-schedule': '0 7 * * *',
       } },
     ))
 
     expect(response.status).toBe(200)
-    expect(ledgerMocks.resolve).toHaveBeenCalledWith(expect.any(Headers))
+    expect(ledgerMocks.resolve).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'GET',
+    }))
     expect(ledgerMocks.begin).toHaveBeenCalledWith({
       supabase: mockSupabaseClient,
       invocation: {

--- a/tests/lib/server/cron-run-ledger.test.ts
+++ b/tests/lib/server/cron-run-ledger.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  beginCleanupHistoryCronRun,
+  CronRunLedgerError,
+  finishCleanupHistoryCronRun,
+  readCleanupHistoryCronHealth,
+  resolveCleanupHistoryInvocation,
+} from '@/lib/server/cron-run-ledger'
+
+function rpcClient(results: Array<{ data: unknown; error: unknown }>) {
+  return {
+    rpc: vi.fn(async () => results.shift() ?? { data: null, error: null }),
+  }
+}
+
+describe('cleanup-history cron run ledger', () => {
+  it('distinguishes a Vercel scheduled invocation from a manual invocation', () => {
+    expect(resolveCleanupHistoryInvocation(new Headers({
+      'x-vercel-cron-schedule': '0 7 * * *',
+    }), 'deployment-1')).toEqual({
+      invocationSource: 'vercel_cron',
+      schedule: '0 7 * * *',
+      deploymentId: 'deployment-1',
+    })
+    expect(resolveCleanupHistoryInvocation(new Headers(), undefined)).toEqual({
+      invocationSource: 'manual',
+      schedule: null,
+      deploymentId: null,
+    })
+  })
+
+  it('starts a durable run through the service-only RPC', async () => {
+    const supabase = rpcClient([{
+      data: {
+        run_id: '00000000-0000-4000-8000-000000000111',
+        started: true,
+      },
+      error: null,
+    }])
+
+    await expect(beginCleanupHistoryCronRun({
+      supabase: supabase as never,
+      invocation: {
+        invocationSource: 'vercel_cron',
+        schedule: '0 7 * * *',
+        deploymentId: 'deployment-1',
+      },
+    })).resolves.toEqual({
+      schemaAvailable: true,
+      runId: '00000000-0000-4000-8000-000000000111',
+      started: true,
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith('begin_cleanup_history_cron_run', {
+      p_invocation_source: 'vercel_cron',
+      p_schedule: '0 7 * * *',
+      p_deployment_id: 'deployment-1',
+    })
+  })
+
+  it('treats only the missing pre-124 RPC as a compatibility state', async () => {
+    const missing = rpcClient([{
+      data: null,
+      error: { code: 'PGRST202', message: 'missing' },
+    }])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await expect(beginCleanupHistoryCronRun({
+      supabase: missing as never,
+      invocation: {
+        invocationSource: 'manual',
+        schedule: null,
+        deploymentId: null,
+      },
+    })).resolves.toEqual({ schemaAvailable: false })
+    expect(warn).toHaveBeenCalledWith('[cron-run-ledger] schema unavailable', {
+      error_code: 'PGRST202',
+    })
+
+    const broken = rpcClient([{
+      data: null,
+      error: { code: '42P01', message: 'provider detail' },
+    }])
+    await expect(beginCleanupHistoryCronRun({
+      supabase: broken as never,
+      invocation: {
+        invocationSource: 'manual',
+        schedule: null,
+        deploymentId: null,
+      },
+    })).rejects.toMatchObject({
+      code: 'cron_run_begin_failed',
+      message: 'Cron run ledger could not be updated',
+    })
+  })
+
+  it('rejects malformed begin responses', async () => {
+    const supabase = rpcClient([{ data: { run_id: 'not-a-uuid' }, error: null }])
+
+    await expect(beginCleanupHistoryCronRun({
+      supabase: supabase as never,
+      invocation: {
+        invocationSource: 'manual',
+        schedule: null,
+        deploymentId: null,
+      },
+    })).rejects.toBeInstanceOf(CronRunLedgerError)
+  })
+
+  it('records a privacy-safe, allowlisted completion summary', async () => {
+    const supabase = rpcClient([{ data: true, error: null }])
+
+    await expect(finishCleanupHistoryCronRun({
+      supabase: supabase as never,
+      run: {
+        schemaAvailable: true,
+        runId: '00000000-0000-4000-8000-000000000111',
+        started: true,
+      },
+      status: 'succeeded',
+      httpStatus: 200,
+      errorCode: null,
+      metrics: {
+        history_rows_deleted: 3,
+        student_purge_processed: 1,
+        student_health_stuck: 0,
+        managed_health_healthy: true,
+      },
+    })).resolves.toBeUndefined()
+    expect(supabase.rpc).toHaveBeenCalledWith('finish_cleanup_history_cron_run', {
+      p_run_id: '00000000-0000-4000-8000-000000000111',
+      p_status: 'succeeded',
+      p_http_status: 200,
+      p_error_code: null,
+      p_metrics: {
+        history_rows_deleted: 3,
+        student_purge_processed: 1,
+        student_health_stuck: 0,
+        managed_health_healthy: true,
+      },
+    })
+  })
+
+  it('does not call finish before migration 124 or for an overlap row', async () => {
+    const supabase = rpcClient([])
+
+    await finishCleanupHistoryCronRun({
+      supabase: supabase as never,
+      run: { schemaAvailable: false },
+      status: 'succeeded',
+      httpStatus: 200,
+      errorCode: null,
+      metrics: {},
+    })
+    await finishCleanupHistoryCronRun({
+      supabase: supabase as never,
+      run: {
+        schemaAvailable: true,
+        runId: '00000000-0000-4000-8000-000000000222',
+        started: false,
+      },
+      status: 'failed',
+      httpStatus: 409,
+      errorCode: 'overlap',
+      metrics: {},
+    })
+
+    expect(supabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('rejects identities and unknown keys before persistence', async () => {
+    const supabase = rpcClient([])
+
+    await expect(finishCleanupHistoryCronRun({
+      supabase: supabase as never,
+      run: {
+        schemaAvailable: true,
+        runId: '00000000-0000-4000-8000-000000000111',
+        started: true,
+      },
+      status: 'failed',
+      httpStatus: 500,
+      errorCode: 'unhandled_error',
+      metrics: { student_id: 'sensitive' } as never,
+    })).rejects.toMatchObject({ code: 'cron_run_metrics_invalid' })
+    expect(supabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('sanitizes finish failures', async () => {
+    const supabase = rpcClient([{
+      data: null,
+      error: { code: 'provider-code', message: 'provider detail' },
+    }])
+
+    await expect(finishCleanupHistoryCronRun({
+      supabase: supabase as never,
+      run: {
+        schemaAvailable: true,
+        runId: '00000000-0000-4000-8000-000000000111',
+        started: true,
+      },
+      status: 'failed',
+      httpStatus: 500,
+      errorCode: 'unhandled_error',
+      metrics: {},
+    })).rejects.toMatchObject({
+      code: 'cron_run_finish_failed',
+      message: 'Cron run ledger could not be updated',
+    })
+  })
+
+  it('reads and validates the privacy-safe operator health snapshot', async () => {
+    const supabase = rpcClient([{
+      data: {
+        version: 1,
+        captured_at: '2026-08-14T12:00:00.000Z',
+        healthy: true,
+        stale_running_count: 0,
+        failed_count_7d: 0,
+        overlap_count_7d: 0,
+        latest_run: {
+          invocation_source: 'vercel_cron',
+          schedule: '0 7 * * *',
+          status: 'succeeded',
+          started_at: '2026-08-14T07:12:00.000Z',
+          completed_at: '2026-08-14T07:12:03.000Z',
+          http_status: 200,
+          error_code: null,
+          metrics: { managed_health_healthy: true },
+        },
+        latest_vercel_run: {
+          schedule: '0 7 * * *',
+          status: 'succeeded',
+          started_at: '2026-08-14T07:12:00.000Z',
+          completed_at: '2026-08-14T07:12:03.000Z',
+          http_status: 200,
+          error_code: null,
+          metrics: { managed_health_healthy: true },
+        },
+      },
+      error: null,
+    }])
+
+    await expect(readCleanupHistoryCronHealth({
+      supabase: supabase as never,
+    })).resolves.toMatchObject({
+      schemaAvailable: true,
+      snapshot: {
+        healthy: true,
+        latest_vercel_run: { status: 'succeeded', http_status: 200 },
+      },
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'get_cleanup_history_cron_health_snapshot',
+      { p_stale_minutes: 120 },
+    )
+  })
+
+  it('fails closed for malformed cron health and invalid thresholds', async () => {
+    const malformed = rpcClient([{ data: { healthy: true }, error: null }])
+    await expect(readCleanupHistoryCronHealth({
+      supabase: malformed as never,
+    })).rejects.toMatchObject({ code: 'cron_run_health_contract_invalid' })
+    await expect(readCleanupHistoryCronHealth({
+      supabase: malformed as never,
+      staleMinutes: 4,
+    })).rejects.toMatchObject({ code: 'cron_run_health_threshold_invalid' })
+  })
+})

--- a/tests/lib/server/cron-run-ledger.test.ts
+++ b/tests/lib/server/cron-run-ledger.test.ts
@@ -15,18 +15,44 @@ function rpcClient(results: Array<{ data: unknown; error: unknown }>) {
 
 describe('cleanup-history cron run ledger', () => {
   it('distinguishes a Vercel scheduled invocation from a manual invocation', () => {
-    expect(resolveCleanupHistoryInvocation(new Headers({
-      'x-vercel-cron-schedule': '0 7 * * *',
+    expect(resolveCleanupHistoryInvocation(new Request('https://example.test/cron', {
+      method: 'GET',
+      headers: {
+        'user-agent': 'vercel-cron/1.0',
+        'x-vercel-cron-schedule': '0 7 * * *',
+      },
     }), 'deployment-1')).toEqual({
       invocationSource: 'vercel_cron',
       schedule: '0 7 * * *',
       deploymentId: 'deployment-1',
     })
-    expect(resolveCleanupHistoryInvocation(new Headers(), undefined)).toEqual({
+    expect(resolveCleanupHistoryInvocation(new Request('https://example.test/cron'), undefined)).toEqual({
       invocationSource: 'manual',
       schedule: null,
       deploymentId: null,
     })
+  })
+
+  it('keeps POST manual and rejects incomplete scheduled metadata', () => {
+    const forgedPost = new Request('https://example.test/cron', {
+      method: 'POST',
+      headers: {
+        'user-agent': 'vercel-cron/1.0',
+        'x-vercel-cron-schedule': '0 7 * * *',
+      },
+    })
+    expect(resolveCleanupHistoryInvocation(forgedPost, undefined)).toEqual({
+      invocationSource: 'manual',
+      schedule: null,
+      deploymentId: null,
+    })
+
+    const incompleteGet = new Request('https://example.test/cron', {
+      headers: { 'user-agent': 'vercel-cron/1.0' },
+    })
+    expect(() => resolveCleanupHistoryInvocation(incompleteGet, undefined)).toThrowError(
+      expect.objectContaining({ code: 'cron_run_invocation_invalid' }),
+    )
   })
 
   it('starts a durable run through the service-only RPC', async () => {
@@ -214,6 +240,9 @@ describe('cleanup-history cron run ledger', () => {
         version: 1,
         captured_at: '2026-08-14T12:00:00.000Z',
         healthy: true,
+        scheduled_run_healthy: true,
+        expected_schedule: '0 7 * * *',
+        scheduled_evidence_max_age_minutes: 1560,
         stale_running_count: 0,
         failed_count_7d: 0,
         overlap_count_7d: 0,
@@ -251,7 +280,10 @@ describe('cleanup-history cron run ledger', () => {
     })
     expect(supabase.rpc).toHaveBeenCalledWith(
       'get_cleanup_history_cron_health_snapshot',
-      { p_stale_minutes: 120 },
+      {
+        p_stale_minutes: 120,
+        p_scheduled_max_age_minutes: 1560,
+      },
     )
   })
 
@@ -264,5 +296,9 @@ describe('cleanup-history cron run ledger', () => {
       supabase: malformed as never,
       staleMinutes: 4,
     })).rejects.toMatchObject({ code: 'cron_run_health_threshold_invalid' })
+    await expect(readCleanupHistoryCronHealth({
+      supabase: malformed as never,
+      scheduledEvidenceMaxAgeMinutes: 59,
+    })).rejects.toMatchObject({ code: 'cron_run_scheduled_age_threshold_invalid' })
   })
 })


### PR DESCRIPTION
## Summary
- add migration 124 with a service-only, privacy-safe cleanup-history run ledger
- serialize overlapping invocations and record scheduled/manual outcomes with allowlisted aggregate metrics
- add compatible route integration, operator health RPC, rollback-only database checks, generated types, CI, tests, and guidance

## Validation
- fresh local migration replay 001-124 without seeds
- pnpm run check:student-purge-db
- pnpm run check:cleanup-history-cron-db
- pnpm run db:types:check
- pnpm test -- --run (4,239 tests)
- pnpm build
- focused 43 ledger/route tests
- TypeScript, lint, Pika audit, shell syntax, and diff checks

## Rollout
Application code is compatible before migration 124. Deploy compatible code first, then apply migration 124 only with fresh production authorization. This PR does not install a schedule, enable a purge scope, run the cron, or grant deletion authority.

## Separate follow-up
Database lint found an inherited ambiguous attempt_count reference in migration 123 fail_student_purge_object. It is intentionally not bundled into migration 124.