### PR TITLE
Improve student survey recovery and accessibility

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; separate prod auth required. student-survey-accessibility adds recoverable results and native radio semantics; 4,242 tests/build/audit pass. Next: PR/review. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. student-survey-accessibility adds result recovery and native radios; 4,242 tests/build/audit pass. Next: PR/review. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. codex/cron-run-ledger: local-only 124 adds durable cron evidence; no new authority. Replay/fixtures/types and 4,240 tests/build/audit pass. Next: PR/deploy, separate prod-124 auth. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; separate prod auth required. student-survey-accessibility adds recoverable results and native radio semantics; 4,242 tests/build/audit pass. Next: PR/review. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18016,3 +18016,44 @@ and terminal cleanup-ledger reconciliation.
 - Verify representative production writers under enforcement before considering
   migration 119. Applying migration 119, generic cleanup, and classroom deletion
   remain separately gated changes.
+
+<!-- pika-session-log-archive-batch:25c04a24b885c7d08ae12548cb79575edab7a8096bee346865e1e169565d3956 -->
+## 2026-08-05 — Verify production managed Storage writers under enforcement
+
+**Risk profile:** bounded production smoke writes using synthetic teacher/student
+accounts; no migration, cleanup, or deletion activation.
+
+**Completed:**
+- Created a synthetic Classroom, allowlisted and enrolled a synthetic student,
+  uploaded one teacher PDF to a Test, and submitted one student image artifact.
+- Saved the Classroom as Course Blueprint
+  `c318ef23-5039-4b64-9977-66bceee54ba0`, instantiated Classroom
+  `7979c0fd-44ae-4c08-a430-39cf432b48fa` from that Blueprint, and hot archived
+  the copy.
+- Verified the deployment export gate remains disabled, then invoked the exact
+  deployed archive writer implementation for the authorized synthetic Classroom.
+  Archive operation `18ff7d6f-84ee-49c9-ab7e-e065b4f8391b` completed and
+  produced a verified, Classroom-owned `classroom-archives` object.
+- Captured and visually inspected teacher/student desktop/mobile production UI.
+  Teacher archive controls and student submitted-artifact surfaces rendered
+  correctly; permanent deletion remained absent.
+
+**Validation:**
+- The five new managed objects cover teacher test material, student assignment
+  artifact, Classroom-to-Blueprint copy, Blueprint-to-Classroom copy, and
+  Classroom archive creation. All use distinct managed identities and exact
+  owner bindings; matching Storage bytes and JSON/relational references exist.
+- Production now contains 144 managed objects and 144 managed-bucket Storage
+  objects, all `ready`: zero ownerless Storage, missing Storage, ownerless
+  identities, unreferenced ready objects, raw references lacking managed IDs,
+  or active operations.
+- The Blueprint and both user accounts remain intact. The copy remains hot
+  archived (no cold tombstone) for a future deletion canary.
+- Migration 119 remains unapplied. Generic cleanup and Classroom deletion remain
+  disabled. Readiness generation 1 remains the activation evidence; writer
+  growth after activation is expected under the enforced protocol.
+
+**Remaining:**
+- Decide separately whether to apply exact migration
+  `119_hot_archived_classroom_purge_managed_ownership.sql` to production. Do not
+  enable generic cleanup or Classroom deletion without separate authorization.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,46 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Verify production managed Storage writers under enforcement
-
-**Risk profile:** bounded production smoke writes using synthetic teacher/student
-accounts; no migration, cleanup, or deletion activation.
-
-**Completed:**
-- Created a synthetic Classroom, allowlisted and enrolled a synthetic student,
-  uploaded one teacher PDF to a Test, and submitted one student image artifact.
-- Saved the Classroom as Course Blueprint
-  `c318ef23-5039-4b64-9977-66bceee54ba0`, instantiated Classroom
-  `7979c0fd-44ae-4c08-a430-39cf432b48fa` from that Blueprint, and hot archived
-  the copy.
-- Verified the deployment export gate remains disabled, then invoked the exact
-  deployed archive writer implementation for the authorized synthetic Classroom.
-  Archive operation `18ff7d6f-84ee-49c9-ab7e-e065b4f8391b` completed and
-  produced a verified, Classroom-owned `classroom-archives` object.
-- Captured and visually inspected teacher/student desktop/mobile production UI.
-  Teacher archive controls and student submitted-artifact surfaces rendered
-  correctly; permanent deletion remained absent.
-
-**Validation:**
-- The five new managed objects cover teacher test material, student assignment
-  artifact, Classroom-to-Blueprint copy, Blueprint-to-Classroom copy, and
-  Classroom archive creation. All use distinct managed identities and exact
-  owner bindings; matching Storage bytes and JSON/relational references exist.
-- Production now contains 144 managed objects and 144 managed-bucket Storage
-  objects, all `ready`: zero ownerless Storage, missing Storage, ownerless
-  identities, unreferenced ready objects, raw references lacking managed IDs,
-  or active operations.
-- The Blueprint and both user accounts remain intact. The copy remains hot
-  archived (no cold tombstone) for a future deletion canary.
-- Migration 119 remains unapplied. Generic cleanup and Classroom deletion remain
-  disabled. Readiness generation 1 remains the activation evidence; writer
-  growth after activation is expected under the enforced protocol.
-
-**Remaining:**
-- Decide separately whether to apply exact migration
-  `119_hot_archived_classroom_purge_managed_ownership.sql` to production. Do not
-  enable generic cleanup or Classroom deletion without separate authorization.
-
 ## 2026-08-05 — Apply production hot-archive purge schema
 
 **Risk profile:** irreversible production schema installation; rollout and
@@ -1069,3 +1029,27 @@ overlap serialization around the existing cleanup-history safety-net route.
   canonical app-managed worktree and collaborator env forms. The compressed
   handoff restores both contracts; startup-doc coverage and the full 4,240-test
   suite pass.
+
+## 2026-08-15 — Make student Surveys recoverable and keyboard-native
+
+**Risk profile:** workspace-state — student-only survey presentation and local
+request state; no API, schema, migration, production, or Gradex change.
+
+**Completed:**
+- Replaced the ambiguous results `null` state with survey-scoped loading,
+  success, and announced error states plus an explicit Retry action.
+- Replaced styled answer buttons with native radios in a named radio group,
+  retaining the existing card treatment while adding checked state, focus, and
+  browser keyboard behavior.
+- Updated the exact native-control policy entry and added component regression
+  coverage for semantic selection and failed-results recovery.
+
+**Validation:**
+- Full suite passes: 4,242 tests across 494 files. Lint, production build,
+  architecture, design/UI policy, Pika audit, and diff checks pass.
+- Playwright and visual inspection pass for student results, edit/selected,
+  focus, error/retry, desktop, mobile, light, and dark states. Arrow-key radio
+  movement passed in Chromium; mobile body width remained within 390px.
+- Teacher verification is not applicable because no teacher-owned surface
+  changed. Composite semantics and keyboard behavior are covered; no manual
+  follow-up remains.

--- a/scripts/ui-control-exceptions.json
+++ b/scripts/ui-control-exceptions.json
@@ -687,9 +687,9 @@
       "reviewBy": "phase-3-surveys",
       "controls": [
         {
-          "kind": "button",
+          "kind": "input:radio",
           "count": 1,
-          "reason": "legacy-form-control"
+          "reason": "native-input-capability"
         },
         {
           "kind": "textarea",

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -38,6 +38,11 @@ type SurveyResultsPayload = {
   results: StudentSurveyQuestionResult[]
 }
 
+type SurveyResultsState =
+  | { surveyId: string; status: 'loading' }
+  | { surveyId: string; status: 'error'; message: string }
+  | { surveyId: string; status: 'success'; payload: SurveyResultsPayload }
+
 function selectedOptionFromResponse(response: SurveyResponseValue | undefined): number | null {
   return response?.question_type === 'multiple_choice' ? response.selected_option : null
 }
@@ -46,22 +51,43 @@ function textFromResponse(response: SurveyResponseValue | undefined): string {
   return response && response.question_type !== 'multiple_choice' ? response.response_text : ''
 }
 
-function StudentSurveyResults({ payload }: { payload: SurveyResultsPayload | null }) {
-  if (!payload) {
+function StudentSurveyResults({
+  state,
+  onRetry,
+}: {
+  state: SurveyResultsState | null
+  onRetry: () => void
+}) {
+  if (!state || state.status === 'loading') {
     return (
-      <div className="flex justify-center py-6">
+      <div className="flex justify-center py-6" role="status">
         <Spinner />
+        <span className="sr-only">Loading class results</span>
       </div>
     )
   }
 
-  if (payload.results.length === 0) {
+  if (state.status === 'error') {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col gap-3 rounded-md border border-danger bg-danger-bg px-3 py-3 text-sm text-danger sm:flex-row sm:items-center sm:justify-between"
+      >
+        <p>{state.message}</p>
+        <Button type="button" variant="secondary" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (state.payload.results.length === 0) {
     return <p className="text-sm text-text-muted">No class results yet.</p>
   }
 
   return (
     <div className="space-y-5">
-      {payload.results.map((result, index) => (
+      {state.payload.results.map((result, index) => (
         <div key={result.question_id} className="space-y-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
@@ -116,7 +142,7 @@ export function StudentSurveyPanel({
 }: StudentSurveyPanelProps) {
   const [detail, setDetail] = useState<SurveyDetailPayload | null>(null)
   const [responses, setResponses] = useState<Record<string, SurveyResponseValue>>({})
-  const [resultsState, setResultsState] = useState<{ surveyId: string; payload: SurveyResultsPayload } | null>(null)
+  const [resultsState, setResultsState] = useState<SurveyResultsState | null>(null)
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [isEditingResponse, setIsEditingResponse] = useState(false)
@@ -126,7 +152,7 @@ export function StudentSurveyPanel({
   const currentSurveyIdRef = useRef(surveyId)
   currentSurveyIdRef.current = surveyId
   const activeDetail = detail?.survey?.id === surveyId ? detail : null
-  const results = resultsState?.surveyId === surveyId ? resultsState.payload : null
+  const activeResultsState = resultsState?.surveyId === surveyId ? resultsState : null
 
   const loadSurvey = useCallback(async () => {
     const requestId = detailRequestIdRef.current + 1
@@ -134,7 +160,7 @@ export function StudentSurveyPanel({
     const requestedSurveyId = surveyId
     setLoading(true)
     setError('')
-    setResultsState(null)
+    setResultsState({ surveyId: requestedSurveyId, status: 'loading' })
     try {
       // Bypass fetchJSONWithCache for selected survey freshness; request ids guard stale responses.
       const response = await fetch(`/api/student/surveys/${surveyId}`)
@@ -166,10 +192,14 @@ export function StudentSurveyPanel({
       const data = await response.json()
       if (resultsRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load results')
-      setResultsState({ surveyId: requestedSurveyId, payload: data })
-    } catch {
+      setResultsState({ surveyId: requestedSurveyId, status: 'success', payload: data })
+    } catch (err) {
       if (resultsRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
-        setResultsState(null)
+        setResultsState({
+          surveyId: requestedSurveyId,
+          status: 'error',
+          message: err instanceof Error ? err.message : 'Failed to load class results',
+        })
       }
     }
   }, [surveyId])
@@ -303,46 +333,58 @@ export function StudentSurveyPanel({
                 <div key={question.id} className="space-y-2">
                   <div>
                     <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
-                    <QuestionMarkdown content={question.question_text} />
+                    <div id={`survey-${surveyId}-question-${question.id}`}>
+                      <QuestionMarkdown content={question.question_text} />
+                    </div>
                   </div>
 
                   {question.question_type === 'multiple_choice' ? (
-                    <div className="space-y-2">
+                    <div
+                      className="space-y-2"
+                      role="radiogroup"
+                      aria-labelledby={`survey-${surveyId}-question-${question.id}`}
+                    >
                       {question.options.map((option, optionIndex) => {
                         const isSelected = selectedOption === optionIndex
                         return (
-                          <button
+                          <label
                             key={optionIndex}
-                            type="button"
-                            disabled={!canRespond || submitting}
-                            onClick={() => {
-                              setResponses((current) => ({
-                                ...current,
-                                [question.id]: {
-                                  question_type: 'multiple_choice',
-                                  selected_option: optionIndex,
-                                },
-                              }))
-                            }}
                             className={[
-                              'flex w-full items-center gap-3 rounded-lg border p-3 text-left text-sm transition-colors',
+                              'relative flex w-full items-center gap-3 rounded-lg border p-3 text-left text-sm transition-colors',
                               isSelected
                                 ? 'border-primary bg-primary/5 text-text-default'
                                 : 'border-border bg-surface hover:bg-surface-hover text-text-default',
-                              !canRespond ? 'cursor-not-allowed opacity-70' : '',
+                              !canRespond || submitting ? 'cursor-not-allowed opacity-70' : 'cursor-pointer',
                             ].join(' ')}
                           >
+                            <input
+                              type="radio"
+                              name={`survey-${surveyId}-question-${question.id}`}
+                              value={optionIndex}
+                              checked={isSelected}
+                              disabled={!canRespond || submitting}
+                              onChange={() => {
+                                setResponses((current) => ({
+                                  ...current,
+                                  [question.id]: {
+                                    question_type: 'multiple_choice',
+                                    selected_option: optionIndex,
+                                  },
+                                }))
+                              }}
+                              className="peer sr-only"
+                            />
                             <span
                               aria-hidden="true"
                               className={[
-                                'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2',
+                                'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-surface',
                                 isSelected ? 'border-primary' : 'border-border',
                               ].join(' ')}
                             >
                               {isSelected && <span className="h-2.5 w-2.5 rounded-full bg-primary" />}
                             </span>
                             <span>{option}</span>
-                          </button>
+                          </label>
                         )
                       })}
                     </div>
@@ -414,7 +456,7 @@ export function StudentSurveyPanel({
             <h2 className="text-xl font-semibold text-text-default">{survey.title}</h2>
             <h3 className="mt-4 text-base font-semibold text-text-default">Class results</h3>
           </div>
-          <StudentSurveyResults payload={results} />
+          <StudentSurveyResults state={activeResultsState} onRetry={() => void loadResults()} />
         </Card>
       )}
     </div>

--- a/tests/components/StudentSurveyPanel.test.tsx
+++ b/tests/components/StudentSurveyPanel.test.tsx
@@ -19,6 +19,10 @@ function jsonResponse(body: unknown): Response {
   return { ok: true, json: async () => body } as Response
 }
 
+function jsonErrorResponse(body: unknown, status = 500): Response {
+  return { ok: false, status, json: async () => body } as Response
+}
+
 function surveyDetailPayload(surveyId: string, title: string, questionText: string) {
   return {
     survey: {
@@ -190,6 +194,51 @@ describe('StudentSurveyPanel', () => {
     expect(screen.getByRole('button', { name: 'View results' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Share your project link response' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'What did you build? response' })).toBeInTheDocument()
+  })
+
+  it('exposes multiple-choice answers as a named radio group', async () => {
+    render(<StudentSurveyPanel surveyId="survey-1" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Respond' }))
+
+    const answerGroup = screen.getByRole('radiogroup', { name: 'Pick one' })
+    const firstOption = screen.getByRole('radio', { name: 'A' })
+    const secondOption = screen.getByRole('radio', { name: 'B' })
+
+    expect(answerGroup).toContainElement(firstOption)
+    expect(firstOption).not.toBeChecked()
+    fireEvent.click(secondOption)
+    expect(secondOption).toBeChecked()
+    expect(firstOption).not.toBeChecked()
+  })
+
+  it('announces a results failure and retries the request', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    let resultsAttempts = 0
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/results')) {
+        resultsAttempts += 1
+        return Promise.resolve(
+          resultsAttempts === 1
+            ? jsonErrorResponse({ error: 'Results are temporarily unavailable' })
+            : jsonResponse(surveyResultsPayload('question-1', 'Pick one'))
+        )
+      }
+      return Promise.resolve(jsonResponse(surveyDetailPayload('survey-1', 'Quick Poll', 'Pick one')))
+    })
+
+    render(<StudentSurveyPanel surveyId="survey-1" />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Results are temporarily unavailable')
+    expect(screen.queryByRole('status', { name: 'Loading class results' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('100%')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('ignores stale detail responses after selected survey changes', async () => {


### PR DESCRIPTION
## Summary
- replace ambiguous student survey results loading with explicit loading, success, and announced failure states
- add an in-place Retry action that preserves stale-request protection
- use native radio inputs in a named group while preserving the existing survey answer styling
- update focused regression coverage and native-control policy evidence

## Validation
- `pnpm test` (4,242 tests)
- `pnpm lint`
- `pnpm build`
- `pnpm check:architecture`
- `pnpm check:design-policy`
- `pnpm check:ui-policy`
- Pika audit and `git diff --check`
- Playwright visual verification: student desktop/mobile, light/dark, results, selected/focus, and error/retry states
- Chromium keyboard verification: Arrow Down moves focus and selection within the radio group

Teacher visual verification is not applicable because no teacher-owned surface changed.