### PR TITLE
Improve teacher survey result recovery

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. student-survey-accessibility adds result recovery and native radios; 4,242 tests/build/audit pass. Next: PR/review. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. Teacher+student Surveys recovery/semantics complete; teacher PR/review next. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18057,3 +18057,31 @@ accounts; no migration, cleanup, or deletion activation.
 - Decide separately whether to apply exact migration
   `119_hot_archived_classroom_purge_managed_ownership.sql` to production. Do not
   enable generic cleanup or Classroom deletion without separate authorization.
+
+<!-- pika-session-log-archive-batch:fa23cb220e4d8aca68e6c0130e0ecbfb90b362b55312b4ef6a40459f4f201713 -->
+## 2026-08-05 — Apply production hot-archive purge schema
+
+**Risk profile:** irreversible production schema installation; rollout and
+execution remained disabled.
+
+**Completed:**
+- Verified production project `zhioqbapgfcrronyuidm`, migration history through
+  118, migration 119 checksum, focused tests, managed-storage lineage, and
+  PostgreSQL function lint.
+- The linked dry run contained only
+  `119_hot_archived_classroom_purge_managed_ownership.sql`.
+- Applied migration 119 exactly once through `supabase db push --linked` under
+  exact production authorization.
+
+**Validation:**
+- Remote migration history now records 119.
+- `classroom_purge_settings.rollout_mode` is `disabled`; canary teacher and
+  Classroom IDs are null.
+- Managed Storage remains `enforced` with 144/144 objects `ready`; no purge or
+  cleanup operation is active.
+- The synthetic hot-archived Classroom, reusable Blueprint, and verified archive
+  remain intact. No purge, generic cleanup, or Storage deletion ran.
+
+**Remaining:**
+- Treat Classroom deletion activation and any first purge canary as separate
+  production decisions requiring fresh target-specific authorization.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,33 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Apply production hot-archive purge schema
-
-**Risk profile:** irreversible production schema installation; rollout and
-execution remained disabled.
-
-**Completed:**
-- Verified production project `zhioqbapgfcrronyuidm`, migration history through
-  118, migration 119 checksum, focused tests, managed-storage lineage, and
-  PostgreSQL function lint.
-- The linked dry run contained only
-  `119_hot_archived_classroom_purge_managed_ownership.sql`.
-- Applied migration 119 exactly once through `supabase db push --linked` under
-  exact production authorization.
-
-**Validation:**
-- Remote migration history now records 119.
-- `classroom_purge_settings.rollout_mode` is `disabled`; canary teacher and
-  Classroom IDs are null.
-- Managed Storage remains `enforced` with 144/144 objects `ready`; no purge or
-  cleanup operation is active.
-- The synthetic hot-archived Classroom, reusable Blueprint, and verified archive
-  remain intact. No purge, generic cleanup, or Storage deletion ran.
-
-**Remaining:**
-- Treat Classroom deletion activation and any first purge canary as separate
-  production decisions requiring fresh target-specific authorization.
-
 ## 2026-08-05 — Enable and verify exact production purge canary
 
 **Risk profile:** production rollout-gate write only; no purge or cleanup.
@@ -1053,3 +1026,24 @@ request state; no API, schema, migration, production, or Gradex change.
 - Teacher verification is not applicable because no teacher-owned surface
   changed. Composite semantics and keyboard behavior are covered; no manual
   follow-up remains.
+
+## 2026-08-15 — Make teacher Survey results recoverable
+
+**Risk profile:** none — teacher-only results presentation and local request
+state; no API, schema, migration, production, or Gradex change.
+
+**Completed:**
+- Replaced false empty-result fallback data with survey-scoped loading, ready,
+  and announced failure states plus explicit Retry actions.
+- Preserved the last valid result snapshot during failed roster/response-count
+  refreshes and kept stale Survey responses out of the selected workspace.
+- Recorded the completed teacher/student Surveys slice in the product audit.
+
+**Validation:**
+- Full suite passes: 4,244 tests across 494 files. Production build, lint,
+  architecture, design/UI policy, Pika audit, and diff checks pass.
+- Playwright and visual inspection pass for teacher results and cold errors at
+  desktop/mobile in light/dark, with no horizontal overflow. Unit interaction
+  coverage proves retained-result failure and successful retry replacement.
+- Composite-widget checklist is not applicable because no composite control or
+  keyboard model changed; alert/status semantics and Retry are role-tested.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -195,12 +195,19 @@ Tests progress:
 - Link snapshots now validate and pin public DNS addresses across manual redirects before fetching. Migration 105 atomically rechecks ownership, archive state, document identity, and URL under row locks before attaching a unique snapshot; it must be applied before deploying the updated sync route.
 - Remaining Tests work is accessible flag/save announcements and the deferred mobile navigation treatment.
 
+Surveys progress:
+
+- Student results now distinguish loading, success, and announced failure states, offer explicit retry recovery, and use native radio semantics for multiple-choice responses.
+- Teacher results now use governed loading and cold-error states. Failed refreshes retain the last valid results with an announced retry warning, and request guards prevent another Survey's response from painting in the selected workspace.
+- Component tests cover cold failure, retry recovery, retained-results refresh failure, successful refresh replacement, and stale Survey isolation. Teacher desktop/mobile and light/dark browser verification preserves the existing results-first workspace with no horizontal overflow.
+- The Phase 3 Surveys slice is complete.
+
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: completed list errors, authoring/grading separation, and standalone preview authorization/framing; remaining accessible flags/save status and deferred mobile navigation.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.
 4. Dashboard: teacher-owned entry detail, responsive summary-first attendance, and removal of invalid classroom commands.
 5. Roster: mobile row detail, keyboard table behavior, bulk-action recovery, and counselor-field access.
-6. Surveys: explicit results error/retry and native-equivalent choice semantics.
+6. Surveys: completed explicit student/teacher results recovery, retained refresh data, stale-response guards, and native choice semantics.
 7. Calendar and lesson plans: independent source failures, compact navigation, and Toronto date/time behavior.
 8. Announcements: explicit failure/read states and Toronto timestamp formatting.
 9. Gradebook: narrow-screen navigation, selected-student detail, and direct table keyboard tests.

--- a/src/components/surveys/TeacherSurveyResultsPane.tsx
+++ b/src/components/surveys/TeacherSurveyResultsPane.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BarChart3 } from 'lucide-react'
-import { Card } from '@/ui'
+import { Button, Card, PageState } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { TeacherSurveyResultsView } from '@/components/surveys/TeacherSurveyWorkspace'
 import type { SurveyQuestionResult, SurveyWithStats } from '@/types'
@@ -15,45 +15,53 @@ type SurveyResultsPayload = {
   }
 }
 
+type SurveyResultsState = {
+  surveyId: string
+  payload: SurveyResultsPayload | null
+  loading: boolean
+  error: string
+}
+
 interface TeacherSurveyResultsPaneProps {
   survey: SurveyWithStats
 }
 
 export function TeacherSurveyResultsPane({ survey }: TeacherSurveyResultsPaneProps) {
-  const [payloadState, setPayloadState] = useState<{ surveyId: string; payload: SurveyResultsPayload } | null>(null)
-  const [error, setError] = useState('')
+  const [resultsState, setResultsState] = useState<SurveyResultsState | null>(null)
   const loadRequestIdRef = useRef(0)
   const currentSurveyIdRef = useRef(survey.id)
   currentSurveyIdRef.current = survey.id
-  const payload = payloadState?.surveyId === survey.id ? payloadState.payload : null
+  const activeState = resultsState?.surveyId === survey.id ? resultsState : null
 
   const loadResults = useCallback(async () => {
     const requestId = loadRequestIdRef.current + 1
     loadRequestIdRef.current = requestId
     const requestedSurveyId = survey.id
-    setError('')
-    setPayloadState(null)
+    setResultsState((current) => current?.surveyId === requestedSurveyId
+      ? { ...current, loading: true, error: '' }
+      : { surveyId: requestedSurveyId, payload: null, loading: true, error: '' })
     try {
       // Bypass fetchJSONWithCache for selected survey results freshness; request ids guard stale responses.
       const response = await fetch(`/api/teacher/surveys/${survey.id}/results`)
       const data = await response.json()
       if (loadRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load survey results')
-      setPayloadState({ surveyId: requestedSurveyId, payload: data })
+      setResultsState({ surveyId: requestedSurveyId, payload: data, loading: false, error: '' })
     } catch (err) {
       if (loadRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
-        setError(err instanceof Error ? err.message : 'Failed to load survey results')
-        setPayloadState({
+        setResultsState((current) => ({
           surveyId: requestedSurveyId,
-          payload: { results: [], stats: { responded: 0, total_students: survey.stats.total_students || 0 } },
-        })
+          payload: current?.surveyId === requestedSurveyId ? current.payload : null,
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to load survey results',
+        }))
       }
     }
-  }, [survey.id, survey.stats.total_students])
+  }, [survey.id])
 
   useEffect(() => {
     void loadResults()
-  }, [loadResults])
+  }, [loadResults, survey.stats.responded, survey.stats.total_students])
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-auto p-3">
@@ -66,17 +74,39 @@ export function TeacherSurveyResultsPane({ survey }: TeacherSurveyResultsPanePro
               <h3 className="text-base font-semibold text-text-default">Results</h3>
             </div>
           </div>
-          {error ? (
-            <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-              {error}
+          {activeState?.payload && activeState.loading ? (
+            <div className="flex items-center gap-2 text-sm text-text-muted" role="status">
+              <Spinner size="sm" />
+              <span>Refreshing survey results</span>
             </div>
           ) : null}
-          {payload ? (
-            <TeacherSurveyResultsView payload={payload} />
-          ) : (
-            <div className="flex justify-center py-6">
-              <Spinner />
+          {activeState?.payload && activeState.error ? (
+            <div
+              role="alert"
+              className="flex flex-col gap-3 rounded-md border border-danger bg-danger-bg px-3 py-3 text-sm text-danger sm:flex-row sm:items-center sm:justify-between"
+            >
+              <p>{activeState.error} The previous results are still shown.</p>
+              <Button type="button" variant="secondary" size="sm" onClick={loadResults}>
+                Retry
+              </Button>
             </div>
+          ) : null}
+          {activeState?.payload ? (
+            <TeacherSurveyResultsView payload={activeState.payload} />
+          ) : activeState?.error ? (
+            <PageState
+              kind="error"
+              title="Survey results unavailable"
+              description={activeState.error}
+              compact
+              action={(
+                <Button type="button" onClick={loadResults}>
+                  Retry
+                </Button>
+              )}
+            />
+          ) : (
+            <PageState kind="loading" title="Loading survey results" compact />
           )}
         </Card>
       </div>

--- a/tests/components/TeacherSurveyResultsPane.test.tsx
+++ b/tests/components/TeacherSurveyResultsPane.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
 import type { ReactNode } from 'react'
@@ -36,6 +37,10 @@ function createDeferred<T>() {
 
 function jsonResponse(body: unknown): Response {
   return { ok: true, json: async () => body } as Response
+}
+
+function jsonErrorResponse(body: unknown): Response {
+  return { ok: false, json: async () => body } as Response
 }
 
 function createMountedRoot() {
@@ -87,6 +92,76 @@ describe('TeacherSurveyResultsPane', () => {
       expect(screen.getAllByText('50%')).toHaveLength(2)
     })
     expect(screen.queryByText('1 (50%)')).not.toBeInTheDocument()
+  })
+
+  it('shows an announced cold error with retry instead of empty results', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonErrorResponse({ error: 'Results service unavailable' }))
+      .mockResolvedValueOnce(jsonResponse({
+        stats: { total_students: 2, responded: 0 },
+        results: [],
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TeacherSurveyResultsPane survey={makeSurvey()} />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Survey results unavailable')
+    expect(alert).toHaveTextContent('Results service unavailable')
+    expect(screen.queryByText('No responses yet.')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('No responses yet.')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('retains valid results and offers retry when a refresh fails', async () => {
+    const user = userEvent.setup()
+    const initialPayload = {
+      stats: { total_students: 2, responded: 1 },
+      results: [{
+        question_id: 'question-1',
+        question_type: 'multiple_choice',
+        question_text: 'Previously loaded question',
+        options: ['A', 'B'],
+        counts: [1, 0],
+        responses: [],
+        total_responses: 1,
+      }],
+    }
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(jsonResponse(initialPayload))
+      .mockResolvedValueOnce(jsonErrorResponse({ error: 'Refresh failed' }))
+      .mockResolvedValueOnce(jsonResponse({
+        stats: { total_students: 3, responded: 2 },
+        results: [{
+          ...initialPayload.results[0],
+          question_text: 'Freshly loaded question',
+          counts: [1, 1],
+          total_responses: 2,
+        }],
+      })))
+
+    const { rerender } = render(<TeacherSurveyResultsPane survey={makeSurvey()} />)
+    expect(await screen.findByText('Previously loaded question')).toBeInTheDocument()
+
+    rerender(<TeacherSurveyResultsPane survey={makeSurvey({
+      stats: { total_students: 3, responded: 0, questions_count: 1 },
+    })} />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Refresh failed')
+    expect(alert).toHaveTextContent('The previous results are still shown.')
+    expect(screen.getByText('Previously loaded question')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Freshly loaded question')).toBeInTheDocument()
+    expect(screen.queryByText('Previously loaded question')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('ignores stale result responses after selected survey changes', async () => {


### PR DESCRIPTION
## Summary
- replace false empty teacher Survey results after fetch failure with governed loading/error states and Retry
- retain the last valid results during failed roster/response-count refreshes while guarding against stale Survey responses
- close the Phase 3 Surveys slice in the product-experience audit

## Verification
- `pnpm test` (4,244 tests across 494 files)
- `pnpm build`
- `pnpm lint`
- `pnpm check:architecture`
- `pnpm check:design-policy`
- `pnpm check:ui-policy`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`

## Visual verification
- Role: teacher; student is unchanged and covered by #998
- Viewports: desktop 1440x900 and mobile 390x844
- Themes: light and dark
- States: successful results, cold results failure, Retry; retained-results refresh failure/recovery is interaction-tested
- No horizontal overflow in any captured viewport

## Accessibility
- cold failures and retained-refresh failures are announced with `role="alert"`
- loading/refresh states use status semantics
- Retry uses the shared Button primitive and is role-tested
- composite-widget checklist: not applicable; no composite interaction or keyboard model changed

## Risk
`none`: teacher-only presentation/request state. No API, schema, migration, production, Gradex, or mobile-workflow redesign.
