### PR TITLE
Improve announcement recovery and timestamps

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. Teacher+student Surveys recovery/semantics complete; teacher PR/review next. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. Surveys and Announcements recovery/semantics complete; select the next Phase 3 slice. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18085,3 +18085,34 @@ execution remained disabled.
 **Remaining:**
 - Treat Classroom deletion activation and any first purge canary as separate
   production decisions requiring fresh target-specific authorization.
+
+<!-- pika-session-log-archive-batch:2a7ac5eef36c7c8e6c5907e493d1d0ddce9bc2a8ee8f3c362387ac76298ebdda -->
+## 2026-08-05 — Enable and verify exact production purge canary
+
+**Risk profile:** production rollout-gate write only; no purge or cleanup.
+
+**Completed:**
+- Revalidated the synthetic target as teacher-owned, hot archived, not cold
+  archived, conflict-free, and without any prior purge operation.
+- Atomically changed `classroom_purge_settings` from `disabled` to `canary` only
+  for teacher `34bd4439-e552-483b-b8aa-e3a8f86009af` and Classroom
+  `7979c0fd-44ae-4c08-a430-39cf432b48fa`.
+- Opened the production impact dialog without entering confirmation or invoking
+  any destructive endpoint.
+
+**Validation:**
+- Impact summary reports 0 students, 104 relational records, and two managed
+  files / 36 KB: one test document and one verified Classroom archive. Both
+  files are present; no Gradex extract, interrupted upload, or conflicting
+  operation exists.
+- Teacher desktop/light and mobile/dark show exactly one canary action, the full
+  irreversible warning, Blueprint/user preservation text, typed-confirmation
+  requirement, and a disabled destructive button.
+- Student desktop/dark and mobile/light show neither the archived canary nor a
+  deletion action; the teacher purge endpoint returns 403 for the student.
+- Final read-only state has zero purge operations, zero active generic cleanup,
+  144 managed objects all `ready`, and the hot Classroom and Blueprint intact.
+
+**Remaining:**
+- The first irreversible production canary purge requires separate exact
+  authorization. Broader rollout and generic cleanup remain disabled.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,36 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Enable and verify exact production purge canary
-
-**Risk profile:** production rollout-gate write only; no purge or cleanup.
-
-**Completed:**
-- Revalidated the synthetic target as teacher-owned, hot archived, not cold
-  archived, conflict-free, and without any prior purge operation.
-- Atomically changed `classroom_purge_settings` from `disabled` to `canary` only
-  for teacher `34bd4439-e552-483b-b8aa-e3a8f86009af` and Classroom
-  `7979c0fd-44ae-4c08-a430-39cf432b48fa`.
-- Opened the production impact dialog without entering confirmation or invoking
-  any destructive endpoint.
-
-**Validation:**
-- Impact summary reports 0 students, 104 relational records, and two managed
-  files / 36 KB: one test document and one verified Classroom archive. Both
-  files are present; no Gradex extract, interrupted upload, or conflicting
-  operation exists.
-- Teacher desktop/light and mobile/dark show exactly one canary action, the full
-  irreversible warning, Blueprint/user preservation text, typed-confirmation
-  requirement, and a disabled destructive button.
-- Student desktop/dark and mobile/light show neither the archived canary nor a
-  deletion action; the teacher purge endpoint returns 403 for the student.
-- Final read-only state has zero purge operations, zero active generic cleanup,
-  144 managed objects all `ready`, and the hot Classroom and Blueprint intact.
-
-**Remaining:**
-- The first irreversible production canary purge requires separate exact
-  authorization. Broader rollout and generic cleanup remain disabled.
-
 ## 2026-08-05 — Complete first production hot-archive purge canary
 
 **Risk profile:** irreversible production deletion of one exact synthetic
@@ -1047,3 +1017,24 @@ state; no API, schema, migration, production, or Gradex change.
   coverage proves retained-result failure and successful retry replacement.
 - Composite-widget checklist is not applicable because no composite control or
   keyboard model changed; alert/status semantics and Retry are role-tested.
+
+## 2026-08-16 — Make Announcement tabs recoverable and Toronto-safe
+
+**Risk profile:** workspace-state — teacher/student Announcement presentation,
+request ownership, and read acknowledgement; no API, schema, migration,
+production, Calendar, mobile redesign, or Gradex change.
+
+**Completed:**
+- Added explicit loading, successful empty, cold-error, and Retry states while
+  preserving valid classroom-scoped data and rejecting stale responses.
+- Made failed student read acknowledgement visible and retryable without
+  prematurely clearing notification state.
+- Centralized Announcement timestamps in `America/Toronto` for teacher and
+  student display and scheduling labels.
+
+**Validation:**
+- Full suite passes: 4,250 tests across 494 files. Focused component/domain
+  tests, lint, TypeScript, Pika audit, and diff checks pass.
+- Visual verification passes for teacher/student desktop/mobile and light/dark
+  loaded/error states, plus the student read-error state. No composite keyboard
+  behavior changed; semantic alert/status and Retry coverage passes.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1031,10 +1031,16 @@ production, Calendar, mobile redesign, or Gradex change.
   prematurely clearing notification state.
 - Centralized Announcement timestamps in `America/Toronto` for teacher and
   student display and scheduling labels.
+- Fenced teacher create/edit/delete and student read completions by committed
+  classroom generation, including abandoned concurrent renders.
 
 **Validation:**
-- Full suite passes: 4,250 tests across 494 files. Focused component/domain
+- Full suite passes: 4,258 tests across 494 files. Focused component/domain
   tests, lint, TypeScript, Pika audit, and diff checks pass.
+- Independent review findings for provider-driven automatic read retry,
+  cross-classroom mutation repainting, and render-phase ownership leakage were
+  remediated with provider-settlement, committed-switch, and suspended-transition
+  regression coverage.
 - Visual verification passes for teacher/student desktop/mobile and light/dark
   loaded/error states, plus the student read-error state. No composite keyboard
   behavior changed; semantic alert/status and Retry coverage passes.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -202,6 +202,14 @@ Surveys progress:
 - Component tests cover cold failure, retry recovery, retained-results refresh failure, successful refresh replacement, and stale Survey isolation. Teacher desktop/mobile and light/dark browser verification preserves the existing results-first workspace with no horizontal overflow.
 - The Phase 3 Surveys slice is complete.
 
+Announcements progress:
+
+- Teacher and student Announcement tabs now distinguish loading, successful empty, loaded, and announced failure states with explicit Retry recovery.
+- Classroom-scoped request guards prevent stale responses or errors from painting under another classroom. Student read acknowledgement failures remain visible and retryable instead of silently clearing notification state.
+- Announcement creation, scheduling, and display timestamps now use `America/Toronto`; focused tests cover standard/daylight offsets, failure recovery, stale classroom isolation, and read retries.
+- Teacher/student desktop/mobile browser verification passed in light/dark for loaded and cold-error states, plus the student read-error state. Calendar multi-source recovery remains in the Calendar and lesson-plans slice.
+- The Phase 3 Announcements slice is complete.
+
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: completed list errors, authoring/grading separation, and standalone preview authorization/framing; remaining accessible flags/save status and deferred mobile navigation.
 3. Daily and attendance: explicit failures, mobile history/table modes, Toronto timestamp verification.
@@ -209,7 +217,7 @@ Surveys progress:
 5. Roster: mobile row detail, keyboard table behavior, bulk-action recovery, and counselor-field access.
 6. Surveys: completed explicit student/teacher results recovery, retained refresh data, stale-response guards, and native choice semantics.
 7. Calendar and lesson plans: independent source failures, compact navigation, and Toronto date/time behavior.
-8. Announcements: explicit failure/read states and Toronto timestamp formatting.
+8. Announcements: completed explicit failure/read states, stale-classroom guards, Retry recovery, and Toronto timestamp formatting.
 9. Gradebook: narrow-screen navigation, selected-student detail, and direct table keyboard tests.
 10. Syllabus/resources: iframe sizing, nested scroll, theme, keyboard traversal, and legacy resource-path disposition.
 11. Authentication and history utility routes: shared shell/page states, session-expiry recovery, and an evidence-based migrate/redirect/retire decision for `/student/history`.

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -1,14 +1,17 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Button } from '@/ui'
+import { Button, PageState, RefreshingIndicator } from '@/ui'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
-import { Spinner } from '@/components/Spinner'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import type { Announcement, Classroom } from '@/types'
 import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui'
-import { normalizeAnnouncementTitle, sortAnnouncementsNewestFirst } from '@/lib/announcements'
+import {
+  formatAnnouncementTimestamp,
+  normalizeAnnouncementTitle,
+  sortAnnouncementsNewestFirst,
+} from '@/lib/announcements'
 
 interface Props {
   classroom: Classroom
@@ -21,31 +24,38 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadErrorClassroomId, setLoadErrorClassroomId] = useState<string | null>(null)
+  const [readError, setReadError] = useState<string | null>(null)
+  const [markingRead, setMarkingRead] = useState(false)
   const [showAll, setShowAll] = useState(false)
   const hasMarkedRead = useRef(false)
+  const markReadInFlightRef = useRef(false)
   const loadRequestIdRef = useRef(0)
+  const markReadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
   const notifications = useStudentNotifications()
 
   const loadAnnouncements = useCallback(async () => {
     const requestId = loadRequestIdRef.current + 1
     loadRequestIdRef.current = requestId
     setLoading(true)
+    setLoadErrorClassroomId(null)
     try {
       const data = await fetchCachedJSON<AnnouncementsResponse>(
         `student-announcements:${classroom.id}`,
         `/api/student/classrooms/${classroom.id}/announcements`,
         { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
       )
-      if (loadRequestIdRef.current !== requestId) return
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
       setAnnouncements(data.announcements || [])
       setLoadedClassroomId(classroom.id)
     } catch (err) {
-      if (loadRequestIdRef.current !== requestId) return
-      setAnnouncements([])
-      setLoadedClassroomId(classroom.id)
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
+      setLoadErrorClassroomId(classroom.id)
       console.error('Error loading announcements:', err)
     } finally {
-      if (loadRequestIdRef.current === requestId) {
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
         setLoading(false)
       }
     }
@@ -53,23 +63,41 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
 
   useEffect(() => {
     hasMarkedRead.current = false
+    markReadInFlightRef.current = false
+    markReadRequestIdRef.current += 1
+    setReadError(null)
+    setMarkingRead(false)
+    setShowAll(false)
   }, [classroom.id])
 
   const markAllAsRead = useCallback(async () => {
-    if (hasMarkedRead.current) return
-    hasMarkedRead.current = true
+    if (hasMarkedRead.current || markReadInFlightRef.current) return
+    const classroomId = classroom.id
+    const requestId = markReadRequestIdRef.current + 1
+    markReadRequestIdRef.current = requestId
+    markReadInFlightRef.current = true
+    setMarkingRead(true)
+    setReadError(null)
 
     try {
-      const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`, {
+      const res = await fetch(`/api/student/classrooms/${classroomId}/announcements`, {
         method: 'POST',
       })
-      if (res.ok) {
-        invalidateCachedJSON(`student-announcements:${classroom.id}`)
-        // Clear the notification count for this classroom
-        notifications?.markAnnouncementsRead?.()
-      }
+      if (!res.ok) throw new Error('Failed to mark announcements as read')
+      if (markReadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
+
+      hasMarkedRead.current = true
+      invalidateCachedJSON(`student-announcements:${classroomId}`)
+      notifications?.markAnnouncementsRead?.()
     } catch (err) {
+      if (markReadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
+      setReadError('Announcements are visible, but Pika could not mark them as read.')
       console.error('Error marking announcements as read:', err)
+    } finally {
+      if (markReadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        markReadInFlightRef.current = false
+        setMarkingRead(false)
+      }
     }
   }, [classroom.id, notifications])
 
@@ -78,43 +106,60 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
   }, [loadAnnouncements])
 
   const currentAnnouncements = loadedClassroomId === classroom.id ? announcements : []
-  const isLoading = loading || loadedClassroomId !== classroom.id
+  const hasCurrentClassroomData = loadedClassroomId === classroom.id
+  const loadError = loadErrorClassroomId === classroom.id
+  const isInitialLoading = !hasCurrentClassroomData && !loadError
 
   // Mark all as read when component mounts and announcements are loaded
   useEffect(() => {
-    if (!isLoading && currentAnnouncements.length > 0) {
+    if (!isInitialLoading && !loadError && currentAnnouncements.length > 0) {
       markAllAsRead()
     }
-  }, [isLoading, currentAnnouncements.length, markAllAsRead])
+  }, [isInitialLoading, loadError, currentAnnouncements.length, markAllAsRead])
 
-  function formatDate(dateString: string) {
-    const date = new Date(dateString)
-    const weekday = date.toLocaleDateString('en-US', { weekday: 'short' })
-    const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-    const time = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
-    return `${weekday} ${monthDay}, ${time}`
+  function retryLoadAnnouncements() {
+    invalidateCachedJSON(`student-announcements:${classroom.id}`)
+    void loadAnnouncements()
   }
 
-  if (isLoading) {
+  if (isInitialLoading) {
+    return <PageState kind="loading" title="Loading announcements" />
+  }
+
+  if (loadError && currentAnnouncements.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <Spinner />
-      </div>
+      <PageState
+        kind="error"
+        title="Announcements couldn't load"
+        description="Pika couldn't load this classroom's announcements. Nothing was changed."
+        action={<Button onClick={retryLoadAnnouncements}>Retry</Button>}
+      />
     )
   }
 
   if (currentAnnouncements.length === 0) {
-    return (
-      <div className={cn('rounded-lg border border-border bg-surface-2 p-4', className ?? 'max-w-2xl mx-auto')}>
-        <p className="text-sm text-text-muted">No announcements yet.</p>
-      </div>
-    )
+    return <PageState kind="empty" title="No announcements yet" />
   }
 
   const sortedAnnouncements = sortAnnouncementsNewestFirst(currentAnnouncements)
 
   return (
     <div className={cn('space-y-3', className ?? 'max-w-2xl mx-auto')}>
+      {loading ? <RefreshingIndicator label="Refreshing announcements" /> : null}
+      {loadError ? (
+        <div role="alert" className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          <span>Pika could not refresh announcements. The last loaded announcements are still shown.</span>
+          <Button variant="secondary" size="sm" onClick={retryLoadAnnouncements}>Retry</Button>
+        </div>
+      ) : null}
+      {readError ? (
+        <div role="alert" className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          <span>{readError}</span>
+          <Button variant="secondary" size="sm" onClick={() => void markAllAsRead()} disabled={markingRead}>
+            {markingRead ? 'Retrying...' : 'Retry'}
+          </Button>
+        </div>
+      ) : null}
       {(showAll ? sortedAnnouncements : sortedAnnouncements.slice(0, 5)).map((announcement) => {
         const title = normalizeAnnouncementTitle(announcement.title)
 
@@ -124,7 +169,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
             className="bg-surface rounded-lg border border-border p-4"
           >
             <p className="text-[11px] text-text-muted mb-2">
-              {formatDate(announcement.created_at)}
+              {formatAnnouncementTimestamp(announcement.created_at)}
               {announcement.updated_at !== announcement.created_at && ' (edited)'}
             </p>
             {title && (

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -35,6 +35,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
   const currentClassroomIdRef = useRef(classroom.id)
   currentClassroomIdRef.current = classroom.id
   const notifications = useStudentNotifications()
+  const markAnnouncementsRead = notifications?.markAnnouncementsRead
 
   const loadAnnouncements = useCallback(async () => {
     const requestId = loadRequestIdRef.current + 1
@@ -88,7 +89,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
 
       hasMarkedRead.current = true
       invalidateCachedJSON(`student-announcements:${classroomId}`)
-      notifications?.markAnnouncementsRead?.()
+      markAnnouncementsRead?.()
     } catch (err) {
       if (markReadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setReadError('Announcements are visible, but Pika could not mark them as read.')
@@ -99,7 +100,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
         setMarkingRead(false)
       }
     }
-  }, [classroom.id, notifications])
+  }, [classroom.id, markAnnouncementsRead])
 
   useEffect(() => {
     loadAnnouncements()

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button, PageState, RefreshingIndicator } from '@/ui'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
@@ -33,7 +33,6 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
   const loadRequestIdRef = useRef(0)
   const markReadRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
-  currentClassroomIdRef.current = classroom.id
   const notifications = useStudentNotifications()
   const markAnnouncementsRead = notifications?.markAnnouncementsRead
 
@@ -62,7 +61,9 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     }
   }, [classroom.id])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    currentClassroomIdRef.current = classroom.id
+    loadRequestIdRef.current += 1
     hasMarkedRead.current = false
     markReadInFlightRef.current = false
     markReadRequestIdRef.current += 1

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useState, useRef } from 'react'
 import { Trash2, Plus, Clock, Calendar, Settings } from 'lucide-react'
 import { Button, ConfirmDialog, FormField, Input, PageState, RefreshingIndicator, SplitButton } from '@/ui'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
@@ -112,7 +112,6 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const saveRequestIdRef = useRef(0)
   const deleteRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
-  currentClassroomIdRef.current = classroom.id
 
   const isReadOnly = !!classroom.archived_at
 
@@ -145,7 +144,9 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     loadAnnouncements()
   }, [loadAnnouncements])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    currentClassroomIdRef.current = classroom.id
+    loadRequestIdRef.current += 1
     saveRequestIdRef.current += 1
     deleteRequestIdRef.current += 1
     setShowAll(false)

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -109,6 +109,8 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const dropdownRef = useRef<HTMLDivElement>(null)
   const editDropdownRef = useRef<HTMLDivElement>(null)
   const loadRequestIdRef = useRef(0)
+  const saveRequestIdRef = useRef(0)
+  const deleteRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
   currentClassroomIdRef.current = classroom.id
 
@@ -144,7 +146,25 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   }, [loadAnnouncements])
 
   useEffect(() => {
+    saveRequestIdRef.current += 1
+    deleteRequestIdRef.current += 1
     setShowAll(false)
+    setEditingId(null)
+    setEditTitle('')
+    setOriginalTitle(null)
+    setEditContent('')
+    setOriginalContent('')
+    setEditScheduleDateTime('')
+    setOriginalScheduledFor(null)
+    setIsCreating(false)
+    setNewTitle('')
+    setNewContent('')
+    setSaving(false)
+    setDeleteTarget(null)
+    setDeleting(false)
+    setScheduleDateTime('')
+    setShowScheduleDropdown(false)
+    setShowEditScheduleDropdown(false)
   }, [classroom.id])
 
   // Focus textarea when editing starts
@@ -231,6 +251,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
 
   async function saveEdit() {
     if (!editingId || !editContent.trim() || saving) return
+    const classroomId = classroom.id
+    const announcementId = editingId
+    const requestId = saveRequestIdRef.current + 1
+    saveRequestIdRef.current = requestId
 
     // Check if anything changed
     const normalizedEditTitle = normalizeAnnouncementTitle(editTitle)
@@ -250,7 +274,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     const optimisticScheduledFor = editScheduleDateTime ? new Date(editScheduleDateTime).toISOString() : null
     setAnnouncements((prev) =>
       prev.map((a) =>
-        a.id === editingId
+        a.id === announcementId
           ? {
               ...a,
               title: normalizedEditTitle,
@@ -274,7 +298,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       }
 
       const res = await fetch(
-        `/api/teacher/classrooms/${classroom.id}/announcements/${editingId}`,
+        `/api/teacher/classrooms/${classroomId}/announcements/${announcementId}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
@@ -283,22 +307,29 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       )
       if (!res.ok) throw new Error('Failed to update')
       const data = await res.json()
+      invalidateCachedJSON(`teacher-announcements:${classroomId}`)
+      invalidateCachedJSON(`student-announcements:${classroomId}`)
+      if (saveRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setAnnouncements((prev) =>
         prev.map((a) => (a.id === data.announcement.id ? data.announcement : a))
       )
-      invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
-      invalidateCachedJSON(`student-announcements:${classroom.id}`)
       cancelEditing()
     } catch (err) {
+      if (saveRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setAnnouncements(prevAnnouncements)
       console.error('Error updating announcement:', err)
     } finally {
-      setSaving(false)
+      if (saveRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        setSaving(false)
+      }
     }
   }
 
   async function createAnnouncement(scheduledFor?: string) {
     if (!newContent.trim() || saving) return
+    const classroomId = classroom.id
+    const requestId = saveRequestIdRef.current + 1
+    saveRequestIdRef.current = requestId
 
     setSaving(true)
     const normalizedNewTitle = normalizeAnnouncementTitle(newTitle)
@@ -306,7 +337,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     const now = new Date().toISOString()
     const optimisticAnnouncement: Announcement = {
       id: tempId,
-      classroom_id: classroom.id,
+      classroom_id: classroomId,
       title: normalizedNewTitle,
       content: newContent.trim(),
       created_by: classroom.teacher_id,
@@ -324,33 +355,40 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
         body.scheduled_for = new Date(scheduledFor).toISOString()
       }
 
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`, {
+      const res = await fetch(`/api/teacher/classrooms/${classroomId}/announcements`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       })
       if (!res.ok) throw new Error('Failed to create')
       const data = await res.json()
+      invalidateCachedJSON(`teacher-announcements:${classroomId}`)
+      invalidateCachedJSON(`student-announcements:${classroomId}`)
+      if (saveRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setAnnouncements((prev) =>
         prev.map((a) => (a.id === tempId ? data.announcement : a))
       )
-      invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
-      invalidateCachedJSON(`student-announcements:${classroom.id}`)
       setIsCreating(false)
       setNewTitle('')
       setNewContent('')
       setScheduleDateTime('')
       setShowScheduleDropdown(false)
     } catch (err) {
+      if (saveRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setAnnouncements((prev) => prev.filter((a) => a.id !== tempId))
       console.error('Error creating announcement:', err)
     } finally {
-      setSaving(false)
+      if (saveRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        setSaving(false)
+      }
     }
   }
 
   async function handleDelete() {
     if (!deleteTarget) return
+    const classroomId = classroom.id
+    const requestId = deleteRequestIdRef.current + 1
+    deleteRequestIdRef.current = requestId
 
     setDeleting(true)
     const target = deleteTarget
@@ -358,19 +396,23 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     setAnnouncements((prev) => prev.filter((a) => a.id !== target.id))
     try {
       const res = await fetch(
-        `/api/teacher/classrooms/${classroom.id}/announcements/${target.id}`,
+        `/api/teacher/classrooms/${classroomId}/announcements/${target.id}`,
         { method: 'DELETE' }
       )
       if (!res.ok) throw new Error('Failed to delete')
-      invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
-      invalidateCachedJSON(`student-announcements:${classroom.id}`)
+      invalidateCachedJSON(`teacher-announcements:${classroomId}`)
+      invalidateCachedJSON(`student-announcements:${classroomId}`)
+      if (deleteRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setDeleteTarget(null)
     } catch (err) {
+      if (deleteRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setAnnouncements(prevAnnouncements)
       console.error('Delete error:', err)
       setDeleteTarget(null)
     } finally {
-      setDeleting(false)
+      if (deleteRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        setDeleting(false)
+      }
     }
   }
 

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -2,8 +2,7 @@
 
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Trash2, Plus, Clock, Calendar, Settings } from 'lucide-react'
-import { Button, ConfirmDialog, FormField, Input, SplitButton } from '@/ui'
-import { Spinner } from '@/components/Spinner'
+import { Button, ConfirmDialog, FormField, Input, PageState, RefreshingIndicator, SplitButton } from '@/ui'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
@@ -17,6 +16,7 @@ import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui'
 import {
   ANNOUNCEMENT_TITLE_MAX_LENGTH,
+  formatAnnouncementTimestamp,
   normalizeAnnouncementTitle,
   sortAnnouncementsNewestFirst,
 } from '@/lib/announcements'
@@ -82,6 +82,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadErrorClassroomId, setLoadErrorClassroomId] = useState<string | null>(null)
   const [showAll, setShowAll] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editTitle, setEditTitle] = useState('')
@@ -108,6 +109,8 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const dropdownRef = useRef<HTMLDivElement>(null)
   const editDropdownRef = useRef<HTMLDivElement>(null)
   const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
 
   const isReadOnly = !!classroom.archived_at
 
@@ -115,22 +118,22 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     const requestId = loadRequestIdRef.current + 1
     loadRequestIdRef.current = requestId
     setLoading(true)
+    setLoadErrorClassroomId(null)
     try {
       const data = await fetchCachedJSON<AnnouncementsResponse>(
         `teacher-announcements:${classroom.id}`,
         `/api/teacher/classrooms/${classroom.id}/announcements`,
         { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
       )
-      if (loadRequestIdRef.current !== requestId) return
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
       setAnnouncements(data.announcements || [])
       setLoadedClassroomId(classroom.id)
     } catch (err) {
-      if (loadRequestIdRef.current !== requestId) return
-      setAnnouncements([])
-      setLoadedClassroomId(classroom.id)
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
+      setLoadErrorClassroomId(classroom.id)
       console.error('Error loading announcements:', err)
     } finally {
-      if (loadRequestIdRef.current === requestId) {
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
         setLoading(false)
       }
     }
@@ -139,6 +142,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   useEffect(() => {
     loadAnnouncements()
   }, [loadAnnouncements])
+
+  useEffect(() => {
+    setShowAll(false)
+  }, [classroom.id])
 
   // Focus textarea when editing starts
   useEffect(() => {
@@ -367,14 +374,6 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     }
   }
 
-  function formatDate(dateString: string) {
-    const date = new Date(dateString)
-    const weekday = date.toLocaleDateString('en-US', { weekday: 'short' })
-    const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-    const time = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
-    return `${weekday} ${monthDay}, ${time}`
-  }
-
   function handleEditKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Escape') {
       cancelEditing()
@@ -402,7 +401,9 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   }
 
   const currentAnnouncements = loadedClassroomId === classroom.id ? announcements : []
-  const isLoading = loading || loadedClassroomId !== classroom.id
+  const hasCurrentClassroomData = loadedClassroomId === classroom.id
+  const loadError = loadErrorClassroomId === classroom.id
+  const isInitialLoading = !hasCurrentClassroomData && !loadError
   const announcementActionItems: TeacherWorkSurfaceActionItem[] = [
     {
       id: 'announcement',
@@ -411,16 +412,35 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     },
   ]
 
-  if (isLoading) {
+  function retryLoadAnnouncements() {
+    invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
+    void loadAnnouncements()
+  }
+
+  if (isInitialLoading) {
+    return <PageState kind="loading" title="Loading announcements" />
+  }
+
+  if (loadError && currentAnnouncements.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <Spinner />
-      </div>
+      <PageState
+        kind="error"
+        title="Announcements couldn't load"
+        description="Pika couldn't load this classroom's announcements. Nothing was changed."
+        action={<Button onClick={retryLoadAnnouncements}>Retry</Button>}
+      />
     )
   }
 
   return (
     <div className={cn('space-y-4', className ?? 'max-w-2xl mx-auto')}>
+      {loading ? <RefreshingIndicator label="Refreshing announcements" /> : null}
+      {loadError ? (
+        <div role="alert" className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          <span>Pika could not refresh announcements. The last loaded announcements are still shown.</span>
+          <Button variant="secondary" size="sm" onClick={retryLoadAnnouncements}>Retry</Button>
+        </div>
+      ) : null}
       {!isReadOnly && (
         <TeacherWorkSurfaceActionBar
           testId="announcements-actionbar-center"
@@ -497,7 +517,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                 className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
               >
                 <Calendar className="h-4 w-4 flex-shrink-0" />
-                <span>{formatDate(scheduleDateTime)}</span>
+                <span>{formatAnnouncementTimestamp(scheduleDateTime)}</span>
               </button>
               <button
                 type="button"
@@ -638,7 +658,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                           className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
                         >
                           <Calendar className="h-4 w-4 flex-shrink-0" />
-                          <span>{formatDate(editScheduleDateTime)}</span>
+                          <span>{formatAnnouncementTimestamp(editScheduleDateTime)}</span>
                         </button>
                         <button
                           type="button"
@@ -725,12 +745,12 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                         <div className="flex items-center gap-2 mb-2">
                           <Clock className="h-3.5 w-3.5 text-amber-600" />
                           <span className="text-xs font-medium text-amber-600">
-                            Scheduled for {formatDate(announcement.scheduled_for!)}
+                            Scheduled for {formatAnnouncementTimestamp(announcement.scheduled_for!)}
                           </span>
                         </div>
                       ) : (
                         <p className="text-xs text-text-muted mb-2">
-                          {formatDate(announcement.created_at)}
+                          {formatAnnouncementTimestamp(announcement.created_at)}
                           {announcement.updated_at !== announcement.created_at && ' (edited)'}
                         </p>
                       )}

--- a/src/lib/announcements.ts
+++ b/src/lib/announcements.ts
@@ -1,4 +1,7 @@
+import { formatInTimeZone } from 'date-fns-tz'
+
 export const ANNOUNCEMENT_TITLE_MAX_LENGTH = 60
+const ANNOUNCEMENT_TIMEZONE = 'America/Toronto'
 
 export type AnnouncementTitleInputResult =
   | { ok: true; value: string | null | undefined }
@@ -40,4 +43,11 @@ export function sortAnnouncementsNewestFirst<T extends { created_at: string }>(
   return [...announcements].sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   )
+}
+
+export function formatAnnouncementTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return formatInTimeZone(date, ANNOUNCEMENT_TIMEZONE, 'EEE MMM d, h:mm a')
 }

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Suspense, startTransition, useState } from 'react'
 import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
 import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
 import {
@@ -101,6 +102,51 @@ function teacherAnnouncementsElement(sectionClassroom: Classroom) {
 function UnreadAnnouncementCount() {
   const notifications = useStudentNotifications()
   return <div>Unread announcements: {notifications?.unreadAnnouncementsCount ?? 0}</div>
+}
+
+const suspendedClassroomRender = new Promise<never>(() => undefined)
+
+function SuspendSecondClassroom({ classroomId }: { classroomId: string }) {
+  if (classroomId === secondClassroom.id) throw suspendedClassroomRender
+  return null
+}
+
+function TeacherTransitionHarness() {
+  const [activeClassroom, setActiveClassroom] = useState(classroom)
+
+  return (
+    <TooltipProvider>
+      <button
+        type="button"
+        onClick={() => startTransition(() => setActiveClassroom(secondClassroom))}
+      >
+        Attempt classroom switch
+      </button>
+      <Suspense fallback={<div>Switching classroom</div>}>
+        <TeacherAnnouncementsSection classroom={activeClassroom} />
+        <SuspendSecondClassroom classroomId={activeClassroom.id} />
+      </Suspense>
+    </TooltipProvider>
+  )
+}
+
+function StudentTransitionHarness() {
+  const [activeClassroom, setActiveClassroom] = useState(classroom)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => startTransition(() => setActiveClassroom(secondClassroom))}
+      >
+        Attempt student classroom switch
+      </button>
+      <Suspense fallback={<div>Switching student classroom</div>}>
+        <StudentAnnouncementsSection classroom={activeClassroom} />
+        <SuspendSecondClassroom classroomId={activeClassroom.id} />
+      </Suspense>
+    </>
+  )
 }
 
 describe('announcement markdown rendering', () => {
@@ -394,6 +440,46 @@ describe('announcement markdown rendering', () => {
     consoleError.mockRestore()
   })
 
+  it('finishes a student read acknowledgement when a classroom switch is suspended', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const readResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') return readResponse.promise
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(<StudentTransitionHarness />)
+    await screen.findByText('Unit update')
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        `/api/student/classrooms/${classroom.id}/announcements`,
+        { method: 'POST' },
+      )
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Attempt student classroom switch' }))
+
+    await act(async () => {
+      readResponse.resolve(
+        new Response(JSON.stringify({ error: 'Unavailable' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Announcements are visible, but Pika could not mark them as read.',
+    )
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled()
+    consoleError.mockRestore()
+  })
+
   it('does not keep stale teacher announcements visible while loading another classroom', async () => {
     let resolveSecondRead: ((response: Response) => void) | null = null
     vi.stubGlobal(
@@ -466,7 +552,8 @@ describe('announcement markdown rendering', () => {
     consoleError.mockRestore()
   })
 
-  it('ignores a completed teacher create after switching classrooms', async () => {
+  it('ignores a failed teacher create after switching classrooms', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const createResponse = deferred<Response>()
     vi.stubGlobal(
       'fetch',
@@ -493,17 +580,13 @@ describe('announcement markdown rendering', () => {
     expect(await screen.findByText('Pending Classroom A update', { selector: 'p' })).toBeInTheDocument()
     view.rerender(teacherAnnouncementsElement(secondClassroom))
     expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
 
     await act(async () => {
       createResponse.resolve(
-        new Response(JSON.stringify({
-          announcement: {
-            ...markdownAnnouncement,
-            id: 'created-announcement',
-            content: 'Pending Classroom A update',
-          },
-        }), {
-          status: 200,
+        new Response(JSON.stringify({ error: 'Unavailable' }), {
+          status: 500,
           headers: { 'Content-Type': 'application/json' },
         }),
       )
@@ -511,9 +594,13 @@ describe('announcement markdown rendering', () => {
 
     expect(screen.getByText('Second classroom update')).toBeInTheDocument()
     expect(screen.queryByText('Pending Classroom A update')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
+    consoleError.mockRestore()
   })
 
-  it('ignores a completed teacher edit after switching classrooms', async () => {
+  it('ignores a failed teacher edit after switching classrooms', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const editResponse = deferred<Response>()
     vi.stubGlobal(
       'fetch',
@@ -539,16 +626,13 @@ describe('announcement markdown rendering', () => {
 
     view.rerender(teacherAnnouncementsElement(secondClassroom))
     expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
 
     await act(async () => {
       editResponse.resolve(
-        new Response(JSON.stringify({
-          announcement: {
-            ...markdownAnnouncement,
-            content: 'Edited Classroom A update',
-          },
-        }), {
-          status: 200,
+        new Response(JSON.stringify({ error: 'Unavailable' }), {
+          status: 500,
           headers: { 'Content-Type': 'application/json' },
         }),
       )
@@ -556,10 +640,12 @@ describe('announcement markdown rendering', () => {
 
     expect(screen.getByText('Second classroom update')).toBeInTheDocument()
     expect(screen.queryByText('Edited Classroom A update')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
+    consoleError.mockRestore()
   })
 
-  it('does not restore a failed teacher delete after switching classrooms', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  it('ignores a successful teacher delete after switching classrooms', async () => {
     const deleteResponse = deferred<Response>()
     vi.stubGlobal(
       'fetch',
@@ -582,6 +668,124 @@ describe('announcement markdown rendering', () => {
 
     view.rerender(teacherAnnouncementsElement(secondClassroom))
     expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
+
+    await act(async () => {
+      deleteResponse.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
+  })
+
+  it('finishes a teacher create when a suspended classroom switch is abandoned', async () => {
+    const createResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') return createResponse.promise
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(<TeacherTransitionHarness />)
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByRole('button', { name: 'New announcement' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Announcement body' }), {
+      target: { value: 'Created while switch is suspended' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }))
+    fireEvent.click(screen.getByText('Attempt classroom switch'))
+
+    await act(async () => {
+      createResponse.resolve(
+        new Response(JSON.stringify({
+          announcement: {
+            ...markdownAnnouncement,
+            id: 'created-during-suspense',
+            content: 'Created while switch is suspended',
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Created while switch is suspended', { selector: 'p' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+  })
+
+  it('finishes a teacher edit when a suspended classroom switch is abandoned', async () => {
+    const editResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'PATCH') return editResponse.promise
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(<TeacherTransitionHarness />)
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByText('bring notes'))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit announcement body' }), {
+      target: { value: 'Edited while switch is suspended' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Attempt classroom switch' }))
+
+    await act(async () => {
+      editResponse.resolve(
+        new Response(JSON.stringify({
+          announcement: {
+            ...markdownAnnouncement,
+            content: 'Edited while switch is suspended',
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Edited while switch is suspended', { selector: 'p' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeEnabled()
+  })
+
+  it('rolls back a teacher delete when a suspended classroom switch is abandoned', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const deleteResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'DELETE') return deleteResponse.promise
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(<TeacherTransitionHarness />)
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete announcement' }))
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))
+    fireEvent.click(screen.getByText('Attempt classroom switch'))
 
     await act(async () => {
       deleteResponse.resolve(
@@ -592,8 +796,8 @@ describe('announcement markdown rendering', () => {
       )
     })
 
-    expect(screen.getByText('Second classroom update')).toBeInTheDocument()
-    expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
+    expect(screen.getByText('Unit update')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete announcement' })).toBeEnabled()
     consoleError.mockRestore()
   })
 

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
 import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
@@ -57,6 +57,21 @@ const secondClassroom: Classroom = {
   ...classroom,
   id: 'classroom-announcements-second',
   title: 'Second Announcements',
+}
+
+const secondClassroomAnnouncement: Announcement = {
+  ...markdownAnnouncement,
+  id: 'second-classroom-announcement',
+  classroom_id: secondClassroom.id,
+  title: 'Second classroom update',
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
 }
 
 function mockAnnouncementFetch(announcements: Announcement[] = [markdownAnnouncement]) {
@@ -447,6 +462,137 @@ describe('announcement markdown rendering', () => {
     view.rerender(teacherAnnouncementsElement(secondClassroom))
 
     expect(await screen.findByRole('alert')).toHaveTextContent("Announcements couldn't load")
+    expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
+    consoleError.mockRestore()
+  })
+
+  it('ignores a completed teacher create after switching classrooms', async () => {
+    const createResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') return createResponse.promise
+        const announcements = String(input).includes(secondClassroom.id)
+          ? [secondClassroomAnnouncement]
+          : [markdownAnnouncement]
+        return new Response(JSON.stringify({ announcements }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const view = render(teacherAnnouncementsElement(classroom))
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByRole('button', { name: 'New announcement' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Announcement body' }), {
+      target: { value: 'Pending Classroom A update' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }))
+
+    expect(await screen.findByText('Pending Classroom A update', { selector: 'p' })).toBeInTheDocument()
+    view.rerender(teacherAnnouncementsElement(secondClassroom))
+    expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+
+    await act(async () => {
+      createResponse.resolve(
+        new Response(JSON.stringify({
+          announcement: {
+            ...markdownAnnouncement,
+            id: 'created-announcement',
+            content: 'Pending Classroom A update',
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.queryByText('Pending Classroom A update')).not.toBeInTheDocument()
+  })
+
+  it('ignores a completed teacher edit after switching classrooms', async () => {
+    const editResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'PATCH') return editResponse.promise
+        const announcements = String(input).includes(secondClassroom.id)
+          ? [secondClassroomAnnouncement]
+          : [markdownAnnouncement]
+        return new Response(JSON.stringify({ announcements }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const view = render(teacherAnnouncementsElement(classroom))
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByText('bring notes'))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit announcement body' }), {
+      target: { value: 'Edited Classroom A update' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }))
+
+    view.rerender(teacherAnnouncementsElement(secondClassroom))
+    expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+
+    await act(async () => {
+      editResponse.resolve(
+        new Response(JSON.stringify({
+          announcement: {
+            ...markdownAnnouncement,
+            content: 'Edited Classroom A update',
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Second classroom update')).toBeInTheDocument()
+    expect(screen.queryByText('Edited Classroom A update')).not.toBeInTheDocument()
+  })
+
+  it('does not restore a failed teacher delete after switching classrooms', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const deleteResponse = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'DELETE') return deleteResponse.promise
+        const announcements = String(input).includes(secondClassroom.id)
+          ? [secondClassroomAnnouncement]
+          : [markdownAnnouncement]
+        return new Response(JSON.stringify({ announcements }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const view = render(teacherAnnouncementsElement(classroom))
+    await screen.findByText('Unit update')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete announcement' }))
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))
+
+    view.rerender(teacherAnnouncementsElement(secondClassroom))
+    expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+
+    await act(async () => {
+      deleteResponse.resolve(
+        new Response(JSON.stringify({ error: 'Unavailable' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(screen.getByText('Second classroom update')).toBeInTheDocument()
     expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
     consoleError.mockRestore()
   })

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -2,6 +2,10 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
 import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
+import {
+  StudentNotificationsProvider,
+  useStudentNotifications,
+} from '@/components/StudentNotificationsProvider'
 import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 import { TooltipProvider } from '@/ui'
 import type { Announcement, Classroom } from '@/types'
@@ -79,10 +83,16 @@ function teacherAnnouncementsElement(sectionClassroom: Classroom) {
   )
 }
 
+function UnreadAnnouncementCount() {
+  const notifications = useStudentNotifications()
+  return <div>Unread announcements: {notifications?.unreadAnnouncementsCount ?? 0}</div>
+}
+
 describe('announcement markdown rendering', () => {
   beforeEach(() => {
     invalidateCachedJSONMatching('teacher-announcements:')
     invalidateCachedJSONMatching('student-announcements:')
+    invalidateCachedJSONMatching('student-notifications:')
     mockAnnouncementFetch()
   })
 
@@ -298,6 +308,74 @@ describe('announcement markdown rendering', () => {
     await waitFor(() => {
       expect(screen.queryByText('Announcements are visible, but Pika could not mark them as read.')).not.toBeInTheDocument()
     })
+    consoleError.mockRestore()
+  })
+
+  it('does not retry a failed read acknowledgement when notification state settles', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let resolveNotifications!: (response: Response) => void
+    const notificationsResponse = new Promise<Response>((resolve) => {
+      resolveNotifications = resolve
+    })
+    let postCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/api/student/notifications')) {
+          return notificationsResponse
+        }
+        if (init?.method === 'POST') {
+          postCount += 1
+          return postCount === 1
+            ? new Response(JSON.stringify({ error: 'Unavailable' }), { status: 500 })
+            : new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 })
+        }
+
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(
+      <StudentNotificationsProvider classroomId={classroom.id}>
+        <UnreadAnnouncementCount />
+        <StudentAnnouncementsSection classroom={classroom} />
+      </StudentNotificationsProvider>,
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Announcements are visible, but Pika could not mark them as read.',
+    )
+    expect(postCount).toBe(1)
+
+    await act(async () => {
+      resolveNotifications(
+        new Response(JSON.stringify({
+          hasTodayEntry: true,
+          unviewedAssignmentsCount: 0,
+          activeTestsCount: 0,
+          unreadAnnouncementsCount: 1,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(await screen.findByText('Unread announcements: 1')).toBeInTheDocument()
+    expect(postCount).toBe(1)
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Announcements are visible, but Pika could not mark them as read.',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(postCount).toBe(2))
+    expect(await screen.findByText('Unread announcements: 0')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     consoleError.mockRestore()
   })
 

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -220,6 +220,87 @@ describe('announcement markdown rendering', () => {
     expect(screen.getByText('bring notes')).toBeInTheDocument()
   })
 
+  it('shows a retryable teacher error instead of a false empty state', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Unavailable' }), { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(teacherAnnouncementsElement(classroom))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Announcements couldn't load")
+    expect(screen.queryByText(/No announcements yet/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Unit update')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
+
+  it('shows a retryable student error instead of a false empty state', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Unavailable' }), { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentAnnouncementsSection classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Announcements couldn't load")
+    expect(screen.queryByText('No announcements yet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Unit update')).toBeInTheDocument()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    consoleError.mockRestore()
+  })
+
+  it('keeps failed student read acknowledgement visible and retryable', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let postCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          postCount += 1
+          return postCount === 1
+            ? new Response(JSON.stringify({ error: 'Unavailable' }), { status: 500 })
+            : new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 })
+        }
+
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    render(<StudentAnnouncementsSection classroom={classroom} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Announcements are visible, but Pika could not mark them as read.',
+    )
+    expect(screen.getByText('Unit update')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(postCount).toBe(2))
+    await waitFor(() => {
+      expect(screen.queryByText('Announcements are visible, but Pika could not mark them as read.')).not.toBeInTheDocument()
+    })
+    consoleError.mockRestore()
+  })
+
   it('does not keep stale teacher announcements visible while loading another classroom', async () => {
     let resolveSecondRead: ((response: Response) => void) | null = null
     vi.stubGlobal(
@@ -264,6 +345,32 @@ describe('announcement markdown rendering', () => {
     })
 
     expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+  })
+
+  it('does not relabel old teacher announcements when the next classroom fails to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes(secondClassroom.id)) {
+          return new Response(JSON.stringify({ error: 'Unavailable' }), { status: 500 })
+        }
+
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const view = render(teacherAnnouncementsElement(classroom))
+    await screen.findByText('Unit update')
+
+    view.rerender(teacherAnnouncementsElement(secondClassroom))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Announcements couldn't load")
+    expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
+    consoleError.mockRestore()
   })
 
   it('marks student announcements read once per classroom', async () => {

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   ANNOUNCEMENT_TITLE_MAX_LENGTH,
+  formatAnnouncementTimestamp,
   getAnnouncementCalendarLabel,
   normalizeAnnouncementTitle,
   parseAnnouncementTitleInput,
@@ -42,5 +43,14 @@ describe('announcement helpers', () => {
     ])
 
     expect(sorted.map((announcement) => announcement.id)).toEqual(['newest', 'older', 'older-scheduled'])
+  })
+
+  it('formats announcement timestamps in Toronto across standard and daylight time', () => {
+    expect(formatAnnouncementTimestamp('2026-01-15T15:00:00.000Z')).toBe('Thu Jan 15, 10:00 AM')
+    expect(formatAnnouncementTimestamp('2026-07-15T15:00:00.000Z')).toBe('Wed Jul 15, 11:00 AM')
+  })
+
+  it('returns an invalid timestamp unchanged', () => {
+    expect(formatAnnouncementTimestamp('not-a-date')).toBe('not-a-date')
   })
 })


### PR DESCRIPTION
## Summary
- add explicit loading, empty, failure, and Retry states to teacher and student Announcement tabs
- keep announcement/read request state scoped to the active classroom and make failed student read acknowledgement retryable
- format announcement and schedule timestamps in America/Toronto
- record the completed bounded Announcements slice while leaving Calendar multi-source recovery open

## Validation
- full Vitest suite: 4,250 tests across 494 files
- focused Vitest: 19 tests across announcement component/domain suites
- pnpm lint
- pnpm exec tsc --noEmit --pretty false
- Pika audit and git diff --check
- Playwright visual verification: teacher/student, desktop/mobile, light/dark, loaded/empty/cold-error, and student read-error states

## Accessibility
- checklist reviewed: yes
- keyboard behavior covered: unchanged; no composite-widget behavior changed
- semantic state covered by tests: yes, using alert/status and named Retry controls
- remaining manual follow-up: none