### PR TITLE
Improve calendar source recovery

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,3 +1,3 @@
-Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. Surveys and Announcements recovery/semantics complete; select the next Phase 3 slice. Migration-123 retry lint stays separate.
+Prod 001–123. Student purge on; cold/generic deletion off. cron-run-ledger remains local-only 124; prod auth required. Surveys, Announcements, and Calendar recovery/semantics complete; select the next Phase 3 slice. Migration-123 retry lint stays separate.
 WT: $HOME/.codex/worktrees/pika/ or $HOME/.codex/worktrees/<id>/pika.
 Env: $HOME/Repos/.env/pika/.env.local; collaborators use .env.example.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18152,3 +18152,37 @@ hot-archived Classroom.
   enables no remaining Classroom. Disabling that stale row or selecting a new
   canary/broader rollout requires fresh authorization. Generic cleanup remains
   disabled.
+
+<!-- pika-session-log-archive-batch:76393174b1d53f39e7eff91965f58f04a00ce9c713265dd672f04b0855d0d511 -->
+## 2026-08-05 — Complete student/artifact production purge canary
+
+**Risk profile:** irreversible production deletion of one exact synthetic
+hot-archived Classroom with a student, assignment artifact, and test material.
+
+**Completed:**
+- Archived synthetic Classroom `1da6bdef-d231-47d2-90ce-c3675c3afcff` through
+  the teacher UI and atomically retargeted the existing exact canary gate.
+- Revalidated no conflict or prior purge and an impact of one student, 106
+  relational records, and two ready managed files / 114,179 bytes.
+- Used the production teacher UI, typed `DELETE`, and completed durable purge
+  operation `afb8e6aa-e36a-4196-9e7e-49d5ab57da99` on its first attempt.
+
+**Validation:**
+- The audit records 106 relational rows and two files deleted: one
+  `assignment-artifacts` object and one `test-documents` object. Both paths are
+  redacted, both hashed identities are absent from Storage, and neither object
+  reappeared.
+- The Classroom, enrollment, roster, assignment/document/artifact, test, 96
+  class days, archive state, managed ownership, purge resources, and purge fence
+  are absent.
+- Course Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, its managed file,
+  and both synthetic user accounts remain intact.
+- Global inventory is 140 ready registry objects and 140 Storage objects, with
+  zero ownerless, missing, unregistered, or generic-cleanup objects. The 20
+  historical archive-source cleanup ledgers remain terminal `deleted`.
+- Teacher and student desktop/mobile light/dark boundaries passed before and
+  after deletion. Teacher GET is 404 after deletion; student access remains 403.
+
+**Remaining:**
+- The exact canary row points to the now-deleted Classroom and therefore enables
+  no remaining Classroom. Broader rollout and generic cleanup remain disabled.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18186,3 +18186,13 @@ hot-archived Classroom with a student, assignment artifact, and test material.
 **Remaining:**
 - The exact canary row points to the now-deleted Classroom and therefore enables
   no remaining Classroom. Broader rollout and generic cleanup remain disabled.
+
+<!-- pika-session-log-archive-batch:c28c32203e3e49bc279bb47cb2b292ca1376eb7e7491f4a9822672d3454425e9 -->
+## 2026-08-05 — Record managed Blueprint lifecycle follow-up
+
+- Added a separate failing feature for durable Blueprint deletion with managed
+  files; no Blueprint deletion implementation was added to the Classroom purge
+  reconciliation patch.
+- The acceptance sequence first creates and verifies a Classroom from preserved
+  canary Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, then exercises the
+  future Blueprint purge so preservation and deletion are independently proven.

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -18116,3 +18116,39 @@ execution remained disabled.
 **Remaining:**
 - The first irreversible production canary purge requires separate exact
   authorization. Broader rollout and generic cleanup remain disabled.
+
+<!-- pika-session-log-archive-batch:85754ac99e1c26b48237b374e51b3ad0ab7e4b41ae5ec8931c9572121f8bf705 -->
+## 2026-08-05 — Complete first production hot-archive purge canary
+
+**Risk profile:** irreversible production deletion of one exact synthetic
+hot-archived Classroom.
+
+**Completed:**
+- Revalidated the exact canary inventory and rollout binding immediately before
+  deletion: no conflict or prior operation, 104 relational records, one test
+  document, and one verified Classroom archive totaling 36 KB.
+- Used the production teacher UI, typed `DELETE`, and started purge operation
+  `e7b434d0-a6b0-4192-b3cb-a50e39985c92`.
+- The durable worker deleted both exact managed objects and finalized on the
+  first operation attempt with no failed file or retry.
+
+**Validation:**
+- The completed audit records 104 relational rows and two files deleted; both
+  object paths are redacted, both hashed identities remain reserved, and no
+  purged Storage object has reappeared.
+- The Classroom, its archive/operation rows, its managed identities, the purge
+  resource snapshot, and its fence are gone. No cold tombstone was created.
+- Course Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, its managed test
+  file, both synthetic users, and original Classroom
+  `1da6bdef-d231-47d2-90ce-c3675c3afcff` remain intact.
+- Global managed inventory is 142 ready registry objects and 142 Storage
+  objects, with zero ownerless or missing objects and zero generic cleanup work.
+- Teacher desktop/light and mobile/dark show no archived canary; teacher GET is
+  404. Student desktop/dark and mobile/light remain isolated; teacher endpoint
+  access is 403. Visual verification passed.
+
+**Remaining:**
+- The rollout row still points in `canary` mode to the deleted Classroom, which
+  enables no remaining Classroom. Disabling that stale row or selecting a new
+  canary/broader rollout requires fresh authorization. Generic cleanup remains
+  disabled.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1026,13 +1026,16 @@ Gradex change.
   Toronto-based.
 
 **Validation:**
-- Full suite passes: 4,286 tests across 495 files. Production build, lint,
+- Full suite passes: 4,288 tests across 495 files. Production build, lint,
   TypeScript, architecture, design/UI policy, Pika audit, and diff checks pass.
 - Independent review found that background lesson refreshes could discard
   edits and successful Retry actions could strand keyboard focus. Pending
   edits now remain authoritative during refreshes, Retry controls stay mounted
   while requests run, and successful recovery focuses the named Calendar
-  workspace; focused teacher/student regressions cover both corrections.
+  workspace. Targeted re-review additionally caught a GET/autosave ordering
+  gap and retry intent crossing classroom boundaries; per-edit acknowledgments
+  and classroom-scoped retry state now fence both cases, with focused
+  teacher/student regressions covering the corrections.
 - Playwright verification passes for teacher/student desktop loaded and partial
   error states in light mode, loaded states in dark mode, and the existing
   mobile layout. Retry controls retain valid lesson data with no overflow.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,41 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Complete first production hot-archive purge canary
-
-**Risk profile:** irreversible production deletion of one exact synthetic
-hot-archived Classroom.
-
-**Completed:**
-- Revalidated the exact canary inventory and rollout binding immediately before
-  deletion: no conflict or prior operation, 104 relational records, one test
-  document, and one verified Classroom archive totaling 36 KB.
-- Used the production teacher UI, typed `DELETE`, and started purge operation
-  `e7b434d0-a6b0-4192-b3cb-a50e39985c92`.
-- The durable worker deleted both exact managed objects and finalized on the
-  first operation attempt with no failed file or retry.
-
-**Validation:**
-- The completed audit records 104 relational rows and two files deleted; both
-  object paths are redacted, both hashed identities remain reserved, and no
-  purged Storage object has reappeared.
-- The Classroom, its archive/operation rows, its managed identities, the purge
-  resource snapshot, and its fence are gone. No cold tombstone was created.
-- Course Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, its managed test
-  file, both synthetic users, and original Classroom
-  `1da6bdef-d231-47d2-90ce-c3675c3afcff` remain intact.
-- Global managed inventory is 142 ready registry objects and 142 Storage
-  objects, with zero ownerless or missing objects and zero generic cleanup work.
-- Teacher desktop/light and mobile/dark show no archived canary; teacher GET is
-  404. Student desktop/dark and mobile/light remain isolated; teacher endpoint
-  access is 403. Visual verification passed.
-
-**Remaining:**
-- The rollout row still points in `canary` mode to the deleted Classroom, which
-  enables no remaining Classroom. Disabling that stale row or selecting a new
-  canary/broader rollout requires fresh authorization. Generic cleanup remains
-  disabled.
-
 ## 2026-08-05 — Complete student/artifact production purge canary
 
 **Risk profile:** irreversible production deletion of one exact synthetic
@@ -1044,3 +1009,27 @@ production, Calendar, mobile redesign, or Gradex change.
 - Visual verification passes for teacher/student desktop/mobile and light/dark
   loaded/error states, plus the student read-error state. No composite keyboard
   behavior changed; semantic alert/status and Retry coverage passes.
+
+## 2026-08-16 — Make Calendar sources independently recoverable
+
+**Risk profile:** none — teacher/student Calendar presentation and local
+request ownership; no API, schema, migration, production, mobile redesign, or
+Gradex change.
+
+**Completed:**
+- Replaced false-empty Calendar fallbacks with independent lesson-plan,
+  assignment, announcement, and class-day loading/error/snapshot contracts.
+- Preserved successful data during partial failures, added source-specific
+  Retry actions, and fenced stale classroom and overlapping teacher assignment
+  refresh responses.
+- Corrected date-only term parsing and made initial/today navigation explicitly
+  Toronto-based.
+
+**Validation:**
+- Full suite passes: 4,285 tests across 495 files. Production build, lint,
+  TypeScript, architecture, design/UI policy, Pika audit, and diff checks pass.
+- Playwright verification passes for teacher/student desktop loaded and partial
+  error states in light mode, loaded states in dark mode, and the existing
+  mobile layout. Retry controls retain valid lesson data with no overflow.
+- No composite control behavior changed; existing Calendar navigation semantics
+  remain covered, and new alert/Retry behavior has focused role tests.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1047,7 +1047,9 @@ the shared local database only. Production was not modified.
   removed both routes from the API validation debt baseline. Calendar dates
   are now validated as real dates before any bulk write begins.
 - Registered the durable mutation-head table as purge-only operational data and
-  included it in classroom purge impact inventory without archiving it.
+  included its exact PostgreSQL count in the purge stability digest and durable
+  operation inventory without archiving it. Mutation-head writes now obey the
+  classroom purge fence.
 
 **Validation:**
 - Full suite passes: 4,314 tests across 498 files. Production build, lint,
@@ -1057,8 +1059,10 @@ the shared local database only. Production was not modified.
   is denied to `anon` and `authenticated` and granted only to `service_role`.
 - Independent review findings covering queue-blocked unload writes,
   identical-payload draft ownership, impossible calendar dates, and schema
-  ownership were remediated with focused regressions. The local classroom
-  schema audit passes across 198 foreign-key relationships.
+  ownership were remediated with focused regressions. Rereview additionally
+  found paginated, unfenced mutation-head purge accounting; migration 125 now
+  computes and fences that count inside the database inventory. The local
+  classroom schema audit passes across 198 foreign-key relationships.
 - Playwright verification passes for the exhausted-save Retry alert in teacher
   light/dark views; the student Calendar remains visually unchanged. Mobile
   redesign remains explicitly deferred.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,15 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Record managed Blueprint lifecycle follow-up
-
-- Added a separate failing feature for durable Blueprint deletion with managed
-  files; no Blueprint deletion implementation was added to the Classroom purge
-  reconciliation patch.
-- The acceptance sequence first creates and verifies a Classroom from preserved
-  canary Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, then exercises the
-  future Blueprint purge so preservation and deletion are independently proven.
-
 ## 2026-08-05 — Validate production-reconciliation patch
 
 - Full Vitest passed: 468 files and 4,047 tests. Production build, lint,
@@ -1034,3 +1025,30 @@ mobile redesign, or Gradex change.
   retry focus through failure and recovery.
 - Playwright verification passes for teacher/student desktop/mobile and
   light/dark Calendar views plus the retained `Retrying class days` state.
+
+## 2026-08-16 — Make Calendar mutations durable across unload and classroom switches
+
+**Risk profile:** schema-and-workspace-state — teacher lesson-plan ordering,
+bulk draft ownership, and visible save recovery; migration 125 was applied to
+the shared local database only. Production was not modified.
+
+**Completed:**
+- Added a durable per-browser-session ordering head and atomic lesson-plan
+  mutation function so reversed save/delete completion cannot overwrite newer
+  teacher intent, including direct keepalive requests during unload.
+- Fenced bulk-save completion by classroom epoch, retained failed classroom
+  drafts, and prevented delayed responses from closing or clearing newer work.
+- Added bounded inline retries with an explicit manual Retry action after
+  exhaustion, preserving the exact unsaved lesson content.
+- Migrated the date and bulk request bodies to feature-owned Zod schemas and
+  removed both routes from the API validation debt baseline.
+
+**Validation:**
+- Full suite passes: 4,309 tests across 498 files. Production build, lint,
+  TypeScript, generated Supabase type drift, Pika audit, and diff checks pass.
+- Local PostgreSQL rollback tests prove newer-save/stale-save,
+  newer-delete/stale-save, and newer-save/stale-delete ordering. RPC execution
+  is denied to `anon` and `authenticated` and granted only to `service_role`.
+- Playwright verification passes for the exhausted-save Retry alert in teacher
+  light/dark views; the student Calendar remains visually unchanged. Mobile
+  redesign remains explicitly deferred.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1036,19 +1036,29 @@ the shared local database only. Production was not modified.
 - Added a durable per-browser-session ordering head and atomic lesson-plan
   mutation function so reversed save/delete completion cannot overwrite newer
   teacher intent, including direct keepalive requests during unload.
+- Retained queued and in-flight inline saves through page unload, with database
+  sequence fencing making repeated keepalive delivery idempotent.
 - Fenced bulk-save completion by classroom epoch, retained failed classroom
-  drafts, and prevented delayed responses from closing or clearing newer work.
+  drafts by revision, and prevented delayed or identical-payload responses from
+  closing or clearing newer work.
 - Added bounded inline retries with an explicit manual Retry action after
   exhaustion, preserving the exact unsaved lesson content.
 - Migrated the date and bulk request bodies to feature-owned Zod schemas and
-  removed both routes from the API validation debt baseline.
+  removed both routes from the API validation debt baseline. Calendar dates
+  are now validated as real dates before any bulk write begins.
+- Registered the durable mutation-head table as purge-only operational data and
+  included it in classroom purge impact inventory without archiving it.
 
 **Validation:**
-- Full suite passes: 4,309 tests across 498 files. Production build, lint,
+- Full suite passes: 4,314 tests across 498 files. Production build, lint,
   TypeScript, generated Supabase type drift, Pika audit, and diff checks pass.
 - Local PostgreSQL rollback tests prove newer-save/stale-save,
   newer-delete/stale-save, and newer-save/stale-delete ordering. RPC execution
   is denied to `anon` and `authenticated` and granted only to `service_role`.
+- Independent review findings covering queue-blocked unload writes,
+  identical-payload draft ownership, impossible calendar dates, and schema
+  ownership were remediated with focused regressions. The local classroom
+  schema audit passes across 198 foreign-key relationships.
 - Playwright verification passes for the exhausted-save Retry alert in teacher
   light/dark views; the student Calendar remains visually unchanged. Mobile
   redesign remains explicitly deferred.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1026,8 +1026,13 @@ Gradex change.
   Toronto-based.
 
 **Validation:**
-- Full suite passes: 4,285 tests across 495 files. Production build, lint,
+- Full suite passes: 4,286 tests across 495 files. Production build, lint,
   TypeScript, architecture, design/UI policy, Pika audit, and diff checks pass.
+- Independent review found that background lesson refreshes could discard
+  edits and successful Retry actions could strand keyboard focus. Pending
+  edits now remain authoritative during refreshes, Retry controls stay mounted
+  while requests run, and successful recovery focuses the named Calendar
+  workspace; focused teacher/student regressions cover both corrections.
 - Playwright verification passes for teacher/student desktop loaded and partial
   error states in light mode, loaded states in dark mode, and the existing
   mobile layout. Retry controls retain valid lesson data with no overflow.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1026,7 +1026,7 @@ Gradex change.
   Toronto-based.
 
 **Validation:**
-- Full suite passes: 4,288 tests across 495 files. Production build, lint,
+- Full suite passes: 4,289 tests across 495 files. Production build, lint,
   TypeScript, architecture, design/UI policy, Pika audit, and diff checks pass.
 - Independent review found that background lesson refreshes could discard
   edits and successful Retry actions could strand keyboard focus. Pending
@@ -1034,8 +1034,10 @@ Gradex change.
   while requests run, and successful recovery focuses the named Calendar
   workspace. Targeted re-review additionally caught a GET/autosave ordering
   gap and retry intent crossing classroom boundaries; per-edit acknowledgments
-  and classroom-scoped retry state now fence both cases, with focused
-  teacher/student regressions covering the corrections.
+  and classroom-scoped retry state now fence both cases. A final ABA review
+  found that returning to a classroom could make an earlier visit's save look
+  current; queued saves now carry a monotonically increasing classroom epoch.
+  Focused teacher/student regressions cover all corrections.
 - Playwright verification passes for teacher/student desktop loaded and partial
   error states in light mode, loaded states in dark mode, and the existing
   mobile layout. Retry controls retain valid lesson data with no overflow.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -11,39 +11,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-08-05 — Complete student/artifact production purge canary
-
-**Risk profile:** irreversible production deletion of one exact synthetic
-hot-archived Classroom with a student, assignment artifact, and test material.
-
-**Completed:**
-- Archived synthetic Classroom `1da6bdef-d231-47d2-90ce-c3675c3afcff` through
-  the teacher UI and atomically retargeted the existing exact canary gate.
-- Revalidated no conflict or prior purge and an impact of one student, 106
-  relational records, and two ready managed files / 114,179 bytes.
-- Used the production teacher UI, typed `DELETE`, and completed durable purge
-  operation `afb8e6aa-e36a-4196-9e7e-49d5ab57da99` on its first attempt.
-
-**Validation:**
-- The audit records 106 relational rows and two files deleted: one
-  `assignment-artifacts` object and one `test-documents` object. Both paths are
-  redacted, both hashed identities are absent from Storage, and neither object
-  reappeared.
-- The Classroom, enrollment, roster, assignment/document/artifact, test, 96
-  class days, archive state, managed ownership, purge resources, and purge fence
-  are absent.
-- Course Blueprint `c318ef23-5039-4b64-9977-66bceee54ba0`, its managed file,
-  and both synthetic user accounts remain intact.
-- Global inventory is 140 ready registry objects and 140 Storage objects, with
-  zero ownerless, missing, unregistered, or generic-cleanup objects. The 20
-  historical archive-source cleanup ledgers remain terminal `deleted`.
-- Teacher and student desktop/mobile light/dark boundaries passed before and
-  after deletion. Teacher GET is 404 after deletion; student access remains 403.
-
-**Remaining:**
-- The exact canary row points to the now-deleted Classroom and therefore enables
-  no remaining Classroom. Broader rollout and generic cleanup remain disabled.
-
 ## 2026-08-05 — Record managed Blueprint lifecycle follow-up
 
 - Added a separate failing feature for durable Blueprint deletion with managed
@@ -1043,3 +1010,27 @@ Gradex change.
   mobile layout. Retry controls retain valid lesson data with no overflow.
 - No composite control behavior changed; existing Calendar navigation semantics
   remain covered, and new alert/Retry behavior has focused role tests.
+
+## 2026-08-16 — Serialize Calendar writes and retained retries
+
+**Risk profile:** workspace-state — teacher lesson-plan mutation ordering and
+teacher/student Calendar retry state; no API, schema, migration, production,
+mobile redesign, or Gradex change.
+
+**Completed:**
+- Serialized inline, bulk, and unload lesson-plan writes per classroom across
+  component remounts so older requests cannot commit after newer edits.
+- Retained failed inline saves with bounded automatic retries, scoped pending
+  edits by classroom, and blocked bulk markdown saves until inline drains
+  succeed.
+- Replaced unload beacons with explicit keepalive `PUT` requests and exposed
+  retained class-day refreshes as pending without clearing their prior error.
+
+**Validation:**
+- Full suite passes: 4,295 tests across 495 files. Production build, lint,
+  TypeScript, architecture, Pika audit, and diff checks pass.
+- Focused regressions cover server commit order, inline-before-bulk order,
+  failed-write retry, unload method/payload, and teacher/student class-day
+  retry focus through failure and recovery.
+- Playwright verification passes for teacher/student desktop/mobile and
+  light/dark Calendar views plus the retained `Retrying class days` state.

--- a/docs/guidance/ui/product-experience-audit-2026-07.md
+++ b/docs/guidance/ui/product-experience-audit-2026-07.md
@@ -207,8 +207,16 @@ Announcements progress:
 - Teacher and student Announcement tabs now distinguish loading, successful empty, loaded, and announced failure states with explicit Retry recovery.
 - Classroom-scoped request guards prevent stale responses or errors from painting under another classroom. Student read acknowledgement failures remain visible and retryable instead of silently clearing notification state.
 - Announcement creation, scheduling, and display timestamps now use `America/Toronto`; focused tests cover standard/daylight offsets, failure recovery, stale classroom isolation, and read retries.
-- Teacher/student desktop/mobile browser verification passed in light/dark for loaded and cold-error states, plus the student read-error state. Calendar multi-source recovery remains in the Calendar and lesson-plans slice.
+- Teacher/student desktop/mobile browser verification passed in light/dark for loaded and cold-error states, plus the student read-error state.
 - The Phase 3 Announcements slice is complete.
+
+Calendar and lesson-plan progress:
+
+- Teacher and student Calendar tabs now track lesson plans, assignments, announcements, and class days independently instead of converting failed reads into empty calendar data.
+- Successful source snapshots remain visible during another source's failure or refresh. Each failed source has a named Retry action, and committed-classroom request generations reject stale responses and overlapping teacher assignment refreshes.
+- Calendar term boundaries use date-only parsing, and initial/today navigation is explicitly Toronto-based so classroom dates do not shift at UTC boundaries.
+- Focused tests cover partial and cold failures, source-specific recovery, retained refresh data, stale classroom isolation, and Toronto term labels. Teacher/student desktop light/dark loaded states and intercepted partial-error states passed Playwright review.
+- The Phase 3 Calendar and lesson-plans slice is complete. Mobile Calendar redesign remains deferred with the broader mobile work.
 
 1. Assignments: save/submit integrity, error states, mobile workspace modes, Gradex status boundary.
 2. Tests: completed list errors, authoring/grading separation, and standalone preview authorization/framing; remaining accessible flags/save status and deferred mobile navigation.
@@ -216,7 +224,7 @@ Announcements progress:
 4. Dashboard: teacher-owned entry detail, responsive summary-first attendance, and removal of invalid classroom commands.
 5. Roster: mobile row detail, keyboard table behavior, bulk-action recovery, and counselor-field access.
 6. Surveys: completed explicit student/teacher results recovery, retained refresh data, stale-response guards, and native choice semantics.
-7. Calendar and lesson plans: independent source failures, compact navigation, and Toronto date/time behavior.
+7. Calendar and lesson plans: completed independent source recovery, retained snapshots, stale-response guards, compact error controls, and Toronto date behavior; mobile redesign remains deferred.
 8. Announcements: completed explicit failure/read states, stale-classroom guards, Retry recovery, and Toronto timestamp formatting.
 9. Gradebook: narrow-screen navigation, selected-student detail, and direct table keyboard tests.
 10. Syllabus/resources: iframe sizing, nested scroll, theme, keyboard traversal, and legacy resource-path disposition.

--- a/src/app/api/teacher/classrooms/[id]/lesson-plans/[date]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/lesson-plans/[date]/route.ts
@@ -3,12 +3,14 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
-import type { TiptapContent } from '@/types'
+import type { TableRow } from '@/types/database'
+import type { Json } from '@/types/database.generated'
 import {
   buildLessonPlanContentFields,
   getLessonPlanMarkdown,
   normalizeLessonPlanMarkdown,
 } from '@/lib/lesson-plan-content'
+import { lessonPlanMutationBodySchema } from '@/lib/validations/lesson-plan-mutations'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -17,8 +19,9 @@ export const revalidate = 0
 export const PUT = withErrorHandler('PutUpsertLessonPlan', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: classroomId, date } = await context.params
-  const body = await request.json()
-  const { content_markdown, content } = body as { content_markdown?: string; content?: TiptapContent }
+  const { content_markdown, content, mutation: mutationVersion } = lessonPlanMutationBodySchema.parse(
+    await request.json(),
+  )
 
   // Validate date format (YYYY-MM-DD)
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
@@ -36,10 +39,7 @@ export const PUT = withErrorHandler('PutUpsertLessonPlan', async (request, conte
         : null
 
   if (markdown === null) {
-    return NextResponse.json(
-      { error: 'Invalid content format' },
-      { status: 400 }
-    )
+    return NextResponse.json({ error: 'Invalid content format' }, { status: 400 })
   }
 
   const contentFields = buildLessonPlanContentFields(markdown)
@@ -53,6 +53,36 @@ export const PUT = withErrorHandler('PutUpsertLessonPlan', async (request, conte
   }
 
   const supabase = getServiceRoleClient()
+
+  if (mutationVersion) {
+    const shouldDelete = normalizeLessonPlanMarkdown(markdown).trim().length === 0
+    const { data, error } = await supabase.rpc('apply_ordered_lesson_plan_mutation', {
+      p_classroom_id: classroomId,
+      p_client_id: mutationVersion.client_id,
+      p_content: contentFields.content as unknown as Json,
+      p_content_markdown: contentFields.content_markdown,
+      p_date: date,
+      p_delete: shouldDelete,
+      p_sequence: mutationVersion.sequence,
+    })
+
+    if (error || !data || typeof data !== 'object' || Array.isArray(data)) {
+      console.error('Error applying ordered lesson plan mutation:', error)
+      return NextResponse.json({ error: 'Failed to save lesson plan' }, { status: 500 })
+    }
+
+    const result = data as { applied?: boolean; lesson_plan?: TableRow<'lesson_plans'> | null }
+    const lessonPlan = result.lesson_plan
+    return NextResponse.json({
+      applied: result.applied === true,
+      lesson_plan: lessonPlan
+        ? {
+            ...lessonPlan,
+            content_markdown: getLessonPlanMarkdown(lessonPlan).markdown,
+          }
+        : null,
+    })
+  }
 
   if (normalizeLessonPlanMarkdown(markdown).trim().length === 0) {
     const { error } = await supabase

--- a/src/app/api/teacher/classrooms/[id]/lesson-plans/[date]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/lesson-plans/[date]/route.ts
@@ -10,7 +10,10 @@ import {
   getLessonPlanMarkdown,
   normalizeLessonPlanMarkdown,
 } from '@/lib/lesson-plan-content'
-import { lessonPlanMutationBodySchema } from '@/lib/validations/lesson-plan-mutations'
+import {
+  lessonPlanDateSchema,
+  lessonPlanMutationBodySchema,
+} from '@/lib/validations/lesson-plan-mutations'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -24,7 +27,7 @@ export const PUT = withErrorHandler('PutUpsertLessonPlan', async (request, conte
   )
 
   // Validate date format (YYYY-MM-DD)
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  if (!lessonPlanDateSchema.safeParse(date).success) {
     return NextResponse.json(
       { error: 'Invalid date format. Expected YYYY-MM-DD' },
       { status: 400 }

--- a/src/app/api/teacher/classrooms/[id]/lesson-plans/bulk/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/lesson-plans/bulk/route.ts
@@ -3,42 +3,23 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
-import type { TiptapContent } from '@/types'
+import type { TableRow } from '@/types/database'
+import type { Json } from '@/types/database.generated'
 import { buildLessonPlanContentFields, getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
+import { bulkLessonPlanMutationBodySchema } from '@/lib/validations/lesson-plan-mutations'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-
-interface BulkPlanEntry {
-  date: string // YYYY-MM-DD
-  content_markdown?: string
-  content?: TiptapContent
-}
 
 // PUT /api/teacher/classrooms/[id]/lesson-plans/bulk - Bulk upsert lesson plans
 export const PUT = withErrorHandler('PutBulkUpsertLessonPlans', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: classroomId } = await context.params
-  const body = await request.json()
-  const { plans = [], cleared_dates = [] } = body as {
-    plans?: BulkPlanEntry[]
-    cleared_dates?: string[]
-  }
-
-  if (!Array.isArray(plans) || !Array.isArray(cleared_dates) || (plans.length === 0 && cleared_dates.length === 0)) {
-    return NextResponse.json(
-      { error: 'plans or cleared_dates is required and must not be empty' },
-      { status: 400 }
-    )
-  }
-
-  const MAX_PLANS = 250
-  if (plans.length > MAX_PLANS || cleared_dates.length > MAX_PLANS) {
-    return NextResponse.json(
-      { error: `Too many plans. Maximum is ${MAX_PLANS} per request.` },
-      { status: 400 }
-    )
-  }
+  const {
+    plans,
+    cleared_dates,
+    mutation: mutationVersion,
+  } = bulkLessonPlanMutationBodySchema.parse(await request.json())
 
   const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
   if (!ownership.ok) {
@@ -46,45 +27,6 @@ export const PUT = withErrorHandler('PutBulkUpsertLessonPlans', async (request, 
       { error: ownership.error },
       { status: ownership.status }
     )
-  }
-
-  // Validate all plans before upserting
-  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-  const errors: string[] = []
-  const seenDates = new Set<string>()
-
-  for (const plan of plans) {
-    if (!dateRegex.test(plan.date)) {
-      errors.push(`Invalid date format: ${plan.date}`)
-      continue
-    }
-    if (seenDates.has(plan.date)) {
-      errors.push(`Duplicate date: ${plan.date}`)
-      continue
-    }
-    seenDates.add(plan.date)
-
-    const hasMarkdown = typeof plan.content_markdown === 'string'
-    const hasContent = !!plan.content && plan.content.type === 'doc'
-    if (!hasMarkdown && !hasContent) {
-      errors.push(`Invalid content for date ${plan.date}`)
-    }
-  }
-
-  for (const date of cleared_dates) {
-    if (!dateRegex.test(date)) {
-      errors.push(`Invalid date format: ${date}`)
-      continue
-    }
-    if (seenDates.has(date)) {
-      errors.push(`Duplicate date: ${date}`)
-      continue
-    }
-    seenDates.add(date)
-  }
-
-  if (errors.length > 0) {
-    return NextResponse.json({ errors }, { status: 400 })
   }
 
   const supabase = getServiceRoleClient()
@@ -105,6 +47,58 @@ export const PUT = withErrorHandler('PutBulkUpsertLessonPlans', async (request, 
       updated_at: now,
     }
   })
+
+  if (mutationVersion) {
+    const lessonPlans: TableRow<'lesson_plans'>[] = []
+    let updated = 0
+    let cleared = 0
+
+    for (const plan of upsertData) {
+      const { data, error } = await supabase.rpc('apply_ordered_lesson_plan_mutation', {
+        p_classroom_id: classroomId,
+        p_client_id: mutationVersion.client_id,
+        p_content: plan.content as unknown as Json,
+        p_content_markdown: plan.content_markdown,
+        p_date: plan.date,
+        p_delete: false,
+        p_sequence: mutationVersion.sequence,
+      })
+      if (error || !data || typeof data !== 'object' || Array.isArray(data)) {
+        console.error('Error applying ordered bulk lesson plan mutation:', error)
+        return NextResponse.json({ error: 'Failed to save lesson plans' }, { status: 500 })
+      }
+      const result = data as { applied?: boolean; lesson_plan?: TableRow<'lesson_plans'> | null }
+      if (result.applied) updated += 1
+      if (result.lesson_plan) lessonPlans.push(result.lesson_plan)
+    }
+
+    for (const date of cleared_dates) {
+      const { data, error } = await supabase.rpc('apply_ordered_lesson_plan_mutation', {
+        p_classroom_id: classroomId,
+        p_client_id: mutationVersion.client_id,
+        p_content: {},
+        p_content_markdown: '',
+        p_date: date,
+        p_delete: true,
+        p_sequence: mutationVersion.sequence,
+      })
+      if (error || !data || typeof data !== 'object' || Array.isArray(data)) {
+        console.error('Error applying ordered bulk lesson plan clear:', error)
+        return NextResponse.json({ error: 'Failed to save lesson plans' }, { status: 500 })
+      }
+      const result = data as { applied?: boolean }
+      if (result.applied) cleared += 1
+    }
+
+    return NextResponse.json({
+      updated,
+      cleared,
+      lesson_plans: lessonPlans.map((lessonPlan) => ({
+        ...lessonPlan,
+        content_markdown: getLessonPlanMarkdown(lessonPlan).markdown,
+      })),
+    })
+  }
 
   let clearedCount = 0
   if (cleared_dates.length > 0) {

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -24,6 +24,7 @@ type StudentAssignmentsResponse = { assignments?: Assignment[] }
 type StudentAnnouncementsResponse = { announcements?: Announcement[] }
 
 type CalendarSource = 'lessonPlans' | 'assignments' | 'announcements'
+type CalendarRetrySource = CalendarSource | 'classDays'
 type SourceStatus = {
   classroomId: string | null
   error: boolean
@@ -52,6 +53,8 @@ export function StudentLessonCalendarTab({
     announcements: 0,
   })
   const currentClassroomIdRef = useRef(classroom.id)
+  const retryingSourcesRef = useRef<Set<CalendarRetrySource>>(new Set())
+  const calendarWorkspaceRef = useRef<HTMLDivElement>(null)
   const {
     classDays,
     error: classDaysError,
@@ -99,7 +102,7 @@ export function StudentLessonCalendarTab({
       ...current,
       [source]: {
         classroomId: requestedClassroomId,
-        error: false,
+        error: current[source].classroomId === requestedClassroomId && current[source].error,
         hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
         isLoading: true,
       },
@@ -138,7 +141,7 @@ export function StudentLessonCalendarTab({
       ...current,
       [source]: {
         classroomId: requestedClassroomId,
-        error: false,
+        error: current[source].classroomId === requestedClassroomId && current[source].error,
         hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
         isLoading: true,
       },
@@ -176,7 +179,7 @@ export function StudentLessonCalendarTab({
       ...current,
       [source]: {
         classroomId: requestedClassroomId,
-        error: false,
+        error: current[source].classroomId === requestedClassroomId && current[source].error,
         hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
         isLoading: true,
       },
@@ -214,33 +217,67 @@ export function StudentLessonCalendarTab({
   const currentAssignments = assignmentsStatus.classroomId === classroom.id && assignmentsStatus.hasLoadedSnapshot ? assignments : []
   const currentAnnouncements = announcementsStatus.classroomId === classroom.id && announcementsStatus.hasLoadedSnapshot ? announcements : []
   const localStatuses = [lessonPlansStatus, assignmentsStatus, announcementsStatus]
-  const isInitialLoading = localStatuses.some((status) => (
-    status.classroomId !== classroom.id || (status.isLoading && !status.hasLoadedSnapshot)
-  )) || (classDaysLoading && !hasClassDaysSnapshot)
-  const isRefreshing = localStatuses.some((status) => status.isLoading) || classDaysLoading
-  const hasAnySnapshot = localStatuses.some((status) => (
+  const hasAnyLocalSnapshot = localStatuses.some((status) => (
     status.classroomId === classroom.id && status.hasLoadedSnapshot
-  )) || hasClassDaysSnapshot
+  ))
+  const hasAnySnapshot = hasAnyLocalSnapshot || hasClassDaysSnapshot
+  const haveLocalSourcesInitialized = localStatuses.every((status) => status.classroomId === classroom.id)
+  const isInitialLoading = !haveLocalSourcesInitialized || (
+    !hasAnyLocalSnapshot && localStatuses.some((status) => status.isLoading)
+  )
+  const isRefreshing = localStatuses.some((status) => status.isLoading) || classDaysLoading
+  const retryLessonPlans = useCallback(() => {
+    retryingSourcesRef.current.add('lessonPlans')
+    void loadLessonPlans(true)
+  }, [loadLessonPlans])
+  const retryAssignments = useCallback(() => {
+    retryingSourcesRef.current.add('assignments')
+    void loadAssignments(true)
+  }, [loadAssignments])
+  const retryAnnouncements = useCallback(() => {
+    retryingSourcesRef.current.add('announcements')
+    void loadAnnouncements(true)
+  }, [loadAnnouncements])
+  const retryClassDays = useCallback(() => {
+    retryingSourcesRef.current.add('classDays')
+    void refreshClassDays()
+  }, [refreshClassDays])
+
+  useEffect(() => {
+    const statuses: Record<CalendarRetrySource, { error: boolean; isLoading: boolean }> = {
+      lessonPlans: lessonPlansStatus,
+      assignments: assignmentsStatus,
+      announcements: announcementsStatus,
+      classDays: { error: Boolean(classDaysError), isLoading: classDaysLoading },
+    }
+    for (const source of retryingSourcesRef.current) {
+      const status = statuses[source]
+      if (status.isLoading) continue
+      retryingSourcesRef.current.delete(source)
+      if (!status.error) calendarWorkspaceRef.current?.focus()
+    }
+  }, [announcementsStatus, assignmentsStatus, classDaysError, classDaysLoading, lessonPlansStatus])
+
   const failures: CalendarSourceFailure[] = []
   if (lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.error) {
-    failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: () => void loadLessonPlans(true) })
+    failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: retryLessonPlans })
   }
   if (assignmentsStatus.classroomId === classroom.id && assignmentsStatus.error) {
-    failures.push({ id: 'assignments', label: 'assignments', isRetrying: assignmentsStatus.isLoading, onRetry: () => void loadAssignments(true) })
+    failures.push({ id: 'assignments', label: 'assignments', isRetrying: assignmentsStatus.isLoading, onRetry: retryAssignments })
   }
   if (announcementsStatus.classroomId === classroom.id && announcementsStatus.error) {
-    failures.push({ id: 'announcements', label: 'announcements', isRetrying: announcementsStatus.isLoading, onRetry: () => void loadAnnouncements(true) })
+    failures.push({ id: 'announcements', label: 'announcements', isRetrying: announcementsStatus.isLoading, onRetry: retryAnnouncements })
   }
   if (classDaysError) {
-    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: () => void refreshClassDays() })
+    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: retryClassDays })
   }
 
   const retryAll = useCallback(() => {
-    void loadLessonPlans(true)
-    void loadAssignments(true)
-    void loadAnnouncements(true)
-    void refreshClassDays()
-  }, [loadAnnouncements, loadAssignments, loadLessonPlans, refreshClassDays])
+    retryLessonPlans()
+    retryAssignments()
+    retryAnnouncements()
+    retryClassDays()
+  }, [retryAnnouncements, retryAssignments, retryClassDays, retryLessonPlans])
 
   // Handle assignment click - navigate to assignments tab with the assignment selected
   const handleAssignmentClick = useCallback(
@@ -287,16 +324,6 @@ export function StudentLessonCalendarTab({
     handleDateChange(nowInToronto())
   }, [handleDateChange])
 
-  if (isInitialLoading) {
-    return (
-      <PageLayout bleedX={false}>
-        <PageContent>
-          <PageState kind="loading" title="Loading calendar" />
-        </PageContent>
-      </PageLayout>
-    )
-  }
-
   if (!hasAnySnapshot && failures.length > 0) {
     return (
       <PageLayout bleedX={false}>
@@ -305,8 +332,22 @@ export function StudentLessonCalendarTab({
             kind="error"
             title="Calendar couldn't load"
             description="Pika couldn't load this classroom's calendar information. Nothing was changed."
-            action={<Button type="button" onClick={retryAll}>Retry</Button>}
+            action={(
+              <Button type="button" onClick={retryAll} disabled={isRefreshing}>
+                {isRefreshing ? 'Retrying...' : 'Retry'}
+              </Button>
+            )}
           />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (isInitialLoading) {
+    return (
+      <PageLayout bleedX={false}>
+        <PageContent>
+          <PageState kind="loading" title="Loading calendar" />
         </PageContent>
       </PageLayout>
     )
@@ -325,24 +366,26 @@ export function StudentLessonCalendarTab({
         onViewModeChange={handleViewModeChange}
       />
       <PageContent className="pb-24 pt-2">
-        {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
-        <CalendarSourceErrors failures={failures} />
-        <div className="overflow-hidden rounded-lg border border-border bg-surface">
-          <LessonCalendar
-            classroom={classroom}
-            lessonPlans={currentLessonPlans}
-            assignments={currentAssignments}
-            announcements={currentAnnouncements}
-            classDays={classDays}
-            viewMode={viewMode}
-            currentDate={currentDate}
-            editable={false}
-            showHeader={false}
-            onDateChange={handleDateChange}
-            onViewModeChange={handleViewModeChange}
-            onAssignmentClick={handleAssignmentClick}
-            onAnnouncementClick={handleAnnouncementClick}
-          />
+        <div ref={calendarWorkspaceRef} role="region" aria-label="Calendar workspace" tabIndex={-1} className="outline-none">
+          {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
+          <CalendarSourceErrors failures={failures} />
+          <div className="overflow-hidden rounded-lg border border-border bg-surface">
+            <LessonCalendar
+              classroom={classroom}
+              lessonPlans={currentLessonPlans}
+              assignments={currentAssignments}
+              announcements={currentAnnouncements}
+              classDays={classDays}
+              viewMode={viewMode}
+              currentDate={currentDate}
+              editable={false}
+              showHeader={false}
+              onDateChange={handleDateChange}
+              onViewModeChange={handleViewModeChange}
+              onAssignmentClick={handleAssignmentClick}
+              onAnnouncementClick={handleAnnouncementClick}
+            />
+          </div>
         </div>
       </PageContent>
     </PageLayout>

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -88,6 +88,7 @@ export function StudentLessonCalendarTab({
     setAssignments([])
     setAnnouncements([])
     setMaxDate(null)
+    retryingSourcesRef.current.clear()
     setSourceStatus(initialSourceStatus())
   }, [classroom.id])
 

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -1,15 +1,17 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, startOfWeek, subMonths, subWeeks } from 'date-fns'
 import { CalendarActionBar } from '@/components/CalendarActionBar'
-import { Spinner } from '@/components/Spinner'
+import { CalendarSourceErrors, type CalendarSourceFailure } from '@/components/CalendarSourceErrors'
 import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
-import { useClassDays } from '@/hooks/useClassDays'
+import { useClassDaysContext } from '@/hooks/useClassDays'
 import { readCookie, writeCookie } from '@/lib/cookies'
-import { fetchCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
+import { nowInToronto } from '@/lib/timezone'
 import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
+import { Button, PageState, RefreshingIndicator } from '@/ui'
 
 interface Props {
   classroom: Classroom
@@ -21,6 +23,20 @@ type StudentLessonPlansResponse = { lesson_plans?: LessonPlan[]; max_date?: stri
 type StudentAssignmentsResponse = { assignments?: Assignment[] }
 type StudentAnnouncementsResponse = { announcements?: Announcement[] }
 
+type CalendarSource = 'lessonPlans' | 'assignments' | 'announcements'
+type SourceStatus = {
+  classroomId: string | null
+  error: boolean
+  hasLoadedSnapshot: boolean
+  isLoading: boolean
+}
+
+const initialSourceStatus = (): Record<CalendarSource, SourceStatus> => ({
+  lessonPlans: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+  assignments: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+  announcements: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+})
+
 export function StudentLessonCalendarTab({
   classroom,
   onNavigateToAssignments = () => {},
@@ -29,12 +45,20 @@ export function StudentLessonCalendarTab({
   const [lessonPlans, setLessonPlans] = useState<LessonPlan[]>([])
   const [assignments, setAssignments] = useState<Assignment[]>([])
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
-  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
-  const loadRequestIdRef = useRef(0)
+  const [sourceStatus, setSourceStatus] = useState(initialSourceStatus)
+  const loadRequestIdsRef = useRef<Record<CalendarSource, number>>({
+    lessonPlans: 0,
+    assignments: 0,
+    announcements: 0,
+  })
   const currentClassroomIdRef = useRef(classroom.id)
-  currentClassroomIdRef.current = classroom.id
-  const classDays = useClassDays(classroom.id)
-  const [loading, setLoading] = useState(true)
+  const {
+    classDays,
+    error: classDaysError,
+    hasLoadedSnapshot: hasClassDaysSnapshot,
+    isLoading: classDaysLoading,
+    refresh: refreshClassDays,
+  } = useClassDaysContext()
   const [viewMode, setViewMode] = useState<CalendarViewMode>(() => {
     const saved = readCookie(`calendarViewMode:${classroom.id}`)
     return (saved === 'week' || saved === 'month' || saved === 'all') ? saved : 'week'
@@ -43,7 +67,7 @@ export function StudentLessonCalendarTab({
     setViewMode(mode)
     writeCookie(`calendarViewMode:${classroom.id}`, mode)
   }, [classroom.id])
-  const [currentDate, setCurrentDate] = useState(new Date())
+  const [currentDate, setCurrentDate] = useState(nowInToronto)
   const [maxDate, setMaxDate] = useState<string | null>(null)
 
   // Always fetch the full term - switching views is then instant
@@ -52,83 +76,171 @@ export function StudentLessonCalendarTab({
     end: classroom.end_date || format(endOfMonth(currentDate), 'yyyy-MM-dd'),
   }
 
-  useEffect(() => {
-    loadRequestIdRef.current += 1
+  useLayoutEffect(() => {
+    currentClassroomIdRef.current = classroom.id
+    loadRequestIdsRef.current.lessonPlans += 1
+    loadRequestIdsRef.current.assignments += 1
+    loadRequestIdsRef.current.announcements += 1
     setLessonPlans([])
     setAssignments([])
     setAnnouncements([])
     setMaxDate(null)
-    setLoadedClassroomId(null)
-    setLoading(true)
+    setSourceStatus(initialSourceStatus())
   }, [classroom.id])
 
-  // Fetch lesson plans, assignments, and announcements in parallel
-  useEffect(() => {
-    async function loadCalendarData() {
-      const requestId = loadRequestIdRef.current + 1
-      loadRequestIdRef.current = requestId
-      const requestedClassroomId = classroom.id
-      const isCurrentLoad = () => (
-        loadRequestIdRef.current === requestId &&
-        currentClassroomIdRef.current === requestedClassroomId
+  const loadLessonPlans = useCallback(async (force = false) => {
+    const source: CalendarSource = 'lessonPlans'
+    const requestedClassroomId = classroom.id
+    const requestId = loadRequestIdsRef.current[source] + 1
+    loadRequestIdsRef.current[source] = requestId
+    const cacheKey = `student-lesson-plans:${requestedClassroomId}:${fetchRange.start}:${fetchRange.end}`
+    if (force) invalidateCachedJSON(cacheKey)
+    setSourceStatus((current) => ({
+      ...current,
+      [source]: {
+        classroomId: requestedClassroomId,
+        error: false,
+        hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
+        isLoading: true,
+      },
+    }))
+    try {
+      const data = await fetchCachedJSON<StudentLessonPlansResponse>(
+        cacheKey,
+        `/api/student/classrooms/${requestedClassroomId}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`,
+        { ttlMs: 20_000, errorMessage: 'Failed to load lesson plans' },
       )
-
-      setLoading(true)
-      try {
-        const [lessonPlansData, assignmentsData, announcementsData] = await Promise.all([
-          fetchCachedJSON<StudentLessonPlansResponse>(
-            `student-lesson-plans:${classroom.id}:${fetchRange.start}:${fetchRange.end}`,
-            `/api/student/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`,
-            { ttlMs: 20_000, errorMessage: 'Failed to load lesson plans' },
-          ).catch((err) => {
-            console.error('Error loading lesson plans:', err)
-            return { lesson_plans: [], max_date: null }
-          }),
-          fetchCachedJSON<StudentAssignmentsResponse>(
-            `student-assignments:${classroom.id}`,
-            `/api/student/assignments?classroom_id=${classroom.id}`,
-            { ttlMs: 20_000, errorMessage: 'Failed to load assignments' },
-          ).catch((err) => {
-            console.error('Error loading calendar assignments:', err)
-            return { assignments: [] }
-          }),
-          fetchCachedJSON<StudentAnnouncementsResponse>(
-            `student-announcements:${classroom.id}`,
-            `/api/student/classrooms/${classroom.id}/announcements`,
-            { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
-          ).catch((err) => {
-            console.error('Error loading calendar announcements:', err)
-            return { announcements: [] }
-          }),
-        ])
-        if (!isCurrentLoad()) return
-        setLessonPlans(lessonPlansData.lesson_plans || [])
-        setMaxDate(lessonPlansData.max_date || null)
-        setAssignments(assignmentsData.assignments || [])
-        setAnnouncements(announcementsData.announcements || [])
-        setLoadedClassroomId(requestedClassroomId)
-      } catch (err) {
-        if (!isCurrentLoad()) return
-        console.error('Error loading calendar data:', err)
-        setLessonPlans([])
-        setMaxDate(null)
-        setAssignments([])
-        setAnnouncements([])
-        setLoadedClassroomId(requestedClassroomId)
-      } finally {
-        if (isCurrentLoad()) {
-          setLoading(false)
-        }
-      }
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      setLessonPlans(data.lesson_plans || [])
+      setMaxDate(data.max_date || null)
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+      }))
+    } catch (err) {
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      console.error('Error loading lesson plans:', err)
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { ...current[source], classroomId: requestedClassroomId, error: true, isLoading: false },
+      }))
     }
-    loadCalendarData()
-  }, [classroom.id, fetchRange.start, fetchRange.end])
+  }, [classroom.id, fetchRange.end, fetchRange.start])
 
-  const hasCurrentClassroomData = loadedClassroomId === classroom.id
-  const currentLessonPlans = hasCurrentClassroomData ? lessonPlans : []
-  const currentAssignments = hasCurrentClassroomData ? assignments : []
-  const currentAnnouncements = hasCurrentClassroomData ? announcements : []
-  const isLoading = loading || !hasCurrentClassroomData
+  const loadAssignments = useCallback(async (force = false) => {
+    const source: CalendarSource = 'assignments'
+    const requestedClassroomId = classroom.id
+    const requestId = loadRequestIdsRef.current[source] + 1
+    loadRequestIdsRef.current[source] = requestId
+    const cacheKey = `student-assignments:${requestedClassroomId}`
+    if (force) invalidateCachedJSON(cacheKey)
+    setSourceStatus((current) => ({
+      ...current,
+      [source]: {
+        classroomId: requestedClassroomId,
+        error: false,
+        hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
+        isLoading: true,
+      },
+    }))
+    try {
+      const data = await fetchCachedJSON<StudentAssignmentsResponse>(
+        cacheKey,
+        `/api/student/assignments?classroom_id=${requestedClassroomId}`,
+        { ttlMs: 20_000, errorMessage: 'Failed to load assignments' },
+      )
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      setAssignments(data.assignments || [])
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+      }))
+    } catch (err) {
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      console.error('Error loading calendar assignments:', err)
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { ...current[source], classroomId: requestedClassroomId, error: true, isLoading: false },
+      }))
+    }
+  }, [classroom.id])
+
+  const loadAnnouncements = useCallback(async (force = false) => {
+    const source: CalendarSource = 'announcements'
+    const requestedClassroomId = classroom.id
+    const requestId = loadRequestIdsRef.current[source] + 1
+    loadRequestIdsRef.current[source] = requestId
+    const cacheKey = `student-announcements:${requestedClassroomId}`
+    if (force) invalidateCachedJSON(cacheKey)
+    setSourceStatus((current) => ({
+      ...current,
+      [source]: {
+        classroomId: requestedClassroomId,
+        error: false,
+        hasLoadedSnapshot: current[source].classroomId === requestedClassroomId && current[source].hasLoadedSnapshot,
+        isLoading: true,
+      },
+    }))
+    try {
+      const data = await fetchCachedJSON<StudentAnnouncementsResponse>(
+        cacheKey,
+        `/api/student/classrooms/${requestedClassroomId}/announcements`,
+        { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
+      )
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      setAnnouncements(data.announcements || [])
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+      }))
+    } catch (err) {
+      if (loadRequestIdsRef.current[source] !== requestId || currentClassroomIdRef.current !== requestedClassroomId) return
+      console.error('Error loading calendar announcements:', err)
+      setSourceStatus((current) => ({
+        ...current,
+        [source]: { ...current[source], classroomId: requestedClassroomId, error: true, isLoading: false },
+      }))
+    }
+  }, [classroom.id])
+
+  useEffect(() => {
+    void Promise.all([loadLessonPlans(), loadAssignments(), loadAnnouncements()])
+  }, [loadAnnouncements, loadAssignments, loadLessonPlans])
+
+  const lessonPlansStatus = sourceStatus.lessonPlans
+  const assignmentsStatus = sourceStatus.assignments
+  const announcementsStatus = sourceStatus.announcements
+  const currentLessonPlans = lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.hasLoadedSnapshot ? lessonPlans : []
+  const currentAssignments = assignmentsStatus.classroomId === classroom.id && assignmentsStatus.hasLoadedSnapshot ? assignments : []
+  const currentAnnouncements = announcementsStatus.classroomId === classroom.id && announcementsStatus.hasLoadedSnapshot ? announcements : []
+  const localStatuses = [lessonPlansStatus, assignmentsStatus, announcementsStatus]
+  const isInitialLoading = localStatuses.some((status) => (
+    status.classroomId !== classroom.id || (status.isLoading && !status.hasLoadedSnapshot)
+  )) || (classDaysLoading && !hasClassDaysSnapshot)
+  const isRefreshing = localStatuses.some((status) => status.isLoading) || classDaysLoading
+  const hasAnySnapshot = localStatuses.some((status) => (
+    status.classroomId === classroom.id && status.hasLoadedSnapshot
+  )) || hasClassDaysSnapshot
+  const failures: CalendarSourceFailure[] = []
+  if (lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.error) {
+    failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: () => void loadLessonPlans(true) })
+  }
+  if (assignmentsStatus.classroomId === classroom.id && assignmentsStatus.error) {
+    failures.push({ id: 'assignments', label: 'assignments', isRetrying: assignmentsStatus.isLoading, onRetry: () => void loadAssignments(true) })
+  }
+  if (announcementsStatus.classroomId === classroom.id && announcementsStatus.error) {
+    failures.push({ id: 'announcements', label: 'announcements', isRetrying: announcementsStatus.isLoading, onRetry: () => void loadAnnouncements(true) })
+  }
+  if (classDaysError) {
+    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: () => void refreshClassDays() })
+  }
+
+  const retryAll = useCallback(() => {
+    void loadLessonPlans(true)
+    void loadAssignments(true)
+    void loadAnnouncements(true)
+    void refreshClassDays()
+  }, [loadAnnouncements, loadAssignments, loadLessonPlans, refreshClassDays])
 
   // Handle assignment click - navigate to assignments tab with the assignment selected
   const handleAssignmentClick = useCallback(
@@ -172,16 +284,29 @@ export function StudentLessonCalendarTab({
   }, [currentDate, handleDateChange, viewMode])
 
   const handleToday = useCallback(() => {
-    handleDateChange(new Date())
+    handleDateChange(nowInToronto())
   }, [handleDateChange])
 
-  if (isLoading && currentLessonPlans.length === 0) {
+  if (isInitialLoading) {
     return (
       <PageLayout bleedX={false}>
         <PageContent>
-          <div className="flex items-center justify-center h-64">
-            <Spinner />
-          </div>
+          <PageState kind="loading" title="Loading calendar" />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (!hasAnySnapshot && failures.length > 0) {
+    return (
+      <PageLayout bleedX={false}>
+        <PageContent>
+          <PageState
+            kind="error"
+            title="Calendar couldn't load"
+            description="Pika couldn't load this classroom's calendar information. Nothing was changed."
+            action={<Button type="button" onClick={retryAll}>Retry</Button>}
+          />
         </PageContent>
       </PageLayout>
     )
@@ -200,6 +325,8 @@ export function StudentLessonCalendarTab({
         onViewModeChange={handleViewModeChange}
       />
       <PageContent className="pb-24 pt-2">
+        {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
+        <CalendarSourceErrors failures={failures} />
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -125,6 +125,7 @@ export function TeacherLessonCalendarTab({
   const [assignmentsRefreshKey, setAssignmentsRefreshKey] = useState(0)
   const [announcementsRefreshKey, setAnnouncementsRefreshKey] = useState(0)
   const currentClassroomIdRef = useRef(classroom.id)
+  const classroomEpochRef = useRef(0)
   const sourceRequestIdsRef = useRef<Record<CalendarSource, number>>({
     lessonPlans: 0,
     assignments: 0,
@@ -137,6 +138,7 @@ export function TeacherLessonCalendarTab({
   const { showMarkdown } = useMarkdownPreference()
 
   useLayoutEffect(() => {
+    classroomEpochRef.current += 1
     currentClassroomIdRef.current = classroom.id
     sourceRequestIdsRef.current.lessonPlans += 1
     sourceRequestIdsRef.current.assignments += 1
@@ -149,6 +151,7 @@ export function TeacherLessonCalendarTab({
 
   // Auto-save tracking
   const pendingChangesRef = useRef<Map<string, string>>(new Map())
+  const pendingChangeEpochsRef = useRef<Map<string, number>>(new Map())
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAtRef = useRef<number>(0)
   const prevSidebarOpenRef = useRef(false)
@@ -392,7 +395,7 @@ export function TeacherLessonCalendarTab({
 
   // Save a single lesson plan
   const saveLessonPlan = useCallback(
-    async (date: string, contentMarkdown: string, editGeneration?: number) => {
+    async (date: string, contentMarkdown: string, saveEpoch: number, editGeneration?: number) => {
       const requestedClassroomId = classroom.id
       try {
         const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/lesson-plans/${date}`, {
@@ -403,6 +406,7 @@ export function TeacherLessonCalendarTab({
         if (res.ok) {
           const data = await res.json()
           invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
+          if (classroomEpochRef.current !== saveEpoch) return
           needsRefreshRef.current = true
           if (currentClassroomIdRef.current !== requestedClassroomId) return
           const currentEdit = lessonEditsRef.current.get(date)
@@ -441,10 +445,14 @@ export function TeacherLessonCalendarTab({
       content,
       date,
       editGeneration: lessonEditsRef.current.get(date)?.generation,
+      saveEpoch: pendingChangeEpochsRef.current.get(date) ?? -1,
     }))
     pendingChangesRef.current.clear()
+    pendingChangeEpochsRef.current.clear()
 
-    await Promise.all(entries.map(({ content, date, editGeneration }) => saveLessonPlan(date, content, editGeneration)))
+    await Promise.all(entries.map(({ content, date, editGeneration, saveEpoch }) => (
+      saveLessonPlan(date, content, saveEpoch, editGeneration)
+    )))
     lastSaveAtRef.current = Date.now()
     setSaving(false)
   }, [saveLessonPlan])
@@ -481,6 +489,7 @@ export function TeacherLessonCalendarTab({
       })
       applyLocalLessonPlanChange(date, contentMarkdown)
       pendingChangesRef.current.set(date, contentMarkdown)
+      pendingChangeEpochsRef.current.set(date, classroomEpochRef.current)
       scheduleSave()
     },
     [applyLocalLessonPlanChange, lessonPlansStatus.hasLoadedSnapshot, scheduleSave]
@@ -500,6 +509,7 @@ export function TeacherLessonCalendarTab({
           )
         }
         pendingChangesRef.current.clear()
+        pendingChangeEpochsRef.current.clear()
       }
     }
 

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -97,7 +97,7 @@ export function TeacherLessonCalendarTab({
   const lessonPlansRef = useRef(visibleLessonPlans)
   lessonPlansRef.current = visibleLessonPlans
   const lessonEditGenerationRef = useRef(0)
-  const lessonEditsRef = useRef<Map<string, { content: string; generation: number }>>(new Map())
+  const lessonEditsRef = useRef<Map<string, { acknowledged: boolean; content: string; generation: number }>>(new Map())
   const {
     classDays,
     error: classDaysError,
@@ -143,6 +143,7 @@ export function TeacherLessonCalendarTab({
     sourceRequestIdsRef.current.announcements += 1
     lessonEditGenerationRef.current = 0
     lessonEditsRef.current.clear()
+    retryingSourcesRef.current.clear()
     setSourceStatus(initialSourceStatus())
   }, [classroom.id])
 
@@ -207,7 +208,10 @@ export function TeacherLessonCalendarTab({
     const requestedClassroomId = classroom.id
 
     async function loadLessonPlans() {
-      const editGenerationAtRequestStart = lessonEditGenerationRef.current
+      const acknowledgedEditsAtRequestStart = new Map<string, number>()
+      for (const [date, edit] of lessonEditsRef.current) {
+        if (edit.acknowledged) acknowledgedEditsAtRequestStart.set(date, edit.generation)
+      }
       const requestId = sourceRequestIdsRef.current.lessonPlans + 1
       sourceRequestIdsRef.current.lessonPlans = requestId
       const isCurrentLoad = () => (
@@ -229,11 +233,13 @@ export function TeacherLessonCalendarTab({
         const plans = await fetchTeacherLessonPlansForRange(requestedClassroomId, fetchRange.start, fetchRange.end)
         if (!isCurrentLoad()) return
         const plansWithPending = applyPendingLessonPlanChanges(plans, pendingChangesRef.current, requestedClassroomId)
-        const editsSinceRequest = new Map<string, string>()
+        const editsToPreserve = new Map<string, string>()
         for (const [date, edit] of lessonEditsRef.current) {
-          if (edit.generation > editGenerationAtRequestStart) editsSinceRequest.set(date, edit.content)
+          if (acknowledgedEditsAtRequestStart.get(date) !== edit.generation) {
+            editsToPreserve.set(date, edit.content)
+          }
         }
-        const plansWithCurrentEdits = applyPendingLessonPlanChanges(plansWithPending, editsSinceRequest, requestedClassroomId)
+        const plansWithCurrentEdits = applyPendingLessonPlanChanges(plansWithPending, editsToPreserve, requestedClassroomId)
         // Seed last-seen content so Tiptap normalization doesn't trigger saves.
         // Local edits remain authoritative while a background refresh settles.
         lastSeenContentRef.current.clear()
@@ -242,6 +248,12 @@ export function TeacherLessonCalendarTab({
         }
         setLessonPlansClassroomId(requestedClassroomId)
         setLessonPlans(plansWithCurrentEdits)
+        for (const [date, generation] of acknowledgedEditsAtRequestStart) {
+          const currentEdit = lessonEditsRef.current.get(date)
+          if (currentEdit?.generation === generation && currentEdit.acknowledged) {
+            lessonEditsRef.current.delete(date)
+          }
+        }
         setSourceStatus((current) => ({
           ...current,
           lessonPlans: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
@@ -380,7 +392,7 @@ export function TeacherLessonCalendarTab({
 
   // Save a single lesson plan
   const saveLessonPlan = useCallback(
-    async (date: string, contentMarkdown: string) => {
+    async (date: string, contentMarkdown: string, editGeneration?: number) => {
       const requestedClassroomId = classroom.id
       try {
         const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/lesson-plans/${date}`, {
@@ -393,6 +405,11 @@ export function TeacherLessonCalendarTab({
           invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
           needsRefreshRef.current = true
           if (currentClassroomIdRef.current !== requestedClassroomId) return
+          const currentEdit = lessonEditsRef.current.get(date)
+          if (editGeneration !== undefined) {
+            if (currentEdit?.generation !== editGeneration || currentEdit.content !== contentMarkdown) return
+            currentEdit.acknowledged = true
+          }
           setLessonPlansClassroomId(requestedClassroomId)
           setLessonPlans((prev) => {
             if (!data.lesson_plan) {
@@ -420,10 +437,14 @@ export function TeacherLessonCalendarTab({
     if (pendingChangesRef.current.size === 0) return
 
     setSaving(true)
-    const entries = Array.from(pendingChangesRef.current.entries())
+    const entries = Array.from(pendingChangesRef.current.entries()).map(([date, content]) => ({
+      content,
+      date,
+      editGeneration: lessonEditsRef.current.get(date)?.generation,
+    }))
     pendingChangesRef.current.clear()
 
-    await Promise.all(entries.map(([date, content]) => saveLessonPlan(date, content)))
+    await Promise.all(entries.map(({ content, date, editGeneration }) => saveLessonPlan(date, content, editGeneration)))
     lastSaveAtRef.current = Date.now()
     setSaving(false)
   }, [saveLessonPlan])
@@ -454,6 +475,7 @@ export function TeacherLessonCalendarTab({
       lastSeenContentRef.current.set(date, contentStr)
       lessonEditGenerationRef.current += 1
       lessonEditsRef.current.set(date, {
+        acknowledged: false,
         content: contentMarkdown,
         generation: lessonEditGenerationRef.current,
       })

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -21,6 +21,7 @@ import {
   fetchTeacherLessonPlansForRange,
   invalidateTeacherLessonPlansForClassroom,
 } from '@/lib/teacher-lesson-plans-client'
+import { enqueueTeacherLessonPlanMutation } from '@/lib/teacher-lesson-plan-mutation-queue'
 import { Button, PageState, RefreshingIndicator } from '@/ui'
 
 /**
@@ -41,7 +42,32 @@ export function isNormalizationNoise(
 
 const AUTOSAVE_DEBOUNCE_MS = 3000
 const AUTOSAVE_MIN_INTERVAL_MS = 10000
+const AUTOSAVE_MAX_RETRIES = 3
 const MARKDOWN_SYNC_DEBOUNCE_MS = 300
+
+type PendingLessonSave = {
+  classroomId: string
+  content: string
+  date: string
+  editGeneration?: number
+  retries: number
+  saveEpoch: number
+}
+
+function pendingLessonSaveKey(classroomId: string, date: string): string {
+  return `${classroomId}:${date}`
+}
+
+function pendingLessonChangesForClassroom(
+  pendingSaves: Map<string, PendingLessonSave>,
+  classroomId: string,
+): Map<string, string> {
+  return new Map(
+    Array.from(pendingSaves.values())
+      .filter((save) => save.classroomId === classroomId)
+      .map((save) => [save.date, save.content]),
+  )
+}
 
 type CalendarSource = 'lessonPlans' | 'assignments' | 'announcements'
 type CalendarRetrySource = CalendarSource | 'classDays'
@@ -63,7 +89,7 @@ export interface CalendarSidebarState {
   markdownError: string | null
   bulkSaving: boolean
   onMarkdownChange: (content: string) => void
-  onSave: () => void
+  onSave: () => Promise<void>
 }
 
 interface Props {
@@ -150,9 +176,9 @@ export function TeacherLessonCalendarTab({
   }, [classroom.id])
 
   // Auto-save tracking
-  const pendingChangesRef = useRef<Map<string, string>>(new Map())
-  const pendingChangeEpochsRef = useRef<Map<string, number>>(new Map())
+  const pendingSavesRef = useRef<Map<string, PendingLessonSave>>(new Map())
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const flushInFlightRef = useRef<Promise<void> | null>(null)
   const lastSaveAtRef = useRef<number>(0)
   const prevSidebarOpenRef = useRef(false)
   const needsRefreshRef = useRef(true) // Force refresh on first open or after save
@@ -235,7 +261,11 @@ export function TeacherLessonCalendarTab({
       try {
         const plans = await fetchTeacherLessonPlansForRange(requestedClassroomId, fetchRange.start, fetchRange.end)
         if (!isCurrentLoad()) return
-        const plansWithPending = applyPendingLessonPlanChanges(plans, pendingChangesRef.current, requestedClassroomId)
+        const plansWithPending = applyPendingLessonPlanChanges(
+          plans,
+          pendingLessonChangesForClassroom(pendingSavesRef.current, requestedClassroomId),
+          requestedClassroomId,
+        )
         const editsToPreserve = new Map<string, string>()
         for (const [date, edit] of lessonEditsRef.current) {
           if (acknowledgedEditsAtRequestStart.get(date) !== edit.generation) {
@@ -395,66 +425,92 @@ export function TeacherLessonCalendarTab({
 
   // Save a single lesson plan
   const saveLessonPlan = useCallback(
-    async (date: string, contentMarkdown: string, saveEpoch: number, editGeneration?: number) => {
-      const requestedClassroomId = classroom.id
-      try {
+    async (
+      requestedClassroomId: string,
+      date: string,
+      contentMarkdown: string,
+      saveEpoch: number,
+      editGeneration?: number,
+      options?: { keepalive?: boolean; updateView?: boolean },
+    ) => {
+      return enqueueTeacherLessonPlanMutation(requestedClassroomId, async () => {
         const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/lesson-plans/${date}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ content_markdown: contentMarkdown }),
+          keepalive: options?.keepalive,
         })
-        if (res.ok) {
-          const data = await res.json()
-          invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
-          if (classroomEpochRef.current !== saveEpoch) return
-          needsRefreshRef.current = true
-          if (currentClassroomIdRef.current !== requestedClassroomId) return
-          const currentEdit = lessonEditsRef.current.get(date)
-          if (editGeneration !== undefined) {
-            if (currentEdit?.generation !== editGeneration || currentEdit.content !== contentMarkdown) return
-            currentEdit.acknowledged = true
-          }
-          setLessonPlansClassroomId(requestedClassroomId)
-          setLessonPlans((prev) => {
-            if (!data.lesson_plan) {
-              return prev.filter((plan) => plan.date !== date)
-            }
-
-            const existing = prev.findIndex((p) => p.date === date)
-            if (existing >= 0) {
-              const updated = [...prev]
-              updated[existing] = data.lesson_plan
-              return updated
-            }
-            return [...prev, data.lesson_plan]
-          })
+        if (!res.ok) {
+          throw new Error(`Failed to save lesson plan (${res.status})`)
         }
-      } catch (err) {
-        console.error('Error saving lesson plan:', err)
-      }
+
+        const data = await res.json()
+        invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
+        if (options?.updateView === false || classroomEpochRef.current !== saveEpoch) return
+        needsRefreshRef.current = true
+        if (currentClassroomIdRef.current !== requestedClassroomId) return
+        const currentEdit = lessonEditsRef.current.get(date)
+        if (editGeneration !== undefined) {
+          if (currentEdit?.generation !== editGeneration || currentEdit.content !== contentMarkdown) return
+          currentEdit.acknowledged = true
+        }
+        setLessonPlansClassroomId(requestedClassroomId)
+        setLessonPlans((prev) => {
+          if (!data.lesson_plan) {
+            return prev.filter((plan) => plan.date !== date)
+          }
+
+          const existing = prev.findIndex((p) => p.date === date)
+          if (existing >= 0) {
+            const updated = [...prev]
+            updated[existing] = data.lesson_plan
+            return updated
+          }
+          return [...prev, data.lesson_plan]
+        })
+      })
     },
-    [classroom.id]
+    []
   )
 
   // Flush pending saves
   const flushPendingSaves = useCallback(async () => {
-    if (pendingChangesRef.current.size === 0) return
+    if (flushInFlightRef.current) return flushInFlightRef.current
+    if (pendingSavesRef.current.size === 0) return
 
-    setSaving(true)
-    const entries = Array.from(pendingChangesRef.current.entries()).map(([date, content]) => ({
-      content,
-      date,
-      editGeneration: lessonEditsRef.current.get(date)?.generation,
-      saveEpoch: pendingChangeEpochsRef.current.get(date) ?? -1,
-    }))
-    pendingChangesRef.current.clear()
-    pendingChangeEpochsRef.current.clear()
+    const flush = async () => {
+      setSaving(true)
+      const entries = Array.from(pendingSavesRef.current.entries())
+      for (const [key] of entries) pendingSavesRef.current.delete(key)
 
-    await Promise.all(entries.map(({ content, date, editGeneration, saveEpoch }) => (
-      saveLessonPlan(date, content, saveEpoch, editGeneration)
-    )))
-    lastSaveAtRef.current = Date.now()
-    setSaving(false)
+      await Promise.all(entries.map(async ([key, entry]) => {
+        const { classroomId, content, date, editGeneration, retries, saveEpoch } = entry
+        try {
+          await saveLessonPlan(classroomId, date, content, saveEpoch, editGeneration)
+        } catch (err) {
+          console.error('Error saving lesson plan:', err)
+          if (!pendingSavesRef.current.has(key)) {
+            pendingSavesRef.current.set(key, { ...entry, retries: retries + 1 })
+          }
+        }
+      }))
+      lastSaveAtRef.current = Date.now()
+      setSaving(false)
+    }
+
+    const flushPromise = flush().finally(() => {
+      flushInFlightRef.current = null
+      const hasRetryableSave = Array.from(pendingSavesRef.current.values())
+        .some((save) => save.retries <= AUTOSAVE_MAX_RETRIES)
+      if (hasRetryableSave) {
+        if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = setTimeout(() => {
+          void flushPendingSaves()
+        }, AUTOSAVE_MIN_INTERVAL_MS)
+      }
+    })
+    flushInFlightRef.current = flushPromise
+    return flushPromise
   }, [saveLessonPlan])
 
   // Schedule save with debounce and throttle
@@ -467,7 +523,7 @@ export function TeacherLessonCalendarTab({
     const delay = Math.max(AUTOSAVE_DEBOUNCE_MS, AUTOSAVE_MIN_INTERVAL_MS - timeSinceLastSave)
 
     saveTimeoutRef.current = setTimeout(() => {
-      flushPendingSaves()
+      void flushPendingSaves()
     }, delay)
   }, [flushPendingSaves])
 
@@ -488,35 +544,40 @@ export function TeacherLessonCalendarTab({
         generation: lessonEditGenerationRef.current,
       })
       applyLocalLessonPlanChange(date, contentMarkdown)
-      pendingChangesRef.current.set(date, contentMarkdown)
-      pendingChangeEpochsRef.current.set(date, classroomEpochRef.current)
+      pendingSavesRef.current.set(pendingLessonSaveKey(classroom.id, date), {
+        classroomId: classroom.id,
+        content: contentMarkdown,
+        date,
+        editGeneration: lessonEditGenerationRef.current,
+        retries: 0,
+        saveEpoch: classroomEpochRef.current,
+      })
       scheduleSave()
     },
-    [applyLocalLessonPlanChange, lessonPlansStatus.hasLoadedSnapshot, scheduleSave]
+    [applyLocalLessonPlanChange, classroom.id, lessonPlansStatus.hasLoadedSnapshot, scheduleSave]
   )
 
   // Flush on unmount and handle page close
   useEffect(() => {
     const handleBeforeUnload = () => {
-      // Synchronously save any pending changes before page unload
-      if (pendingChangesRef.current.size > 0) {
-        const entries = Array.from(pendingChangesRef.current.entries())
-        for (const [date, contentMarkdown] of entries) {
-          // Use sendBeacon for reliable delivery during page unload
-          navigator.sendBeacon(
-            `/api/teacher/classrooms/${classroom.id}/lesson-plans/${date}`,
-            new Blob([JSON.stringify({ content_markdown: contentMarkdown })], { type: 'application/json' })
-          )
+      if (pendingSavesRef.current.size > 0) {
+        const entries = Array.from(pendingSavesRef.current.entries())
+        for (const [key, { classroomId, content, date, editGeneration, saveEpoch }] of entries) {
+          void saveLessonPlan(classroomId, date, content, saveEpoch, editGeneration, {
+            keepalive: true,
+            updateView: false,
+          }).catch((err) => {
+            console.error('Error saving lesson plan during page unload:', err)
+          })
+          pendingSavesRef.current.delete(key)
         }
-        pendingChangesRef.current.clear()
-        pendingChangeEpochsRef.current.clear()
       }
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
 
     // Capture ref value for cleanup
-    const pendingChanges = pendingChangesRef.current
+    const pendingSaves = pendingSavesRef.current
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
@@ -528,11 +589,11 @@ export function TeacherLessonCalendarTab({
       }
       // Flush any pending changes on component unmount (e.g., navigation)
       // The fetch will complete even after unmount
-      if (pendingChanges.size > 0) {
-        flushPendingSaves()
+      if (pendingSaves.size > 0) {
+        void flushPendingSaves()
       }
     }
-  }, [classroom.id, flushPendingSaves])
+  }, [classroom.id, flushPendingSaves, saveLessonPlan])
 
   // Fetch and generate markdown content
   const loadMarkdownContent = useCallback(async () => {
@@ -546,7 +607,11 @@ export function TeacherLessonCalendarTab({
       const end = classroom.end_date || fetchRange.end
       const cachedPlans = await fetchTeacherLessonPlansForRange(requestedClassroomId, start, end)
       if (!isCurrentLoad()) return
-      const plans = applyPendingLessonPlanChanges(cachedPlans, pendingChangesRef.current, requestedClassroomId)
+      const plans = applyPendingLessonPlanChanges(
+        cachedPlans,
+        pendingLessonChangesForClassroom(pendingSavesRef.current, requestedClassroomId),
+        requestedClassroomId,
+      )
       const markdown = lessonPlansToMarkdown(classroom, plans, start, end)
       setMarkdownContentClassroomId(requestedClassroomId)
       setMarkdownContent(markdown)
@@ -640,12 +705,20 @@ export function TeacherLessonCalendarTab({
         return
       }
 
-      // Bulk save
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/lesson-plans/bulk`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plans: result.plans, cleared_dates: result.clearedDates }),
-      })
+      await flushPendingSaves()
+      const hasPendingInlineSave = Array.from(pendingSavesRef.current.values())
+        .some((save) => save.classroomId === classroom.id)
+      if (hasPendingInlineSave) {
+        setMarkdownError('Pending calendar edits could not be saved. Try again.')
+        return
+      }
+      const res = await enqueueTeacherLessonPlanMutation(classroom.id, () => (
+        fetch(`/api/teacher/classrooms/${classroom.id}/lesson-plans/bulk`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plans: result.plans, cleared_dates: result.clearedDates }),
+        })
+      ))
 
       if (!res.ok) {
         const data = await res.json()
@@ -665,7 +738,7 @@ export function TeacherLessonCalendarTab({
     } finally {
       setBulkSaving(false)
     }
-  }, [classroom, markdownContentClassroomId, setSidebarOpen])
+  }, [classroom, flushPendingSaves, markdownContentClassroomId, setSidebarOpen])
 
   // Handle assignment click - navigate to assignments tab with assignment selected
   const handleAssignmentClick = useCallback(

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -21,7 +21,11 @@ import {
   fetchTeacherLessonPlansForRange,
   invalidateTeacherLessonPlansForClassroom,
 } from '@/lib/teacher-lesson-plans-client'
-import { enqueueTeacherLessonPlanMutation } from '@/lib/teacher-lesson-plan-mutation-queue'
+import {
+  allocateTeacherLessonPlanMutationVersion,
+  enqueueTeacherLessonPlanMutation,
+  type TeacherLessonPlanMutationVersion,
+} from '@/lib/teacher-lesson-plan-mutation-queue'
 import { Button, PageState, RefreshingIndicator } from '@/ui'
 
 /**
@@ -52,6 +56,13 @@ type PendingLessonSave = {
   editGeneration?: number
   retries: number
   saveEpoch: number
+  mutation: TeacherLessonPlanMutationVersion
+}
+
+type PendingBulkLessonSave = {
+  body: string
+  classroomId: string
+  mutation: TeacherLessonPlanMutationVersion
 }
 
 function pendingLessonSaveKey(classroomId: string, date: string): string {
@@ -147,6 +158,7 @@ export function TeacherLessonCalendarTab({
   const visibleMarkdownContent = markdownContentClassroomId === classroom.id ? markdownContent : ''
   const [markdownError, setMarkdownError] = useState<string | null>(null)
   const [bulkSaving, setBulkSaving] = useState(false)
+  const [failedSaveClassroomIds, setFailedSaveClassroomIds] = useState<Set<string>>(() => new Set())
   const [refreshKey, setRefreshKey] = useState(0)
   const [assignmentsRefreshKey, setAssignmentsRefreshKey] = useState(0)
   const [announcementsRefreshKey, setAnnouncementsRefreshKey] = useState(0)
@@ -172,17 +184,21 @@ export function TeacherLessonCalendarTab({
     lessonEditGenerationRef.current = 0
     lessonEditsRef.current.clear()
     retryingSourcesRef.current.clear()
+    setBulkSaving(false)
     setSourceStatus(initialSourceStatus())
   }, [classroom.id])
 
   // Auto-save tracking
   const pendingSavesRef = useRef<Map<string, PendingLessonSave>>(new Map())
+  const pendingBulkSavesRef = useRef<Map<string, PendingBulkLessonSave>>(new Map())
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const flushInFlightRef = useRef<Promise<void> | null>(null)
   const lastSaveAtRef = useRef<number>(0)
   const prevSidebarOpenRef = useRef(false)
   const needsRefreshRef = useRef(true) // Force refresh on first open or after save
   const markdownContentRef = useRef('') // Ref to avoid stale closure in save handler
+  const markdownDraftsRef = useRef<Map<string, string>>(new Map())
+  const markdownErrorsRef = useRef<Map<string, string>>(new Map())
   const markdownSyncTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const applyLocalLessonPlanChange = useCallback((date: string, contentMarkdown: string) => {
@@ -431,14 +447,16 @@ export function TeacherLessonCalendarTab({
       contentMarkdown: string,
       saveEpoch: number,
       editGeneration?: number,
-      options?: { keepalive?: boolean; updateView?: boolean },
+      mutation?: TeacherLessonPlanMutationVersion,
+      options?: { updateView?: boolean },
     ) => {
+      const mutationVersion = mutation ?? allocateTeacherLessonPlanMutationVersion()
       return enqueueTeacherLessonPlanMutation(requestedClassroomId, async () => {
         const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/lesson-plans/${date}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content_markdown: contentMarkdown }),
-          keepalive: options?.keepalive,
+          body: JSON.stringify({ content_markdown: contentMarkdown, mutation: mutationVersion }),
+          keepalive: true,
         })
         if (!res.ok) {
           throw new Error(`Failed to save lesson plan (${res.status})`)
@@ -483,10 +501,11 @@ export function TeacherLessonCalendarTab({
       const entries = Array.from(pendingSavesRef.current.entries())
       for (const [key] of entries) pendingSavesRef.current.delete(key)
 
+      const touchedClassroomIds = new Set(entries.map(([, entry]) => entry.classroomId))
       await Promise.all(entries.map(async ([key, entry]) => {
-        const { classroomId, content, date, editGeneration, retries, saveEpoch } = entry
+        const { classroomId, content, date, editGeneration, mutation, retries, saveEpoch } = entry
         try {
-          await saveLessonPlan(classroomId, date, content, saveEpoch, editGeneration)
+          await saveLessonPlan(classroomId, date, content, saveEpoch, editGeneration, mutation)
         } catch (err) {
           console.error('Error saving lesson plan:', err)
           if (!pendingSavesRef.current.has(key)) {
@@ -494,6 +513,17 @@ export function TeacherLessonCalendarTab({
           }
         }
       }))
+      setFailedSaveClassroomIds((current) => {
+        const next = new Set(current)
+        for (const classroomId of touchedClassroomIds) {
+          const exhausted = Array.from(pendingSavesRef.current.values()).some((save) => (
+            save.classroomId === classroomId && save.retries > AUTOSAVE_MAX_RETRIES
+          ))
+          if (exhausted) next.add(classroomId)
+          else next.delete(classroomId)
+        }
+        return next
+      })
       lastSaveAtRef.current = Date.now()
       setSaving(false)
     }
@@ -551,6 +581,7 @@ export function TeacherLessonCalendarTab({
         editGeneration: lessonEditGenerationRef.current,
         retries: 0,
         saveEpoch: classroomEpochRef.current,
+        mutation: allocateTeacherLessonPlanMutationVersion(),
       })
       scheduleSave()
     },
@@ -562,15 +593,27 @@ export function TeacherLessonCalendarTab({
     const handleBeforeUnload = () => {
       if (pendingSavesRef.current.size > 0) {
         const entries = Array.from(pendingSavesRef.current.entries())
-        for (const [key, { classroomId, content, date, editGeneration, saveEpoch }] of entries) {
-          void saveLessonPlan(classroomId, date, content, saveEpoch, editGeneration, {
+        for (const [key, { classroomId, content, date, mutation }] of entries) {
+          void fetch(`/api/teacher/classrooms/${classroomId}/lesson-plans/${date}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content_markdown: content, mutation }),
             keepalive: true,
-            updateView: false,
           }).catch((err) => {
             console.error('Error saving lesson plan during page unload:', err)
           })
           pendingSavesRef.current.delete(key)
         }
+      }
+      for (const { body, classroomId } of pendingBulkSavesRef.current.values()) {
+        void fetch(`/api/teacher/classrooms/${classroomId}/lesson-plans/bulk`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          keepalive: true,
+        }).catch((err) => {
+          console.error('Error saving bulk lesson plans during page unload:', err)
+        })
       }
     }
 
@@ -632,12 +675,14 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     if (previousMarkdownClassroomIdRef.current === classroom.id) return
     previousMarkdownClassroomIdRef.current = classroom.id
-    markdownContentRef.current = ''
-    setMarkdownContent('')
-    setMarkdownContentClassroomId('')
-    setMarkdownError(null)
+    const retainedDraft = markdownDraftsRef.current.get(classroom.id)
+    const retainedError = markdownErrorsRef.current.get(classroom.id) ?? null
+    markdownContentRef.current = retainedDraft ?? ''
+    setMarkdownContent(retainedDraft ?? '')
+    setMarkdownContentClassroomId(retainedDraft === undefined ? '' : classroom.id)
+    setMarkdownError(retainedError)
     needsRefreshRef.current = true
-    if (showMarkdown && isSidebarOpen) {
+    if (retainedDraft === undefined && showMarkdown && isSidebarOpen) {
       loadMarkdownContent()
     }
   }, [classroom.id, isSidebarOpen, loadMarkdownContent, showMarkdown])
@@ -652,6 +697,8 @@ export function TeacherLessonCalendarTab({
   const handleMarkdownChange = useCallback((content: string) => {
     // Always update ref immediately so save has latest content
     markdownContentRef.current = content
+    markdownDraftsRef.current.set(classroom.id, content)
+    markdownErrorsRef.current.delete(classroom.id)
     setMarkdownContentClassroomId(classroom.id)
 
     // Debounce state update to reduce parent re-renders
@@ -681,62 +728,116 @@ export function TeacherLessonCalendarTab({
 
   // Handle markdown save
   const handleMarkdownSave = useCallback(async () => {
+    const requestedClassroomId = classroom.id
+    const requestedClassroomEpoch = classroomEpochRef.current
+    const markdownPayload = markdownContentRef.current
+    const mutation = allocateTeacherLessonPlanMutationVersion()
+    const bulkMutationKey = `${mutation.client_id}:${mutation.sequence}`
+    const isCurrentOperation = () => (
+      currentClassroomIdRef.current === requestedClassroomId &&
+      classroomEpochRef.current === requestedClassroomEpoch
+    )
     setMarkdownError(null)
+    markdownErrorsRef.current.delete(requestedClassroomId)
     if (markdownContentClassroomId !== classroom.id) {
       setMarkdownError('Lesson plans are still loading')
       return
     }
+    markdownDraftsRef.current.set(requestedClassroomId, markdownPayload)
     setBulkSaving(true)
 
     try {
-      const result = markdownToLessonPlans(markdownContentRef.current, classroom)
+      const result = markdownToLessonPlans(markdownPayload, classroom)
 
       if (result.errors.length > 0) {
-        setMarkdownError(result.errors.join('\n'))
+        const error = result.errors.join('\n')
+        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+          markdownErrorsRef.current.set(requestedClassroomId, error)
+          if (isCurrentOperation()) setMarkdownError(error)
+        }
         setBulkSaving(false)
         return
       }
 
       if (result.plans.length === 0 && result.clearedDates.length === 0) {
-        invalidateTeacherLessonPlansForClassroom(classroom.id)
+        markdownDraftsRef.current.delete(requestedClassroomId)
+        markdownErrorsRef.current.delete(requestedClassroomId)
+        invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
+        if (!isCurrentOperation()) return
         needsRefreshRef.current = true
         setSidebarOpen(false)
         setRefreshKey((k) => k + 1)
         return
       }
 
+      const bulkBody = JSON.stringify({
+        plans: result.plans,
+        cleared_dates: result.clearedDates,
+        mutation,
+      })
+      pendingBulkSavesRef.current.set(bulkMutationKey, {
+        body: bulkBody,
+        classroomId: requestedClassroomId,
+        mutation,
+      })
+
       await flushPendingSaves()
       const hasPendingInlineSave = Array.from(pendingSavesRef.current.values())
         .some((save) => save.classroomId === classroom.id)
       if (hasPendingInlineSave) {
-        setMarkdownError('Pending calendar edits could not be saved. Try again.')
+        const error = 'Pending calendar edits could not be saved. Try again.'
+        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+          markdownErrorsRef.current.set(requestedClassroomId, error)
+          if (isCurrentOperation()) setMarkdownError(error)
+        }
         return
       }
       const res = await enqueueTeacherLessonPlanMutation(classroom.id, () => (
         fetch(`/api/teacher/classrooms/${classroom.id}/lesson-plans/bulk`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ plans: result.plans, cleared_dates: result.clearedDates }),
+          body: bulkBody,
+          keepalive: true,
         })
       ))
 
       if (!res.ok) {
         const data = await res.json()
-        setMarkdownError(data.error || 'Failed to save')
-        setBulkSaving(false)
+        const error = data.error || 'Failed to save'
+        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+          markdownErrorsRef.current.set(requestedClassroomId, error)
+          if (isCurrentOperation()) setMarkdownError(error)
+        }
         return
       }
 
-      // Success - close panel and refresh calendar
-      invalidateTeacherLessonPlansForClassroom(classroom.id)
+      if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+        markdownDraftsRef.current.delete(requestedClassroomId)
+        markdownErrorsRef.current.delete(requestedClassroomId)
+      }
+      for (const [key, pending] of pendingBulkSavesRef.current) {
+        if (
+          pending.classroomId === requestedClassroomId &&
+          pending.mutation.client_id === mutation.client_id &&
+          pending.mutation.sequence <= mutation.sequence
+        ) {
+          pendingBulkSavesRef.current.delete(key)
+        }
+      }
+      invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
+      if (!isCurrentOperation()) return
       needsRefreshRef.current = true // Force refresh on next sidebar open
       setSidebarOpen(false)
       setRefreshKey((k) => k + 1)
     } catch (err) {
       console.error('Error saving markdown:', err)
-      setMarkdownError('Failed to save lesson plans')
+      const error = 'Failed to save lesson plans'
+      if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+        markdownErrorsRef.current.set(requestedClassroomId, error)
+        if (isCurrentOperation()) setMarkdownError(error)
+      }
     } finally {
-      setBulkSaving(false)
+      if (isCurrentOperation()) setBulkSaving(false)
     }
   }, [classroom, flushPendingSaves, markdownContentClassroomId, setSidebarOpen])
 
@@ -822,6 +923,20 @@ export function TeacherLessonCalendarTab({
     void refreshClassDays()
   }, [refreshClassDays])
 
+  const retryFailedSaves = useCallback(() => {
+    for (const [key, save] of pendingSavesRef.current) {
+      if (save.classroomId === classroom.id) {
+        pendingSavesRef.current.set(key, { ...save, retries: 0 })
+      }
+    }
+    setFailedSaveClassroomIds((current) => {
+      const next = new Set(current)
+      next.delete(classroom.id)
+      return next
+    })
+    void flushPendingSaves()
+  }, [classroom.id, flushPendingSaves])
+
   const localStatuses = [lessonPlansStatus, assignmentsStatus, announcementsStatus]
   const hasAnyLocalSnapshot = localStatuses.some((status) => (
     status.classroomId === classroom.id && status.hasLoadedSnapshot
@@ -849,6 +964,9 @@ export function TeacherLessonCalendarTab({
   }, [announcementsStatus, assignmentsStatus, classDaysError, classDaysLoading, lessonPlansStatus])
 
   const failures: CalendarSourceFailure[] = []
+  const saveFailures: CalendarSourceFailure[] = failedSaveClassroomIds.has(classroom.id)
+    ? [{ id: 'lesson-plan-saves', label: 'lesson plan changes', isRetrying: saving, onRetry: retryFailedSaves }]
+    : []
   if (lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.error) {
     failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: retryLessonPlans })
   }
@@ -928,6 +1046,10 @@ export function TeacherLessonCalendarTab({
         <div ref={calendarWorkspaceRef} role="region" aria-label="Calendar workspace" tabIndex={-1} className="outline-none">
           {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
           <CalendarSourceErrors failures={failures} />
+          <CalendarSourceErrors
+            failures={saveFailures}
+            message="Some lesson plan changes could not be saved."
+          />
           <div className="overflow-hidden rounded-lg border border-border bg-surface">
             <LessonCalendar
               classroom={classroom}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -1,25 +1,27 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, subMonths, subWeeks } from 'date-fns'
 import { CalendarActionBar } from '@/components/CalendarActionBar'
-import { Spinner } from '@/components/Spinner'
+import { CalendarSourceErrors, type CalendarSourceFailure } from '@/components/CalendarSourceErrors'
 import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useRightSidebar } from '@/components/layout'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { applyPendingLessonPlanChanges, lessonPlansToMarkdown, markdownToLessonPlans } from '@/lib/lesson-plan-markdown'
-import { useClassDays } from '@/hooks/useClassDays'
+import { useClassDaysContext } from '@/hooks/useClassDays'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
 import { normalizeLessonPlanMarkdown } from '@/lib/lesson-plan-content'
+import { nowInToronto } from '@/lib/timezone'
 import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import {
   fetchTeacherLessonPlansForRange,
   invalidateTeacherLessonPlansForClassroom,
 } from '@/lib/teacher-lesson-plans-client'
+import { Button, PageState, RefreshingIndicator } from '@/ui'
 
 /**
  * Returns true if the content change is identical to the last value emitted
@@ -40,6 +42,20 @@ export function isNormalizationNoise(
 const AUTOSAVE_DEBOUNCE_MS = 3000
 const AUTOSAVE_MIN_INTERVAL_MS = 10000
 const MARKDOWN_SYNC_DEBOUNCE_MS = 300
+
+type CalendarSource = 'lessonPlans' | 'assignments' | 'announcements'
+type SourceStatus = {
+  classroomId: string | null
+  error: boolean
+  hasLoadedSnapshot: boolean
+  isLoading: boolean
+}
+
+const initialSourceStatus = (): Record<CalendarSource, SourceStatus> => ({
+  lessonPlans: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+  assignments: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+  announcements: { classroomId: null, error: false, hasLoadedSnapshot: false, isLoading: true },
+})
 
 export interface CalendarSidebarState {
   markdownContent: string
@@ -64,18 +80,28 @@ export function TeacherLessonCalendarTab({
 }: Props) {
   const [lessonPlans, setLessonPlans] = useState<LessonPlan[]>([])
   const [lessonPlansClassroomId, setLessonPlansClassroomId] = useState(classroom.id)
-  const visibleLessonPlans = lessonPlansClassroomId === classroom.id ? lessonPlans : []
-  const lessonPlansRef = useRef(visibleLessonPlans)
-  lessonPlansRef.current = visibleLessonPlans
   // Track last-seen markdown per date to suppress duplicate autosave emissions.
   const lastSeenContentRef = useRef<Map<string, string>>(new Map())
   const [assignments, setAssignments] = useState<Assignment[]>([])
   const [assignmentsClassroomId, setAssignmentsClassroomId] = useState(classroom.id)
-  const visibleAssignments = assignmentsClassroomId === classroom.id ? assignments : []
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [announcementsClassroomId, setAnnouncementsClassroomId] = useState(classroom.id)
-  const visibleAnnouncements = announcementsClassroomId === classroom.id ? announcements : []
-  const classDays = useClassDays(classroom.id)
+  const [sourceStatus, setSourceStatus] = useState(initialSourceStatus)
+  const lessonPlansStatus = sourceStatus.lessonPlans
+  const assignmentsStatus = sourceStatus.assignments
+  const announcementsStatus = sourceStatus.announcements
+  const visibleLessonPlans = lessonPlansClassroomId === classroom.id && lessonPlansStatus.hasLoadedSnapshot ? lessonPlans : []
+  const visibleAssignments = assignmentsClassroomId === classroom.id && assignmentsStatus.hasLoadedSnapshot ? assignments : []
+  const visibleAnnouncements = announcementsClassroomId === classroom.id && announcementsStatus.hasLoadedSnapshot ? announcements : []
+  const lessonPlansRef = useRef(visibleLessonPlans)
+  lessonPlansRef.current = visibleLessonPlans
+  const {
+    classDays,
+    error: classDaysError,
+    hasLoadedSnapshot: hasClassDaysSnapshot,
+    isLoading: classDaysLoading,
+    refresh: refreshClassDays,
+  } = useClassDaysContext()
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [viewMode, setViewMode] = useState<CalendarViewMode>(() => {
@@ -86,18 +112,32 @@ export function TeacherLessonCalendarTab({
     setViewMode(mode)
     writeCookie(`calendarViewMode:${classroom.id}`, mode)
   }, [classroom.id])
-  const [currentDate, setCurrentDate] = useState(new Date())
+  const [currentDate, setCurrentDate] = useState(nowInToronto)
   const [markdownContent, setMarkdownContent] = useState('')
   const [markdownContentClassroomId, setMarkdownContentClassroomId] = useState('')
   const visibleMarkdownContent = markdownContentClassroomId === classroom.id ? markdownContent : ''
   const [markdownError, setMarkdownError] = useState<string | null>(null)
   const [bulkSaving, setBulkSaving] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [assignmentsRefreshKey, setAssignmentsRefreshKey] = useState(0)
+  const [announcementsRefreshKey, setAnnouncementsRefreshKey] = useState(0)
   const currentClassroomIdRef = useRef(classroom.id)
-  currentClassroomIdRef.current = classroom.id
+  const sourceRequestIdsRef = useRef<Record<CalendarSource, number>>({
+    lessonPlans: 0,
+    assignments: 0,
+    announcements: 0,
+  })
 
   const { toggle: toggleSidebar, isOpen: isSidebarOpen, setOpen: setSidebarOpen } = useRightSidebar()
   const { showMarkdown } = useMarkdownPreference()
+
+  useLayoutEffect(() => {
+    currentClassroomIdRef.current = classroom.id
+    sourceRequestIdsRef.current.lessonPlans += 1
+    sourceRequestIdsRef.current.assignments += 1
+    sourceRequestIdsRef.current.announcements += 1
+    setSourceStatus(initialSourceStatus())
+  }, [classroom.id])
 
   // Auto-save tracking
   const pendingChangesRef = useRef<Map<string, string>>(new Map())
@@ -158,10 +198,25 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     let cancelled = false
     const requestedClassroomId = classroom.id
-    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
 
     async function loadLessonPlans() {
+      const requestId = sourceRequestIdsRef.current.lessonPlans + 1
+      sourceRequestIdsRef.current.lessonPlans = requestId
+      const isCurrentLoad = () => (
+        !cancelled &&
+        sourceRequestIdsRef.current.lessonPlans === requestId &&
+        currentClassroomIdRef.current === requestedClassroomId
+      )
       setLoading(true)
+      setSourceStatus((current) => ({
+        ...current,
+        lessonPlans: {
+          classroomId: requestedClassroomId,
+          error: false,
+          hasLoadedSnapshot: current.lessonPlans.classroomId === requestedClassroomId && current.lessonPlans.hasLoadedSnapshot,
+          isLoading: true,
+        },
+      }))
       try {
         const plans = await fetchTeacherLessonPlansForRange(requestedClassroomId, fetchRange.start, fetchRange.end)
         if (!isCurrentLoad()) return
@@ -172,9 +227,17 @@ export function TeacherLessonCalendarTab({
         }
         setLessonPlansClassroomId(requestedClassroomId)
         setLessonPlans(plans)
+        setSourceStatus((current) => ({
+          ...current,
+          lessonPlans: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+        }))
       } catch (err) {
         if (!isCurrentLoad()) return
         console.error('Error loading lesson plans:', err)
+        setSourceStatus((current) => ({
+          ...current,
+          lessonPlans: { ...current.lessonPlans, classroomId: requestedClassroomId, error: true, isLoading: false },
+        }))
       } finally {
         if (isCurrentLoad()) {
           setLoading(false)
@@ -192,9 +255,24 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     let cancelled = false
     const requestedClassroomId = classroom.id
-    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
 
     async function loadAssignments() {
+      const requestId = sourceRequestIdsRef.current.assignments + 1
+      sourceRequestIdsRef.current.assignments = requestId
+      const isCurrentLoad = () => (
+        !cancelled &&
+        sourceRequestIdsRef.current.assignments === requestId &&
+        currentClassroomIdRef.current === requestedClassroomId
+      )
+      setSourceStatus((current) => ({
+        ...current,
+        assignments: {
+          classroomId: requestedClassroomId,
+          error: false,
+          hasLoadedSnapshot: current.assignments.classroomId === requestedClassroomId && current.assignments.hasLoadedSnapshot,
+          isLoading: true,
+        },
+      }))
       try {
         const data = await fetchCachedJSON<{ assignments?: Assignment[] }>(
           `teacher-assignments:${requestedClassroomId}`,
@@ -204,9 +282,17 @@ export function TeacherLessonCalendarTab({
         if (!isCurrentLoad()) return
         setAssignmentsClassroomId(requestedClassroomId)
         setAssignments(data.assignments || [])
+        setSourceStatus((current) => ({
+          ...current,
+          assignments: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+        }))
       } catch (err) {
         if (!isCurrentLoad()) return
         console.error('Error loading assignments:', err)
+        setSourceStatus((current) => ({
+          ...current,
+          assignments: { ...current.assignments, classroomId: requestedClassroomId, error: true, isLoading: false },
+        }))
       }
     }
     loadAssignments()
@@ -224,15 +310,30 @@ export function TeacherLessonCalendarTab({
       cancelled = true
       window.removeEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
     }
-  }, [classroom.id])
+  }, [assignmentsRefreshKey, classroom.id])
 
   // Fetch announcements for the classroom
   useEffect(() => {
     let cancelled = false
     const requestedClassroomId = classroom.id
-    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
 
     async function loadAnnouncements() {
+      const requestId = sourceRequestIdsRef.current.announcements + 1
+      sourceRequestIdsRef.current.announcements = requestId
+      const isCurrentLoad = () => (
+        !cancelled &&
+        sourceRequestIdsRef.current.announcements === requestId &&
+        currentClassroomIdRef.current === requestedClassroomId
+      )
+      setSourceStatus((current) => ({
+        ...current,
+        announcements: {
+          classroomId: requestedClassroomId,
+          error: false,
+          hasLoadedSnapshot: current.announcements.classroomId === requestedClassroomId && current.announcements.hasLoadedSnapshot,
+          isLoading: true,
+        },
+      }))
       try {
         const data = await fetchCachedJSON<{ announcements?: Announcement[] }>(
           `teacher-announcements:${requestedClassroomId}`,
@@ -242,9 +343,17 @@ export function TeacherLessonCalendarTab({
         if (!isCurrentLoad()) return
         setAnnouncementsClassroomId(requestedClassroomId)
         setAnnouncements(data.announcements || [])
+        setSourceStatus((current) => ({
+          ...current,
+          announcements: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
+        }))
       } catch (err) {
         if (!isCurrentLoad()) return
         console.error('Error loading announcements:', err)
+        setSourceStatus((current) => ({
+          ...current,
+          announcements: { ...current.announcements, classroomId: requestedClassroomId, error: true, isLoading: false },
+        }))
       }
     }
     loadAnnouncements()
@@ -252,7 +361,7 @@ export function TeacherLessonCalendarTab({
     return () => {
       cancelled = true
     }
-  }, [classroom.id])
+  }, [announcementsRefreshKey, classroom.id])
 
   // Save a single lesson plan
   const saveLessonPlan = useCallback(
@@ -545,7 +654,7 @@ export function TeacherLessonCalendarTab({
   }, [viewMode])
 
   const handleToday = useCallback(() => {
-    setCurrentDate(new Date())
+    setCurrentDate(nowInToronto())
   }, [])
 
   // Notify parent when sidebar opens/closes, content changes, or error/saving state changes
@@ -565,13 +674,70 @@ export function TeacherLessonCalendarTab({
     }
   }, [showMarkdown, isSidebarOpen, visibleMarkdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
 
-  if (loading && visibleLessonPlans.length === 0) {
+  const retryLessonPlans = useCallback(() => {
+    invalidateTeacherLessonPlansForClassroom(classroom.id)
+    setRefreshKey((key) => key + 1)
+  }, [classroom.id])
+
+  const retryAssignments = useCallback(() => {
+    invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+    setAssignmentsRefreshKey((key) => key + 1)
+  }, [classroom.id])
+
+  const retryAnnouncements = useCallback(() => {
+    invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
+    setAnnouncementsRefreshKey((key) => key + 1)
+  }, [classroom.id])
+
+  const localStatuses = [lessonPlansStatus, assignmentsStatus, announcementsStatus]
+  const isInitialLoading = localStatuses.some((status) => (
+    status.classroomId !== classroom.id || (status.isLoading && !status.hasLoadedSnapshot)
+  )) || (classDaysLoading && !hasClassDaysSnapshot)
+  const isRefreshing = loading || localStatuses.some((status) => status.isLoading) || classDaysLoading
+  const hasAnySnapshot = localStatuses.some((status) => (
+    status.classroomId === classroom.id && status.hasLoadedSnapshot
+  )) || hasClassDaysSnapshot
+  const failures: CalendarSourceFailure[] = []
+  if (lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.error) {
+    failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: retryLessonPlans })
+  }
+  if (assignmentsStatus.classroomId === classroom.id && assignmentsStatus.error) {
+    failures.push({ id: 'assignments', label: 'assignments', isRetrying: assignmentsStatus.isLoading, onRetry: retryAssignments })
+  }
+  if (announcementsStatus.classroomId === classroom.id && announcementsStatus.error) {
+    failures.push({ id: 'announcements', label: 'announcements', isRetrying: announcementsStatus.isLoading, onRetry: retryAnnouncements })
+  }
+  if (classDaysError) {
+    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: () => void refreshClassDays() })
+  }
+
+  const retryAll = useCallback(() => {
+    retryLessonPlans()
+    retryAssignments()
+    retryAnnouncements()
+    void refreshClassDays()
+  }, [refreshClassDays, retryAnnouncements, retryAssignments, retryLessonPlans])
+
+  if (isInitialLoading) {
     return (
       <PageLayout bleedX={false}>
         <PageContent>
-          <div className="flex items-center justify-center h-64">
-            <Spinner />
-          </div>
+          <PageState kind="loading" title="Loading calendar" />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (!hasAnySnapshot && failures.length > 0) {
+    return (
+      <PageLayout bleedX={false}>
+        <PageContent>
+          <PageState
+            kind="error"
+            title="Calendar couldn't load"
+            description="Pika couldn't load this classroom's calendar information. Nothing was changed."
+            action={<Button type="button" onClick={retryAll}>Retry</Button>}
+          />
         </PageContent>
       </PageLayout>
     )
@@ -604,6 +770,8 @@ export function TeacherLessonCalendarTab({
         ) : null}
       />
       <PageContent className="pb-24 pt-2">
+        {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
+        <CalendarSourceErrors failures={failures} />
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -65,8 +65,17 @@ type PendingBulkLessonSave = {
   mutation: TeacherLessonPlanMutationVersion
 }
 
+type MarkdownLessonDraft = {
+  content: string
+  revision: number
+}
+
 function pendingLessonSaveKey(classroomId: string, date: string): string {
   return `${classroomId}:${date}`
+}
+
+function lessonSaveMutationKey(save: PendingLessonSave): string {
+  return `${save.mutation.client_id}:${save.mutation.sequence}`
 }
 
 function pendingLessonChangesForClassroom(
@@ -190,6 +199,7 @@ export function TeacherLessonCalendarTab({
 
   // Auto-save tracking
   const pendingSavesRef = useRef<Map<string, PendingLessonSave>>(new Map())
+  const unsettledSavesRef = useRef<Map<string, PendingLessonSave>>(new Map())
   const pendingBulkSavesRef = useRef<Map<string, PendingBulkLessonSave>>(new Map())
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const flushInFlightRef = useRef<Promise<void> | null>(null)
@@ -197,7 +207,8 @@ export function TeacherLessonCalendarTab({
   const prevSidebarOpenRef = useRef(false)
   const needsRefreshRef = useRef(true) // Force refresh on first open or after save
   const markdownContentRef = useRef('') // Ref to avoid stale closure in save handler
-  const markdownDraftsRef = useRef<Map<string, string>>(new Map())
+  const markdownDraftsRef = useRef<Map<string, MarkdownLessonDraft>>(new Map())
+  const markdownDraftRevisionRef = useRef(0)
   const markdownErrorsRef = useRef<Map<string, string>>(new Map())
   const markdownSyncTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -499,7 +510,10 @@ export function TeacherLessonCalendarTab({
     const flush = async () => {
       setSaving(true)
       const entries = Array.from(pendingSavesRef.current.entries())
-      for (const [key] of entries) pendingSavesRef.current.delete(key)
+      for (const [key, entry] of entries) {
+        pendingSavesRef.current.delete(key)
+        unsettledSavesRef.current.set(lessonSaveMutationKey(entry), entry)
+      }
 
       const touchedClassroomIds = new Set(entries.map(([, entry]) => entry.classroomId))
       await Promise.all(entries.map(async ([key, entry]) => {
@@ -511,6 +525,8 @@ export function TeacherLessonCalendarTab({
           if (!pendingSavesRef.current.has(key)) {
             pendingSavesRef.current.set(key, { ...entry, retries: retries + 1 })
           }
+        } finally {
+          unsettledSavesRef.current.delete(lessonSaveMutationKey(entry))
         }
       }))
       setFailedSaveClassroomIds((current) => {
@@ -591,9 +607,12 @@ export function TeacherLessonCalendarTab({
   // Flush on unmount and handle page close
   useEffect(() => {
     const handleBeforeUnload = () => {
-      if (pendingSavesRef.current.size > 0) {
-        const entries = Array.from(pendingSavesRef.current.entries())
-        for (const [key, { classroomId, content, date, mutation }] of entries) {
+      const unloadSaves = new Map<string, PendingLessonSave>(unsettledSavesRef.current)
+      for (const save of pendingSavesRef.current.values()) {
+        unloadSaves.set(lessonSaveMutationKey(save), save)
+      }
+      if (unloadSaves.size > 0) {
+        for (const { classroomId, content, date, mutation } of unloadSaves.values()) {
           void fetch(`/api/teacher/classrooms/${classroomId}/lesson-plans/${date}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -602,7 +621,6 @@ export function TeacherLessonCalendarTab({
           }).catch((err) => {
             console.error('Error saving lesson plan during page unload:', err)
           })
-          pendingSavesRef.current.delete(key)
         }
       }
       for (const { body, classroomId } of pendingBulkSavesRef.current.values()) {
@@ -677,8 +695,8 @@ export function TeacherLessonCalendarTab({
     previousMarkdownClassroomIdRef.current = classroom.id
     const retainedDraft = markdownDraftsRef.current.get(classroom.id)
     const retainedError = markdownErrorsRef.current.get(classroom.id) ?? null
-    markdownContentRef.current = retainedDraft ?? ''
-    setMarkdownContent(retainedDraft ?? '')
+    markdownContentRef.current = retainedDraft?.content ?? ''
+    setMarkdownContent(retainedDraft?.content ?? '')
     setMarkdownContentClassroomId(retainedDraft === undefined ? '' : classroom.id)
     setMarkdownError(retainedError)
     needsRefreshRef.current = true
@@ -697,7 +715,11 @@ export function TeacherLessonCalendarTab({
   const handleMarkdownChange = useCallback((content: string) => {
     // Always update ref immediately so save has latest content
     markdownContentRef.current = content
-    markdownDraftsRef.current.set(classroom.id, content)
+    markdownDraftRevisionRef.current += 1
+    markdownDraftsRef.current.set(classroom.id, {
+      content,
+      revision: markdownDraftRevisionRef.current,
+    })
     markdownErrorsRef.current.delete(classroom.id)
     setMarkdownContentClassroomId(classroom.id)
 
@@ -733,6 +755,11 @@ export function TeacherLessonCalendarTab({
     const markdownPayload = markdownContentRef.current
     const mutation = allocateTeacherLessonPlanMutationVersion()
     const bulkMutationKey = `${mutation.client_id}:${mutation.sequence}`
+    markdownDraftRevisionRef.current += 1
+    const draftRevision = markdownDraftRevisionRef.current
+    const draftIsCurrent = () => (
+      markdownDraftsRef.current.get(requestedClassroomId)?.revision === draftRevision
+    )
     const isCurrentOperation = () => (
       currentClassroomIdRef.current === requestedClassroomId &&
       classroomEpochRef.current === requestedClassroomEpoch
@@ -743,7 +770,10 @@ export function TeacherLessonCalendarTab({
       setMarkdownError('Lesson plans are still loading')
       return
     }
-    markdownDraftsRef.current.set(requestedClassroomId, markdownPayload)
+    markdownDraftsRef.current.set(requestedClassroomId, {
+      content: markdownPayload,
+      revision: draftRevision,
+    })
     setBulkSaving(true)
 
     try {
@@ -751,17 +781,18 @@ export function TeacherLessonCalendarTab({
 
       if (result.errors.length > 0) {
         const error = result.errors.join('\n')
-        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+        if (draftIsCurrent()) {
           markdownErrorsRef.current.set(requestedClassroomId, error)
           if (isCurrentOperation()) setMarkdownError(error)
         }
-        setBulkSaving(false)
         return
       }
 
       if (result.plans.length === 0 && result.clearedDates.length === 0) {
-        markdownDraftsRef.current.delete(requestedClassroomId)
-        markdownErrorsRef.current.delete(requestedClassroomId)
+        if (draftIsCurrent()) {
+          markdownDraftsRef.current.delete(requestedClassroomId)
+          markdownErrorsRef.current.delete(requestedClassroomId)
+        }
         invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
         if (!isCurrentOperation()) return
         needsRefreshRef.current = true
@@ -786,7 +817,7 @@ export function TeacherLessonCalendarTab({
         .some((save) => save.classroomId === classroom.id)
       if (hasPendingInlineSave) {
         const error = 'Pending calendar edits could not be saved. Try again.'
-        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+        if (draftIsCurrent()) {
           markdownErrorsRef.current.set(requestedClassroomId, error)
           if (isCurrentOperation()) setMarkdownError(error)
         }
@@ -804,14 +835,14 @@ export function TeacherLessonCalendarTab({
       if (!res.ok) {
         const data = await res.json()
         const error = data.error || 'Failed to save'
-        if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+        if (draftIsCurrent()) {
           markdownErrorsRef.current.set(requestedClassroomId, error)
           if (isCurrentOperation()) setMarkdownError(error)
         }
         return
       }
 
-      if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+      if (draftIsCurrent()) {
         markdownDraftsRef.current.delete(requestedClassroomId)
         markdownErrorsRef.current.delete(requestedClassroomId)
       }
@@ -832,7 +863,7 @@ export function TeacherLessonCalendarTab({
     } catch (err) {
       console.error('Error saving markdown:', err)
       const error = 'Failed to save lesson plans'
-      if (markdownDraftsRef.current.get(requestedClassroomId) === markdownPayload) {
+      if (draftIsCurrent()) {
         markdownErrorsRef.current.set(requestedClassroomId, error)
         if (isCurrentOperation()) setMarkdownError(error)
       }

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -44,6 +44,7 @@ const AUTOSAVE_MIN_INTERVAL_MS = 10000
 const MARKDOWN_SYNC_DEBOUNCE_MS = 300
 
 type CalendarSource = 'lessonPlans' | 'assignments' | 'announcements'
+type CalendarRetrySource = CalendarSource | 'classDays'
 type SourceStatus = {
   classroomId: string | null
   error: boolean
@@ -95,6 +96,8 @@ export function TeacherLessonCalendarTab({
   const visibleAnnouncements = announcementsClassroomId === classroom.id && announcementsStatus.hasLoadedSnapshot ? announcements : []
   const lessonPlansRef = useRef(visibleLessonPlans)
   lessonPlansRef.current = visibleLessonPlans
+  const lessonEditGenerationRef = useRef(0)
+  const lessonEditsRef = useRef<Map<string, { content: string; generation: number }>>(new Map())
   const {
     classDays,
     error: classDaysError,
@@ -127,6 +130,8 @@ export function TeacherLessonCalendarTab({
     assignments: 0,
     announcements: 0,
   })
+  const retryingSourcesRef = useRef<Set<CalendarRetrySource>>(new Set())
+  const calendarWorkspaceRef = useRef<HTMLDivElement>(null)
 
   const { toggle: toggleSidebar, isOpen: isSidebarOpen, setOpen: setSidebarOpen } = useRightSidebar()
   const { showMarkdown } = useMarkdownPreference()
@@ -136,6 +141,8 @@ export function TeacherLessonCalendarTab({
     sourceRequestIdsRef.current.lessonPlans += 1
     sourceRequestIdsRef.current.assignments += 1
     sourceRequestIdsRef.current.announcements += 1
+    lessonEditGenerationRef.current = 0
+    lessonEditsRef.current.clear()
     setSourceStatus(initialSourceStatus())
   }, [classroom.id])
 
@@ -200,6 +207,7 @@ export function TeacherLessonCalendarTab({
     const requestedClassroomId = classroom.id
 
     async function loadLessonPlans() {
+      const editGenerationAtRequestStart = lessonEditGenerationRef.current
       const requestId = sourceRequestIdsRef.current.lessonPlans + 1
       sourceRequestIdsRef.current.lessonPlans = requestId
       const isCurrentLoad = () => (
@@ -212,7 +220,7 @@ export function TeacherLessonCalendarTab({
         ...current,
         lessonPlans: {
           classroomId: requestedClassroomId,
-          error: false,
+          error: current.lessonPlans.classroomId === requestedClassroomId && current.lessonPlans.error,
           hasLoadedSnapshot: current.lessonPlans.classroomId === requestedClassroomId && current.lessonPlans.hasLoadedSnapshot,
           isLoading: true,
         },
@@ -220,13 +228,20 @@ export function TeacherLessonCalendarTab({
       try {
         const plans = await fetchTeacherLessonPlansForRange(requestedClassroomId, fetchRange.start, fetchRange.end)
         if (!isCurrentLoad()) return
-        // Seed last-seen content so Tiptap normalization doesn't trigger saves
+        const plansWithPending = applyPendingLessonPlanChanges(plans, pendingChangesRef.current, requestedClassroomId)
+        const editsSinceRequest = new Map<string, string>()
+        for (const [date, edit] of lessonEditsRef.current) {
+          if (edit.generation > editGenerationAtRequestStart) editsSinceRequest.set(date, edit.content)
+        }
+        const plansWithCurrentEdits = applyPendingLessonPlanChanges(plansWithPending, editsSinceRequest, requestedClassroomId)
+        // Seed last-seen content so Tiptap normalization doesn't trigger saves.
+        // Local edits remain authoritative while a background refresh settles.
         lastSeenContentRef.current.clear()
-        for (const plan of plans) {
+        for (const plan of plansWithCurrentEdits) {
           lastSeenContentRef.current.set(plan.date, plan.content_markdown ?? '')
         }
         setLessonPlansClassroomId(requestedClassroomId)
-        setLessonPlans(plans)
+        setLessonPlans(plansWithCurrentEdits)
         setSourceStatus((current) => ({
           ...current,
           lessonPlans: { classroomId: requestedClassroomId, error: false, hasLoadedSnapshot: true, isLoading: false },
@@ -268,7 +283,7 @@ export function TeacherLessonCalendarTab({
         ...current,
         assignments: {
           classroomId: requestedClassroomId,
-          error: false,
+          error: current.assignments.classroomId === requestedClassroomId && current.assignments.error,
           hasLoadedSnapshot: current.assignments.classroomId === requestedClassroomId && current.assignments.hasLoadedSnapshot,
           isLoading: true,
         },
@@ -329,7 +344,7 @@ export function TeacherLessonCalendarTab({
         ...current,
         announcements: {
           classroomId: requestedClassroomId,
-          error: false,
+          error: current.announcements.classroomId === requestedClassroomId && current.announcements.error,
           hasLoadedSnapshot: current.announcements.classroomId === requestedClassroomId && current.announcements.hasLoadedSnapshot,
           isLoading: true,
         },
@@ -430,18 +445,23 @@ export function TeacherLessonCalendarTab({
   // Handle content change from calendar
   const handleContentChange = useCallback(
     (date: string, contentMarkdown: string) => {
-      if (loading) return
+      if (!lessonPlansStatus.hasLoadedSnapshot) return
       const contentStr = contentMarkdown
       if (isNormalizationNoise(lastSeenContentRef.current, lessonPlansRef.current, date, contentStr)) {
         lastSeenContentRef.current.set(date, contentStr)
         return
       }
       lastSeenContentRef.current.set(date, contentStr)
+      lessonEditGenerationRef.current += 1
+      lessonEditsRef.current.set(date, {
+        content: contentMarkdown,
+        generation: lessonEditGenerationRef.current,
+      })
       applyLocalLessonPlanChange(date, contentMarkdown)
       pendingChangesRef.current.set(date, contentMarkdown)
       scheduleSave()
     },
-    [applyLocalLessonPlanChange, loading, scheduleSave]
+    [applyLocalLessonPlanChange, lessonPlansStatus.hasLoadedSnapshot, scheduleSave]
   )
 
   // Flush on unmount and handle page close
@@ -675,28 +695,54 @@ export function TeacherLessonCalendarTab({
   }, [showMarkdown, isSidebarOpen, visibleMarkdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
 
   const retryLessonPlans = useCallback(() => {
+    retryingSourcesRef.current.add('lessonPlans')
     invalidateTeacherLessonPlansForClassroom(classroom.id)
     setRefreshKey((key) => key + 1)
   }, [classroom.id])
 
   const retryAssignments = useCallback(() => {
+    retryingSourcesRef.current.add('assignments')
     invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
     setAssignmentsRefreshKey((key) => key + 1)
   }, [classroom.id])
 
   const retryAnnouncements = useCallback(() => {
+    retryingSourcesRef.current.add('announcements')
     invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
     setAnnouncementsRefreshKey((key) => key + 1)
   }, [classroom.id])
 
+  const retryClassDays = useCallback(() => {
+    retryingSourcesRef.current.add('classDays')
+    void refreshClassDays()
+  }, [refreshClassDays])
+
   const localStatuses = [lessonPlansStatus, assignmentsStatus, announcementsStatus]
-  const isInitialLoading = localStatuses.some((status) => (
-    status.classroomId !== classroom.id || (status.isLoading && !status.hasLoadedSnapshot)
-  )) || (classDaysLoading && !hasClassDaysSnapshot)
-  const isRefreshing = loading || localStatuses.some((status) => status.isLoading) || classDaysLoading
-  const hasAnySnapshot = localStatuses.some((status) => (
+  const hasAnyLocalSnapshot = localStatuses.some((status) => (
     status.classroomId === classroom.id && status.hasLoadedSnapshot
-  )) || hasClassDaysSnapshot
+  ))
+  const hasAnySnapshot = hasAnyLocalSnapshot || hasClassDaysSnapshot
+  const haveLocalSourcesInitialized = localStatuses.every((status) => status.classroomId === classroom.id)
+  const isInitialLoading = !haveLocalSourcesInitialized || (
+    !hasAnyLocalSnapshot && localStatuses.some((status) => status.isLoading)
+  )
+  const isRefreshing = loading || localStatuses.some((status) => status.isLoading) || classDaysLoading
+
+  useEffect(() => {
+    const statuses: Record<CalendarRetrySource, { error: boolean; isLoading: boolean }> = {
+      lessonPlans: lessonPlansStatus,
+      assignments: assignmentsStatus,
+      announcements: announcementsStatus,
+      classDays: { error: Boolean(classDaysError), isLoading: classDaysLoading },
+    }
+    for (const source of retryingSourcesRef.current) {
+      const status = statuses[source]
+      if (status.isLoading) continue
+      retryingSourcesRef.current.delete(source)
+      if (!status.error) calendarWorkspaceRef.current?.focus()
+    }
+  }, [announcementsStatus, assignmentsStatus, classDaysError, classDaysLoading, lessonPlansStatus])
+
   const failures: CalendarSourceFailure[] = []
   if (lessonPlansStatus.classroomId === classroom.id && lessonPlansStatus.error) {
     failures.push({ id: 'lesson-plans', label: 'lesson plans', isRetrying: lessonPlansStatus.isLoading, onRetry: retryLessonPlans })
@@ -708,25 +754,15 @@ export function TeacherLessonCalendarTab({
     failures.push({ id: 'announcements', label: 'announcements', isRetrying: announcementsStatus.isLoading, onRetry: retryAnnouncements })
   }
   if (classDaysError) {
-    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: () => void refreshClassDays() })
+    failures.push({ id: 'class-days', label: 'class days', isRetrying: classDaysLoading, onRetry: retryClassDays })
   }
 
   const retryAll = useCallback(() => {
     retryLessonPlans()
     retryAssignments()
     retryAnnouncements()
-    void refreshClassDays()
-  }, [refreshClassDays, retryAnnouncements, retryAssignments, retryLessonPlans])
-
-  if (isInitialLoading) {
-    return (
-      <PageLayout bleedX={false}>
-        <PageContent>
-          <PageState kind="loading" title="Loading calendar" />
-        </PageContent>
-      </PageLayout>
-    )
-  }
+    retryClassDays()
+  }, [retryAnnouncements, retryAssignments, retryClassDays, retryLessonPlans])
 
   if (!hasAnySnapshot && failures.length > 0) {
     return (
@@ -736,8 +772,22 @@ export function TeacherLessonCalendarTab({
             kind="error"
             title="Calendar couldn't load"
             description="Pika couldn't load this classroom's calendar information. Nothing was changed."
-            action={<Button type="button" onClick={retryAll}>Retry</Button>}
+            action={(
+              <Button type="button" onClick={retryAll} disabled={isRefreshing}>
+                {isRefreshing ? 'Retrying...' : 'Retry'}
+              </Button>
+            )}
           />
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  if (isInitialLoading) {
+    return (
+      <PageLayout bleedX={false}>
+        <PageContent>
+          <PageState kind="loading" title="Loading calendar" />
         </PageContent>
       </PageLayout>
     )
@@ -770,25 +820,27 @@ export function TeacherLessonCalendarTab({
         ) : null}
       />
       <PageContent className="pb-24 pt-2">
-        {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
-        <CalendarSourceErrors failures={failures} />
-        <div className="overflow-hidden rounded-lg border border-border bg-surface">
-          <LessonCalendar
-            classroom={classroom}
-            lessonPlans={visibleLessonPlans}
-            assignments={visibleAssignments}
-            announcements={visibleAnnouncements}
-            classDays={classDays}
-            viewMode={viewMode}
-            currentDate={currentDate}
-            editable={!classroom.archived_at}
-            showHeader={false}
-            onDateChange={setCurrentDate}
-            onViewModeChange={handleViewModeChange}
-            onContentChange={handleContentChange}
-            onAssignmentClick={handleAssignmentClick}
-            onAnnouncementClick={handleAnnouncementClick}
-          />
+        <div ref={calendarWorkspaceRef} role="region" aria-label="Calendar workspace" tabIndex={-1} className="outline-none">
+          {isRefreshing ? <RefreshingIndicator label="Refreshing calendar" className="mb-2" /> : null}
+          <CalendarSourceErrors failures={failures} />
+          <div className="overflow-hidden rounded-lg border border-border bg-surface">
+            <LessonCalendar
+              classroom={classroom}
+              lessonPlans={visibleLessonPlans}
+              assignments={visibleAssignments}
+              announcements={visibleAnnouncements}
+              classDays={classDays}
+              viewMode={viewMode}
+              currentDate={currentDate}
+              editable={!classroom.archived_at}
+              showHeader={false}
+              onDateChange={setCurrentDate}
+              onViewModeChange={handleViewModeChange}
+              onContentChange={handleContentChange}
+              onAssignmentClick={handleAssignmentClick}
+              onAnnouncementClick={handleAnnouncementClick}
+            />
+          </div>
         </div>
       </PageContent>
     </PageLayout>

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { format } from 'date-fns'
+import { format, parseISO } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
@@ -45,7 +45,7 @@ export function getCalendarHeaderLabel(
   }
 
   if (rangeStart && rangeEnd) {
-    return `${format(new Date(rangeStart), 'MMM d, yyyy')} - ${format(new Date(rangeEnd), 'MMM d, yyyy')}`
+    return `${format(parseISO(rangeStart), 'MMM d, yyyy')} - ${format(parseISO(rangeEnd), 'MMM d, yyyy')}`
   }
 
   return 'All Dates'

--- a/src/components/CalendarSourceErrors.tsx
+++ b/src/components/CalendarSourceErrors.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/ui'
+
+export interface CalendarSourceFailure {
+  id: string
+  label: string
+  isRetrying: boolean
+  onRetry: () => void
+}
+
+export function CalendarSourceErrors({ failures }: { failures: CalendarSourceFailure[] }) {
+  if (failures.length === 0) return null
+
+  return (
+    <div
+      role="alert"
+      className="mb-2 flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger"
+    >
+      <p className="font-medium">Some calendar information could not be loaded.</p>
+      <div className="flex flex-wrap gap-2">
+        {failures.map((failure) => (
+          <Button
+            key={failure.id}
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={failure.isRetrying}
+            onClick={failure.onRetry}
+          >
+            {failure.isRetrying ? `Retrying ${failure.label}` : `Retry ${failure.label}`}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/CalendarSourceErrors.tsx
+++ b/src/components/CalendarSourceErrors.tsx
@@ -7,7 +7,13 @@ export interface CalendarSourceFailure {
   onRetry: () => void
 }
 
-export function CalendarSourceErrors({ failures }: { failures: CalendarSourceFailure[] }) {
+export function CalendarSourceErrors({
+  failures,
+  message = 'Some calendar information could not be loaded.',
+}: {
+  failures: CalendarSourceFailure[]
+  message?: string
+}) {
   if (failures.length === 0) return null
 
   return (
@@ -15,7 +21,7 @@ export function CalendarSourceErrors({ failures }: { failures: CalendarSourceFai
       role="alert"
       className="mb-2 flex flex-wrap items-center justify-between gap-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger"
     >
-      <p className="font-medium">Some calendar information could not be loaded.</p>
+      <p className="font-medium">{message}</p>
       <div className="flex flex-wrap gap-2">
         {failures.map((failure) => (
           <Button

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState, useEffect, useCallback } from 'react'
-import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, isSameDay, startOfMonth, endOfMonth, addMonths, subMonths, isWeekend, addDays } from 'date-fns'
+import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, isSameDay, startOfMonth, endOfMonth, addMonths, subMonths, isWeekend, addDays, parseISO } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import { ChevronLeft, ChevronRight, PanelRight, PanelRightClose } from 'lucide-react'
 import { LessonDayCell } from './LessonDayCell'
@@ -191,8 +191,8 @@ export function LessonCalendar({
 
     // 'all' mode: show entire term if available
     if (classroom.start_date && classroom.end_date) {
-      const termStart = new Date(classroom.start_date)
-      const termEnd = new Date(classroom.end_date)
+      const termStart = parseISO(classroom.start_date)
+      const termEnd = parseISO(classroom.end_date)
       // Extend to full weeks
       const calendarStart = startOfWeek(termStart, { weekStartsOn: 0 })
       const calendarEnd = endOfWeek(termEnd, { weekStartsOn: 0 })
@@ -329,7 +329,7 @@ export function LessonCalendar({
     }
     // 'all' mode
     if (classroom.start_date && classroom.end_date) {
-      return `${format(new Date(classroom.start_date), 'MMM d, yyyy')} - ${format(new Date(classroom.end_date), 'MMM d, yyyy')}`
+      return `${format(parseISO(classroom.start_date), 'MMM d, yyyy')} - ${format(parseISO(classroom.end_date), 'MMM d, yyyy')}`
     }
     return 'All Dates'
   }, [viewMode, currentDate, classroom.start_date, classroom.end_date])

--- a/src/contexts/ClassDaysContext.tsx
+++ b/src/contexts/ClassDaysContext.tsx
@@ -46,10 +46,8 @@ function ClassDaysProviderState({ classroomId, children }: ClassDaysProviderProp
   const loadClassDays = useCallback(async (options?: { force?: boolean }) => {
     const loadSequence = loadSequenceRef.current + 1
     loadSequenceRef.current = loadSequence
-    setError(null)
-    if (!hasLoadedDataRef.current) {
-      setIsLoading(true)
-    }
+    if (!hasLoadedDataRef.current) setError(null)
+    setIsLoading(true)
 
     try {
       if (options?.force) {

--- a/src/lib/contracts/classroom-data.ts
+++ b/src/lib/contracts/classroom-data.ts
@@ -327,6 +327,16 @@ export const CLASSROOM_PURGE_ONLY_RELATIONAL_RESOURCES = [
     },
     privacy: ['student_work', 'operations'],
   },
+  {
+    table: 'lesson_plan_mutation_heads',
+    primary_key: ['classroom_id', 'date', 'client_id'],
+    scope: {
+      kind: 'foreign_key',
+      parent: 'classrooms',
+      column: 'classroom_id',
+    },
+    privacy: ['operations'],
+  },
 ] as const satisfies readonly {
   table: string
   primary_key: readonly string[]

--- a/src/lib/server/classroom-purge.ts
+++ b/src/lib/server/classroom-purge.ts
@@ -304,7 +304,7 @@ async function readStableImpact(
     const assignmentDocIds = (resources.assignment_docs || [])
       .map((row) => row.id)
       .filter((id): id is string => typeof id === 'string')
-    const [users, saveOperations, lessonPlanMutationHeads] = await Promise.all([
+    const [users, saveOperations] = await Promise.all([
       loadChunkedRows<unknown>({
         supabase,
         table: 'users',
@@ -316,12 +316,6 @@ async function readStableImpact(
         table: 'assignment_doc_save_operations',
         select: 'id',
         filters: [{ column: 'assignment_doc_id', values: assignmentDocIds }],
-      }),
-      loadChunkedRows<unknown>({
-        supabase,
-        table: 'lesson_plan_mutation_heads',
-        select: 'classroom_id,date,client_id',
-        filters: [{ column: 'classroom_id', values: [classroomId] }],
       }),
     ])
     if (users.error) {
@@ -340,14 +334,6 @@ async function readStableImpact(
         true,
       )
     }
-    if (lessonPlanMutationHeads.error) {
-      throw new ClassroomPurgeError(
-        lessonPlanMutationHeads.error.code || 'classroom_operation_inventory_failed',
-        'Could not inventory lesson-plan mutation records',
-        500,
-        true,
-      )
-    }
     const affectedUsers = z.array(affectedUserSchema).parse(users.rows)
     const classroomCounts = Object.fromEntries([
       ...CLASSROOM_RELATIONAL_RESOURCES.map((resource) => [
@@ -358,9 +344,7 @@ async function readStableImpact(
         resource.table,
         resource.table === 'assignment_doc_save_operations'
           ? saveOperations.rows.length
-          : resource.table === 'lesson_plan_mutation_heads'
-            ? lessonPlanMutationHeads.rows.length
-            : 0,
+          : 0,
       ] as const),
     ])
     const resourceCounts = mergeClassroomPurgeResourceCounts(

--- a/src/lib/server/classroom-purge.ts
+++ b/src/lib/server/classroom-purge.ts
@@ -304,7 +304,7 @@ async function readStableImpact(
     const assignmentDocIds = (resources.assignment_docs || [])
       .map((row) => row.id)
       .filter((id): id is string => typeof id === 'string')
-    const [users, saveOperations] = await Promise.all([
+    const [users, saveOperations, lessonPlanMutationHeads] = await Promise.all([
       loadChunkedRows<unknown>({
         supabase,
         table: 'users',
@@ -316,6 +316,12 @@ async function readStableImpact(
         table: 'assignment_doc_save_operations',
         select: 'id',
         filters: [{ column: 'assignment_doc_id', values: assignmentDocIds }],
+      }),
+      loadChunkedRows<unknown>({
+        supabase,
+        table: 'lesson_plan_mutation_heads',
+        select: 'classroom_id,date,client_id',
+        filters: [{ column: 'classroom_id', values: [classroomId] }],
       }),
     ])
     if (users.error) {
@@ -334,6 +340,14 @@ async function readStableImpact(
         true,
       )
     }
+    if (lessonPlanMutationHeads.error) {
+      throw new ClassroomPurgeError(
+        lessonPlanMutationHeads.error.code || 'classroom_operation_inventory_failed',
+        'Could not inventory lesson-plan mutation records',
+        500,
+        true,
+      )
+    }
     const affectedUsers = z.array(affectedUserSchema).parse(users.rows)
     const classroomCounts = Object.fromEntries([
       ...CLASSROOM_RELATIONAL_RESOURCES.map((resource) => [
@@ -342,7 +356,11 @@ async function readStableImpact(
       ] as const),
       ...CLASSROOM_PURGE_ONLY_RELATIONAL_RESOURCES.map((resource) => [
         resource.table,
-        resource.table === 'assignment_doc_save_operations' ? saveOperations.rows.length : 0,
+        resource.table === 'assignment_doc_save_operations'
+          ? saveOperations.rows.length
+          : resource.table === 'lesson_plan_mutation_heads'
+            ? lessonPlanMutationHeads.rows.length
+            : 0,
       ] as const),
     ])
     const resourceCounts = mergeClassroomPurgeResourceCounts(

--- a/src/lib/teacher-lesson-plan-mutation-queue.ts
+++ b/src/lib/teacher-lesson-plan-mutation-queue.ts
@@ -1,0 +1,33 @@
+const classroomMutationTails = new Map<string, Promise<void>>()
+
+/**
+ * Serializes lesson-plan mutations for a classroom, including across Calendar
+ * component remounts. A rejected mutation does not block later queued work.
+ */
+export function enqueueTeacherLessonPlanMutation<T>(
+  classroomId: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  const previous = classroomMutationTails.get(classroomId) ?? Promise.resolve()
+  const result = previous.catch(() => undefined).then(mutation)
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  )
+
+  classroomMutationTails.set(classroomId, tail)
+  void tail.then(() => {
+    if (classroomMutationTails.get(classroomId) === tail) {
+      classroomMutationTails.delete(classroomId)
+    }
+  })
+
+  return result
+}
+
+export function resetTeacherLessonPlanMutationQueuesForTests(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('Lesson-plan mutation queues can only be reset in tests')
+  }
+  classroomMutationTails.clear()
+}

--- a/src/lib/teacher-lesson-plan-mutation-queue.ts
+++ b/src/lib/teacher-lesson-plan-mutation-queue.ts
@@ -1,4 +1,58 @@
+import { safeSessionGetJson, safeSessionRemove, safeSessionSetJson } from '@/lib/client-storage'
+
 const classroomMutationTails = new Map<string, Promise<void>>()
+const MUTATION_SESSION_STORAGE_KEY = 'pika:lesson-plan-mutation-session'
+
+export type TeacherLessonPlanMutationVersion = {
+  client_id: string
+  sequence: number
+}
+
+let fallbackMutationVersion: TeacherLessonPlanMutationVersion | null = null
+
+function createMutationVersion(): TeacherLessonPlanMutationVersion {
+  return { client_id: globalThis.crypto.randomUUID(), sequence: 0 }
+}
+
+function readMutationVersion(): TeacherLessonPlanMutationVersion {
+  if (typeof window === 'undefined') {
+    fallbackMutationVersion ??= createMutationVersion()
+    return fallbackMutationVersion
+  }
+
+  if (fallbackMutationVersion) return fallbackMutationVersion
+  const parsed = safeSessionGetJson<Partial<TeacherLessonPlanMutationVersion>>(
+    MUTATION_SESSION_STORAGE_KEY,
+  )
+  if (
+    typeof parsed?.client_id === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(parsed.client_id) &&
+    typeof parsed.sequence === 'number' &&
+    Number.isSafeInteger(parsed.sequence) &&
+    parsed.sequence >= 0
+  ) {
+    return { client_id: parsed.client_id, sequence: parsed.sequence }
+  }
+
+  const created = createMutationVersion()
+  if (!safeSessionSetJson(MUTATION_SESSION_STORAGE_KEY, created)) {
+    fallbackMutationVersion = created
+  }
+  return created
+}
+
+export function allocateTeacherLessonPlanMutationVersion(): TeacherLessonPlanMutationVersion {
+  const current = readMutationVersion()
+  const next = { ...current, sequence: current.sequence + 1 }
+
+  if (typeof window === 'undefined') {
+    fallbackMutationVersion = next
+  } else if (!safeSessionSetJson(MUTATION_SESSION_STORAGE_KEY, next)) {
+    fallbackMutationVersion = next
+  }
+
+  return next
+}
 
 /**
  * Serializes lesson-plan mutations for a classroom, including across Calendar
@@ -30,4 +84,6 @@ export function resetTeacherLessonPlanMutationQueuesForTests(): void {
     throw new Error('Lesson-plan mutation queues can only be reset in tests')
   }
   classroomMutationTails.clear()
+  fallbackMutationVersion = null
+  safeSessionRemove(MUTATION_SESSION_STORAGE_KEY)
 }

--- a/src/lib/validations/lesson-plan-mutations.ts
+++ b/src/lib/validations/lesson-plan-mutations.ts
@@ -8,6 +8,26 @@ export const lessonPlanMutationVersionSchema = z.object({
 
 export type LessonPlanMutationVersion = z.infer<typeof lessonPlanMutationVersionSchema>
 
+function isRealCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (year < 1 || month < 1 || month > 12 || day < 1) return false
+
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  return day <= daysInMonth[month - 1]
+}
+
+export const lessonPlanDateSchema = z.string().superRefine((value, context) => {
+  if (!isRealCalendarDate(value)) {
+    context.addIssue({ code: 'custom', message: `Invalid date format: ${value}` })
+  }
+})
+
 const tiptapContentSchema = z.custom<TiptapContent>((value) => (
   typeof value === 'object' &&
   value !== null &&
@@ -33,14 +53,14 @@ export const lessonPlanMutationBodySchema = z.object({
 })
 
 const bulkLessonPlanEntrySchema = z.object({
-  date: z.string(),
+  date: lessonPlanDateSchema,
   content_markdown: z.string().optional(),
   content: tiptapContentSchema.optional(),
 }).strict()
 
 export const bulkLessonPlanMutationBodySchema = z.object({
   plans: z.array(bulkLessonPlanEntrySchema).max(250, 'Too many plans. Maximum is 250 per request.').default([]),
-  cleared_dates: z.array(z.string()).max(250, 'Too many plans. Maximum is 250 per request.').default([]),
+  cleared_dates: z.array(lessonPlanDateSchema).max(250, 'Too many plans. Maximum is 250 per request.').default([]),
   mutation: lessonPlanMutationVersionSchema.optional(),
 }).strict().superRefine((value, context) => {
   if (value.plans.length === 0 && value.cleared_dates.length === 0) {
@@ -50,12 +70,8 @@ export const bulkLessonPlanMutationBodySchema = z.object({
     })
   }
 
-  const datePattern = /^\d{4}-\d{2}-\d{2}$/
   const seenDates = new Set<string>()
   for (const [index, plan] of value.plans.entries()) {
-    if (!datePattern.test(plan.date)) {
-      context.addIssue({ code: 'custom', message: `Invalid date format: ${plan.date}`, path: ['plans', index, 'date'] })
-    }
     if (seenDates.has(plan.date)) {
       context.addIssue({ code: 'custom', message: `Duplicate date: ${plan.date}`, path: ['plans', index, 'date'] })
     }
@@ -66,9 +82,6 @@ export const bulkLessonPlanMutationBodySchema = z.object({
   }
 
   for (const [index, date] of value.cleared_dates.entries()) {
-    if (!datePattern.test(date)) {
-      context.addIssue({ code: 'custom', message: `Invalid date format: ${date}`, path: ['cleared_dates', index] })
-    }
     if (seenDates.has(date)) {
       context.addIssue({ code: 'custom', message: `Duplicate date: ${date}`, path: ['cleared_dates', index] })
     }

--- a/src/lib/validations/lesson-plan-mutations.ts
+++ b/src/lib/validations/lesson-plan-mutations.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+import type { TiptapContent } from '@/types'
+
+export const lessonPlanMutationVersionSchema = z.object({
+  client_id: z.string().uuid(),
+  sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+}).strict()
+
+export type LessonPlanMutationVersion = z.infer<typeof lessonPlanMutationVersionSchema>
+
+const tiptapContentSchema = z.custom<TiptapContent>((value) => (
+  typeof value === 'object' &&
+  value !== null &&
+  (value as { type?: unknown }).type === 'doc' &&
+  (
+    (value as { content?: unknown }).content === undefined ||
+    Array.isArray((value as { content?: unknown }).content)
+  )
+), 'Invalid content format')
+
+export const lessonPlanMutationBodySchema = z.object({
+  content_markdown: z.string().optional(),
+  content: tiptapContentSchema.optional(),
+  mutation: lessonPlanMutationVersionSchema.optional(),
+}).strict().superRefine((value, context) => {
+  if (typeof value.content_markdown !== 'string' && !value.content) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Invalid content format',
+      path: ['content'],
+    })
+  }
+})
+
+const bulkLessonPlanEntrySchema = z.object({
+  date: z.string(),
+  content_markdown: z.string().optional(),
+  content: tiptapContentSchema.optional(),
+}).strict()
+
+export const bulkLessonPlanMutationBodySchema = z.object({
+  plans: z.array(bulkLessonPlanEntrySchema).max(250, 'Too many plans. Maximum is 250 per request.').default([]),
+  cleared_dates: z.array(z.string()).max(250, 'Too many plans. Maximum is 250 per request.').default([]),
+  mutation: lessonPlanMutationVersionSchema.optional(),
+}).strict().superRefine((value, context) => {
+  if (value.plans.length === 0 && value.cleared_dates.length === 0) {
+    context.addIssue({
+      code: 'custom',
+      message: 'plans or cleared_dates is required and must not be empty',
+    })
+  }
+
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/
+  const seenDates = new Set<string>()
+  for (const [index, plan] of value.plans.entries()) {
+    if (!datePattern.test(plan.date)) {
+      context.addIssue({ code: 'custom', message: `Invalid date format: ${plan.date}`, path: ['plans', index, 'date'] })
+    }
+    if (seenDates.has(plan.date)) {
+      context.addIssue({ code: 'custom', message: `Duplicate date: ${plan.date}`, path: ['plans', index, 'date'] })
+    }
+    seenDates.add(plan.date)
+    if (typeof plan.content_markdown !== 'string' && !plan.content) {
+      context.addIssue({ code: 'custom', message: `Invalid content for date ${plan.date}`, path: ['plans', index] })
+    }
+  }
+
+  for (const [index, date] of value.cleared_dates.entries()) {
+    if (!datePattern.test(date)) {
+      context.addIssue({ code: 'custom', message: `Invalid date format: ${date}`, path: ['cleared_dates', index] })
+    }
+    if (seenDates.has(date)) {
+      context.addIssue({ code: 'custom', message: `Duplicate date: ${date}`, path: ['cleared_dates', index] })
+    }
+    seenDates.add(date)
+  }
+})

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -3982,6 +3982,38 @@ export type Database = {
           },
         ]
       }
+      lesson_plan_mutation_heads: {
+        Row: {
+          classroom_id: string
+          client_id: string
+          date: string
+          last_sequence: number
+          updated_at: string
+        }
+        Insert: {
+          classroom_id: string
+          client_id: string
+          date: string
+          last_sequence: number
+          updated_at?: string
+        }
+        Update: {
+          classroom_id?: string
+          client_id?: string
+          date?: string
+          last_sequence?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_plan_mutation_heads_classroom_id_fkey"
+            columns: ["classroom_id"]
+            isOneToOne: false
+            referencedRelation: "classrooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       lesson_plans: {
         Row: {
           artifact_id: string
@@ -6164,6 +6196,18 @@ export type Database = {
           isOneToOne: true
           isSetofReturn: false
         }
+      }
+      apply_ordered_lesson_plan_mutation: {
+        Args: {
+          p_classroom_id: string
+          p_client_id: string
+          p_content: Json
+          p_content_markdown: string
+          p_date: string
+          p_delete: boolean
+          p_sequence: number
+        }
+        Returns: Json
       }
       archived_classroom_blueprint_snapshot_from_plan: {
         Args: { p_blueprint_id: string; p_draft_revision: number; p_plan: Json }

--- a/supabase/migrations/125_ordered_lesson_plan_mutations.sql
+++ b/supabase/migrations/125_ordered_lesson_plan_mutations.sql
@@ -14,6 +14,77 @@ alter table public.lesson_plan_mutation_heads enable row level security;
 revoke all on table public.lesson_plan_mutation_heads from public, anon, authenticated;
 grant select, insert, update, delete on table public.lesson_plan_mutation_heads to service_role;
 
+create trigger lesson_plan_mutation_head_purge_fence
+before insert or update or delete on public.lesson_plan_mutation_heads
+for each row execute function public.reject_classroom_resource_change_during_purge(
+  'classrooms', 'classroom_id'
+);
+
+-- Migration 118 predates mutation heads. Preserve its inventory implementation
+-- behind a private helper and extend the public result with an exact database
+-- count so purge confirmation, begin-time fencing, and durable operation counts
+-- all use the same value without PostgREST pagination.
+alter function public.get_hot_archived_classroom_purge_inventory(uuid, uuid)
+  rename to get_hot_archived_classroom_purge_inventory_without_lesson_heads;
+alter function public.get_hot_archived_classroom_purge_inventory_without_lesson_heads(
+  uuid, uuid
+) set schema private;
+
+revoke all on function private.get_hot_archived_classroom_purge_inventory_without_lesson_heads(
+  uuid, uuid
+) from public, anon, authenticated, service_role;
+
+create function public.get_hot_archived_classroom_purge_inventory(
+  p_teacher_id uuid,
+  p_classroom_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_inventory jsonb;
+  v_operational_counts jsonb;
+  v_operational_digest text;
+begin
+  v_inventory := private.get_hot_archived_classroom_purge_inventory_without_lesson_heads(
+    p_teacher_id,
+    p_classroom_id
+  );
+  if not coalesce((v_inventory->>'ok')::boolean, false) then
+    return v_inventory;
+  end if;
+
+  v_operational_counts := coalesce(
+    v_inventory->'operational_counts',
+    '{}'::jsonb
+  ) || jsonb_build_object(
+    'lesson_plan_mutation_heads',
+    (
+      select count(*)::integer
+      from public.lesson_plan_mutation_heads
+      where classroom_id = p_classroom_id
+    )
+  );
+  v_operational_digest := encode(extensions.digest(
+    convert_to(v_operational_counts::text, 'UTF8'), 'sha256'
+  ), 'hex');
+
+  return v_inventory || jsonb_build_object(
+    'operational_counts', v_operational_counts,
+    'operational_inventory_sha256', v_operational_digest
+  );
+end;
+$$;
+
+revoke all on function public.get_hot_archived_classroom_purge_inventory(
+  uuid, uuid
+) from public, anon, authenticated;
+grant execute on function public.get_hot_archived_classroom_purge_inventory(
+  uuid, uuid
+) to service_role;
+
 create or replace function public.apply_ordered_lesson_plan_mutation(
   p_classroom_id uuid,
   p_date date,

--- a/supabase/migrations/125_ordered_lesson_plan_mutations.sql
+++ b/supabase/migrations/125_ordered_lesson_plan_mutations.sql
@@ -1,0 +1,116 @@
+-- Preserve teacher intent when lesson-plan requests complete out of order.
+
+create table public.lesson_plan_mutation_heads (
+  classroom_id uuid not null references public.classrooms(id) on delete cascade,
+  date date not null,
+  client_id uuid not null,
+  last_sequence bigint not null check (last_sequence > 0),
+  updated_at timestamptz not null default now(),
+  primary key (classroom_id, date, client_id)
+);
+
+alter table public.lesson_plan_mutation_heads enable row level security;
+
+revoke all on table public.lesson_plan_mutation_heads from public, anon, authenticated;
+grant select, insert, update, delete on table public.lesson_plan_mutation_heads to service_role;
+
+create or replace function public.apply_ordered_lesson_plan_mutation(
+  p_classroom_id uuid,
+  p_date date,
+  p_content_markdown text,
+  p_content jsonb,
+  p_delete boolean,
+  p_client_id uuid,
+  p_sequence bigint
+)
+returns jsonb
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_accepted boolean := false;
+  v_lesson_plan public.lesson_plans%rowtype;
+begin
+  if p_sequence <= 0 then
+    raise exception 'Lesson-plan mutation sequence must be positive';
+  end if;
+
+  insert into public.lesson_plan_mutation_heads (
+    classroom_id,
+    date,
+    client_id,
+    last_sequence,
+    updated_at
+  ) values (
+    p_classroom_id,
+    p_date,
+    p_client_id,
+    p_sequence,
+    now()
+  )
+  on conflict (classroom_id, date, client_id) do update
+  set last_sequence = excluded.last_sequence,
+      updated_at = now()
+  where public.lesson_plan_mutation_heads.last_sequence < excluded.last_sequence
+  returning true into v_accepted;
+
+  if not coalesce(v_accepted, false) then
+    select * into v_lesson_plan
+    from public.lesson_plans
+    where classroom_id = p_classroom_id
+      and date = p_date;
+
+    return jsonb_build_object(
+      'applied', false,
+      'lesson_plan', case when found then to_jsonb(v_lesson_plan) else null end
+    );
+  end if;
+
+  if p_delete then
+    delete from public.lesson_plans
+    where classroom_id = p_classroom_id
+      and date = p_date;
+
+    return jsonb_build_object('applied', true, 'lesson_plan', null);
+  end if;
+
+  insert into public.lesson_plans (
+    classroom_id,
+    date,
+    content_markdown,
+    content,
+    updated_at
+  ) values (
+    p_classroom_id,
+    p_date,
+    p_content_markdown,
+    p_content,
+    now()
+  )
+  on conflict (classroom_id, date) do update
+  set content_markdown = excluded.content_markdown,
+      content = excluded.content,
+      updated_at = excluded.updated_at
+  returning * into v_lesson_plan;
+
+  return jsonb_build_object(
+    'applied', true,
+    'lesson_plan', to_jsonb(v_lesson_plan)
+  );
+end;
+$$;
+
+revoke all on function public.apply_ordered_lesson_plan_mutation(
+  uuid, date, text, jsonb, boolean, uuid, bigint
+) from public, anon, authenticated;
+grant execute on function public.apply_ordered_lesson_plan_mutation(
+  uuid, date, text, jsonb, boolean, uuid, bigint
+) to service_role;
+
+comment on table public.lesson_plan_mutation_heads is
+  'Per-browser-session ordering fence for teacher lesson-plan mutations.';
+
+comment on function public.apply_ordered_lesson_plan_mutation(
+  uuid, date, text, jsonb, boolean, uuid, bigint
+) is
+  'Atomically rejects stale lesson-plan mutations before applying delete or upsert.';

--- a/tests/api/teacher/lesson-plans-bulk.test.ts
+++ b/tests/api/teacher/lesson-plans-bulk.test.ts
@@ -132,6 +132,31 @@ describe('PUT /api/teacher/classrooms/[id]/lesson-plans/bulk', () => {
     expect(data.error).toContain('Invalid date format: invalid-date')
   })
 
+  it('rejects every plan before writing when one calendar date is impossible', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/lesson-plans/bulk',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          plans: [
+            { date: '2026-02-27', content_markdown: 'Valid plan' },
+            { date: '2026-02-31', content_markdown: 'Impossible plan' },
+          ],
+          mutation: {
+            client_id: '10000000-0000-4000-8000-000000000001',
+            sequence: 8,
+          },
+        }),
+      },
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+
+    expect(response.status).toBe(400)
+    expect((await response.json()).error).toContain('Invalid date format: 2026-02-31')
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
   it('should return 400 for duplicate dates in plans', async () => {
     const plans = [
       { date: '2025-01-06', content: { type: 'doc', content: [] } },

--- a/tests/api/teacher/lesson-plans-bulk.test.ts
+++ b/tests/api/teacher/lesson-plans-bulk.test.ts
@@ -12,11 +12,59 @@ vi.mock('@/lib/server/classrooms', () => ({
   assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
 }))
 
-const mockSupabaseClient = { from: vi.fn() }
+const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }
 
 describe('PUT /api/teacher/classrooms/[id]/lesson-plans/bulk', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('routes every versioned bulk date through the atomic ordering function', async () => {
+    mockSupabaseClient.rpc
+      .mockResolvedValueOnce({
+        data: {
+          applied: true,
+          lesson_plan: {
+            id: 'lp-1',
+            classroom_id: 'c-1',
+            date: '2025-01-06',
+            content: { type: 'doc', content: [] },
+            content_markdown: 'Plan',
+          },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: { applied: true, lesson_plan: null }, error: null })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/lesson-plans/bulk',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          plans: [{ date: '2025-01-06', content_markdown: 'Plan' }],
+          cleared_dates: ['2025-01-07'],
+          mutation: {
+            client_id: '10000000-0000-4000-8000-000000000001',
+            sequence: 7,
+          },
+        }),
+      },
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledTimes(2)
+    expect(mockSupabaseClient.rpc).toHaveBeenNthCalledWith(1, 'apply_ordered_lesson_plan_mutation', expect.objectContaining({
+      p_date: '2025-01-06',
+      p_delete: false,
+      p_sequence: 7,
+    }))
+    expect(mockSupabaseClient.rpc).toHaveBeenNthCalledWith(2, 'apply_ordered_lesson_plan_mutation', expect.objectContaining({
+      p_date: '2025-01-07',
+      p_delete: true,
+      p_sequence: 7,
+    }))
+    expect(await response.json()).toMatchObject({ updated: 1, cleared: 1 })
   })
 
   it('should return 400 when plans array is missing', async () => {
@@ -81,7 +129,7 @@ describe('PUT /api/teacher/classrooms/[id]/lesson-plans/bulk', () => {
     const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
     expect(response.status).toBe(400)
     const data = await response.json()
-    expect(data.errors).toContain('Invalid date format: invalid-date')
+    expect(data.error).toContain('Invalid date format: invalid-date')
   })
 
   it('should return 400 for duplicate dates in plans', async () => {
@@ -100,7 +148,7 @@ describe('PUT /api/teacher/classrooms/[id]/lesson-plans/bulk', () => {
     const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
     expect(response.status).toBe(400)
     const data = await response.json()
-    expect(data.errors).toContain('Duplicate date: 2025-01-06')
+    expect(data.error).toContain('Duplicate date: 2025-01-06')
   })
 
   it('should return 400 for invalid content in plans', async () => {
@@ -118,7 +166,7 @@ describe('PUT /api/teacher/classrooms/[id]/lesson-plans/bulk', () => {
     const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
     expect(response.status).toBe(400)
     const data = await response.json()
-    expect(data.errors).toContain('Invalid content for date 2025-01-06')
+    expect(data.error).toContain('Invalid content format')
   })
 
   it('should return 403 when teacher cannot mutate classroom', async () => {

--- a/tests/api/teacher/lesson-plans-date.test.ts
+++ b/tests/api/teacher/lesson-plans-date.test.ts
@@ -82,6 +82,24 @@ describe('PUT /api/teacher/classrooms/[id]/lesson-plans/[date]', () => {
     expect(data.error).toContain('Invalid date format')
   })
 
+  it('should return 400 for an impossible calendar date', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/lesson-plans/2026-02-31',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content_markdown: 'Plan' }),
+      },
+    )
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: 'c-1', date: '2026-02-31' }),
+    })
+
+    expect(response.status).toBe(400)
+    expect((await response.json()).error).toContain('Invalid date format')
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
   it('should return 400 for missing content', async () => {
     const request = new NextRequest(
       'http://localhost:3000/api/teacher/classrooms/c-1/lesson-plans/2025-01-06',

--- a/tests/api/teacher/lesson-plans-date.test.ts
+++ b/tests/api/teacher/lesson-plans-date.test.ts
@@ -12,11 +12,58 @@ vi.mock('@/lib/server/classrooms', () => ({
   assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
 }))
 
-const mockSupabaseClient = { from: vi.fn() }
+const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }
 
 describe('PUT /api/teacher/classrooms/[id]/lesson-plans/[date]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('applies versioned mutations through the atomic ordering function', async () => {
+    const mockLessonPlan = {
+      id: 'lp-ordered',
+      classroom_id: 'c-1',
+      date: '2025-01-06',
+      content: { type: 'doc', content: [] },
+      content_markdown: 'Newest',
+    }
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: { applied: true, lesson_plan: mockLessonPlan },
+      error: null,
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/lesson-plans/2025-01-06',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          content_markdown: 'Newest',
+          mutation: {
+            client_id: '10000000-0000-4000-8000-000000000001',
+            sequence: 2,
+          },
+        }),
+      },
+    )
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: 'c-1', date: '2025-01-06' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'apply_ordered_lesson_plan_mutation',
+      expect.objectContaining({
+        p_classroom_id: 'c-1',
+        p_client_id: '10000000-0000-4000-8000-000000000001',
+        p_date: '2025-01-06',
+        p_delete: false,
+        p_sequence: 2,
+      }),
+    )
+    expect(await response.json()).toMatchObject({
+      applied: true,
+      lesson_plan: { id: 'lp-ordered', content_markdown: 'Newest' },
+    })
   })
 
   it('should return 400 for invalid date format', async () => {

--- a/tests/architecture/api-zod-boundary-baseline.json
+++ b/tests/architecture/api-zod-boundary-baseline.json
@@ -14,8 +14,6 @@
   "src/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route.ts",
   "src/app/api/teacher/classrooms/[id]/announcements/route.ts",
   "src/app/api/teacher/classrooms/[id]/classwork/reorder/route.ts",
-  "src/app/api/teacher/classrooms/[id]/lesson-plans/[date]/route.ts",
-  "src/app/api/teacher/classrooms/[id]/lesson-plans/bulk/route.ts",
   "src/app/api/teacher/classrooms/[id]/lesson-plans/copy/route.ts",
   "src/app/api/teacher/classrooms/[id]/materials/[materialId]/route.ts",
   "src/app/api/teacher/classrooms/[id]/materials/route.ts",

--- a/tests/components/CalendarActionBar.test.tsx
+++ b/tests/components/CalendarActionBar.test.tsx
@@ -1,8 +1,17 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { CalendarActionBar, CalendarDateNavigator } from '@/components/CalendarActionBar'
+import { CalendarActionBar, CalendarDateNavigator, getCalendarHeaderLabel } from '@/components/CalendarActionBar'
 
 describe('CalendarActionBar', () => {
+  it('keeps date-only term boundaries on their classroom calendar dates', () => {
+    expect(getCalendarHeaderLabel(
+      'all',
+      new Date(2025, 0, 1),
+      '2025-01-01',
+      '2025-06-30',
+    )).toBe('Jan 1, 2025 - Jun 30, 2025')
+  })
+
   it('exposes named date navigation controls', () => {
     const onPrev = vi.fn()
     const onNext = vi.fn()

--- a/tests/components/CalendarSourceErrors.test.tsx
+++ b/tests/components/CalendarSourceErrors.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CalendarSourceErrors } from '@/components/CalendarSourceErrors'
+
+describe('CalendarSourceErrors', () => {
+  it('does not render when every calendar source is available', () => {
+    render(<CalendarSourceErrors failures={[]} />)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('announces a custom failure and exposes its retry action', () => {
+    const onRetry = vi.fn()
+
+    render(
+      <CalendarSourceErrors
+        message="Some lesson plan changes could not be saved."
+        failures={[{
+          id: 'lesson-plans',
+          label: 'lesson plan changes',
+          isRetrying: false,
+          onRetry,
+        }]}
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Some lesson plan changes could not be saved.',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry lesson plan changes' }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('disables a retry action while it is running', () => {
+    render(
+      <CalendarSourceErrors
+        failures={[{
+          id: 'class-days',
+          label: 'class days',
+          isRetrying: true,
+          onRetry: vi.fn(),
+        }]}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Retrying class days' })).toBeDisabled()
+  })
+})

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -253,6 +253,45 @@ describe('StudentLessonCalendarTab', () => {
     expect(assignmentReads).toBe(2)
   })
 
+  it('keeps a retained class-day retry focused until failure or recovery settles', async () => {
+    classDaysState.error = 'The class schedule could not be loaded.'
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url.includes('lesson-plans')) return { lesson_plans: [{ id: 'lesson-1' }] }
+        if (url.includes('assignments')) return { assignments: [] }
+        if (url.includes('announcements')) return { announcements: [] }
+        return {}
+      },
+    }))
+
+    const view = render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    const retryButton = await screen.findByRole('button', { name: 'Retry class days' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+
+    classDaysState.isLoading = true
+    view.rerender(<StudentLessonCalendarTab classroom={classroom} />)
+    expect(screen.getByRole('button', { name: 'Retrying class days' })).toBeDisabled()
+    expect(document.activeElement).toBe(retryButton)
+
+    classDaysState.isLoading = false
+    view.rerender(<StudentLessonCalendarTab classroom={classroom} />)
+    expect(screen.getByRole('button', { name: 'Retry class days' })).toBeInTheDocument()
+    expect(document.activeElement).toBe(retryButton)
+
+    fireEvent.click(retryButton)
+    classDaysState.isLoading = true
+    view.rerender(<StudentLessonCalendarTab classroom={classroom} />)
+    classDaysState.isLoading = false
+    classDaysState.error = null
+    view.rerender(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
+    })
+  })
+
   it('shows a retryable cold error when no calendar source loads', async () => {
     classDaysState.error = 'The class schedule could not be loaded.'
     classDaysState.hasLoadedSnapshot = false

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -266,6 +266,47 @@ describe('StudentLessonCalendarTab', () => {
     expect(classDaysState.refresh).toHaveBeenCalledTimes(1)
   })
 
+  it('does not carry retry focus intent into another classroom', async () => {
+    let resolveFirstClassroomRetry!: (value: any) => void
+    const firstClassroomRetry = new Promise<any>((resolve) => {
+      resolveFirstClassroomRetry = resolve
+    })
+    let firstClassroomAssignmentReads = 0
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes(`classroom_id=${classroom.id}`)) {
+        firstClassroomAssignmentReads += 1
+        if (firstClassroomAssignmentReads === 1) {
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'Failed' }) })
+        }
+        return firstClassroomRetry
+      }
+      if (url.includes('lesson-plans')) {
+        const lessonId = url.includes(secondClassroom.id) ? 'classroom-2-lesson' : 'classroom-1-lesson'
+        return Promise.resolve({ ok: true, json: async () => ({ lesson_plans: [{ id: lessonId }] }) })
+      }
+      if (url.includes('assignments')) {
+        return Promise.resolve({ ok: true, json: async () => ({ assignments: [{ id: 'classroom-2-assignment' }] }) })
+      }
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    const retryButton = await screen.findByRole('button', { name: 'Retry assignments' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+    expect(await screen.findByRole('button', { name: 'Retrying assignments' })).toBeDisabled()
+
+    view.rerender(<StudentLessonCalendarTab classroom={secondClassroom} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-ids', 'classroom-2-lesson')
+    })
+    expect(document.activeElement).not.toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
+
+    resolveFirstClassroomRetry({ ok: true, json: async () => ({ assignments: [] }) })
+  })
+
   it('ignores late calendar responses after switching classrooms', async () => {
     type PendingFetch = {
       url: string

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -1,15 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { StudentLessonCalendarTab } from '@/app/classrooms/[classroomId]/StudentLessonCalendarTab'
 import { createMockClassroom } from '../helpers/mocks'
 import { invalidateCachedJSON } from '@/lib/request-cache'
+import { AppMessageProvider } from '@/ui'
+import type { ReactNode } from 'react'
+
+const classDaysState = vi.hoisted(() => ({
+  classDays: [],
+  error: null as string | null,
+  hasLoadedSnapshot: true,
+  isLoading: false,
+  refresh: vi.fn(async () => {}),
+}))
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('@/hooks/useClassDays', () => ({
-  useClassDays: () => [],
+  useClassDaysContext: () => classDaysState,
 }))
 
 vi.mock('@/lib/cookies', () => ({
@@ -32,6 +42,10 @@ vi.mock('@/components/LessonCalendar', () => ({
   CalendarViewMode: {},
 }))
 
+function Wrapper({ children }: { children: ReactNode }) {
+  return <AppMessageProvider>{children}</AppMessageProvider>
+}
+
 describe('StudentLessonCalendarTab', () => {
   const classroom = createMockClassroom({
     start_date: '2025-01-01',
@@ -51,6 +65,11 @@ describe('StudentLessonCalendarTab', () => {
     invalidateCachedJSON(`student-lesson-plans:${secondClassroom.id}:2025-01-01:2025-06-30`)
     invalidateCachedJSON(`student-assignments:${secondClassroom.id}`)
     invalidateCachedJSON(`student-announcements:${secondClassroom.id}`)
+    classDaysState.classDays = []
+    classDaysState.error = null
+    classDaysState.hasLoadedSnapshot = true
+    classDaysState.isLoading = false
+    classDaysState.refresh.mockClear()
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -88,7 +107,7 @@ describe('StudentLessonCalendarTab', () => {
       })
     })
 
-    render(<StudentLessonCalendarTab classroom={classroom} />)
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     // All 3 fetches should be initiated before any resolve
     await waitFor(() => {
@@ -112,7 +131,7 @@ describe('StudentLessonCalendarTab', () => {
       json: async () => ({ lesson_plans: [], assignments: [], announcements: [] }),
     })
 
-    render(<StudentLessonCalendarTab classroom={classroom} />)
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -134,7 +153,7 @@ describe('StudentLessonCalendarTab', () => {
       },
     }))
 
-    const first = render(<StudentLessonCalendarTab classroom={classroom} />)
+    const first = render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -146,7 +165,7 @@ describe('StudentLessonCalendarTab', () => {
     })
 
     first.unmount()
-    render(<StudentLessonCalendarTab classroom={classroom} />)
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     await waitFor(() => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
@@ -180,14 +199,59 @@ describe('StudentLessonCalendarTab', () => {
       }
     })
 
-    render(<StudentLessonCalendarTab classroom={classroom} />)
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     await waitFor(() => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '0')
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-count', '1')
     })
+    expect(screen.getByRole('alert')).toHaveTextContent('Some calendar information could not be loaded')
+    expect(screen.getByRole('button', { name: 'Retry assignments' })).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries only the failed calendar source and adds its recovered data', async () => {
+    let assignmentReads = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('assignments')) {
+        assignmentReads += 1
+        if (assignmentReads === 1) {
+          return { ok: false, json: async () => ({ error: 'Failed' }) }
+        }
+        return { ok: true, json: async () => ({ assignments: [{ id: 'assignment-1' }] }) }
+      }
+      return {
+        ok: true,
+        json: async () => url.includes('lesson-plans')
+          ? { lesson_plans: [{ id: 'lesson-1' }] }
+          : { announcements: [{ id: 'announcement-1' }] },
+      }
+    })
+
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry assignments' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '1')
+    })
+    expect(screen.queryByRole('button', { name: 'Retry assignments' })).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(assignmentReads).toBe(2)
+  })
+
+  it('shows a retryable cold error when no calendar source loads', async () => {
+    classDaysState.error = 'The class schedule could not be loaded.'
+    classDaysState.hasLoadedSnapshot = false
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({ error: 'Failed' }) })
+
+    render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    expect(await screen.findByRole('heading', { name: "Calendar couldn't load" })).toBeInTheDocument()
+    expect(screen.queryByTestId('lesson-calendar')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(classDaysState.refresh).toHaveBeenCalledTimes(1)
   })
 
   it('ignores late calendar responses after switching classrooms', async () => {
@@ -230,7 +294,7 @@ describe('StudentLessonCalendarTab', () => {
       })
     }
 
-    const view = render(<StudentLessonCalendarTab classroom={classroom} />)
+    const view = render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(3)

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -213,28 +213,40 @@ describe('StudentLessonCalendarTab', () => {
 
   it('retries only the failed calendar source and adds its recovered data', async () => {
     let assignmentReads = 0
-    fetchMock.mockImplementation(async (url: string) => {
+    let resolveAssignmentRetry!: (value: any) => void
+    const assignmentRetry = new Promise<any>((resolve) => {
+      resolveAssignmentRetry = resolve
+    })
+    fetchMock.mockImplementation((url: string) => {
       if (url.includes('assignments')) {
         assignmentReads += 1
         if (assignmentReads === 1) {
-          return { ok: false, json: async () => ({ error: 'Failed' }) }
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'Failed' }) })
         }
-        return { ok: true, json: async () => ({ assignments: [{ id: 'assignment-1' }] }) }
+        return assignmentRetry
       }
-      return {
+      return Promise.resolve({
         ok: true,
         json: async () => url.includes('lesson-plans')
           ? { lesson_plans: [{ id: 'lesson-1' }] }
           : { announcements: [{ id: 'announcement-1' }] },
-      }
+      })
     })
 
     render(<StudentLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Retry assignments' }))
+    const retryButton = await screen.findByRole('button', { name: 'Retry assignments' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+
+    expect(await screen.findByRole('button', { name: 'Retrying assignments' })).toBeDisabled()
+    expect(document.activeElement).toBe(retryButton)
+
+    resolveAssignmentRetry({ ok: true, json: async () => ({ assignments: [{ id: 'assignment-1' }] }) })
 
     await waitFor(() => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '1')
+      expect(document.activeElement).toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
     })
     expect(screen.queryByRole('button', { name: 'Retry assignments' })).not.toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(4)

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -744,6 +744,62 @@ describe('TeacherLessonCalendarTab', () => {
     })
   })
 
+  it('ignores an autosave from an earlier visit after returning to the classroom', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const firstVisitAutosave = deferred<any>()
+    let classroomAAutosaves = 0
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`) && init?.method === 'PUT') {
+        classroomAAutosaves += 1
+        if (classroomAAutosaves === 1) return firstVisitAutosave.promise
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+        })
+      }
+      if (url.includes('lesson-plans')) {
+        const classroomId = url.includes(secondClassroom.id) ? secondClassroom.id : classroom.id
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plans: [lessonPlan({ classroom_id: classroomId })] }),
+        })
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', classroom.id))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    view.rerender(<TeacherLessonCalendarTab classroom={secondClassroom} />)
+    await waitFor(() => expect(classroomAAutosaves).toBe(1))
+    await waitFor(() => expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id))
+
+    view.rerender(<TeacherLessonCalendarTab classroom={classroom} />)
+    await waitFor(() => expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', classroom.id))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
+
+    firstVisitAutosave.resolve({
+      ok: true,
+      json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Late saved lesson' }) }),
+    })
+    await act(async () => firstVisitAutosave.promise)
+
+    expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
+  })
+
   it('invalidates cached teacher lesson plans after an autosaved edit', async () => {
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -57,6 +57,7 @@ vi.mock('@/components/LessonCalendar', () => ({
       data-testid="lesson-calendar"
       data-lesson-count={lessonPlans.length}
       data-lesson-classrooms={lessonPlans.map((plan: LessonPlan) => plan.classroom_id).join(',')}
+      data-lesson-content={lessonPlans.map((plan: LessonPlan) => plan.content_markdown).join(',')}
       data-assignment-classrooms={assignments.map((assignment: any) => assignment.classroom_id).join(',')}
       data-assignment-ids={assignments.map((assignment: any) => assignment.id).join(',')}
       data-announcement-classrooms={announcements.map((announcement: any) => announcement.classroom_id).join(',')}
@@ -165,25 +166,23 @@ describe('TeacherLessonCalendarTab', () => {
 
   it('keeps successful sources visible and retries only failed assignments', async () => {
     let assignmentReads = 0
-    fetchMock.mockImplementation(async (url: string) => {
+    const assignmentRetry = deferred<any>()
+    fetchMock.mockImplementation((url: string) => {
       if (url.includes('assignments')) {
         assignmentReads += 1
         if (assignmentReads === 1) {
-          return { ok: false, json: async () => ({ error: 'Failed' }) }
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'Failed' }) })
         }
-        return {
-          ok: true,
-          json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
-        }
+        return assignmentRetry.promise
       }
-      return {
+      return Promise.resolve({
         ok: true,
         json: async () => {
           if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
           if (url.includes('announcements')) return { announcements: [{ id: 'announcement-1', classroom_id: classroom.id }] }
           return {}
         },
-      }
+      })
     })
 
     render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
@@ -192,13 +191,82 @@ describe('TeacherLessonCalendarTab', () => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', classroom.id)
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Retry assignments' }))
+    const retryButton = screen.getByRole('button', { name: 'Retry assignments' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+
+    expect(await screen.findByRole('button', { name: 'Retrying assignments' })).toBeDisabled()
+    expect(document.activeElement).toBe(retryButton)
+
+    assignmentRetry.resolve({
+      ok: true,
+      json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', classroom.id)
+      expect(document.activeElement).toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
     })
     expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(assignmentReads).toBe(2)
+  })
+
+  it('keeps local lesson edits while a retained snapshot refresh is in flight', async () => {
+    const refreshedLessonPlans = deferred<any>()
+    let lessonPlanReads = 0
+    let latestSidebarState: CalendarSidebarState | null = null
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/bulk') && init?.method === 'PUT') {
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      }
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        return Promise.resolve({ ok: true, json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }) })
+      }
+      if (url.includes('lesson-plans')) {
+        lessonPlanReads += 1
+        if (lessonPlanReads === 1) {
+          return Promise.resolve({ ok: true, json: async () => ({ lesson_plans: [lessonPlan()] }) })
+        }
+        return refreshedLessonPlans.promise
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    sidebarState.isOpen = true
+    render(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
+    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nSidebar lesson'))
+    await act(async () => latestSidebarState?.onSave())
+    await waitFor(() => expect(lessonPlanReads).toBe(2))
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(fetchMock.mock.calls.some(([url, init]) => String(url).includes('/lesson-plans/2025-01-06') && init?.method === 'PUT')).toBe(true)
+    vi.useRealTimers()
+
+    refreshedLessonPlans.resolve({ ok: true, json: async () => ({ lesson_plans: [lessonPlan()] }) })
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
+    })
   })
 
   it('shows a retryable cold error when no calendar source loads', async () => {

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -69,6 +69,9 @@ vi.mock('@/components/LessonCalendar', () => ({
       <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Newest lesson')}>
         Edit lesson again
       </button>
+      <button type="button" onClick={() => onContentChange?.('2025-01-07', 'Second date lesson')}>
+        Edit second date
+      </button>
     </div>
   ),
   CalendarViewMode: {},
@@ -809,6 +812,90 @@ describe('TeacherLessonCalendarTab', () => {
     expect(latestSidebarState?.markdownError).toBeNull()
   })
 
+  it('keeps an identical later draft when an earlier bulk save succeeds', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const firstBulkSave = deferred<any>()
+    let bulkSaveCount = 0
+    let latestSidebarState: CalendarSidebarState | null = null
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/bulk') && init?.method === 'PUT') {
+        bulkSaveCount += 1
+        if (bulkSaveCount === 1) return firstBulkSave.promise
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ error: 'Later identical save failed' }),
+        })
+      }
+      if (/\/lesson-plans\/2025-01-06$/.test(url) && init?.method === 'PUT') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+        })
+      }
+      if (url.includes('lesson-plans')) {
+        const classroomId = url.includes(secondClassroom.id) ? secondClassroom.id : classroom.id
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plans: [lessonPlan({ classroom_id: classroomId })] }),
+        })
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    sidebarState.isOpen = true
+    const renderTab = (activeClassroom = classroom) => (
+      <TeacherLessonCalendarTab
+        classroom={activeClassroom}
+        onSidebarStateChange={(state) => { latestSidebarState = state }}
+      />
+    )
+    const view = render(renderTab(), { wrapper: Wrapper })
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
+
+    const identicalDraft = '## 2025-01-06\nIdentical draft'
+    act(() => latestSidebarState?.onMarkdownChange(identicalDraft))
+    let earlierSave!: Promise<void>
+    act(() => { earlierSave = latestSidebarState!.onSave() })
+    await waitFor(() => expect(bulkSaveCount).toBe(1))
+
+    view.rerender(renderTab(secondClassroom))
+    await waitFor(() => expect(latestSidebarState?.markdownContent).not.toBe(''))
+    view.rerender(renderTab())
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toBe(identicalDraft))
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    let laterSave!: Promise<void>
+    act(() => { laterSave = latestSidebarState!.onSave() })
+
+    firstBulkSave.resolve({ ok: true, json: async () => ({ lesson_plans: [] }) })
+    await act(async () => {
+      await earlierSave
+      await laterSave
+    })
+
+    expect(latestSidebarState?.markdownContent).toBe(identicalDraft)
+    expect(latestSidebarState?.markdownError).toBe('Later identical save failed')
+    expect(sidebarState.setOpen).not.toHaveBeenCalledWith(false)
+    vi.useRealTimers()
+  })
+
   it('ignores late autosave responses after the classroom changes', async () => {
     const secondClassroom = createMockClassroom({
       id: 'classroom-2',
@@ -1072,10 +1159,11 @@ describe('TeacherLessonCalendarTab', () => {
       await Promise.resolve()
     })
 
-    expect(saveBodies).toHaveLength(2)
+    expect(saveBodies).toHaveLength(3)
     expect(saveBodies[0]).toMatchObject({ content_markdown: 'Updated lesson', mutation: { sequence: 1 } })
-    expect(saveBodies[1]).toMatchObject({ content_markdown: 'Newest lesson', mutation: { sequence: 2 } })
-    expect(saveBodies[1].mutation.client_id).toBe(saveBodies[0].mutation.client_id)
+    expect(saveBodies[1]).toMatchObject({ content_markdown: 'Updated lesson', mutation: { sequence: 1 } })
+    expect(saveBodies[2]).toMatchObject({ content_markdown: 'Newest lesson', mutation: { sequence: 2 } })
+    expect(saveBodies[2].mutation.client_id).toBe(saveBodies[0].mutation.client_id)
 
     secondSave.resolve({
       ok: true,
@@ -1090,6 +1178,63 @@ describe('TeacherLessonCalendarTab', () => {
     })
 
     expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Newest lesson')
+    vi.useRealTimers()
+  })
+
+  it('sends a queue-blocked second date directly during unload', async () => {
+    const firstSave = deferred<any>()
+    const saves: Array<{ date: string; content: string }> = []
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      const dateMatch = url.match(/lesson-plans\/(2025-01-\d{2})$/)
+      if (dateMatch && init?.method === 'PUT') {
+        const body = JSON.parse(String(init.body))
+        saves.push({ date: dateMatch[1], content: body.content_markdown })
+        if (saves.length === 1) return firstSave.promise
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ applied: true, lesson_plan: lessonPlan({ date: dateMatch[1] }) }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit second date' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(saves).toEqual([{ date: '2025-01-06', content: 'Updated lesson' }])
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+    expect(saves).toContainEqual({ date: '2025-01-07', content: 'Second date lesson' })
+
+    firstSave.resolve({
+      ok: true,
+      json: async () => ({ applied: true, lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+    })
+    await act(async () => {
+      await firstSave.promise
+      await Promise.resolve()
+      await Promise.resolve()
+    })
     vi.useRealTimers()
   })
 

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -9,6 +9,7 @@ import type { CalendarSidebarState } from '@/app/classrooms/[classroomId]/Teache
 import type { LessonPlan } from '@/types'
 import type { ReactNode } from 'react'
 import { TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
+import { resetTeacherLessonPlanMutationQueuesForTests } from '@/lib/teacher-lesson-plan-mutation-queue'
 
 const sidebarState = vi.hoisted(() => ({
   isOpen: false,
@@ -65,6 +66,9 @@ vi.mock('@/components/LessonCalendar', () => ({
       <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Updated lesson')}>
         Edit lesson
       </button>
+      <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Newest lesson')}>
+        Edit lesson again
+      </button>
     </div>
   ),
   CalendarViewMode: {},
@@ -110,6 +114,7 @@ describe('TeacherLessonCalendarTab', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    resetTeacherLessonPlanMutationQueuesForTests()
     invalidateTeacherLessonPlansForClassroom(classroom.id)
     invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
     invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
@@ -126,6 +131,7 @@ describe('TeacherLessonCalendarTab', () => {
   })
 
   afterEach(() => {
+    resetTeacherLessonPlanMutationQueuesForTests()
     invalidateTeacherLessonPlansForClassroom(classroom.id)
     invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
     invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
@@ -211,6 +217,45 @@ describe('TeacherLessonCalendarTab', () => {
     expect(assignmentReads).toBe(2)
   })
 
+  it('keeps a retained class-day retry focused until failure or recovery settles', async () => {
+    classDaysState.error = 'The class schedule could not be loaded.'
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+        if (url.includes('assignments')) return { assignments: [] }
+        if (url.includes('announcements')) return { announcements: [] }
+        return {}
+      },
+    }))
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    const retryButton = await screen.findByRole('button', { name: 'Retry class days' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+
+    classDaysState.isLoading = true
+    view.rerender(<TeacherLessonCalendarTab classroom={classroom} />)
+    expect(screen.getByRole('button', { name: 'Retrying class days' })).toBeDisabled()
+    expect(document.activeElement).toBe(retryButton)
+
+    classDaysState.isLoading = false
+    view.rerender(<TeacherLessonCalendarTab classroom={classroom} />)
+    expect(screen.getByRole('button', { name: 'Retry class days' })).toBeInTheDocument()
+    expect(document.activeElement).toBe(retryButton)
+
+    fireEvent.click(retryButton)
+    classDaysState.isLoading = true
+    view.rerender(<TeacherLessonCalendarTab classroom={classroom} />)
+    classDaysState.isLoading = false
+    classDaysState.error = null
+    view.rerender(<TeacherLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
+    })
+  })
+
   it('keeps local lesson edits while a retained snapshot refresh is in flight', async () => {
     const refreshedLessonPlans = deferred<any>()
     const autosave = deferred<any>()
@@ -261,14 +306,25 @@ describe('TeacherLessonCalendarTab', () => {
     vi.useRealTimers()
 
     act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nUpdated lesson'))
-    await act(async () => latestSidebarState?.onSave())
-    await waitFor(() => expect(lessonPlanReads).toBe(2))
+    let markdownSave!: Promise<void>
+    act(() => {
+      markdownSave = latestSidebarState!.onSave()
+    })
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/lesson-plans/bulk'))).toBe(false)
 
     autosave.resolve({
       ok: true,
       json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
     })
-    await act(async () => autosave.promise)
+    await act(async () => markdownSave)
+    await waitFor(() => expect(lessonPlanReads).toBe(2))
+    const mutationUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'PUT')
+      .map(([url]) => String(url))
+    expect(mutationUrls).toEqual([
+      `/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`,
+      `/api/teacher/classrooms/${classroom.id}/lesson-plans/bulk`,
+    ])
 
     refreshedLessonPlans.resolve({ ok: true, json: async () => ({ lesson_plans: [lessonPlan()] }) })
     await waitFor(() => {
@@ -798,6 +854,153 @@ describe('TeacherLessonCalendarTab', () => {
     await act(async () => firstVisitAutosave.promise)
 
     expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
+  })
+
+  it('serializes repeated inline saves so the newest value commits last', async () => {
+    const firstSave = deferred<any>()
+    const saveBodies: string[] = []
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        saveBodies.push(String(init.body))
+        if (saveBodies.length === 1) return firstSave.promise
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Newest lesson' }) }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(saveBodies).toEqual([JSON.stringify({ content_markdown: 'Updated lesson' })])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson again' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+    })
+    expect(saveBodies).toHaveLength(1)
+
+    firstSave.resolve({
+      ok: true,
+      json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+    })
+    await act(async () => {
+      await firstSave.promise
+      await Promise.resolve()
+      await vi.runAllTimersAsync()
+    })
+
+    expect(saveBodies).toEqual([
+      JSON.stringify({ content_markdown: 'Updated lesson' }),
+      JSON.stringify({ content_markdown: 'Newest lesson' }),
+    ])
+    vi.useRealTimers()
+  })
+
+  it('retains a failed inline save and retries it', async () => {
+    let saves = 0
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        saves += 1
+        if (saves === 1) {
+          return Promise.resolve({ ok: false, status: 500, json: async () => ({ error: 'Failed' }) })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(saves).toBe(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(saves).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('uses an explicit keepalive PUT for pending changes during unload', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        return {
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+        }
+      }
+      return {
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      }
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`,
+      expect.objectContaining({
+        body: JSON.stringify({ content_markdown: 'Updated lesson' }),
+        keepalive: true,
+        method: 'PUT',
+      }),
+    )
   })
 
   it('invalidates cached teacher lesson plans after an autosaved edit', async () => {

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -213,6 +213,7 @@ describe('TeacherLessonCalendarTab', () => {
 
   it('keeps local lesson edits while a retained snapshot refresh is in flight', async () => {
     const refreshedLessonPlans = deferred<any>()
+    const autosave = deferred<any>()
     let lessonPlanReads = 0
     let latestSidebarState: CalendarSidebarState | null = null
 
@@ -221,7 +222,7 @@ describe('TeacherLessonCalendarTab', () => {
         return Promise.resolve({ ok: true, json: async () => ({}) })
       }
       if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
-        return Promise.resolve({ ok: true, json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }) })
+        return autosave.promise
       }
       if (url.includes('lesson-plans')) {
         lessonPlanReads += 1
@@ -247,10 +248,6 @@ describe('TeacherLessonCalendarTab', () => {
     )
 
     await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
-    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nSidebar lesson'))
-    await act(async () => latestSidebarState?.onSave())
-    await waitFor(() => expect(lessonPlanReads).toBe(2))
-
     vi.useFakeTimers()
     fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
     expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
@@ -263,10 +260,67 @@ describe('TeacherLessonCalendarTab', () => {
     expect(fetchMock.mock.calls.some(([url, init]) => String(url).includes('/lesson-plans/2025-01-06') && init?.method === 'PUT')).toBe(true)
     vi.useRealTimers()
 
+    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nUpdated lesson'))
+    await act(async () => latestSidebarState?.onSave())
+    await waitFor(() => expect(lessonPlanReads).toBe(2))
+
+    autosave.resolve({
+      ok: true,
+      json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+    })
+    await act(async () => autosave.promise)
+
     refreshedLessonPlans.resolve({ ok: true, json: async () => ({ lesson_plans: [lessonPlan()] }) })
     await waitFor(() => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Updated lesson')
     })
+  })
+
+  it('does not carry retry focus intent into another classroom', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const firstClassroomRetry = deferred<any>()
+    let firstClassroomAssignmentReads = 0
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes(`classroom_id=${classroom.id}`)) {
+        firstClassroomAssignmentReads += 1
+        if (firstClassroomAssignmentReads === 1) {
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'Failed' }) })
+        }
+        return firstClassroomRetry.promise
+      }
+      if (url.includes('lesson-plans')) {
+        const classroomId = url.includes(secondClassroom.id) ? secondClassroom.id : classroom.id
+        return Promise.resolve({ ok: true, json: async () => ({ lesson_plans: [lessonPlan({ classroom_id: classroomId })] }) })
+      }
+      if (url.includes('assignments')) {
+        return Promise.resolve({ ok: true, json: async () => ({ assignments: [{ id: 'assignment-2', classroom_id: secondClassroom.id }] }) })
+      }
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    const retryButton = await screen.findByRole('button', { name: 'Retry assignments' })
+    retryButton.focus()
+    fireEvent.click(retryButton)
+    expect(await screen.findByRole('button', { name: 'Retrying assignments' })).toBeDisabled()
+
+    view.rerender(<TeacherLessonCalendarTab classroom={secondClassroom} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+    })
+    expect(document.activeElement).not.toBe(screen.getByRole('region', { name: 'Calendar workspace' }))
+
+    firstClassroomRetry.resolve({ ok: true, json: async () => ({ assignments: [] }) })
   })
 
   it('shows a retryable cold error when no calendar source loads', async () => {

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -694,6 +694,121 @@ describe('TeacherLessonCalendarTab', () => {
     })
   })
 
+  it('retains a failed bulk draft for its originating classroom only', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const bulkSave = deferred<any>()
+    let latestSidebarState: CalendarSidebarState | null = null
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/bulk') && init?.method === 'PUT') return bulkSave.promise
+      if (url.includes('lesson-plans')) {
+        const isSecond = url.includes(secondClassroom.id)
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            lesson_plans: [lessonPlan({
+              classroom_id: isSecond ? secondClassroom.id : classroom.id,
+              content_markdown: isSecond ? 'Second classroom lesson' : 'Original lesson',
+            })],
+          }),
+        })
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    sidebarState.isOpen = true
+    const renderTab = (activeClassroom = classroom) => (
+      <TeacherLessonCalendarTab
+        classroom={activeClassroom}
+        onSidebarStateChange={(state) => { latestSidebarState = state }}
+      />
+    )
+    const view = render(renderTab(), { wrapper: Wrapper })
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
+
+    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nExact failed draft'))
+    let savePromise!: Promise<void>
+    act(() => { savePromise = latestSidebarState!.onSave() })
+    await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/lesson-plans/bulk'))).toBe(true))
+
+    view.rerender(renderTab(secondClassroom))
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Second classroom lesson'))
+
+    bulkSave.resolve({ ok: false, json: async () => ({ error: 'Bulk A failed' }) })
+    await act(async () => savePromise)
+    expect(latestSidebarState?.markdownError).not.toBe('Bulk A failed')
+
+    view.rerender(renderTab())
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toBe('## 2025-01-06\nExact failed draft')
+      expect(latestSidebarState?.markdownError).toBe('Bulk A failed')
+    })
+  })
+
+  it('does not let an earlier visit bulk success close a later visit sidebar', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const bulkSave = deferred<any>()
+    let latestSidebarState: CalendarSidebarState | null = null
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/bulk') && init?.method === 'PUT') return bulkSave.promise
+      if (url.includes('lesson-plans')) {
+        const classroomId = url.includes(secondClassroom.id) ? secondClassroom.id : classroom.id
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plans: [lessonPlan({ classroom_id: classroomId })] }),
+        })
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    sidebarState.isOpen = true
+    const renderTab = (activeClassroom = classroom) => (
+      <TeacherLessonCalendarTab
+        classroom={activeClassroom}
+        onSidebarStateChange={(state) => { latestSidebarState = state }}
+      />
+    )
+    const view = render(renderTab(), { wrapper: Wrapper })
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
+    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nSaved draft'))
+    let savePromise!: Promise<void>
+    act(() => { savePromise = latestSidebarState!.onSave() })
+    await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/lesson-plans/bulk'))).toBe(true))
+
+    view.rerender(renderTab(secondClassroom))
+    await waitFor(() => expect(latestSidebarState?.markdownContent).not.toBe(''))
+    view.rerender(renderTab())
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toBe('## 2025-01-06\nSaved draft'))
+    sidebarState.setOpen.mockClear()
+
+    bulkSave.resolve({ ok: true, json: async () => ({ lesson_plans: [] }) })
+    await act(async () => savePromise)
+
+    expect(sidebarState.setOpen).not.toHaveBeenCalledWith(false)
+    expect(latestSidebarState?.markdownError).toBeNull()
+  })
+
   it('ignores late autosave responses after the classroom changes', async () => {
     const secondClassroom = createMockClassroom({
       id: 'classroom-2',
@@ -890,7 +1005,10 @@ describe('TeacherLessonCalendarTab', () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    expect(saveBodies).toEqual([JSON.stringify({ content_markdown: 'Updated lesson' })])
+    expect(JSON.parse(saveBodies[0])).toMatchObject({
+      content_markdown: 'Updated lesson',
+      mutation: { sequence: 1 },
+    })
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit lesson again' }))
     await act(async () => {
@@ -909,10 +1027,129 @@ describe('TeacherLessonCalendarTab', () => {
       await vi.runAllTimersAsync()
     })
 
-    expect(saveBodies).toEqual([
-      JSON.stringify({ content_markdown: 'Updated lesson' }),
-      JSON.stringify({ content_markdown: 'Newest lesson' }),
+    expect(saveBodies.map((body) => JSON.parse(body))).toEqual([
+      expect.objectContaining({ content_markdown: 'Updated lesson', mutation: expect.objectContaining({ sequence: 1 }) }),
+      expect.objectContaining({ content_markdown: 'Newest lesson', mutation: expect.objectContaining({ sequence: 2 }) }),
     ])
+    vi.useRealTimers()
+  })
+
+  it('sends a newer pending edit directly on unload while an older save is in flight', async () => {
+    const firstSave = deferred<any>()
+    const secondSave = deferred<any>()
+    const saveBodies: Array<{ content_markdown: string; mutation: { client_id: string; sequence: number } }> = []
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        saveBodies.push(JSON.parse(String(init.body)))
+        return saveBodies.length === 1 ? firstSave.promise : secondSave.promise
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson again' }))
+
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+
+    expect(saveBodies).toHaveLength(2)
+    expect(saveBodies[0]).toMatchObject({ content_markdown: 'Updated lesson', mutation: { sequence: 1 } })
+    expect(saveBodies[1]).toMatchObject({ content_markdown: 'Newest lesson', mutation: { sequence: 2 } })
+    expect(saveBodies[1].mutation.client_id).toBe(saveBodies[0].mutation.client_id)
+
+    secondSave.resolve({
+      ok: true,
+      json: async () => ({ applied: true, lesson_plan: lessonPlan({ content_markdown: 'Newest lesson' }) }),
+    })
+    firstSave.resolve({
+      ok: true,
+      json: async () => ({ applied: false, lesson_plan: lessonPlan({ content_markdown: 'Newest lesson' }) }),
+    })
+    await act(async () => {
+      await Promise.all([firstSave.promise, secondSave.promise])
+    })
+
+    expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-content', 'Newest lesson')
+    vi.useRealTimers()
+  })
+
+  it('starts a queued bulk save with keepalive during unload', async () => {
+    const inlineSave = deferred<any>()
+    let latestSidebarState: CalendarSidebarState | null = null
+    const bulkBodies: Array<{ mutation: { sequence: number }; plans: unknown[] }> = []
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') return inlineSave.promise
+      if (url.includes('/lesson-plans/bulk') && init?.method === 'PUT') {
+        bulkBodies.push(JSON.parse(String(init.body)))
+        return Promise.resolve({ ok: true, json: async () => ({ lesson_plans: [] }) })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+
+    sidebarState.isOpen = true
+    render(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => { latestSidebarState = state }}
+      />,
+      { wrapper: Wrapper },
+    )
+    await waitFor(() => expect(latestSidebarState?.markdownContent).toContain('Original lesson'))
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => latestSidebarState?.onMarkdownChange('## 2025-01-06\nBulk lesson'))
+    let bulkSave!: Promise<void>
+    act(() => { bulkSave = latestSidebarState!.onSave() })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+    expect(bulkBodies).toHaveLength(1)
+    expect(bulkBodies[0]).toMatchObject({ mutation: { sequence: 2 } })
+
+    inlineSave.resolve({
+      ok: true,
+      json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+    })
+    await act(async () => bulkSave)
+    expect(bulkBodies).toHaveLength(2)
+    expect(bulkBodies[1].mutation).toEqual(bulkBodies[0].mutation)
     vi.useRealTimers()
   })
 
@@ -964,6 +1201,56 @@ describe('TeacherLessonCalendarTab', () => {
     vi.useRealTimers()
   })
 
+  it('shows an explicit retry after automatic inline retries are exhausted', async () => {
+    let saves = 0
+    const saveBodies: Array<{ content_markdown: string }> = []
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        saves += 1
+        saveBodies.push(JSON.parse(String(init.body)))
+        if (saves <= 4) {
+          return Promise.resolve({ ok: false, status: 500, json: async () => ({ error: 'Failed' }) })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ lesson_plan: lessonPlan({ content_markdown: 'Updated lesson' }) }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      })
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+    await screen.findByTestId('lesson-calendar')
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    expect(saves).toBe(4)
+    expect(screen.getByRole('alert')).toHaveTextContent('Some lesson plan changes could not be saved.')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry lesson plan changes' }))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(saves).toBe(5)
+    expect(saveBodies.at(-1)).toMatchObject({ content_markdown: 'Updated lesson' })
+    expect(screen.queryByRole('button', { name: 'Retry lesson plan changes' })).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it('uses an explicit keepalive PUT for pending changes during unload', async () => {
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
@@ -993,14 +1280,17 @@ describe('TeacherLessonCalendarTab', () => {
       await Promise.resolve()
     })
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      `/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`,
-      expect.objectContaining({
-        body: JSON.stringify({ content_markdown: 'Updated lesson' }),
-        keepalive: true,
-        method: 'PUT',
-      }),
-    )
+    const unloadCall = fetchMock.mock.calls.find(([url, init]) => (
+      String(url).endsWith('/lesson-plans/2025-01-06') && init?.keepalive === true
+    ))
+    expect(unloadCall?.[1]).toEqual(expect.objectContaining({
+      keepalive: true,
+      method: 'PUT',
+    }))
+    expect(JSON.parse(String(unloadCall?.[1]?.body))).toMatchObject({
+      content_markdown: 'Updated lesson',
+      mutation: { sequence: 1 },
+    })
   })
 
   it('invalidates cached teacher lesson plans after an autosaved edit', async () => {

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TeacherLessonCalendarTab } from '@/app/classrooms/[classroomId]/TeacherLessonCalendarTab'
 import { createMockClassroom } from '../helpers/mocks'
-import { TooltipProvider } from '@/ui'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
 import { invalidateTeacherLessonPlansForClassroom } from '@/lib/teacher-lesson-plans-client'
 import { invalidateCachedJSON } from '@/lib/request-cache'
 import type { CalendarSidebarState } from '@/app/classrooms/[classroomId]/TeacherLessonCalendarTab'
 import type { LessonPlan } from '@/types'
 import type { ReactNode } from 'react'
+import { TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
 
 const sidebarState = vi.hoisted(() => ({
   isOpen: false,
@@ -15,12 +16,20 @@ const sidebarState = vi.hoisted(() => ({
   setOpen: vi.fn(),
 }))
 
+const classDaysState = vi.hoisted(() => ({
+  classDays: [],
+  error: null as string | null,
+  hasLoadedSnapshot: true,
+  isLoading: false,
+  refresh: vi.fn(async () => {}),
+}))
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('@/hooks/useClassDays', () => ({
-  useClassDays: () => [],
+  useClassDaysContext: () => classDaysState,
 }))
 
 vi.mock('@/lib/cookies', () => ({
@@ -49,6 +58,7 @@ vi.mock('@/components/LessonCalendar', () => ({
       data-lesson-count={lessonPlans.length}
       data-lesson-classrooms={lessonPlans.map((plan: LessonPlan) => plan.classroom_id).join(',')}
       data-assignment-classrooms={assignments.map((assignment: any) => assignment.classroom_id).join(',')}
+      data-assignment-ids={assignments.map((assignment: any) => assignment.id).join(',')}
       data-announcement-classrooms={announcements.map((announcement: any) => announcement.classroom_id).join(',')}
     >
       <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Updated lesson')}>
@@ -83,7 +93,11 @@ function deferred<T>() {
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <TooltipProvider>{children}</TooltipProvider>
+  return (
+    <AppMessageProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </AppMessageProvider>
+  )
 }
 
 describe('TeacherLessonCalendarTab', () => {
@@ -101,6 +115,11 @@ describe('TeacherLessonCalendarTab', () => {
     sidebarState.isOpen = false
     sidebarState.toggle.mockReset()
     sidebarState.setOpen.mockReset()
+    classDaysState.classDays = []
+    classDaysState.error = null
+    classDaysState.hasLoadedSnapshot = true
+    classDaysState.isLoading = false
+    classDaysState.refresh.mockClear()
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -142,6 +161,104 @@ describe('TeacherLessonCalendarTab', () => {
     expect(urls.filter((url) => url.includes('/lesson-plans?'))).toHaveLength(1)
     expect(urls.filter((url) => url.includes('/assignments'))).toHaveLength(1)
     expect(urls.filter((url) => url.includes('/announcements'))).toHaveLength(1)
+  })
+
+  it('keeps successful sources visible and retries only failed assignments', async () => {
+    let assignmentReads = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('assignments')) {
+        assignmentReads += 1
+        if (assignmentReads === 1) {
+          return { ok: false, json: async () => ({ error: 'Failed' }) }
+        }
+        return {
+          ok: true,
+          json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
+        }
+      }
+      return {
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('announcements')) return { announcements: [{ id: 'announcement-1', classroom_id: classroom.id }] }
+          return {}
+        },
+      }
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', classroom.id)
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry assignments' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', classroom.id)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(assignmentReads).toBe(2)
+  })
+
+  it('shows a retryable cold error when no calendar source loads', async () => {
+    classDaysState.error = 'The class schedule could not be loaded.'
+    classDaysState.hasLoadedSnapshot = false
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({ error: 'Failed' }) })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    expect(await screen.findByRole('heading', { name: "Calendar couldn't load" })).toBeInTheDocument()
+    expect(screen.queryByTestId('lesson-calendar')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(classDaysState.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains the last assignment snapshot when an event refresh fails', async () => {
+    let assignmentReads = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('assignments')) {
+        assignmentReads += 1
+        if (assignmentReads === 2) {
+          return { ok: false, json: async () => ({ error: 'Failed' }) }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            assignments: [{
+              id: assignmentReads === 1 ? 'assignment-1' : 'assignment-2',
+              classroom_id: classroom.id,
+            }],
+          }),
+        }
+      }
+      return {
+        ok: true,
+        json: async () => url.includes('lesson-plans')
+          ? { lesson_plans: [lessonPlan()] }
+          : { announcements: [] },
+      }
+    })
+
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-ids', 'assignment-1')
+    })
+
+    window.dispatchEvent(new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
+      detail: { classroomId: classroom.id },
+    }))
+
+    await screen.findByRole('button', { name: 'Retry assignments' })
+    expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-ids', 'assignment-1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry assignments' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-ids', 'assignment-2')
+    })
+    expect(assignmentReads).toBe(3)
   })
 
   it('ignores stale classroom-scoped loads after the classroom changes', async () => {

--- a/tests/components/calendar-view-persistence.test.tsx
+++ b/tests/components/calendar-view-persistence.test.tsx
@@ -25,7 +25,13 @@ vi.mock('@/components/layout', () => ({
 
 // Mock the class days hook
 vi.mock('@/hooks/useClassDays', () => ({
-  useClassDays: () => [],
+  useClassDaysContext: () => ({
+    classDays: [],
+    error: null,
+    hasLoadedSnapshot: true,
+    isLoading: false,
+    refresh: vi.fn(async () => {}),
+  }),
 }))
 
 // Mock the keyboard shortcut hook

--- a/tests/contexts/ClassDaysContext.test.tsx
+++ b/tests/contexts/ClassDaysContext.test.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from 'react'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -185,6 +185,54 @@ describe('ClassDaysProvider', () => {
     expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-01')
     expect(screen.getByTestId('probe-snapshot')).toHaveTextContent('true')
     expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
+  })
+
+  it('keeps a retained refresh pending and preserves its error until it settles', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const retainedRetry = deferred<{ class_days: ClassDay[] }>()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-01')] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Class days unavailable' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => retainedRetry.promise,
+      } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    await screen.findByText('2026-05-01')
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh probe' }))
+    await screen.findByText('The class schedule could not be loaded.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh probe' }))
+
+    expect(screen.getByTestId('probe-loading')).toHaveTextContent('true')
+    expect(screen.getByTestId('probe-error')).toHaveTextContent(
+      'The class schedule could not be loaded.',
+    )
+    expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-01')
+
+    await act(async () => {
+      retainedRetry.resolve({ class_days: [classDay('2026-05-02')] })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-loading')).toHaveTextContent('false')
+      expect(screen.getByTestId('probe-error')).toHaveTextContent('')
+      expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-02')
+    })
+    expect(consoleError).toHaveBeenCalledTimes(1)
   })
 
   it('resets the provider subtree before children observe a new classroom', async () => {

--- a/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
+++ b/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { CLASSROOM_PURGE_ONLY_RELATIONAL_RESOURCES } from '@/lib/contracts/classroom-data'
 
 const migration = readFileSync(
   join(process.cwd(), 'supabase/migrations/125_ordered_lesson_plan_mutations.sql'),
@@ -23,5 +24,13 @@ describe('ordered lesson-plan mutations migration', () => {
     expect(migration).toContain('delete from public.lesson_plans')
     expect(migration).toContain('on conflict (classroom_id, date) do update')
     expect(migration).toContain('grant execute on function public.apply_ordered_lesson_plan_mutation')
+  })
+
+  it('tracks mutation heads as purge-only classroom operational state', () => {
+    expect(CLASSROOM_PURGE_ONLY_RELATIONAL_RESOURCES).toContainEqual(expect.objectContaining({
+      table: 'lesson_plan_mutation_heads',
+      primary_key: ['classroom_id', 'date', 'client_id'],
+      privacy: ['operations'],
+    }))
   })
 })

--- a/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
+++ b/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  join(process.cwd(), 'supabase/migrations/125_ordered_lesson_plan_mutations.sql'),
+  'utf8',
+)
+
+describe('ordered lesson-plan mutations migration', () => {
+  it('advances a durable per-session head only for a newer sequence', () => {
+    expect(migration).toContain('create table public.lesson_plan_mutation_heads')
+    expect(migration).toContain('primary key (classroom_id, date, client_id)')
+    expect(migration).toContain('on conflict (classroom_id, date, client_id) do update')
+    expect(migration).toContain(
+      'where public.lesson_plan_mutation_heads.last_sequence < excluded.last_sequence',
+    )
+  })
+
+  it('applies the ordering fence and lesson write in one database function', () => {
+    expect(migration).toContain('function public.apply_ordered_lesson_plan_mutation')
+    expect(migration).toContain("'applied', false")
+    expect(migration).toContain('delete from public.lesson_plans')
+    expect(migration).toContain('on conflict (classroom_id, date) do update')
+    expect(migration).toContain('grant execute on function public.apply_ordered_lesson_plan_mutation')
+  })
+})

--- a/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
+++ b/tests/unit/ordered-lesson-plan-mutations-migration.test.ts
@@ -32,5 +32,18 @@ describe('ordered lesson-plan mutations migration', () => {
       primary_key: ['classroom_id', 'date', 'client_id'],
       privacy: ['operations'],
     }))
+    expect(migration).toContain('lesson_plan_mutation_head_purge_fence')
+    expect(migration).toContain(
+      'get_hot_archived_classroom_purge_inventory_without_lesson_heads',
+    )
+    expect(migration).toMatch(
+      /get_hot_archived_classroom_purge_inventory_without_lesson_heads\([\s\S]*?set schema private/,
+    )
+    expect(migration).toMatch(
+      /'lesson_plan_mutation_heads',[\s\S]*?select count\(\*\)::integer[\s\S]*?where classroom_id = p_classroom_id/,
+    )
+    expect(migration).toContain(
+      "'operational_inventory_sha256', v_operational_digest",
+    )
   })
 })

--- a/tests/unit/teacher-lesson-plan-mutation-queue.test.ts
+++ b/tests/unit/teacher-lesson-plan-mutation-queue.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  allocateTeacherLessonPlanMutationVersion,
+  resetTeacherLessonPlanMutationQueuesForTests,
+} from '@/lib/teacher-lesson-plan-mutation-queue'
+
+describe('teacher lesson-plan mutation versions', () => {
+  beforeEach(() => {
+    resetTeacherLessonPlanMutationQueuesForTests()
+  })
+
+  it('keeps one browser-tab client id and advances its durable sequence', () => {
+    const first = allocateTeacherLessonPlanMutationVersion()
+    const second = allocateTeacherLessonPlanMutationVersion()
+
+    expect(second.client_id).toBe(first.client_id)
+    expect(first.sequence).toBe(1)
+    expect(second.sequence).toBe(2)
+  })
+
+  it('replaces malformed session state before allocating a mutation', () => {
+    window.sessionStorage.setItem(
+      'pika:lesson-plan-mutation-session',
+      JSON.stringify({ client_id: 'not-a-uuid', sequence: -1 }),
+    )
+
+    const mutation = allocateTeacherLessonPlanMutationVersion()
+
+    expect(mutation.client_id).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(mutation.sequence).toBe(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ const jsdomOnlyTsSuites = [
   'tests/lib/flag-questions.test.ts',
   'tests/unit/classroom-ux-metrics.test.ts',
   'tests/unit/client-storage.test.ts',
+  'tests/unit/teacher-lesson-plan-mutation-queue.test.ts',
 ]
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- track lesson plans, assignments, announcements, and class days independently in teacher and student calendars
- retain successful snapshots, expose source-specific retries, and fence stale or overlapping responses
- correct date-only term parsing and use Toronto time for initial/today navigation

## User impact
Calendar fetch failures no longer look like missing classroom data. Teachers and students can continue using successfully loaded calendar information and retry only the failed source.

## Validation
- `pnpm test` (495 files, 4,285 tests)
- `pnpm build`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm check:architecture`
- `pnpm check:design-policy`
- `pnpm check:ui-policy`
- Pika pre-commit audit
- Playwright teacher/student desktop light/dark loaded states and intercepted partial-error states; existing mobile layout also checked

No migrations, database writes, production changes, mobile redesign, or Gradex changes.